### PR TITLE
feat: persist guardrail execution evidence (#62)

### DIFF
--- a/projects/agenticos/mcp-server/src/tools/__tests__/branch-bootstrap.test.ts
+++ b/projects/agenticos/mcp-server/src/tools/__tests__/branch-bootstrap.test.ts
@@ -12,6 +12,17 @@ vi.mock('util', () => ({
   promisify: vi.fn(() => execAsyncMock),
 }));
 
+const persistGuardrailEvidenceMock = vi.hoisted(() => vi.fn().mockResolvedValue({
+  attempted: true,
+  persisted: true,
+  project_id: 'agenticos',
+  state_path: '/repo/.context/state.yaml',
+}));
+
+vi.mock('../../utils/guardrail-evidence.js', () => ({
+  persistGuardrailEvidence: persistGuardrailEvidenceMock,
+}));
+
 vi.mock('fs/promises', () => ({
   access: accessMock,
   mkdir: mkdirMock,
@@ -24,6 +35,12 @@ describe('runBranchBootstrap', () => {
     vi.clearAllMocks();
     accessMock.mockRejectedValue(new Error('missing'));
     mkdirMock.mockResolvedValue(undefined);
+    persistGuardrailEvidenceMock.mockResolvedValue({
+      attempted: true,
+      persisted: true,
+      project_id: 'agenticos',
+      state_path: '/repo/.context/state.yaml',
+    });
   });
 
   it('returns CREATED and issues git worktree add from the intended remote base', async () => {
@@ -47,7 +64,7 @@ describe('runBranchBootstrap', () => {
       repo_path: '/repo/mcp-server',
       remote_base_branch: 'origin/main',
       worktree_root: '/tmp/worktrees',
-    })) as { status: string; branch_name: string; base_commit: string; worktree_path: string; notes: string[] };
+    })) as { status: string; branch_name: string; base_commit: string; worktree_path: string; notes: string[]; persistence?: { persisted: boolean } };
 
     expect(result.status).toBe('CREATED');
     expect(result.branch_name).toBe('feat/36-guardrail-helper');
@@ -55,6 +72,8 @@ describe('runBranchBootstrap', () => {
     expect(result.worktree_path).toBe('/tmp/worktrees/mcp-server-36-guardrail-helper');
     expect(result.notes.join(' ')).toContain('origin/main');
     expect(mkdirMock).toHaveBeenCalledWith('/tmp/worktrees', { recursive: true });
+    expect(result.persistence?.persisted).toBe(true);
+    expect(persistGuardrailEvidenceMock).toHaveBeenCalledTimes(1);
   });
 
   it('returns BLOCK when the target branch already exists', async () => {

--- a/projects/agenticos/mcp-server/src/tools/__tests__/pr-scope-check.test.ts
+++ b/projects/agenticos/mcp-server/src/tools/__tests__/pr-scope-check.test.ts
@@ -10,6 +10,17 @@ vi.mock('util', () => ({
   promisify: vi.fn(() => execAsyncMock),
 }));
 
+const persistGuardrailEvidenceMock = vi.hoisted(() => vi.fn().mockResolvedValue({
+  attempted: true,
+  persisted: true,
+  project_id: 'agenticos',
+  state_path: '/repo/.context/state.yaml',
+}));
+
+vi.mock('../../utils/guardrail-evidence.js', () => ({
+  persistGuardrailEvidence: persistGuardrailEvidenceMock,
+}));
+
 import { runPrScopeCheck } from '../pr-scope-check.js';
 
 function mockGitResponses(responses: Record<string, string>): void {
@@ -26,6 +37,12 @@ function mockGitResponses(responses: Record<string, string>): void {
 describe('runPrScopeCheck', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    persistGuardrailEvidenceMock.mockResolvedValue({
+      attempted: true,
+      persisted: true,
+      project_id: 'agenticos',
+      state_path: '/repo/.context/state.yaml',
+    });
   });
 
   it('returns PASS when commits and files stay within the intended issue scope', async () => {
@@ -41,11 +58,13 @@ describe('runPrScopeCheck', () => {
       repo_path: '/repo',
       declared_target_files: ['projects/agenticos/mcp-server/src/tools/**', 'projects/agenticos/mcp-server/src/index.ts'],
       expected_issue_scope: 'single_guardrail_feature',
-    })) as { status: string; unexpected_files: string[]; unrelated_commit_subjects: string[] };
+    })) as { status: string; unexpected_files: string[]; unrelated_commit_subjects: string[]; persistence?: { persisted: boolean } };
 
     expect(result.status).toBe('PASS');
     expect(result.unexpected_files).toEqual([]);
     expect(result.unrelated_commit_subjects).toEqual([]);
+    expect(result.persistence?.persisted).toBe(true);
+    expect(persistGuardrailEvidenceMock).toHaveBeenCalledTimes(1);
   });
 
   it('returns BLOCK when commit subjects do not match the current issue', async () => {

--- a/projects/agenticos/mcp-server/src/tools/__tests__/preflight.test.ts
+++ b/projects/agenticos/mcp-server/src/tools/__tests__/preflight.test.ts
@@ -10,6 +10,17 @@ vi.mock('util', () => ({
   promisify: vi.fn(() => execAsyncMock),
 }));
 
+const persistGuardrailEvidenceMock = vi.hoisted(() => vi.fn().mockResolvedValue({
+  attempted: true,
+  persisted: true,
+  project_id: 'agenticos',
+  state_path: '/repo/.context/state.yaml',
+}));
+
+vi.mock('../../utils/guardrail-evidence.js', () => ({
+  persistGuardrailEvidence: persistGuardrailEvidenceMock,
+}));
+
 import { runPreflight } from '../preflight.js';
 
 function mockGitResponses(responses: Record<string, string>): void {
@@ -26,6 +37,12 @@ function mockGitResponses(responses: Record<string, string>): void {
 describe('runPreflight', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    persistGuardrailEvidenceMock.mockResolvedValue({
+      attempted: true,
+      persisted: true,
+      project_id: 'agenticos',
+      state_path: '/repo/.context/state.yaml',
+    });
   });
 
   it('returns PASS for a correctly isolated implementation branch', async () => {
@@ -45,11 +62,13 @@ describe('runPreflight', () => {
       repo_path: '/repo',
       declared_target_files: ['projects/agenticos/mcp-server/src/tools/preflight.ts'],
       worktree_required: true,
-    })) as { status: string; worktree_ok: boolean; branch_based_on_intended_remote: boolean };
+    })) as { status: string; worktree_ok: boolean; branch_based_on_intended_remote: boolean; persistence?: { persisted: boolean } };
 
     expect(result.status).toBe('PASS');
     expect(result.worktree_ok).toBe(true);
     expect(result.branch_based_on_intended_remote).toBe(true);
+    expect(result.persistence?.persisted).toBe(true);
+    expect(persistGuardrailEvidenceMock).toHaveBeenCalledTimes(1);
   });
 
   it('returns REDIRECT when implementation starts on main workspace', async () => {

--- a/projects/agenticos/mcp-server/src/tools/branch-bootstrap.ts
+++ b/projects/agenticos/mcp-server/src/tools/branch-bootstrap.ts
@@ -2,6 +2,7 @@ import { exec } from 'child_process';
 import { access, mkdir } from 'fs/promises';
 import { basename, join } from 'path';
 import { promisify } from 'util';
+import { persistGuardrailEvidence, type GuardrailPersistenceResult } from '../utils/guardrail-evidence.js';
 
 const execAsync = promisify(exec);
 
@@ -21,6 +22,7 @@ interface BranchBootstrapResult {
   worktree_path: string;
   notes: string[];
   block_reasons: string[];
+  persistence?: GuardrailPersistenceResult;
 }
 
 async function runGit(repoPath: string, args: string): Promise<string> {
@@ -82,12 +84,50 @@ export async function runBranchBootstrap(args: BranchBootstrapArgs): Promise<str
   }
 
   if (result.block_reasons.length > 0 || !slug || !repo_path || !worktree_root || !issue_id) {
+    result.persistence = await persistGuardrailEvidence({
+      command: 'agenticos_branch_bootstrap',
+      repo_path,
+      payload: {
+        issue_id: issue_id || null,
+        branch_type,
+        slug: slug || null,
+        remote_base_branch,
+        requested_worktree_root: worktree_root || null,
+        result: {
+          status: result.status,
+          branch_name: result.branch_name,
+          base_commit: result.base_commit,
+          worktree_path: result.worktree_path,
+          notes: result.notes,
+          block_reasons: result.block_reasons,
+        },
+      },
+    });
     return JSON.stringify(result, null, 2);
   }
 
   const sanitizedSlug = sanitizeSegment(slug);
   if (!sanitizedSlug) {
     result.block_reasons.push('slug must contain at least one alphanumeric character');
+    result.persistence = await persistGuardrailEvidence({
+      command: 'agenticos_branch_bootstrap',
+      repo_path,
+      payload: {
+        issue_id,
+        branch_type,
+        slug,
+        remote_base_branch,
+        requested_worktree_root: worktree_root,
+        result: {
+          status: result.status,
+          branch_name: result.branch_name,
+          base_commit: result.base_commit,
+          worktree_path: result.worktree_path,
+          notes: result.notes,
+          block_reasons: result.block_reasons,
+        },
+      },
+    });
     return JSON.stringify(result, null, 2);
   }
 
@@ -99,6 +139,25 @@ export async function runBranchBootstrap(args: BranchBootstrapArgs): Promise<str
     result.base_commit = await runGit(repo_path, `rev-parse ${remote_base_branch}`);
   } catch {
     result.block_reasons.push(`failed to resolve remote base ${remote_base_branch}`);
+    result.persistence = await persistGuardrailEvidence({
+      command: 'agenticos_branch_bootstrap',
+      repo_path,
+      payload: {
+        issue_id,
+        branch_type,
+        slug,
+        remote_base_branch,
+        requested_worktree_root: worktree_root,
+        result: {
+          status: result.status,
+          branch_name: result.branch_name,
+          base_commit: result.base_commit,
+          worktree_path: result.worktree_path,
+          notes: result.notes,
+          block_reasons: result.block_reasons,
+        },
+      },
+    });
     return JSON.stringify(result, null, 2);
   }
 
@@ -114,6 +173,25 @@ export async function runBranchBootstrap(args: BranchBootstrapArgs): Promise<str
   }
 
   if (result.block_reasons.length > 0) {
+    result.persistence = await persistGuardrailEvidence({
+      command: 'agenticos_branch_bootstrap',
+      repo_path,
+      payload: {
+        issue_id,
+        branch_type,
+        slug,
+        remote_base_branch,
+        requested_worktree_root: worktree_root,
+        result: {
+          status: result.status,
+          branch_name: result.branch_name,
+          base_commit: result.base_commit,
+          worktree_path: result.worktree_path,
+          notes: result.notes,
+          block_reasons: result.block_reasons,
+        },
+      },
+    });
     return JSON.stringify(result, null, 2);
   }
 
