### PR TITLE
feat(mcp-server): add agenticos_pr_scope_check tool (#36)

### DIFF
--- a/projects/agenticos/mcp-server/src/index.ts
+++ b/projects/agenticos/mcp-server/src/index.ts
@@ -34,7 +34,7 @@ import {
   ListResourcesRequestSchema,
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { initProject, switchProject, listProjects, getStatus, saveState, recordSession, runPreflight, runBranchBootstrap } from './tools/index.js';
+import { initProject, switchProject, listProjects, getStatus, saveState, recordSession, runPreflight, runBranchBootstrap, runPrScopeCheck } from './tools/index.js';
 import { getProjectContext } from './resources/index.js';
 
 const server = new Server(
@@ -170,6 +170,25 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         required: ['issue_id', 'slug', 'repo_path', 'worktree_root'],
       },
     },
+    {
+      name: 'agenticos_pr_scope_check',
+      description: 'Validate that the current branch diff is scoped to the intended issue relative to the intended remote base.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          issue_id: { type: 'string', description: 'GitHub issue number or identifier for the current task' },
+          repo_path: { type: 'string', description: 'Absolute repository or worktree path to evaluate' },
+          remote_base_branch: { type: 'string', description: 'Remote base branch to compare against (default: origin/main)' },
+          declared_target_files: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Files or path globs the task intends to touch',
+          },
+          expected_issue_scope: { type: 'string', description: 'Short label describing the expected scope of the issue branch' },
+        },
+        required: ['issue_id', 'repo_path', 'declared_target_files'],
+      },
+    },
   ],
 }));
 
@@ -194,6 +213,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       return { content: [{ type: 'text', text: await runPreflight(args ?? {}) }] };
     case 'agenticos_branch_bootstrap':
       return { content: [{ type: 'text', text: await runBranchBootstrap(args ?? {}) }] };
+    case 'agenticos_pr_scope_check':
+      return { content: [{ type: 'text', text: await runPrScopeCheck(args ?? {}) }] };
     default:
       throw new Error(`Unknown tool: ${name}`);
   }

