### PR TITLE
feat(agentic): add Claude Code slash commands for development workflow

### DIFF
--- a/.claude/commands/develop.md
+++ b/.claude/commands/develop.md
@@ -1,0 +1,74 @@
+---
+name: develop
+description: Given a GitHub issue number, create a worktree branch, implement the change, and open a PR. Usage: /develop <issue-number> or /develop <issue-url>
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Agent
+  - AskUserQuestion
+---
+
+# /develop
+
+Given a GitHub issue, implement it following the Issue-First workflow.
+
+## Usage
+
+```
+/develop 12
+/develop https://github.com/madlouse/AgenticOS/issues/12
+```
+
+## Steps
+
+### 1. Understand the Issue
+- Fetch the issue details with `gh issue view <number> --json title,body,labels`
+- Read the acceptance criteria carefully
+- Ask clarifying questions if the requirements are unclear
+
+### 2. Create Branch
+- Create a branch following the naming convention: `<type>/<issue-number>-<slug>`
+  where type is derived from labels (feat/fix/docs/chore/ci/refactor/test)
+  and slug is a short lowercase description of the issue
+- Use a **separate worktree directory** (not inside the repo):
+  ```bash
+  git worktree add /path/to/worktree -b branch-name
+  ```
+
+### 3. Implement
+- Read CLAUDE.md and AGENTS.md at the repo root for development rules
+- Implement the change following the conventions:
+  - TypeScript strict mode
+  - Conventional Commits format
+  - No direct commits to main
+- Build and verify: `cd mcp-server && npm run build`
+
+### 4. Record & Commit
+- Call `agenticos_record()` with session summary
+- Commit using Conventional Commits: `<type>(scope): <description>`
+- Always include `Closes #<issue-number>` in the commit message
+
+### 5. Open PR
+- Push branch to origin
+- Create PR with `gh pr create`
+- Reference the issue: `Closes #<issue-number>`
+
+## Branch Naming Examples
+
+| Issue | Label | Branch |
+|-------|-------|--------|
+| #12 "Add export tool" | enhancement | `feat/12-export-tool` |
+| #3 "Fix save error" | bug | `fix/3-save-error` |
+| #8 "Add CI pipeline" | enhancement | `feat/8-ci-pipeline` |
+| #5 "Update docs" | documentation | `docs/5-update-readme` |
+
+## Forbidden Actions
+
+- Never push directly to `main`
+- Never commit `node_modules/`, `build/`, `.env`
+- Never modify files under `projects/` (user data)
+- Never skip the PR — even for small changes

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,0 +1,98 @@
+---
+name: release
+description: Prepare and execute a release: bump version, update CHANGELOG, create git tag. Usage: /release <major|minor|patch>
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Grep
+---
+
+# /release
+
+Prepare and execute a release following semantic versioning.
+
+## Usage
+
+```
+/release patch  # 0.2.0 → 0.2.1 (bug fixes)
+/release minor  # 0.2.0 → 0.3.0 (new features)
+/release major  # 0.2.0 → 1.0.0 (breaking changes)
+```
+
+## Pre-Release Checklist
+
+Before running `/release`, verify:
+- [ ] All PRs for this release are merged to `main`
+- [ ] CI passes on `main`
+- [ ] No uncommitted changes on `main`
+- [ ] Conventional Commits are used in the release commits
+
+## Steps
+
+### 1. Update Version
+
+Update `package.json` and `mcp-server/src/index.ts`:
+
+```bash
+# Determine new version
+current=$(git describe --tags --abbrev=0)
+echo "Current version: $current"
+
+# Update package.json version field
+# Update mcp-server/src/index.ts version constant
+```
+
+### 2. Generate CHANGELOG Entry
+
+Use `git log` to generate the changelog from Conventional Commits since last tag:
+
+```bash
+git log --format="%s" $(git describe --tags --abbrev=0)..HEAD --grep -E "^(feat|fix|docs|chore|refactor|test|ci):"
+```
+
+Categorize into:
+- **Breaking Changes** (feat!: or fix!: or BREAKING CHANGE:)
+- **New Features** (feat:)
+- **Bug Fixes** (fix:)
+- **Other Changes** (docs, chore, refactor, ci, test)
+
+### 3. Update Files
+
+Update these files with the new version:
+1. `mcp-server/package.json` — `version` field
+2. `mcp-server/src/index.ts` — version constant
+3. `CHANGELOG.md` — prepend new version entry with today's date
+
+### 4. Commit
+
+```bash
+git add mcp-server/package.json mcp-server/src/index.ts CHANGELOG.md
+git commit -m "release: bump version to <new-version>"
+```
+
+### 5. Tag
+
+```bash
+git tag -a v<new-version> -m "Release v<new-version>"
+```
+
+### 6. Push
+
+```bash
+git push origin main --tags
+```
+
+## Current Version
+
+Check with:
+```bash
+grep '"version"' mcp-server/package.json | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+'
+```
+
+## Forbidden Actions
+
+- Never modify version field without following the full release process
+- Never force-push tags
+- Never release with failing CI

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,0 +1,72 @@
+---
+name: review
+description: Review the current branch's diff against main for convention compliance. Run without arguments to check the current branch.
+allowed-tools:
+  - Bash
+  - Read
+  - Glob
+  - Grep
+---
+
+# /review
+
+Review the current branch for compliance with project conventions.
+
+## Usage
+
+```
+/review
+/review feat/12-export-tool
+```
+
+## Checks
+
+### 1. Branch Naming
+Verify branch name follows `<type>/<issue-number>-<slug>`:
+```bash
+git branch --show-current
+```
+
+### 2. Commit Convention
+Check commits follow Conventional Commits:
+```bash
+git log main..HEAD --oneline
+```
+
+Expected format: `<type>(scope): <description>`
+
+### 3. PR Reference
+Verify the branch has an associated PR:
+```bash
+gh pr list --head $(git branch --show-current) --state open
+```
+
+### 4. Build Pass
+Verify the code compiles:
+```bash
+cd mcp-server && npm run build
+```
+
+### 5. No Forbidden Changes
+Check no files under `projects/` were modified:
+```bash
+git diff main --stat | grep "projects/"
+```
+
+### 6. No Sensitive Files
+Check for accidental commits:
+```bash
+git diff main --name-only | grep -E "node_modules|build/|\.env|package-lock"
+```
+
+## Output Format
+
+Provide a checklist with ✅/❌ for each check, and list any issues found.
+If all checks pass, output: "All checks passed. Ready to merge."
+
+## When to Run
+
+- Before opening a PR
+- After making significant changes
+- Before requesting review
+- Before merging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Claude Code slash commands: `/develop`, `/review`, `/release` for standardized development workflow
+
+## [0.1.0] — 2026-03-19
+
+### Added
+- AgenticOS MCP Server core implementation
+- MCP tools: `init`, `switch`, `list`, `save`
+- MCP resource: `agenticos://context/current`
+- Homebrew tap distribution
+- Cross-machine portability support
+- `--version` flag
+- Knowledge base for AgenticOS development
+
+### Fixed
+- Cross-machine path resolution
+- Homebrew Formula sha256


