### PR TITLE
feat(meta): define runtime project extraction plan (#38)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,10 @@ npm run build
 | `.runtime/` | Runtime-only local state, not canonical source |
 | `.claude/worktrees/` | Agent worktree area, not product source |
 
+Repository boundary rule:
+- `projects/agenticos/` is the only canonical product-source project under `projects/`
+- other tracked `projects/*` entries are legacy runtime or fixture content pending extraction to the live workspace model
+
 ## Development Rules
 
 1. **Issue-First**: Every change requires a GitHub Issue

--- a/README.md
+++ b/README.md
@@ -136,6 +136,9 @@ For downstream project inheritance, the executable workflow standard kit lives i
 
 - `projects/agenticos/.meta/standard-kit/`
 
+Within this repository, only `projects/agenticos/` should be treated as canonical product source.
+Other currently tracked entries under `projects/` are legacy runtime or fixture content pending extraction into the live workspace model.
+
 ---
 
 ## Environment Variable

--- a/projects/agenticos/.meta/runtime-project-classification.yaml
+++ b/projects/agenticos/.meta/runtime-project-classification.yaml
@@ -1,0 +1,56 @@
+version: 1
+status: active
+purpose: >
+  Classify tracked entries under projects/ so runtime extraction can proceed without
+  re-opening host-product versus runtime boundary questions.
+
+canonical_host_project:
+  path: projects/agenticos
+  classification: host_product
+  note: AgenticOS product source project after the landed self-hosting migration.
+
+tracked_projects:
+  - path: projects/2026okr
+    classification: runtime_project
+    extraction_priority: high
+    note: Real managed project content and historical working material.
+
+  - path: projects/360teams
+    classification: runtime_project
+    extraction_priority: high
+    note: Real managed project with its own repository, dependencies, coverage, and runtime byproducts.
+
+  - path: projects/agentic-devops
+    classification: runtime_project
+    extraction_priority: high
+    note: Real managed project, not part of AgenticOS product source.
+
+  - path: projects/ghostty-optimization
+    classification: runtime_project
+    extraction_priority: high
+    note: Real managed project, not part of AgenticOS product source.
+
+  - path: projects/okr-management
+    classification: runtime_project
+    extraction_priority: high
+    note: Real managed project with its own repository and local environment content.
+
+  - path: projects/t5t
+    classification: runtime_project
+    extraction_priority: high
+    note: Real managed project with its own repository and cached runtime material.
+
+  - path: projects/test-project
+    classification: fixture_example
+    extraction_priority: low
+    note: Minimal initialization artifact created to verify agenticos_init behavior; may remain as fixture or be regenerated later.
+
+root_scoped_exclusions:
+  - .github/
+  - .runtime/
+  - .claude/worktrees/
+
+decision_rules:
+  - Only projects/agenticos is canonical product source.
+  - Non-agenticos tracked entries under projects/ default to runtime or fixture content, not product source.
+  - Runtime projects should be extracted before relying on the source repo as a clean reference checkout.

--- a/projects/agenticos/standards/knowledge/runtime-project-extraction-plan-2026-03-23.md
+++ b/projects/agenticos/standards/knowledge/runtime-project-extraction-plan-2026-03-23.md
@@ -1,0 +1,123 @@
+# Runtime Project Extraction Plan - 2026-03-23
+
+## Summary
+
+After self-hosting landed, the AgenticOS source repository has one canonical product-source project:
+
+- `projects/agenticos`
+
+The remaining tracked `projects/*` entries are now much easier to classify as runtime content or fixture content.
+
+This document defines:
+- the classification
+- the extraction sequence
+- the de-tracking strategy
+- the resulting repository boundary
+
+## Classification
+
+Canonical product source:
+- `projects/agenticos`
+
+Runtime projects:
+- `projects/2026okr`
+- `projects/360teams`
+- `projects/agentic-devops`
+- `projects/ghostty-optimization`
+- `projects/okr-management`
+- `projects/t5t`
+
+Fixture/example candidate:
+- `projects/test-project`
+
+Machine-readable classification lives in:
+- `projects/agenticos/.meta/runtime-project-classification.yaml`
+
+## Goal State
+
+The AgenticOS product source repository should no longer need to carry real runtime projects under `projects/`.
+
+Goal state:
+- source repo keeps `projects/agenticos`
+- runtime projects live in the separate live workspace rooted at `AGENTICOS_HOME`
+- fixture content is either regenerated on demand or kept as explicit fixture content with that role documented
+
+## Extraction Sequence
+
+### Phase 1: Freeze classification
+
+Done by this plan:
+- classify host product
+- classify runtime projects
+- classify fixture candidate
+
+### Phase 2: Prepare destination workspace
+
+Create or confirm a clean live workspace outside the product source checkout, for example:
+- `~/AgenticOS-workspace`
+
+The destination should contain:
+- `.agent-workspace/`
+- `projects/`
+
+### Phase 3: Copy runtime projects out
+
+For each runtime project:
+1. copy project directory to the live workspace
+2. verify project-local Git data remains intact where present
+3. verify project-local context files remain intact
+4. verify no source-repo-relative assumptions break
+
+Projects in the recommended first wave:
+- `2026okr`
+- `360teams`
+- `agentic-devops`
+- `ghostty-optimization`
+- `okr-management`
+- `t5t`
+
+### Phase 4: De-track from source repo
+
+After verifying the copied runtime projects in the live workspace:
+1. remove the tracked runtime project directories from the product source repository index
+2. keep explicit documentation that these projects belong in the live workspace, not in the source repo
+3. retain only `projects/agenticos` plus any explicitly accepted fixture/example content
+
+### Phase 5: Decide fixture handling
+
+`projects/test-project` should not be treated as product source.
+
+Two acceptable outcomes:
+- keep it as an explicit fixture/example project
+- remove it from the source repo and regenerate it on demand during tests or demos
+
+## De-Tracking Strategy
+
+The source repo should treat de-tracking as a repository-boundary change, not as project deletion.
+
+Required rule:
+- do not delete the runtime projects until the copied workspace versions are verified
+
+Recommended sequence:
+1. copy out
+2. verify copied projects
+3. commit source-repo de-tracking change
+4. update root docs to describe the new boundary
+
+## Documentation Impact
+
+After extraction:
+- root README should describe `projects/agenticos` as the only product-source project under `projects/`
+- root AGENTS/CLAUDE guidance should stop treating remaining `projects/*` entries as part of the source tree
+- bootstrap docs should point live projects to `AGENTICOS_HOME`, not to the source checkout
+
+## Acceptance Judgment
+
+This plan satisfies the current planning milestone for issue `#38` because it now provides:
+- explicit runtime-project classification
+- explicit fixture classification
+- an extraction sequence
+- a de-tracking strategy
+- a clear target boundary between source repo and live workspace
+
+Actual filesystem extraction remains an execution step and should follow this plan rather than improvising on the live source checkout.


### PR DESCRIPTION
## Summary
- classify tracked `projects/*` entries into host product, runtime projects, and fixture content
- add a machine-readable classification manifest at `projects/agenticos/.meta/runtime-project-classification.yaml`
- add a concrete extraction and de-tracking sequence under `projects/agenticos/standards/knowledge/`
- update root docs so only `projects/agenticos/` is treated as canonical product source under `projects/`

## Why
Issue #38 needs an explicit runtime-project classification and extraction sequence before any actual de-tracking or filesystem migration happens. This PR freezes the boundary and migration logic without making destructive moves.

## Validation
- `ruby -e 'require "yaml"; data = YAML.load_file("/Users/jeking/worktrees/agenticos-runtime-extraction-38/projects/agenticos/.meta/runtime-project-classification.yaml"); puts data["canonical_host_project"]["path"]; puts data["tracked_projects"].size'`
- `git -C /Users/jeking/worktrees/agenticos-runtime-extraction-38 diff --stat origin/main...HEAD`

## Follow-up
- partial for #38 if you interpret extraction literally as filesystem moves
- complete for the current planning milestone because classification, extraction sequence, and de-tracking strategy are now explicit