### PR TITLE
feat(mcp-server): add agenticos_branch_bootstrap helper (#36)

### DIFF
--- a/projects/agenticos/mcp-server/src/index.ts
+++ b/projects/agenticos/mcp-server/src/index.ts
@@ -34,7 +34,7 @@ import {
   ListResourcesRequestSchema,
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { initProject, switchProject, listProjects, getStatus, saveState, recordSession, runPreflight } from './tools/index.js';
+import { initProject, switchProject, listProjects, getStatus, saveState, recordSession, runPreflight, runBranchBootstrap } from './tools/index.js';
 import { getProjectContext } from './resources/index.js';
 
 const server = new Server(
@@ -154,6 +154,22 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         required: ['task_type', 'repo_path'],
       },
     },
+    {
+      name: 'agenticos_branch_bootstrap',
+      description: 'Create an issue branch and isolated worktree from the intended remote base. Returns JSON with CREATED or BLOCK.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          issue_id: { type: 'string', description: 'GitHub issue number or identifier for the current task' },
+          branch_type: { type: 'string', description: 'Branch prefix such as feat, fix, or chore' },
+          slug: { type: 'string', description: 'Short task slug used to derive branch and worktree names' },
+          repo_path: { type: 'string', description: 'Absolute repository path where the branch should be created' },
+          remote_base_branch: { type: 'string', description: 'Remote base branch to branch from (default: origin/main)' },
+          worktree_root: { type: 'string', description: 'Absolute root directory under which the new worktree should be created' },
+        },
+        required: ['issue_id', 'slug', 'repo_path', 'worktree_root'],
+      },
+    },
   ],
 }));
 
@@ -176,6 +192,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       return { content: [{ type: 'text', text: await getStatus() }] };
     case 'agenticos_preflight':
       return { content: [{ type: 'text', text: await runPreflight(args ?? {}) }] };
+    case 'agenticos_branch_bootstrap':
+      return { content: [{ type: 'text', text: await runBranchBootstrap(args ?? {}) }] };
     default:
       throw new Error(`Unknown tool: ${name}`);
   }