@@ -126,5 +204,24 @@ export async function runBranchBootstrap(args: BranchBootstrapArgs): Promise<str
   result.status = 'CREATED';
   result.notes.push(`created branch ${result.branch_name} from ${remote_base_branch}`);
   result.notes.push(`created isolated worktree at ${result.worktree_path}`);
+  result.persistence = await persistGuardrailEvidence({
+    command: 'agenticos_branch_bootstrap',
+    repo_path,
+    payload: {
+      issue_id,
+      branch_type,
+      slug,
+      remote_base_branch,
+      requested_worktree_root: worktree_root,
+      result: {
+        status: result.status,
+        branch_name: result.branch_name,
+        base_commit: result.base_commit,
+        worktree_path: result.worktree_path,
+        notes: result.notes,
+        block_reasons: result.block_reasons,
+      },
+    },
+  });
   return JSON.stringify(result, null, 2);
 }

--- a/projects/agenticos/mcp-server/src/tools/pr-scope-check.ts
+++ b/projects/agenticos/mcp-server/src/tools/pr-scope-check.ts
@@ -1,5 +1,6 @@
 import { exec } from 'child_process';
 import { promisify } from 'util';
+import { persistGuardrailEvidence, type GuardrailPersistenceResult } from '../utils/guardrail-evidence.js';
 
 const execAsync = promisify(exec);
 
