### PR TITLE
docs: narrow scope, add ROADMAP.md, update CHANGELOG for v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_No unreleased changes._
+
+## [0.2.0] — 2026-03-22
+
 ### Added
-- Claude Code slash commands: `/develop`, `/review`, `/release` for standardized development workflow
+- Claude Code slash commands: `/develop`, `/review`, `/release`
+- `agenticos_record` tool for session recording
+- `agenticos_status` tool for project status
+- Template versioning with auto-upgrade on project switch
+- GitHub Actions CI pipeline (lint, build)
+- Open-source development workflow (CONTRIBUTING.md, AGENTS.md)
+
+### Fixed
+- Init idempotency: duplicate project detection and handling (#2)
+- Save error handling: phased git status reporting (#3)
+- Version consistency across package.json, index.ts, formula (#16)
+
+### Changed
+- Distribution via GitHub Releases + Homebrew (not npm)
+- Narrowed scope: deferred memory.jsonl and changelog.md to future versions
 
 ## [0.1.0] — 2026-03-19
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,47 @@
+# AgenticOS Roadmap
+
+> AI-native project management — persist context across sessions for any MCP-compatible AI tool.
+
+## v0.2.0 — Current Release
+
+**Theme**: Core infrastructure + developer workflow
+
+- [x] MCP Server with 6 tools (init, switch, list, record, save, status) + 1 resource
+- [x] Three-layer architecture: Universal Protocol → MCP Server → Agent-Specific Config
+- [x] Session recording: conversations/ + state.yaml auto-sync to CLAUDE.md
+- [x] Template versioning with auto-upgrade on project switch
+- [x] Registry with relative paths — cross-machine portable
+- [x] GitHub Releases + Homebrew distribution
+- [x] CI pipeline (TypeScript lint, build, test)
+- [x] Open-source workflow: Issue → Branch → PR
+
+## v0.3.0 — Next
+
+**Theme**: Cross-tool validation + developer experience
+
+- [ ] Cross-tool verification: validate full workflow in Cursor and Codex
+- [ ] Project DNA auto-population from first record
+- [ ] `agenticos_search` — search across knowledge/ and conversations/
+- [ ] `agenticos_archive` — archive completed projects
+- [ ] Improved quick-start.md: auto-enrich on first session record
+- [ ] CURSOR.md / AGENTS.md templates for non-Claude tools
+
+## v1.0.0 — Future
+
+**Theme**: Production-ready + ecosystem
+
+- [ ] npm registry distribution (for npx usage)
+- [ ] Project templates (custom init scaffolding)
+- [ ] Team collaboration support (shared registries)
+- [ ] Optional visualization dashboard
+- [ ] Optional cloud sync backend
+- [ ] Plugin/extension system for custom tools
+
+## Non-Goals (v0.2.0)
+
+These are explicitly deferred and will not be implemented in the current release:
+
+- **memory.jsonl** — conversations/ + state.yaml serve this purpose
+- **Project-level changelog.md** — git log is the changelog
+- **npm publish** — GitHub Releases + Homebrew is the distribution strategy
+- **External server dependencies** — all data stays local

--- a/projects/agentic-os-development/knowledge/complete-design.md
+++ b/projects/agentic-os-development/knowledge/complete-design.md
@@ -188,8 +188,10 @@ Agent 读取 CLAUDE.md 触发规则
 ### Decision 3: 完整记录机制
 - 对话日志（原始）
 - 项目日志（时间线）
-- 记忆流（结构化）
+- 记忆流（结构化）— 通过 state.yaml 实现
 - 知识库（提炼）
+
+> 注: memory.jsonl 和项目级 changelog.md 已推迟到未来版本，当前 conversations/ + state.yaml + knowledge/ 构成完整的持久化方案。
 
 ### Decision 4: 智能意图识别
 - 显式命令直接执行
@@ -212,6 +214,7 @@ agenticos-mcp/
 │   ├── tools/
 │   │   ├── init.ts        # 创建项目
 │   │   ├── project.ts     # 切换/列出
+│   │   ├── record.ts      # 会话记录
 │   │   └── save.ts        # 保存备份
 │   ├── resources/
 │   │   └── context.ts     # 项目上下文
@@ -312,8 +315,8 @@ Agent: 调用 agenticos_switch → 加载上下文 → 继续工作
 ## 12. 未来演进
 
 ### 短期
-- 测试 MCP Server
-- 发布到 npm
+- ✅ MCP Server 核心完成
+- 通过 GitHub Releases + Homebrew 分发
 - 验证跨工具兼容性
 
 ### 中期

--- a/projects/agentic-os-development/knowledge/design-decisions.md
+++ b/projects/agentic-os-development/knowledge/design-decisions.md
@@ -74,6 +74,16 @@
 - ⚠️ 需要维护多个文件
 - ⚠️ 可能有信息重复
 
+#### v0.2.0 Status Update
+
+| Layer | Status | Notes |
+|-------|--------|-------|
+| conversations/ | Implemented | Via `agenticos_record` tool |
+| knowledge/ | Implemented | Manual agent-written files |
+| state.yaml | Implemented | Structured session state, auto-synced to CLAUDE.md |
+| memory.jsonl | Deferred | Conversation records in conversations/ serve this purpose for now |
+| changelog.md | Deferred | Git log is the changelog; no separate project-level file needed |
+
 ---
 
 ### Decision 4: 智能意图识别 + 双层激活机制


### PR DESCRIPTION
## Summary
- Narrow design docs to v0.2.0 scope (remove memory.jsonl, changelog.md references)
- Add ROADMAP.md with vision and milestone tracking
- Update CHANGELOG.md with v0.2.0 entry

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)