### PR TITLE
feat(mcp-server): add agenticos_preflight guardrail tool (#36)

### DIFF
--- a/projects/agenticos/mcp-server/src/index.ts
+++ b/projects/agenticos/mcp-server/src/index.ts
@@ -34,7 +34,7 @@ import {
   ListResourcesRequestSchema,
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { initProject, switchProject, listProjects, getStatus, saveState, recordSession } from './tools/index.js';
+import { initProject, switchProject, listProjects, getStatus, saveState, recordSession, runPreflight } from './tools/index.js';
 import { getProjectContext } from './resources/index.js';
 
 const server = new Server(
@@ -119,6 +119,41 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
       description: 'Show status of the active project: last recorded time, current task, pending items, recent decisions.',
       inputSchema: { type: 'object', properties: {} },
     },
+    {
+      name: 'agenticos_preflight',
+      description: 'Run machine-checkable guardrail preflight before implementation or PR creation. Returns JSON with PASS, BLOCK, or REDIRECT.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          issue_id: { type: 'string', description: 'GitHub issue number or identifier for the current task' },
+          task_type: {
+            type: 'string',
+            enum: ['discussion_only', 'analysis_or_doc', 'implementation', 'bootstrap'],
+            description: 'Classified task type',
+          },
+          repo_path: { type: 'string', description: 'Absolute repository or worktree path to evaluate' },
+          remote_base_branch: { type: 'string', description: 'Remote base branch to compare against (default: origin/main)' },
+          declared_target_files: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Files or path globs the task intends to touch',
+          },
+          structural_move: { type: 'boolean', description: 'Whether the task changes repository structure' },
+          worktree_required: { type: 'boolean', description: 'Whether isolated worktree execution is mandatory' },
+          root_scoped_exceptions: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Repository-root infrastructure exceptions such as .github/',
+          },
+          clean_reproducibility_gate: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Required clean baseline verification commands such as npm ci and npm run build',
+          },
+        },
+        required: ['task_type', 'repo_path'],
+      },
+    },
   ],
 }));
 
@@ -139,6 +174,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       return { content: [{ type: 'text', text: await saveState(args) }] };
     case 'agenticos_status':
       return { content: [{ type: 'text', text: await getStatus() }] };
+    case 'agenticos_preflight':
+      return { content: [{ type: 'text', text: await runPreflight(args ?? {}) }] };
     default:
       throw new Error(`Unknown tool: ${name}`);
   }

--- a/projects/agenticos/mcp-server/src/tools/__tests__/preflight.test.ts
+++ b/projects/agenticos/mcp-server/src/tools/__tests__/preflight.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const execAsyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock('child_process', () => ({
+  exec: vi.fn(),
+}));
+
+vi.mock('util', () => ({
+  promisify: vi.fn(() => execAsyncMock),
+}));
+
+import { runPreflight } from '../preflight.js';
+
+function mockGitResponses(responses: Record<string, string>): void {
+  execAsyncMock.mockImplementation(async (cmd: string) => {
+    for (const [pattern, stdout] of Object.entries(responses)) {
+      if (cmd.includes(pattern)) {
+        return { stdout, stderr: '' };
+      }
+    }
+    throw new Error(`Unexpected command: ${cmd}`);
+  });
+}
+
+describe('runPreflight', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns PASS for a correctly isolated implementation branch', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --abbrev-ref HEAD': 'feat/36-guardrail-preflight\n',
+      'rev-parse HEAD': 'abc123\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo\nHEAD abc123\nbranch refs/heads/feat/36-guardrail-preflight\n',
+      'log --format=%s origin/main..HEAD': '',
+    });
+
+    const result = JSON.parse(await runPreflight({
+      issue_id: '36',
+      task_type: 'implementation',
+      repo_path: '/repo',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/preflight.ts'],
+      worktree_required: true,
+    })) as { status: string; worktree_ok: boolean; branch_based_on_intended_remote: boolean };
+
+    expect(result.status).toBe('PASS');
+    expect(result.worktree_ok).toBe(true);
+    expect(result.branch_based_on_intended_remote).toBe(true);
+  });
+
+  it('returns REDIRECT when implementation starts on main workspace', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --abbrev-ref HEAD': 'main\n',
+      'rev-parse HEAD': 'abc123\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'worktree list --porcelain': 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n',
+      'log --format=%s origin/main..HEAD': '',
+    });
+
+    const result = JSON.parse(await runPreflight({
+      issue_id: '36',
+      task_type: 'implementation',
+      repo_path: '/repo',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/preflight.ts'],
+      worktree_required: true,
+    })) as { status: string; redirect_actions: string[] };
+
+    expect(result.status).toBe('REDIRECT');
+    expect(result.redirect_actions[0]).toContain('isolated issue branch/worktree');
+  });
+
+  it('returns BLOCK when branch contains unrelated commits relative to origin/main', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --abbrev-ref HEAD': 'fix/43-mcp-server-clean-install-baseline\n',
+      'rev-parse HEAD': 'abc123\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base111\n',
+      'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo\nHEAD abc123\nbranch refs/heads/fix/43-mcp-server-clean-install-baseline\n',
+      'log --format=%s origin/main..HEAD': 'feat(switch): inline project context in switch output (fixes #23)\nfix(record): defensively parse JSON-stringified array args (fixes #24)\n',
+    });
+
+    const result = JSON.parse(await runPreflight({
+      issue_id: '36',
+      task_type: 'implementation',
+      repo_path: '/repo',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/preflight.ts'],
+      worktree_required: true,
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons[0]).toContain('unrelated commits');
+  });
+
+  it('returns BLOCK for structural move without root exception or reproducibility gate', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --abbrev-ref HEAD': 'feat/40-self-hosting\n',
+      'rev-parse HEAD': 'abc123\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo\nHEAD abc123\nbranch refs/heads/feat/40-self-hosting\n',
+      'log --format=%s origin/main..HEAD': '',
+    });
+
+    const result = JSON.parse(await runPreflight({
+      issue_id: '40',
+      task_type: 'implementation',
+      repo_path: '/repo',
+      declared_target_files: ['projects/agenticos/**'],
+      worktree_required: true,
+      structural_move: true,
+      root_scoped_exceptions: [],
+      clean_reproducibility_gate: [],
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons.join(' ')).toContain('.github/');
+    expect(result.block_reasons.join(' ')).toContain('clean_reproducibility_gate');
+  });
+});