@@ -23,6 +24,7 @@ interface PrScopeCheckResult {
   branch_fork_point: string;
   expected_issue_scope: string;
   block_reasons: string[];
+  persistence?: GuardrailPersistenceResult;
 }
 
 async function runGit(repoPath: string, args: string): Promise<string> {
@@ -104,6 +106,29 @@ export async function runPrScopeCheck(args: PrScopeCheckArgs): Promise<string> {
 
   if (result.block_reasons.length > 0 || !repo_path || !issue_id || declared_target_files.length === 0) {
     result.summary = result.block_reasons.join('; ');
+    result.persistence = await persistGuardrailEvidence({
+      command: 'agenticos_pr_scope_check',
+      repo_path,
+      payload: {
+        issue_id: issue_id || null,
+        remote_base_branch,
+        declared_target_files,
+        expected_issue_scope,
+        result: {
+          status: result.status,
+          summary: result.summary,
+          commit_count: result.commit_count,
+          changed_files: result.changed_files,
+          unexpected_files: result.unexpected_files,
+          unrelated_commit_subjects: result.unrelated_commit_subjects,
+          branch_ancestry_verified: result.branch_ancestry_verified,
+          remote_base_branch: result.remote_base_branch,
+          branch_fork_point: result.branch_fork_point,
+          expected_issue_scope: result.expected_issue_scope,
+          block_reasons: result.block_reasons,
+        },
+      },
+    });
     return JSON.stringify(result, null, 2);
   }
 
@@ -114,6 +139,29 @@ export async function runPrScopeCheck(args: PrScopeCheckArgs): Promise<string> {
   } catch {
     result.block_reasons.push(`current branch is not comparable to ${remote_base_branch}`);
     result.summary = result.block_reasons.join('; ');
+    result.persistence = await persistGuardrailEvidence({
+      command: 'agenticos_pr_scope_check',
+      repo_path,
+      payload: {
+        issue_id,
+        remote_base_branch,
+        declared_target_files,
+        expected_issue_scope,
+        result: {
+          status: result.status,
+          summary: result.summary,
+          commit_count: result.commit_count,
+          changed_files: result.changed_files,
+          unexpected_files: result.unexpected_files,
+          unrelated_commit_subjects: result.unrelated_commit_subjects,
+          branch_ancestry_verified: result.branch_ancestry_verified,
+          remote_base_branch: result.remote_base_branch,
+          branch_fork_point: result.branch_fork_point,
+          expected_issue_scope: result.expected_issue_scope,
+          block_reasons: result.block_reasons,
+        },
+      },
+    });
     return JSON.stringify(result, null, 2);
   }
 
@@ -140,10 +188,56 @@ export async function runPrScopeCheck(args: PrScopeCheckArgs): Promise<string> {
   if (result.block_reasons.length > 0) {
     result.status = 'BLOCK';
     result.summary = result.block_reasons.join('; ');
+    result.persistence = await persistGuardrailEvidence({
+      command: 'agenticos_pr_scope_check',
+      repo_path,
+      payload: {
+        issue_id,
+        remote_base_branch,
+        declared_target_files,
+        expected_issue_scope,
+        result: {
+          status: result.status,
+          summary: result.summary,
+          commit_count: result.commit_count,
+          changed_files: result.changed_files,
+          unexpected_files: result.unexpected_files,
+          unrelated_commit_subjects: result.unrelated_commit_subjects,
+          branch_ancestry_verified: result.branch_ancestry_verified,
+          remote_base_branch: result.remote_base_branch,
+          branch_fork_point: result.branch_fork_point,
+          expected_issue_scope: result.expected_issue_scope,
+          block_reasons: result.block_reasons,
+        },
+      },
+    });
     return JSON.stringify(result, null, 2);
   }
 
   result.status = 'PASS';
   result.summary = 'pr scope check passed';
+  result.persistence = await persistGuardrailEvidence({
+    command: 'agenticos_pr_scope_check',
+    repo_path,
+    payload: {
+      issue_id,
+      remote_base_branch,
+      declared_target_files,
+      expected_issue_scope,
+      result: {
+        status: result.status,
+        summary: result.summary,
+        commit_count: result.commit_count,
+        changed_files: result.changed_files,
+        unexpected_files: result.unexpected_files,
+        unrelated_commit_subjects: result.unrelated_commit_subjects,
+        branch_ancestry_verified: result.branch_ancestry_verified,
+        remote_base_branch: result.remote_base_branch,
+        branch_fork_point: result.branch_fork_point,
+        expected_issue_scope: result.expected_issue_scope,
+        block_reasons: result.block_reasons,
+      },
+    },
+  });
   return JSON.stringify(result, null, 2);
 }

--- a/projects/agenticos/mcp-server/src/tools/preflight.ts
+++ b/projects/agenticos/mcp-server/src/tools/preflight.ts
@@ -1,5 +1,6 @@
 import { exec } from 'child_process';
 import { promisify } from 'util';
+import { persistGuardrailEvidence, type GuardrailPersistenceResult } from '../utils/guardrail-evidence.js';
 
 const execAsync = promisify(exec);
 
@@ -39,6 +40,7 @@ interface PreflightResult {
     workspace_type: WorkspaceType;
     commit_subjects_since_base: string[];
   };
+  persistence?: GuardrailPersistenceResult;
 }
 
 async function runGit(repoPath: string, args: string): Promise<string> {
@@ -151,7 +153,22 @@ export async function runPreflight(args: PreflightArgs): Promise<string> {
     result.evidence.workspace_type = await detectWorkspaceType(repo_path);
   } catch {
     result.block_reasons.push('failed to resolve git repository identity or remote base');
-    return JSON.stringify(finalizeResult(result), null, 2);
+    const finalized = finalizeResult(result);
+    finalized.persistence = await persistGuardrailEvidence({
+      command: 'agenticos_preflight',
+      repo_path,
+      payload: {
+        issue_id: issue_id || null,
+        task_type,
+        declared_target_files,
+        structural_move,
+        worktree_required,
+        root_scoped_exceptions,
+        clean_reproducibility_gate,
+        result: finalized,
+      },
+    });
+    return JSON.stringify(finalized, null, 2);
   }
 
   if (worktree_required) {
@@ -204,5 +221,32 @@ export async function runPreflight(args: PreflightArgs): Promise<string> {
     result.reproducibility_gate_defined = true;
   }
 
-  return JSON.stringify(finalizeResult(result), null, 2);
+  const finalized = finalizeResult(result);
+  finalized.persistence = await persistGuardrailEvidence({
+    command: 'agenticos_preflight',
+    repo_path,
+    payload: {
+      issue_id: issue_id || null,
+      task_type,
+      declared_target_files,
+      structural_move,
+      worktree_required,
+      root_scoped_exceptions,
+      clean_reproducibility_gate,
+      result: {
+        status: finalized.status,
+        summary: finalized.summary,
+        repo_identity_confirmed: finalized.repo_identity_confirmed,
+        branch_ancestry_verified: finalized.branch_ancestry_verified,
+        branch_based_on_intended_remote: finalized.branch_based_on_intended_remote,
+        worktree_ok: finalized.worktree_ok,
+        scope_ok: finalized.scope_ok,
+        reproducibility_gate_defined: finalized.reproducibility_gate_defined,
+        block_reasons: finalized.block_reasons,
+        redirect_actions: finalized.redirect_actions,
+        evidence: finalized.evidence,
+      },
+    },
+  });
+  return JSON.stringify(finalized, null, 2);
 }

--- a/projects/agenticos/mcp-server/src/utils/__tests__/guardrail-evidence.test.ts
+++ b/projects/agenticos/mcp-server/src/utils/__tests__/guardrail-evidence.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const yamlMock = vi.hoisted(() => ({
+  parse: vi.fn(),
+  stringify: vi.fn((obj: unknown) => JSON.stringify(obj)),
+}));
+
+vi.mock('fs/promises', () => ({
+  access: vi.fn(),
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+}));
+
+vi.mock('yaml', () => ({
+  default: yamlMock,
+}));
+
+vi.mock('../registry.js', () => ({
+  loadRegistry: vi.fn(),
+}));
+
+import { access, readFile, writeFile } from 'fs/promises';
+import { loadRegistry } from '../registry.js';
+import { persistGuardrailEvidence } from '../guardrail-evidence.js';
+
+const accessMock = access as unknown as ReturnType<typeof vi.fn>;
+const readFileMock = readFile as unknown as ReturnType<typeof vi.fn>;
+const writeFileMock = writeFile as unknown as ReturnType<typeof vi.fn>;
+const loadRegistryMock = loadRegistry as unknown as ReturnType<typeof vi.fn>;
+
+describe('persistGuardrailEvidence', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    yamlMock.parse.mockImplementation((content: string) => {
+      try {
+        return JSON.parse(content);
+      } catch {
+        return undefined;
+      }
+    });
+    yamlMock.stringify.mockImplementation((obj: unknown) => JSON.stringify(obj));
+    loadRegistryMock.mockResolvedValue({
+      active_project: 'agenticos',
+      projects: [
+        {
+          id: 'agenticos',
+          name: 'AgenticOS',
+          path: '/workspace/projects/agenticos',
+          status: 'active',
+          created: '2026-03-23',
+          last_accessed: '2026-03-23T00:00:00.000Z',
+        },
+      ],
+    });
+    accessMock.mockResolvedValue(undefined);
+    readFileMock.mockResolvedValue(JSON.stringify({ session: {}, working_memory: { facts: [], decisions: [], pending: [] } }));
+    writeFileMock.mockResolvedValue(undefined);
+  });
+
+  it('persists latest preflight evidence into the matching managed project state', async () => {
+    const result = await persistGuardrailEvidence({
+      command: 'agenticos_preflight',
+      repo_path: '/workspace/projects/agenticos/mcp-server',
+      payload: {
+        issue_id: '62',
+        result: { status: 'PASS', summary: 'preflight passed' },
+      },
+    });
+
+    expect(result.persisted).toBe(true);
+    expect(result.project_id).toBe('agenticos');
+    expect(writeFileMock).toHaveBeenCalledTimes(1);
+
+    const [, content] = writeFileMock.mock.calls[0];
+    const writtenState = JSON.parse(content as string);
+    expect(writtenState.guardrail_evidence.last_command).toBe('agenticos_preflight');
+    expect(writtenState.guardrail_evidence.preflight.issue_id).toBe('62');
+    expect(writtenState.guardrail_evidence.preflight.result.status).toBe('PASS');
+  });
+
+  it('overwrites the previous latest entry for the same command instead of appending', async () => {
+    readFileMock.mockResolvedValue(JSON.stringify({
+      guardrail_evidence: {
+        last_command: 'agenticos_preflight',
+        preflight: {
+          command: 'agenticos_preflight',
+          recorded_at: '2026-03-23T09:00:00.000Z',
+          issue_id: '36',
+          result: { status: 'BLOCK' },
+        },
+        pr_scope_check: {
+          command: 'agenticos_pr_scope_check',
+          issue_id: '36',
+          result: { status: 'PASS' },
+        },
+      },
+    }));
+
+    await persistGuardrailEvidence({
+      command: 'agenticos_preflight',
+      repo_path: '/workspace/projects/agenticos/mcp-server',
+      payload: {
+        issue_id: '62',
+        result: { status: 'PASS', summary: 'preflight passed' },
+      },
+    });
+
+    const [, content] = writeFileMock.mock.calls[0];
+    const writtenState = JSON.parse(content as string);
+    expect(writtenState.guardrail_evidence.preflight.issue_id).toBe('62');
+    expect(writtenState.guardrail_evidence.preflight.result.status).toBe('PASS');
+    expect(writtenState.guardrail_evidence.pr_scope_check.issue_id).toBe('36');
+  });
+
+  it('falls back to the nearest on-disk project root when registry does not contain the repo path', async () => {
+    loadRegistryMock.mockResolvedValue({
+      active_project: null,
+      projects: [],
+    });
+    accessMock
+      .mockRejectedValueOnce(new Error('missing repo-level .project.yaml'))
+      .mockRejectedValueOnce(new Error('missing repo-level state'))
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined);
+    readFileMock
+      .mockResolvedValueOnce(JSON.stringify({ meta: { id: 'local-agenticos' } }))
+      .mockResolvedValueOnce(JSON.stringify({ session: {}, working_memory: { facts: [], decisions: [], pending: [] } }));
+
+    const result = await persistGuardrailEvidence({
+      command: 'agenticos_branch_bootstrap',
+      repo_path: '/workspace/source/projects/agenticos/mcp-server',
+      payload: {
+        issue_id: '62',
+        result: { status: 'CREATED', branch_name: 'feat/62-guardrail-evidence' },
+      },
+    });
+
+    expect(result.persisted).toBe(true);
+    expect(result.project_id).toBe('local-agenticos');
+
+    const [statePath, content] = writeFileMock.mock.calls[0];
+    expect(statePath).toBe('/workspace/source/projects/agenticos/.context/state.yaml');
+    const writtenState = JSON.parse(content as string);
+    expect(writtenState.guardrail_evidence.branch_bootstrap.issue_id).toBe('62');
+  });
+
+  it('does not write state when repo_path is outside managed projects', async () => {
+    loadRegistryMock.mockResolvedValue({
+      active_project: null,
+      projects: [],
+    });
+    accessMock.mockRejectedValue(new Error('missing'));
+    readFileMock.mockRejectedValue(new Error('missing'));
+
+    const result = await persistGuardrailEvidence({
+      command: 'agenticos_pr_scope_check',
+      repo_path: '/external/repo',
+      payload: {
+        issue_id: '62',
+        result: { status: 'BLOCK' },
+      },
+    });
+
+    expect(result.persisted).toBe(false);
+    expect(result.reason).toContain('not within a resolvable AgenticOS project');
+    expect(writeFileMock).not.toHaveBeenCalled();
+  });
+});

