### PR TITLE
feat(meta): package downstream workflow standard kit (#35)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ npm run build
 | `projects/agenticos/` | AgenticOS product-source project inside the workspace |
 | `projects/agenticos/standards/` | AgenticOS standards and product-definition area |
 | `projects/agenticos/.meta/` | Templates and agent protocol guides |
+| `projects/agenticos/.meta/standard-kit/` | Downstream reusable workflow standard package |
 | `projects/agenticos/homebrew-tap/` | Homebrew distribution formula |
 | `.github/` | Repository-level automation that must stay at root |
 | `.runtime/` | Runtime-only local state, not canonical source |
@@ -86,3 +87,4 @@ Key constraint: paths stored as relative in registry, resolved to absolute at ru
 | Full system design | `projects/agenticos/standards/knowledge/complete-design.md` |
 | Why MCP over CLI | `projects/agenticos/standards/knowledge/cli-vs-mcp-analysis.md` |
 | Workflow research | `projects/agenticos/standards/knowledge/open-source-workflow-research.md` |
+| Downstream standard kit | `projects/agenticos/.meta/standard-kit/README.md` |

--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ Runtime-only byproducts should not be treated as canonical source:
 
 If you are developing AgenticOS itself from a Git checkout, keep that source checkout separate from your live `AGENTICOS_HOME` workspace.
 
+For downstream project inheritance, the executable workflow standard kit lives in:
+
+- `projects/agenticos/.meta/standard-kit/`
+
 ---
 
 ## Environment Variable

--- a/projects/agenticos/.meta/agent-guide.md
+++ b/projects/agenticos/.meta/agent-guide.md
@@ -1,5 +1,9 @@
 # Agent Guide for AIOS
 
+> Legacy note: this file predates the self-hosting and guardrail standard-kit model.
+> Canonical downstream packaging rules now live in `.meta/standard-kit/README.md`.
+> If guidance here conflicts with the standard kit, the standard kit wins.
+
 ## For All AI Agents
 
 This guide helps any AI Agent (Claude, Gemini, Cursor, etc.) work with AIOS projects.

--- a/projects/agenticos/.meta/rules.md
+++ b/projects/agenticos/.meta/rules.md
@@ -1,5 +1,9 @@
 # AIOS Collaboration Rules
 
+> Legacy note: this file predates the executable guardrail and standard-kit packaging model.
+> Canonical downstream packaging and inheritance rules now live in `.meta/standard-kit/`.
+> If guidance here conflicts with the standard kit, the standard kit wins.
+
 ## Core Principles
 
 1. **Agent Autonomy** - AI Agents manage project structure and content

--- a/projects/agenticos/.meta/standard-kit/README.md
+++ b/projects/agenticos/.meta/standard-kit/README.md
@@ -1,0 +1,63 @@
+# AgenticOS Downstream Standard Kit
+
+Versioned standard package for downstream AgenticOS-managed projects.
+
+## Purpose
+
+This kit defines the canonical files, generated files, inheritance rules, and upgrade model for the executable AgenticOS workflow standard.
+
+It exists so a downstream project can adopt the AgenticOS execution model without relying on chat history or reverse-engineering the main product repository.
+
+## Scope
+
+This kit covers:
+- project-scoped agent instructions
+- execution templates
+- generated project files
+- versioning and upgrade rules
+
+This kit does not include repository-root infrastructure such as:
+- `.github/`
+- release automation
+- root-only CI wiring
+
+Those remain repository-level concerns and must be handled separately.
+
+## Canonical Sources
+
+### Canonical generated files
+
+These are generated or upgraded by `projects/agenticos/mcp-server/src/utils/distill.ts`:
+- `AGENTS.md`
+- `CLAUDE.md`
+
+### Canonical copied templates
+
+These live under `projects/agenticos/.meta/templates/`:
+- `.project.yaml`
+- `quick-start.md`
+- `state.yaml`
+- `agent-preflight-checklist.yaml`
+- `issue-design-brief.md`
+- `submission-evidence.md`
+
+### Standards reference area
+
+The standards rationale, design history, and protocol documents live under:
+- `projects/agenticos/standards/`
+
+Downstream projects should inherit the templates and generated rules, not the full standards history by default.
+
+## Package Contents
+
+See:
+- `manifest.yaml`
+- `inheritance-rules.md`
+- `adoption-checklist.md`
+
+## Packaging Rule
+
+If there is a conflict between older `.meta` guidance and this package:
+- this standard kit wins
+
+Files such as `.meta/agent-guide.md` and `.meta/rules.md` are retained only as legacy references unless they are explicitly updated to match this package.

--- a/projects/agenticos/.meta/standard-kit/adoption-checklist.md
+++ b/projects/agenticos/.meta/standard-kit/adoption-checklist.md
@@ -1,0 +1,37 @@
+# Downstream Adoption Checklist
+
+Use this checklist when adopting the AgenticOS workflow standard in a downstream project.
+
+## Project Files
+
+- [ ] copy `.project.yaml` from the canonical template
+- [ ] create `.context/quick-start.md`
+- [ ] create `.context/state.yaml`
+- [ ] create `tasks/templates/agent-preflight-checklist.yaml`
+- [ ] create `tasks/templates/issue-design-brief.md`
+- [ ] create `tasks/templates/submission-evidence.md`
+
+## Generated Agent Instructions
+
+- [ ] generate or upgrade `AGENTS.md`
+- [ ] generate or upgrade `CLAUDE.md`
+- [ ] confirm the generated files contain the guardrail protocol
+- [ ] confirm the template marker version matches the current distill version
+
+## Execution Expectations
+
+- [ ] implementation work runs `agenticos_preflight`
+- [ ] redirected implementation work uses `agenticos_branch_bootstrap`
+- [ ] PR submission or merge runs `agenticos_pr_scope_check`
+- [ ] implementation work uses issue-first branch naming and isolated worktrees
+
+## Repository Boundary
+
+- [ ] `.github/` is handled as repository-root infrastructure, not as project-scoped inherited content
+- [ ] `.runtime/` and `.claude/worktrees/` are excluded from project-source inheritance
+
+## Upgrade Readiness
+
+- [ ] copied templates are treated as project-owned after adoption
+- [ ] generated files are allowed to upgrade through template version changes
+- [ ] any future standard-kit upgrade is reviewed against local customizations

--- a/projects/agenticos/.meta/standard-kit/inheritance-rules.md
+++ b/projects/agenticos/.meta/standard-kit/inheritance-rules.md
@@ -1,0 +1,70 @@
+# Inheritance Rules
+
+## Rule 1: Generated Files vs Copied Templates
+
+There are two inheritance modes.
+
+### Generated files
+
+- `AGENTS.md`
+- `CLAUDE.md`
+
+These are generated or upgraded by the distillation layer.
+
+Implication:
+- downstream projects should not treat them as free-form scratch files
+- local project-specific content may exist, but upgrades must preserve the canonical guardrail protocol and template marker
+
+### Copied templates
+
+- `.project.yaml`
+- `.context/quick-start.md`
+- `.context/state.yaml`
+- `tasks/templates/agent-preflight-checklist.yaml`
+- `tasks/templates/issue-design-brief.md`
+- `tasks/templates/submission-evidence.md`
+
+These are copied into each project and then become project-owned working files.
+
+Implication:
+- downstream projects are expected to customize them
+- later upgrades should be explicit and reviewable, not silently overwritten
+
+## Rule 2: Repository-Root Infrastructure Is Not Part Of The Project Kit
+
+The downstream standard kit is project-scoped.
+
+It does not include:
+- `.github/`
+- release workflows
+- root-only CI policies
+- local runtime directories such as `.runtime/` or `.claude/worktrees/`
+
+These belong to repository or local runtime layers, not to the project-scoped standard package.
+
+## Rule 3: Standards History Is Reference Material, Not Default Payload
+
+`projects/agenticos/standards/` is the design and product-definition area.
+
+Downstream projects should consume:
+- the generated instructions
+- the execution templates
+- the packaging rules
+
+They should not need the full internal standards history unless they are doing standards work themselves.
+
+## Rule 4: Upgrade Safety
+
+Generated files:
+- may be upgraded automatically when template markers change
+- must preserve user-extended sections where supported by the generator
+
+Copied templates:
+- must not be silently replaced after project adoption
+- should be reviewed against canonical sources during explicit upgrade work
+
+## Rule 5: Package Conflicts Resolve Toward The Kit
+
+If older guidance elsewhere in `.meta/` conflicts with this package:
+- the standard kit wins
+- the conflicting file should be treated as legacy until updated

--- a/projects/agenticos/.meta/standard-kit/manifest.yaml
+++ b/projects/agenticos/.meta/standard-kit/manifest.yaml
@@ -1,0 +1,82 @@
+version: 1
+kit_id: downstream-standard-kit
+kit_version: 0.1.0
+status: active
+purpose: >
+  Package the executable AgenticOS workflow standard for downstream projects.
+
+layers:
+  generated_files:
+    description: Files generated or upgraded by the distillation layer.
+    entries:
+      - path: AGENTS.md
+        canonical_source: projects/agenticos/mcp-server/src/utils/distill.ts
+        inheritance: generated
+        customizable: limited
+      - path: CLAUDE.md
+        canonical_source: projects/agenticos/mcp-server/src/utils/distill.ts
+        inheritance: generated
+        customizable: limited
+
+  copied_templates:
+    description: Files copied into a downstream project and then edited in-project.
+    entries:
+      - path: .project.yaml
+        canonical_source: projects/agenticos/.meta/templates/.project.yaml
+        inheritance: copied_template
+        customizable: yes
+      - path: .context/quick-start.md
+        canonical_source: projects/agenticos/.meta/templates/quick-start.md
+        inheritance: copied_template
+        customizable: yes
+      - path: .context/state.yaml
+        canonical_source: projects/agenticos/.meta/templates/state.yaml
+        inheritance: copied_template
+        customizable: yes
+      - path: tasks/templates/agent-preflight-checklist.yaml
+        canonical_source: projects/agenticos/.meta/templates/agent-preflight-checklist.yaml
+        inheritance: copied_template
+        customizable: yes
+      - path: tasks/templates/issue-design-brief.md
+        canonical_source: projects/agenticos/.meta/templates/issue-design-brief.md
+        inheritance: copied_template
+        customizable: yes
+      - path: tasks/templates/submission-evidence.md
+        canonical_source: projects/agenticos/.meta/templates/submission-evidence.md
+        inheritance: copied_template
+        customizable: yes
+
+  excluded_root_infra:
+    description: Root-scoped repository infrastructure that downstream projects must not inherit as project-scoped standards.
+    entries:
+      - path: .github/
+        reason: repository_root_infrastructure
+      - path: .runtime/
+        reason: local_runtime_state
+      - path: .claude/worktrees/
+        reason: local_runtime_state
+
+upgrade_rules:
+  template_marker_version:
+    AGENTS.md: 3
+    CLAUDE.md: 3
+  compatibility_rule: >
+    Generated files may be upgraded in place by distill when the template marker version changes.
+  copied_template_rule: >
+    Copied templates are project-owned after adoption. Upgrades should be opt-in and compare against canonical sources.
+
+adoption:
+  required_files:
+    - AGENTS.md
+    - CLAUDE.md
+    - .project.yaml
+    - .context/quick-start.md
+    - .context/state.yaml
+    - tasks/templates/agent-preflight-checklist.yaml
+    - tasks/templates/issue-design-brief.md
+    - tasks/templates/submission-evidence.md
+  required_behavior:
+    - implementation_preflight
+    - issue_first_branching
+    - isolated_worktree_execution
+    - pr_scope_validation


### PR DESCRIPTION
## Summary
- add a downstream standard kit under `projects/agenticos/.meta/standard-kit/`
- define canonical generated files, copied templates, root-scoped exclusions, and upgrade rules in a versioned manifest
- add inheritance rules and an adoption checklist for downstream projects
- mark older `.meta` guidance as legacy when it conflicts with the new standard kit
- expose the standard-kit entry point from root docs

## Why
Issue #35 requires a reusable, versioned package model so downstream projects can adopt the executable AgenticOS workflow standard without relying on standards chat history.

## Validation
- `ruby -e 'require "yaml"; data = YAML.load_file("/Users/jeking/worktrees/agenticos-standard-kit-35/projects/agenticos/.meta/standard-kit/manifest.yaml"); puts data["kit_id"]'`
- `ruby -e 'require "yaml"; root="/Users/jeking/worktrees/agenticos-standard-kit-35"; data=YAML.load_file(root+"/projects/agenticos/.meta/standard-kit/manifest.yaml"); sources=[]; data["layers"].each_value{|layer| next unless layer["entries"]; layer["entries"].each{|entry| src=entry["canonical_source"]; sources << src if src}}; missing=sources.reject{|src| File.exist?(File.join(root, src))}; abort("missing canonical sources: #{missing.join(", ")}") unless missing.empty?; puts "canonical sources ok"'`

## Follow-up
- partial for #35
- future work can automate adoption and upgrade flows, but this PR establishes the package model and canonical boundaries