### PR TITLE
fix(ci): change npm ci to npm install and add test step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,14 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies
-        run: npm ci
+        run: npm install
         working-directory: mcp-server
       - name: TypeScript type check
         run: npm run lint
         working-directory: mcp-server
       - name: Build
         run: npm run build
+        working-directory: mcp-server
+      - name: Run tests
+        run: npm test
         working-directory: mcp-server


### PR DESCRIPTION
## Summary
- Change `npm ci` to `npm install` in CI — fixes Linux CI failure due to platform-specific native modules
- Add test step to CI workflow

## Test plan
- [x] CI runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)