--- a/projects/agenticos/mcp-server/src/utils/guardrail-evidence.ts
+++ b/projects/agenticos/mcp-server/src/utils/guardrail-evidence.ts
@@ -1,0 +1,183 @@
+import { access, readFile, writeFile } from 'fs/promises';
+import { dirname, join, resolve, sep } from 'path';
+import yaml from 'yaml';
+import { loadRegistry } from './registry.js';
+
+type GuardrailCommand =
+  | 'agenticos_preflight'
+  | 'agenticos_branch_bootstrap'
+  | 'agenticos_pr_scope_check';
+
+interface GuardrailEvidenceState {
+  updated_at?: string;
+  last_command?: GuardrailCommand;
+  preflight?: Record<string, unknown>;
+  branch_bootstrap?: Record<string, unknown>;
+  pr_scope_check?: Record<string, unknown>;
+}
+
+type GuardrailEvidenceSlot = 'preflight' | 'branch_bootstrap' | 'pr_scope_check';
+
+interface StateYaml {
+  guardrail_evidence?: GuardrailEvidenceState;
+  [key: string]: unknown;
+}
+
+export interface GuardrailPersistenceResult {
+  attempted: boolean;
+  persisted: boolean;
+  project_id?: string;
+  state_path?: string;
+  reason?: string;
+}
+
+interface PersistGuardrailEvidenceArgs {
+  command: GuardrailCommand;
+  repo_path?: string;
+  payload: Record<string, unknown>;
+}
+
+interface ResolvedProjectTarget {
+  id: string;
+  path: string;
+}
+
+function normalizePath(path: string): string {
+  return resolve(path);
+}
+
+function isWithinProject(repoPath: string, projectPath: string): boolean {
+  if (repoPath === projectPath) return true;
+  return repoPath.startsWith(`${projectPath}${sep}`);
+}
+
+function getCommandSlot(command: GuardrailCommand): GuardrailEvidenceSlot {
+  switch (command) {
+    case 'agenticos_preflight':
+      return 'preflight';
+    case 'agenticos_branch_bootstrap':
+      return 'branch_bootstrap';
+    case 'agenticos_pr_scope_check':
+      return 'pr_scope_check';
+  }
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function findProjectRootFromRepoPath(repoPath: string): Promise<ResolvedProjectTarget | null> {
+  let currentPath = normalizePath(repoPath);
+
+  while (true) {
+    const projectYamlPath = join(currentPath, '.project.yaml');
+    const statePath = join(currentPath, '.context', 'state.yaml');
+    const hasProjectYaml = await pathExists(projectYamlPath);
+    const hasState = await pathExists(statePath);
+
+    if (hasProjectYaml && hasState) {
+      let projectId = currentPath.split(sep).filter(Boolean).pop() || 'unknown-project';
+      try {
+        const projectYaml = yaml.parse(await readFile(projectYamlPath, 'utf-8')) || {};
+        if (projectYaml?.meta?.id) {
+          projectId = String(projectYaml.meta.id);
+        }
+      } catch {
+        // Fall back to directory-derived project id.
+      }
+
+      return {
+        id: projectId,
+        path: currentPath,
+      };
+    }
+
+    const parentPath = dirname(currentPath);
+    if (parentPath === currentPath) {
+      return null;
+    }
+    currentPath = parentPath;
+  }
+}
+
+async function resolveProjectTarget(repoPath: string): Promise<ResolvedProjectTarget | null> {
+  const registry = await loadRegistry();
+  const normalizedRepoPath = normalizePath(repoPath);
+  const matchingProjects = registry.projects
+    .map((project) => ({ ...project, path: normalizePath(project.path) }))
+    .filter((project) => isWithinProject(normalizedRepoPath, project.path))
+    .sort((a, b) => b.path.length - a.path.length);
+
+  const registryProject = matchingProjects[0];
+  if (registryProject) {
+    return {
+      id: registryProject.id,
+      path: registryProject.path,
+    };
+  }
+
+  return findProjectRootFromRepoPath(normalizedRepoPath);
+}
+
+export async function persistGuardrailEvidence(
+  args: PersistGuardrailEvidenceArgs,
+): Promise<GuardrailPersistenceResult> {
+  const { command, repo_path, payload } = args;
+
+  if (!repo_path) {
+    return {
+      attempted: false,
+      persisted: false,
+      reason: 'repo_path is required for guardrail evidence persistence',
+    };
+  }
+
+  const project = await resolveProjectTarget(repo_path);
+  if (!project) {
+    return {
+      attempted: true,
+      persisted: false,
+      reason: `repo_path is not within a resolvable AgenticOS project: ${repo_path}`,
+    };
+  }
+
+  const statePath = join(project.path, '.context', 'state.yaml');
+  let state: StateYaml = {};
+
+  try {
+    const content = await readFile(statePath, 'utf-8');
+    state = (yaml.parse(content) || {}) as StateYaml;
+  } catch {
+    state = {};
+  }
+
+  if (!state.guardrail_evidence) {
+    state.guardrail_evidence = {};
+  }
+
+  const recordedAt = new Date().toISOString();
+  const slot = getCommandSlot(command);
+
+  state.guardrail_evidence.updated_at = recordedAt;
+  state.guardrail_evidence.last_command = command;
+  state.guardrail_evidence[slot] = {
+    command,
+    recorded_at: recordedAt,
+    repo_path,
+    ...payload,
+  };
+
+  await writeFile(statePath, yaml.stringify(state), 'utf-8');
+
+  return {
+    attempted: true,
+    persisted: true,
+    project_id: project.id,
+    state_path: statePath,
+  };
+}


### PR DESCRIPTION
## Summary
- persist the latest structured evidence for preflight, branch bootstrap, and PR scope checks into project `.context/state.yaml`
- resolve the target project from either the managed registry path or the nearest on-disk `.project.yaml` + `.context/state.yaml` root
- return persistence metadata from guardrail commands and add tests for overwrite semantics and unmanaged repo no-op behavior

## Verification
- `npm install`
- `npm run build`
- `npm test -- --run src/utils/__tests__/guardrail-evidence.test.ts src/tools/__tests__/preflight.test.ts src/tools/__tests__/branch-bootstrap.test.ts src/tools/__tests__/pr-scope-check.test.ts`
- `npm test`

Closes #62