--- a/projects/agenticos/mcp-server/src/tools/__tests__/pr-scope-check.test.ts
+++ b/projects/agenticos/mcp-server/src/tools/__tests__/pr-scope-check.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const execAsyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock('child_process', () => ({
+  exec: vi.fn(),
+}));
+
+vi.mock('util', () => ({
+  promisify: vi.fn(() => execAsyncMock),
+}));
+
+import { runPrScopeCheck } from '../pr-scope-check.js';
+
+function mockGitResponses(responses: Record<string, string>): void {
+  execAsyncMock.mockImplementation(async (cmd: string) => {
+    for (const [pattern, stdout] of Object.entries(responses)) {
+      if (cmd.includes(pattern)) {
+        return { stdout, stderr: '' };
+      }
+    }
+    throw new Error(`Unexpected command: ${cmd}`);
+  });
+}
+
+describe('runPrScopeCheck', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns PASS when commits and files stay within the intended issue scope', async () => {
+    mockGitResponses({
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'log --format=%s origin/main..HEAD': 'feat(mcp-server): add agenticos_branch_bootstrap helper (#36)\n',
+      'diff --name-only origin/main...HEAD': 'projects/agenticos/mcp-server/src/tools/branch-bootstrap.ts\nprojects/agenticos/mcp-server/src/tools/__tests__/branch-bootstrap.test.ts\n',
+    });
+
+    const result = JSON.parse(await runPrScopeCheck({
+      issue_id: '36',
+      repo_path: '/repo',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/**', 'projects/agenticos/mcp-server/src/index.ts'],
+      expected_issue_scope: 'single_guardrail_feature',
+    })) as { status: string; unexpected_files: string[]; unrelated_commit_subjects: string[] };
+
+    expect(result.status).toBe('PASS');
+    expect(result.unexpected_files).toEqual([]);
+    expect(result.unrelated_commit_subjects).toEqual([]);
+  });
+
+  it('returns BLOCK when commit subjects do not match the current issue', async () => {
+    mockGitResponses({
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'log --format=%s origin/main..HEAD': 'fix(record): defensively parse JSON-stringified array args (fixes #24)\n',
+      'diff --name-only origin/main...HEAD': 'projects/agenticos/mcp-server/src/tools/preflight.ts\n',
+    });
+
+    const result = JSON.parse(await runPrScopeCheck({
+      issue_id: '36',
+      repo_path: '/repo',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/**'],
+      expected_issue_scope: 'single_guardrail_feature',
+    })) as { status: string; unrelated_commit_subjects: string[]; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.unrelated_commit_subjects).toHaveLength(1);
+    expect(result.block_reasons[0]).toContain('unrelated commits');
+  });
+
+  it('returns BLOCK when changed files escape the declared target scope', async () => {
+    mockGitResponses({
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'log --format=%s origin/main..HEAD': 'feat(mcp-server): add agenticos_pr_scope_check (#36)\n',
+      'diff --name-only origin/main...HEAD': 'projects/agenticos/mcp-server/src/tools/pr-scope-check.ts\nREADME.md\n',
+    });
+
+    const result = JSON.parse(await runPrScopeCheck({
+      issue_id: '36',
+      repo_path: '/repo',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/**'],
+      expected_issue_scope: 'single_guardrail_feature',
+    })) as { status: string; unexpected_files: string[]; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.unexpected_files).toContain('README.md');
+    expect(result.block_reasons.join(' ')).toContain('declared target scope');
+  });
+
+  it('returns BLOCK when the branch is not comparable to the intended remote base', async () => {
+    execAsyncMock.mockRejectedValue(new Error('bad ref'));
+
+    const result = JSON.parse(await runPrScopeCheck({
+      issue_id: '36',
+      repo_path: '/repo',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/**'],
+      expected_issue_scope: 'single_guardrail_feature',
+    })) as { status: string; branch_ancestry_verified: boolean; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.branch_ancestry_verified).toBe(false);
+    expect(result.block_reasons[0]).toContain('not comparable');
+  });
+});

--- a/projects/agenticos/mcp-server/src/tools/index.ts
+++ b/projects/agenticos/mcp-server/src/tools/index.ts
@@ -4,3 +4,4 @@ export { saveState } from './save.js';
 export { recordSession } from './record.js';
 export { runPreflight } from './preflight.js';
 export { runBranchBootstrap } from './branch-bootstrap.js';
+export { runPrScopeCheck } from './pr-scope-check.js';

--- a/projects/agenticos/mcp-server/src/tools/pr-scope-check.ts
+++ b/projects/agenticos/mcp-server/src/tools/pr-scope-check.ts
@@ -1,0 +1,149 @@
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+interface PrScopeCheckArgs {
+  issue_id?: string;
+  repo_path?: string;
+  remote_base_branch?: string;
+  declared_target_files?: string[];
+  expected_issue_scope?: string;
+}
+
+interface PrScopeCheckResult {
+  status: 'PASS' | 'BLOCK';
+  summary: string;
+  commit_count: number;
+  changed_files: string[];
+  unexpected_files: string[];
+  unrelated_commit_subjects: string[];
+  branch_ancestry_verified: boolean;
+  remote_base_branch: string;
+  branch_fork_point: string;
+  expected_issue_scope: string;
+  block_reasons: string[];
+}
+
+async function runGit(repoPath: string, args: string): Promise<string> {
+  const { stdout } = await execAsync(`git -C "${repoPath}" ${args}`);
+  return stdout.trim();
+}
+
+function normalizeLines(content: string): string[] {
+  return content
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function patternToRegex(pattern: string): RegExp {
+  const normalized = pattern.replace(/\\/g, '/');
+  const tokens = normalized.match(/\*\*|\*|\.{3}|[^*.]+/g) ?? [];
+  const source = tokens
+    .map((token) => {
+      if (token === '**' || token === '...') {
+        return '.*';
+      }
+      if (token === '*') {
+        return '[^/]*';
+      }
+      return escapeRegex(token);
+    })
+    .join('');
+  return new RegExp(`^${source}$`);
+}
+
+function fileMatchesDeclaredScope(file: string, patterns: string[]): boolean {
+  return patterns.some((pattern) => {
+    const normalizedPattern = pattern.endsWith('/') ? `${pattern}**` : pattern;
+    return patternToRegex(normalizedPattern).test(file);
+  });
+}
+
+function makeBaseResult(remoteBaseBranch: string, expectedIssueScope: string): PrScopeCheckResult {
+  return {
+    status: 'BLOCK',
+    summary: '',
+    commit_count: 0,
+    changed_files: [],
+    unexpected_files: [],
+    unrelated_commit_subjects: [],
+    branch_ancestry_verified: false,
+    remote_base_branch: remoteBaseBranch,
+    branch_fork_point: '',
+    expected_issue_scope: expectedIssueScope,
+    block_reasons: [],
+  };
+}
+
+export async function runPrScopeCheck(args: PrScopeCheckArgs): Promise<string> {
+  const {
+    issue_id,
+    repo_path,
+    remote_base_branch = 'origin/main',
+    declared_target_files = [],
+    expected_issue_scope = 'unspecified',
+  } = args;
+
+  const result = makeBaseResult(remote_base_branch, expected_issue_scope);
+
+  if (!issue_id) {
+    result.block_reasons.push('issue_id is required');
+  }
+  if (!repo_path) {
+    result.block_reasons.push('repo_path is required');
+  }
+  if (declared_target_files.length === 0) {
+    result.block_reasons.push('declared_target_files is required');
+  }
+
+  if (result.block_reasons.length > 0 || !repo_path || !issue_id || declared_target_files.length === 0) {
+    result.summary = result.block_reasons.join('; ');
+    return JSON.stringify(result, null, 2);
+  }
+
+  try {
+    await runGit(repo_path, `rev-parse ${remote_base_branch}`);
+    result.branch_fork_point = await runGit(repo_path, `merge-base HEAD ${remote_base_branch}`);
+    result.branch_ancestry_verified = true;
+  } catch {
+    result.block_reasons.push(`current branch is not comparable to ${remote_base_branch}`);
+    result.summary = result.block_reasons.join('; ');
+    return JSON.stringify(result, null, 2);
+  }
+
+  const subjects = normalizeLines(
+    await runGit(repo_path, `log --format=%s ${remote_base_branch}..HEAD`).catch(() => '')
+  );
+  const changedFiles = normalizeLines(
+    await runGit(repo_path, `diff --name-only ${remote_base_branch}...HEAD`).catch(() => '')
+  );
+
+  result.commit_count = subjects.length;
+  result.changed_files = changedFiles;
+  result.unrelated_commit_subjects = subjects.filter((subject) => !subject.includes(`#${issue_id}`));
+  result.unexpected_files = changedFiles.filter((file) => !fileMatchesDeclaredScope(file, declared_target_files));
+
+  if (result.unrelated_commit_subjects.length > 0) {
+    result.block_reasons.push(`branch includes unrelated commits relative to ${remote_base_branch}`);
+  }
+
+  if (result.unexpected_files.length > 0) {
+    result.block_reasons.push('changed files escape the declared target scope');
+  }
+
+  if (result.block_reasons.length > 0) {
+    result.status = 'BLOCK';
+    result.summary = result.block_reasons.join('; ');
+    return JSON.stringify(result, null, 2);
+  }
+
+  result.status = 'PASS';
+  result.summary = 'pr scope check passed';
+  return JSON.stringify(result, null, 2);
+}


### PR DESCRIPTION
## Summary
- add `agenticos_pr_scope_check` as the third guardrail command slice
- validate commit subjects and changed files against the intended issue scope relative to the remote base
- block when the branch is not comparable to the intended remote base
- add focused unit tests for pass and block behavior

## Why
This is the third implementation slice for #36. It completes the initial guardrail command trio by checking that a branch stays within the intended issue scope before PR submission.

## Validation
- `cd /Users/jeking/worktrees/agenticos-guardrail-36-scope/projects/agenticos/mcp-server && npm install && npm run build && npm test`

## Follow-up
- partial for #36
- remaining work is wiring these commands into the expected agent execution flow and templates