### PR DESCRIPTION
## Closes Issue
Closes #11

## Summary

Add Claude Code slash commands for standardized development workflow:

### `/develop <issue-number>`
Given a GitHub issue number or URL, this command:
1. Fetches issue details and acceptance criteria
2. Creates a properly named branch (`<type>/<issue-number>-<slug>`) in a separate worktree
3. Implements the change following CLAUDE.md/AGENTS.md conventions
4. Commits using Conventional Commits with `Closes #N` footer
5. Opens a PR referencing the issue

### `/review`
Checks the current branch for convention compliance:
- Branch naming convention
- Conventional Commits format
- PR reference
- Build passes
- No forbidden changes (projects/, node_modules/, .env)

### `/release <major|minor|patch>`
Prepares a release:
1. Generates CHANGELOG entry from Conventional Commits since last tag
2. Updates version in `package.json` and `index.ts`
3. Creates git tag and pushes

## Files Added

- `.claude/commands/develop.md` — `/develop` command
- `.claude/commands/review.md` — `/review` command
- `.claude/commands/release.md` — `/release` command
- `CHANGELOG.md` — initialized following Keep a Changelog format

## After Merge

Slash commands are automatically available when working on the repo in Claude Code.

## Test Plan

- [x] Files created correctly in `.claude/commands/`
- [x] CHANGELOG.md follows Keep a Changelog format

🤖 Generated with [Claude Code](https://claude.com/claude-code)