--- a/projects/agenticos/mcp-server/src/tools/index.ts
+++ b/projects/agenticos/mcp-server/src/tools/index.ts
@@ -2,3 +2,4 @@ export { initProject } from './init.js';
 export { switchProject, listProjects, getStatus } from './project.js';
 export { saveState } from './save.js';
 export { recordSession } from './record.js';
+export { runPreflight } from './preflight.js';

--- a/projects/agenticos/mcp-server/src/tools/preflight.ts
+++ b/projects/agenticos/mcp-server/src/tools/preflight.ts
@@ -1,0 +1,208 @@
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+type TaskType = 'discussion_only' | 'analysis_or_doc' | 'implementation' | 'bootstrap';
+type WorkspaceType = 'main' | 'isolated_worktree';
+type GuardrailStatus = 'PASS' | 'BLOCK' | 'REDIRECT';
+
+interface PreflightArgs {
+  issue_id?: string;
+  task_type?: TaskType;
+  repo_path?: string;
+  remote_base_branch?: string;
+  declared_target_files?: string[];
+  structural_move?: boolean;
+  worktree_required?: boolean;
+  root_scoped_exceptions?: string[];
+  clean_reproducibility_gate?: string[];
+}
+
+interface PreflightResult {
+  status: GuardrailStatus;
+  summary: string;
+  repo_identity_confirmed: boolean;
+  branch_ancestry_verified: boolean;
+  branch_based_on_intended_remote: boolean;
+  worktree_ok: boolean;
+  scope_ok: boolean;
+  reproducibility_gate_defined: boolean;
+  block_reasons: string[];
+  redirect_actions: string[];
+  evidence: {
+    current_branch: string;
+    current_head: string;
+    remote_base_branch: string;
+    remote_base_head: string;
+    branch_fork_point: string;
+    workspace_type: WorkspaceType;
+    commit_subjects_since_base: string[];
+  };
+}
+
+async function runGit(repoPath: string, args: string): Promise<string> {
+  const { stdout } = await execAsync(`git -C "${repoPath}" ${args}`);
+  return stdout.trim();
+}
+
+function normalizeLines(content: string): string[] {
+  return content
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+async function detectWorkspaceType(repoPath: string): Promise<WorkspaceType> {
+  try {
+    const output = await runGit(repoPath, 'worktree list --porcelain');
+    const worktreeLines = output
+      .split('\n')
+      .filter((line) => line.startsWith('worktree '))
+      .map((line) => line.replace(/^worktree\s+/, '').trim());
+
+    if (worktreeLines.length > 0 && worktreeLines[0] === repoPath) {
+      return 'main';
+    }
+    return 'isolated_worktree';
+  } catch {
+    return 'main';
+  }
+}
+
+function finalizeResult(result: PreflightResult): PreflightResult {
+  if (result.block_reasons.length > 0) {
+    result.status = 'BLOCK';
+    result.summary = result.block_reasons.join('; ');
+    return result;
+  }
+
+  if (result.redirect_actions.length > 0) {
+    result.status = 'REDIRECT';
+    result.summary = result.redirect_actions.join('; ');
+    return result;
+  }
+
+  result.status = 'PASS';
+  result.summary = 'preflight passed';
+  return result;
+}
+
+function makeBaseResult(remoteBaseBranch: string): PreflightResult {
+  return {
+    status: 'BLOCK',
+    summary: '',
+    repo_identity_confirmed: false,
+    branch_ancestry_verified: false,
+    branch_based_on_intended_remote: false,
+    worktree_ok: false,
+    scope_ok: false,
+    reproducibility_gate_defined: false,
+    block_reasons: [],
+    redirect_actions: [],
+    evidence: {
+      current_branch: '',
+      current_head: '',
+      remote_base_branch: remoteBaseBranch,
+      remote_base_head: '',
+      branch_fork_point: '',
+      workspace_type: 'main',
+      commit_subjects_since_base: [],
+    },
+  };
+}
+
+export async function runPreflight(args: PreflightArgs): Promise<string> {
+  const {
+    issue_id,
+    task_type = 'discussion_only',
+    repo_path,
+    remote_base_branch = 'origin/main',
+    declared_target_files = [],
+    structural_move = false,
+    worktree_required = task_type === 'implementation',
+    root_scoped_exceptions = ['.github/'],
+    clean_reproducibility_gate = [],
+  } = args;
+
+  const result = makeBaseResult(remote_base_branch);
+
+  if (!repo_path) {
+    result.block_reasons.push('repo_path is required');
+    return JSON.stringify(finalizeResult(result), null, 2);
+  }
+
+  if (task_type === 'implementation' && !issue_id) {
+    result.block_reasons.push('issue_id is required for implementation work');
+  }
+
+  if (task_type === 'implementation' && declared_target_files.length === 0) {
+    result.block_reasons.push('declared_target_files is required for implementation work');
+  }
+
+  try {
+    const gitRoot = await runGit(repo_path, 'rev-parse --show-toplevel');
+    result.repo_identity_confirmed = gitRoot.length > 0;
+    result.evidence.current_branch = await runGit(repo_path, 'rev-parse --abbrev-ref HEAD');
+    result.evidence.current_head = await runGit(repo_path, 'rev-parse HEAD');
+    result.evidence.remote_base_head = await runGit(repo_path, `rev-parse ${remote_base_branch}`);
+    result.evidence.branch_fork_point = await runGit(repo_path, `merge-base HEAD ${remote_base_branch}`);
+    result.branch_ancestry_verified = true;
+    result.evidence.workspace_type = await detectWorkspaceType(repo_path);
+  } catch {
+    result.block_reasons.push('failed to resolve git repository identity or remote base');
+    return JSON.stringify(finalizeResult(result), null, 2);
+  }
+
+  if (worktree_required) {
+    const branchIsProtected = result.evidence.current_branch === 'main' || result.evidence.current_branch === remote_base_branch;
+    if (branchIsProtected || result.evidence.workspace_type === 'main') {
+      result.redirect_actions.push('create an isolated issue branch/worktree before implementation');
+    } else {
+      result.worktree_ok = true;
+    }
+  } else {
+    result.worktree_ok = true;
+  }
+
+  if (task_type === 'implementation') {
+    const subjectsRaw = await runGit(repo_path, `log --format=%s ${remote_base_branch}..HEAD`).catch(() => '');
+    const subjects = normalizeLines(subjectsRaw);
+    result.evidence.commit_subjects_since_base = subjects;
+
+    if (subjects.length > 0) {
+      const issueMarker = issue_id ? `#${issue_id}` : '';
+      const unrelatedSubjects = subjects.filter((subject) => !issueMarker || !subject.includes(issueMarker));
+      if (unrelatedSubjects.length > 0) {
+        result.block_reasons.push(`branch includes unrelated commits relative to ${remote_base_branch}`);
+      } else {
+        result.branch_based_on_intended_remote = true;
+      }
+    } else {
+      result.branch_based_on_intended_remote = true;
+    }
+
+    if (structural_move) {
+      const hasGithubException = root_scoped_exceptions.includes('.github/');
+      if (!hasGithubException) {
+        result.block_reasons.push('structural_move requires a root-scoped exception entry for .github/');
+      }
+
+      if (clean_reproducibility_gate.length === 0) {
+        result.block_reasons.push('structural_move requires a clean_reproducibility_gate');
+      } else {
+        result.reproducibility_gate_defined = true;
+      }
+    } else {
+      result.reproducibility_gate_defined = clean_reproducibility_gate.length > 0 || !structural_move;
+    }
+
+    result.scope_ok = declared_target_files.length > 0;
+  } else {
+    result.branch_based_on_intended_remote = true;
+    result.scope_ok = true;
+    result.reproducibility_gate_defined = true;
+  }
+
+  return JSON.stringify(finalizeResult(result), null, 2);
+}


### PR DESCRIPTION
## Summary
- add `agenticos_preflight` as the first implemented guardrail command
- return machine-readable JSON with `PASS`, `BLOCK`, or `REDIRECT`
- check repo identity, branch/worktree state, remote-base ancestry, structural-move exceptions, and reproducibility gate definition
- add focused unit tests for pass, redirect, and block behavior

## Why
This is the minimum implementation slice for #36. It gives AgenticOS a real preflight gate before implementation work or PR creation instead of relying only on documented process rules.

## Validation
- `cd /Users/jeking/worktrees/agenticos-guardrail-36/projects/agenticos/mcp-server && npm install && npm run build && npm test`

## Follow-up
- partial for #36
- next slices are `agenticos_branch_bootstrap` and `agenticos_pr_scope_check`