--- a/projects/agenticos/mcp-server/src/tools/__tests__/branch-bootstrap.test.ts
+++ b/projects/agenticos/mcp-server/src/tools/__tests__/branch-bootstrap.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const execAsyncMock = vi.hoisted(() => vi.fn());
+const accessMock = vi.hoisted(() => vi.fn());
+const mkdirMock = vi.hoisted(() => vi.fn());
+
+vi.mock('child_process', () => ({
+  exec: vi.fn(),
+}));
+
+vi.mock('util', () => ({
+  promisify: vi.fn(() => execAsyncMock),
+}));
+
+vi.mock('fs/promises', () => ({
+  access: accessMock,
+  mkdir: mkdirMock,
+}));
+
+import { runBranchBootstrap } from '../branch-bootstrap.js';
+
+describe('runBranchBootstrap', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    accessMock.mockRejectedValue(new Error('missing'));
+    mkdirMock.mockResolvedValue(undefined);
+  });
+
+  it('returns CREATED and issues git worktree add from the intended remote base', async () => {
+    execAsyncMock.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('rev-parse origin/main')) {
+        return { stdout: 'base123\n', stderr: '' };
+      }
+      if (cmd.includes('show-ref --verify --quiet refs/heads/feat/36-guardrail-helper')) {
+        throw new Error('branch missing');
+      }
+      if (cmd.includes('worktree add "/tmp/worktrees/mcp-server-36-guardrail-helper" -b feat/36-guardrail-helper base123')) {
+        return { stdout: 'Preparing worktree\n', stderr: '' };
+      }
+      throw new Error(`Unexpected command: ${cmd}`);
+    });
+
+    const result = JSON.parse(await runBranchBootstrap({
+      issue_id: '36',
+      branch_type: 'feat',
+      slug: 'guardrail helper',
+      repo_path: '/repo/mcp-server',
+      remote_base_branch: 'origin/main',
+      worktree_root: '/tmp/worktrees',
+    })) as { status: string; branch_name: string; base_commit: string; worktree_path: string; notes: string[] };
+
+    expect(result.status).toBe('CREATED');
+    expect(result.branch_name).toBe('feat/36-guardrail-helper');
+    expect(result.base_commit).toBe('base123');
+    expect(result.worktree_path).toBe('/tmp/worktrees/mcp-server-36-guardrail-helper');
+    expect(result.notes.join(' ')).toContain('origin/main');
+    expect(mkdirMock).toHaveBeenCalledWith('/tmp/worktrees', { recursive: true });
+  });
+
+  it('returns BLOCK when the target branch already exists', async () => {
+    execAsyncMock.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('rev-parse origin/main')) {
+        return { stdout: 'base123\n', stderr: '' };
+      }
+      if (cmd.includes('show-ref --verify --quiet refs/heads/feat/36-guardrail-helper')) {
+        return { stdout: '', stderr: '' };
+      }
+      throw new Error(`Unexpected command: ${cmd}`);
+    });
+
+    const result = JSON.parse(await runBranchBootstrap({
+      issue_id: '36',
+      branch_type: 'feat',
+      slug: 'guardrail helper',
+      repo_path: '/repo/mcp-server',
+      worktree_root: '/tmp/worktrees',
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons[0]).toContain('branch already exists');
+    expect(mkdirMock).not.toHaveBeenCalled();
+  });
+
+  it('returns BLOCK when the target worktree path already exists', async () => {
+    execAsyncMock.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('rev-parse origin/main')) {
+        return { stdout: 'base123\n', stderr: '' };
+      }
+      if (cmd.includes('show-ref --verify --quiet refs/heads/feat/36-guardrail-helper')) {
+        throw new Error('branch missing');
+      }
+      throw new Error(`Unexpected command: ${cmd}`);
+    });
+    accessMock.mockResolvedValue(undefined);
+
+    const result = JSON.parse(await runBranchBootstrap({
+      issue_id: '36',
+      branch_type: 'feat',
+      slug: 'guardrail helper',
+      repo_path: '/repo/mcp-server',
+      worktree_root: '/tmp/worktrees',
+    })) as { status: string; block_reasons: string[]; worktree_path: string };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons[0]).toContain('worktree path already exists');
+    expect(result.worktree_path).toBe('/tmp/worktrees/mcp-server-36-guardrail-helper');
+    expect(mkdirMock).not.toHaveBeenCalled();
+  });
+
+  it('returns BLOCK when the remote base cannot be resolved', async () => {
+    execAsyncMock.mockRejectedValue(new Error('bad ref'));
+
+    const result = JSON.parse(await runBranchBootstrap({
+      issue_id: '36',
+      branch_type: 'feat',
+      slug: 'guardrail helper',
+      repo_path: '/repo/mcp-server',
+      remote_base_branch: 'origin/main',
+      worktree_root: '/tmp/worktrees',
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons[0]).toContain('failed to resolve remote base');
+  });
+});

--- a/projects/agenticos/mcp-server/src/tools/branch-bootstrap.ts
+++ b/projects/agenticos/mcp-server/src/tools/branch-bootstrap.ts
@@ -1,0 +1,130 @@
+import { exec } from 'child_process';
+import { access, mkdir } from 'fs/promises';
+import { basename, join } from 'path';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+interface BranchBootstrapArgs {
+  issue_id?: string;
+  branch_type?: string;
+  slug?: string;
+  repo_path?: string;
+  remote_base_branch?: string;
+  worktree_root?: string;
+}
+
+interface BranchBootstrapResult {
+  status: 'CREATED' | 'BLOCK';
+  branch_name: string;
+  base_commit: string;
+  worktree_path: string;
+  notes: string[];
+  block_reasons: string[];
+}
+
+async function runGit(repoPath: string, args: string): Promise<string> {
+  const { stdout } = await execAsync(`git -C "${repoPath}" ${args}`);
+  return stdout.trim();
+}
+
+function sanitizeSegment(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function makeBaseResult(): BranchBootstrapResult {
+  return {
+    status: 'BLOCK',
+    branch_name: '',
+    base_commit: '',
+    worktree_path: '',
+    notes: [],
+    block_reasons: [],
+  };
+}
+
+export async function runBranchBootstrap(args: BranchBootstrapArgs): Promise<string> {
+  const {
+    issue_id,
+    branch_type = 'feat',
+    slug,
+    repo_path,
+    remote_base_branch = 'origin/main',
+    worktree_root,
+  } = args;
+
+  const result = makeBaseResult();
+
+  if (!issue_id) {
+    result.block_reasons.push('issue_id is required');
+  }
+  if (!slug) {
+    result.block_reasons.push('slug is required');
+  }
+  if (!repo_path) {
+    result.block_reasons.push('repo_path is required');
+  }
+  if (!worktree_root) {
+    result.block_reasons.push('worktree_root is required');
+  }
+
+  if (result.block_reasons.length > 0 || !slug || !repo_path || !worktree_root || !issue_id) {
+    return JSON.stringify(result, null, 2);
+  }
+
+  const sanitizedSlug = sanitizeSegment(slug);
+  if (!sanitizedSlug) {
+    result.block_reasons.push('slug must contain at least one alphanumeric character');
+    return JSON.stringify(result, null, 2);
+  }
+
+  const repoName = sanitizeSegment(basename(repo_path)) || 'repo';
+  result.branch_name = `${branch_type}/${issue_id}-${sanitizedSlug}`;
+  result.worktree_path = join(worktree_root, `${repoName}-${issue_id}-${sanitizedSlug}`);
+
+  try {
+    result.base_commit = await runGit(repo_path, `rev-parse ${remote_base_branch}`);
+  } catch {
+    result.block_reasons.push(`failed to resolve remote base ${remote_base_branch}`);
+    return JSON.stringify(result, null, 2);
+  }
+
+  try {
+    await runGit(repo_path, `show-ref --verify --quiet refs/heads/${result.branch_name}`);
+    result.block_reasons.push(`branch already exists: ${result.branch_name}`);
+  } catch {
+    // Expected when the branch does not yet exist.
+  }
+
+  if (await pathExists(result.worktree_path)) {
+    result.block_reasons.push(`worktree path already exists: ${result.worktree_path}`);
+  }
+
+  if (result.block_reasons.length > 0) {
+    return JSON.stringify(result, null, 2);
+  }
+
+  await mkdir(worktree_root, { recursive: true });
+  await runGit(
+    repo_path,
+    `worktree add "${result.worktree_path}" -b ${result.branch_name} ${result.base_commit}`
+  );
+
+  result.status = 'CREATED';
+  result.notes.push(`created branch ${result.branch_name} from ${remote_base_branch}`);
+  result.notes.push(`created isolated worktree at ${result.worktree_path}`);
+  return JSON.stringify(result, null, 2);
+}

--- a/projects/agenticos/mcp-server/src/tools/index.ts
+++ b/projects/agenticos/mcp-server/src/tools/index.ts
@@ -3,3 +3,4 @@ export { switchProject, listProjects, getStatus } from './project.js';
 export { saveState } from './save.js';
 export { recordSession } from './record.js';
 export { runPreflight } from './preflight.js';
+export { runBranchBootstrap } from './branch-bootstrap.js';


### PR DESCRIPTION
## Summary
- add `agenticos_branch_bootstrap` as the first mutating helper for guardrail setup
- create an issue branch and isolated worktree from the intended remote base
- block when the target branch or worktree path already exists unexpectedly
- add focused unit tests for create and block behavior

## Why
This is the second implementation slice for #36. It complements `agenticos_preflight` by providing the safe helper that preflight can redirect to when implementation work starts on the wrong branch or workspace.

## Validation
- `cd /Users/jeking/worktrees/agenticos-guardrail-36-bootstrap/projects/agenticos/mcp-server && npm install && npm run build && npm test`

## Follow-up
- partial for #36
- next slice is `agenticos_pr_scope_check`
- later work still needs to wire guardrail commands into the expected agent execution flow