### PR TITLE
docs(standards): execute first standalone consolidation wave (#68)

### DIFF
--- a/projects/agenticos/.meta/standard-kit/README.md
+++ b/projects/agenticos/.meta/standard-kit/README.md
@@ -39,6 +39,7 @@ These live under `projects/agenticos/.meta/templates/`:
 - `state.yaml`
 - `agent-preflight-checklist.yaml`
 - `issue-design-brief.md`
+- `non-code-evaluation-rubric.yaml`
 - `submission-evidence.md`
 
 ### Standards reference area

--- a/projects/agenticos/.meta/standard-kit/adoption-checklist.md
+++ b/projects/agenticos/.meta/standard-kit/adoption-checklist.md
@@ -9,6 +9,7 @@ Use this checklist when adopting the AgenticOS workflow standard in a downstream
 - [ ] create `.context/state.yaml`
 - [ ] create `tasks/templates/agent-preflight-checklist.yaml`
 - [ ] create `tasks/templates/issue-design-brief.md`
+- [ ] create `tasks/templates/non-code-evaluation-rubric.yaml`
 - [ ] create `tasks/templates/submission-evidence.md`
 
 ## Generated Agent Instructions

--- a/projects/agenticos/.meta/standard-kit/manifest.yaml
+++ b/projects/agenticos/.meta/standard-kit/manifest.yaml
@@ -41,6 +41,10 @@ layers:
         canonical_source: projects/agenticos/.meta/templates/issue-design-brief.md
         inheritance: copied_template
         customizable: yes
+      - path: tasks/templates/non-code-evaluation-rubric.yaml
+        canonical_source: projects/agenticos/.meta/templates/non-code-evaluation-rubric.yaml
+        inheritance: copied_template
+        customizable: yes
       - path: tasks/templates/submission-evidence.md
         canonical_source: projects/agenticos/.meta/templates/submission-evidence.md
         inheritance: copied_template
@@ -74,6 +78,7 @@ adoption:
     - .context/state.yaml
     - tasks/templates/agent-preflight-checklist.yaml
     - tasks/templates/issue-design-brief.md
+    - tasks/templates/non-code-evaluation-rubric.yaml
     - tasks/templates/submission-evidence.md
   required_behavior:
     - implementation_preflight

--- a/projects/agenticos/.meta/templates/non-code-evaluation-rubric.yaml
+++ b/projects/agenticos/.meta/templates/non-code-evaluation-rubric.yaml
@@ -1,0 +1,50 @@
+version: 0.1
+name: non-code-evaluation-rubric
+purpose: Evaluate protocol, documentation, design, or analysis outputs before submission.
+
+artifact:
+  path: ""
+  type: protocol_doc
+  allowed_types:
+    - protocol_doc
+    - design_doc
+    - knowledge_doc
+    - issue_draft
+    - workflow_spec
+
+goal:
+  intended_outcome: ""
+  linked_issue: ""
+
+criteria:
+  - name: goal_alignment
+    question: Does the artifact solve the stated issue rather than only improving wording?
+    pass_threshold: explicit_and_substantive
+    result: pending
+    notes: ""
+  - name: executability
+    question: Are the rules or acceptance criteria operational enough to be implemented or checked?
+    pass_threshold: contains_checks_or_pseudocode
+    result: pending
+    notes: ""
+  - name: consistency
+    question: Is the artifact consistent with current project positioning, workflow model, and adjacent standards?
+    pass_threshold: no_material_conflicts
+    result: pending
+    notes: ""
+  - name: completeness
+    question: Does the artifact cover entry conditions, core flow, edge cases, and failure states?
+    pass_threshold: all_major_sections_present
+    result: pending
+    notes: ""
+  - name: downstream_usability
+    question: Could another agent use this artifact without the original chat history?
+    pass_threshold: yes
+    result: pending
+    notes: ""
+
+evaluation:
+  method: llm_rubric_review
+  passes_required: 1
+  overall_result: pending
+  residual_risks: []

--- a/projects/agenticos/standards/.context/quick-start.md
+++ b/projects/agenticos/standards/.context/quick-start.md
@@ -1,13 +1,44 @@
-# agentic-os-development - Quick Start
+# AgenticOS Standards - Quick Start
 
 ## Project Overview
 
+`projects/agenticos/standards/` is the canonical standards and protocol area inside the main AgenticOS product repository.
+
+Its job is to define and evolve:
+
+- project metadata and context conventions
+- executable agent workflow rules
+- reusable downstream standards and templates
+- migration and execution reports that future agents can resume from
 
 ## Current Status
-- Created: 2026-03-20
-- Status: Active
+
+- canonical standards location has been frozen in the main repo by issue `#66` / PR `#67`
+- the old standalone `projects/agentic-os-development` repo is now treated as a retired transitional snapshot
+- issue `#68` is the first real consolidation wave
+- selected high-signal standards reports from the retired standalone repo have been backfilled into `knowledge/`
+- the retired standalone `.context/`, issue-draft history, and entry files are now preserved under:
+  - `archive/standalone-agentic-os-development-2026-03-23/`
+- live standards guidance now points only to this main-repo standards area
+- reusable downstream templates are canonically surfaced under:
+  - `projects/agenticos/.meta/templates/`
+  - `projects/agenticos/.meta/standard-kit/`
+- `non-code-evaluation-rubric.yaml` has been restored into the main template surface as part of this consolidation wave
+
+## Recommended Entry Documents
+
+Start here:
+
+1. `knowledge/standalone-standards-repo-consolidation-audit-2026-03-23.md`
+2. `knowledge/standalone-standards-first-consolidation-wave-2026-03-23.md`
+3. `knowledge/product-positioning-and-design-review-2026-03-22.md`
+4. `knowledge/agent-preflight-and-execution-protocol-2026-03-23.md`
+5. `knowledge/guardrail-flow-wiring-report-2026-03-23.md`
+6. `knowledge/downstream-standard-kit-implementation-report-2026-03-23.md`
 
 ## Next Steps
-1. Define project goals
-2. Set up initial tasks
-3. Begin development
+
+1. Land issue `#68` so the main repo becomes the only place where live standards work is updated
+2. Decide whether any archived standalone artifacts still deserve a second canonical merge wave
+3. Decide whether standard-kit adoption and upgrade should become first-class commands
+4. Decide whether status surfaces should summarize latest guardrail evidence more explicitly

--- a/projects/agenticos/standards/.context/state.yaml
+++ b/projects/agenticos/standards/.context/state.yaml
@@ -1,72 +1,44 @@
 session:
-  id: session-2026-03-22-001
-  started: 2026-03-22T06:00:00.000Z
-  agent: claude-sonnet-4.6
-  last_backup: 2026-03-22T07:15:31.962Z
+  id: standards-main-2026-03-23-001
+  started: 2026-03-23T09:30:00.000Z
+  agent: codex
+  last_backup: 2026-03-23T10:35:00.000Z
+
 current_task:
-  title: v0.2.1 发布 + 文档规范更新
-  status: completed
-  updated: 2026-03-22T07:30:00.000Z
+  title: execute the first consolidation wave for the retired standalone standards repo inside the main AgenticOS repository
+  status: in_progress
+  updated: 2026-03-23T10:35:00.000Z
+
 working_memory:
   facts:
-    - zsh-autosuggestions 安装完成
-    - Zed 配置部署到 ~/.config/zed/settings.json
-    - Cmux hooks 部署到 ~/.claude/hooks/cmux-notify-hook.sh
-    - .zshrc 备份到 ~/.config-backup/ghostty-opt-20260321-133433/zshrc.bak
-    - Shell 快捷函数追加完成 (cw/cc/cb/z.)
-    - Ghostty copy-on-select 改为 false
-    - "PR #8 已创建：https://github.com/madlouse/AgenticOS/pull/8（模板版本化）"
-    - distill.ts 新增：CURRENT_TEMPLATE_VERSION、extractTemplateVersion()、upgradeClaudeMd()、ensureVersionMarker()
-    - project.ts 新增：switchProject 时检测版本并自动升级（保留用户内容）
-    - 两个 worktree 坑：1) repo 内部 worktree 导致 commit 打 main 2) reset --hard 会 revert 未提交的文件
-    - "PR #6 已创建：基础设施（CLAUDE.md/AGENTS.md 修订、模板、LICENSE）"
-    - "PR #8 已创建：MCP Server 模板版本化机制"
-    - "PR #10 已创建：CI lint/test 脚本准备（workflow 文件需手动添加）"
-    - 创建 homebrew-ghostty 仓库 (https://github.com/madlouse/homebrew-ghostty)
-    - ghostty-cmux.rb Formula 完成，SHA256 已验证
-    - README.md 重写为 Agent-friendly 版本并推送
-    - brew tap madlouse/ghostty 测试成功，formula 正常解析
-    - 175 tests pass across 4 test files
-    - SKILL.md v2.5.0 with docs + calendar commands
-    - DEVELOPMENT.md updated with miniapp-cdp.js, docs.js, calendar.js, calendar-parser.test.js
-    - "calendar-parser.test.js: 43 tests for calendar.js exported functions"
-    - "docs --action shared 正常列出 20 份文档"
-    - "docs --action read 对文字文档（docs/ 和 docx/ 路径）成功读取内容"
-    - "Canvas 表格（sheets/）返回明确提示，不再报 Document not found"
-    - "固定了 ~/.opencli/clis/360teams/ 与项目 clis/ 不同步的问题"
-    - 合并 PR #19（vitest 单测）和 PR #21（CI 修复）到 main
-    - 关闭 Issue #1 #2 #3 #13 #14 #15 #16（全部清零）
-    - 发布 v0.2.1：单测套件 + CI 修复
-    - 更新 Homebrew Formula sha256 为 v0.2.1 实际值 f87d5e1a...
-    - 更新 CONTRIBUTING.md：GitHub Flow 规范、发布流程、常见陷阱
-    - 更新 AGENTS.md：同步 Git Flow 规范
+    - projects/agenticos/standards is now the only canonical location for ongoing AgenticOS standards work
+    - the standalone repo projects/agentic-os-development is now a retired transitional snapshot, not an active canonical repo
+    - issue #66 was merged as PR #67 to freeze the canonical standards location and define merge/archive/discard rules
+    - issue #68 tracks the first real consolidation wave after the audit
+    - the first consolidation wave backfills missing high-signal standards knowledge documents into the main standards knowledge area
+    - the retired standalone raw context, conversations, entry files, and local issue drafts are archived under archive/standalone-agentic-os-development-2026-03-23/
+    - active standards entry files must point only to the main standards area, not to the retired standalone repo
+    - reusable downstream templates are canonically surfaced under projects/agenticos/.meta/templates/
+    - reusable downstream packaging rules are canonically surfaced under projects/agenticos/.meta/standard-kit/
+    - non-code-evaluation-rubric.yaml has been restored into the main template surface as part of issue #68
   decisions:
-    - "bootstrap.sh 实际执行: 全部成功，无报错"
-    - Ghostty copy-on-select 改为 false (sed 直接修改)
-    - Worktree 应建立在 repo 外部而非内部，否则 git 命令会混淆
-    - commit 到错误分支后用 `git reset --hard HEAD~1` 撤销，但会同时 revert 文件——需重新应用变更
-    - 最终方案：在 repo 外建立独立 worktree 目录
-    - CI workflow 文件通过 GitHub API 推送需要 workflow scope，OAuth token 不够
-    - 解决方案：在 PR body 中提供 workflow 文件完整内容，用户手动添加
-    - "双仓库架构: ghostty-optimization(配置) + homebrew-ghostty(安装入口)"
-    - "Formula: ghostty-cmux.rb，自动安装 Cmux/Zed/starship 等 + 克隆配置仓库 + 运行 bootstrap"
-    - README 改为 Agent-friendly：明确安装命令、架构图、文件结构、开发状态
-    - Cmux 通过 manaflow-ai/cmux/cmux tap 安装，非直接 cask
-    - tests/helpers.test.js 中 T5T helper 函数应从 helpers.js 导入（非 t5t.js），因为 helpers.js 包含完整数据转换函数，t5t.js 只导出 innerText 解析函数
-    - parseCalendarDayFromText 需要 null guard 防止 null 输入导致 TypeError
-    - docs.js 由于跨域 iframe 限制，仅实现 status 动作，这是已知技术约束而非设计缺陷
-    - refreshIframeContext 从 miniapp-cdp.js 导入而非本地定义，避免重复代码和 bug
-    - canvas 文档返回特定提示而非报错，保持命令稳定性
-    - 导航使用 setTimeout 推迟 50ms，避免 context 在返回前被销毁
-    - iframe 导航使用 parent frame 的 iframe.src 设置，绕过跨域限制
-    - 使用 GitHub Flow（单 main 分支）替代 Git Flow，适合单人/AI-agent 协作项目
-    - branch protection 去掉 required reviews（GitHub 不允许自审），只保留 CI required
-    - 所有 workflow 用 npm install 替换 npm ci，避免 lock file 不同步问题
-    - Homebrew formula sha256 必须在每次 release 后立即更新，不留 placeholder
+    - keep one main AgenticOS product repository and one canonical standards area inside it
+    - merge durable standards knowledge into the main repo, but archive raw standalone context/history instead of treating it as live state
+    - keep the archive read-only and use it only for provenance or later selective recovery
+    - preserve the live .context/.last_record marker because current tooling still uses it
   pending:
-    - Homebrew tap 是否需要独立仓库发布（目前在主 repo 内）
-    - "Node.js 20 actions deprecation 警告（2026-06-02 前需升级到 Node 24）"
-    - agenticos_record 存在 bug：JSON 数组字符串被逐字符展开写入 YAML，需修复序列化逻辑
+    - commit, push, and open the first consolidation-wave PR for issue #68
+    - decide whether archived standalone material needs a second merge wave or can remain archive-only
+    - decide whether standard-kit adoption and upgrade should become first-class commands
+    - decide whether live status surfaces should summarize the latest guardrail evidence more explicitly
+
 loaded_context:
   - .project.yaml
   - .context/quick-start.md
+  - knowledge/standalone-standards-repo-consolidation-audit-2026-03-23.md
+  - knowledge/standalone-standards-first-consolidation-wave-2026-03-23.md
+  - knowledge/product-positioning-and-design-review-2026-03-22.md
+  - knowledge/agent-preflight-and-execution-protocol-2026-03-23.md
+  - knowledge/guardrail-flow-wiring-report-2026-03-23.md
+  - knowledge/downstream-standard-kit-implementation-report-2026-03-23.md
+  - knowledge/runtime-project-extraction-closure-report-2026-03-23.md

--- a/projects/agenticos/standards/.project.yaml
+++ b/projects/agenticos/standards/.project.yaml
@@ -1,7 +1,7 @@
 meta:
-  name: agentic-os-development
-  id: agentic-os-development
-  description: ""
+  name: agenticos-standards
+  id: agenticos-standards
+  description: Canonical standards and protocol area inside the main AgenticOS product repository.
   created: 2026-03-20
   version: 1.0.0
 agent_context:

--- a/projects/agenticos/standards/AGENTS.md
+++ b/projects/agenticos/standards/AGENTS.md
@@ -1,51 +1,37 @@
-# AGENTS.md — AgenticOS Development
+# AGENTS.md — AgenticOS Standards
 
-## Recording Protocol (MANDATORY)
+## Canonical Standards Note
 
-This project uses AgenticOS for persistent context management.
-All session activity MUST be recorded via MCP tools.
+- all ongoing standards work for AgenticOS must be recorded in this main repository under `projects/agenticos/standards/`
+- the retired standalone snapshot lives under `archive/standalone-agentic-os-development-2026-03-23/`
+- archive contents are legacy reference material only; they are not the live canonical source
 
-### How to Record
+## Session Start
 
-Call the MCP tool `agenticos_record` with:
-- `summary` (required): What happened in this session
-- `decisions`: Key decisions made
-- `outcomes`: What was accomplished
-- `pending`: What remains to be done
-- `current_task`: { title, status } to update current task
+Before doing standards work, read:
 
-### When to Record
+1. `.project.yaml`
+2. `.context/quick-start.md`
+3. `.context/state.yaml`
+4. the specific `knowledge/` documents relevant to the issue you are working on
 
-1. After completing any meaningful unit of work
-2. Before ending the session (MANDATORY — context is lost otherwise)
+Treat archived standalone material as read-only historical evidence, not as the authoritative current state.
 
-After recording, call `agenticos_save` to commit to Git.
+## Working Rules
 
-### Session Start
-
-On session start, read these files for context:
-1. `.project.yaml` — Project metadata
-2. `.context/state.yaml` — Current state and working memory
-3. `.context/conversations/` — Previous session records
-
-Then greet the user with: project name, last progress, current pending items, suggested next step.
-
-## Project
-
-**Name**: AgenticOS Development
-**Description**: Agent-first project management OS — AI Agent autonomously manages project state, cross-session context recovery, and cross-tool collaboration.
+1. Standards work follows the main AgenticOS workflow: issue first, isolated branch/worktree, verification before merge.
+2. Use `knowledge/` for durable decisions, execution reports, migration reports, and protocol changes.
+3. Keep `.context/quick-start.md` and `.context/state.yaml` current enough that another agent can resume without chat history.
+4. Do not create a second active standards repo or write new canonical records into `projects/agentic-os-development`.
+5. Prefer canonical template surfaces under `projects/agenticos/.meta/templates/` and `projects/agenticos/.meta/standard-kit/` over ad hoc local template copies.
 
 ## Directory Structure
 
 | Path | Purpose |
 |------|---------|
-| `.project.yaml` | Project metadata |
-| `.context/state.yaml` | Session state and working memory |
-| `.context/conversations/` | Session records (auto-generated) |
-| `knowledge/` | Persistent knowledge: architecture, decisions, trade-offs |
-| `knowledge/architecture.md` | Three-layer architecture design |
-| `knowledge/design-decisions.md` | 5 key design decisions with rationale |
-| `knowledge/complete-design.md` | Complete system design document |
-| `tasks/` | Task tracking |
-| `artifacts/` | Outputs and deliverables |
-| `changelog.md` | Project changelog |
+| `.project.yaml` | Standards area metadata |
+| `.context/quick-start.md` | Human-readable entry status for this standards area |
+| `.context/state.yaml` | Structured current state and working memory |
+| `knowledge/` | Canonical standards reasoning, design history, and execution reports |
+| `archive/` | Retired standalone standards snapshots kept only for provenance |
+| `changelog.md` | Historical change log carried forward from the standalone phase |

--- a/projects/agenticos/standards/CLAUDE.md
+++ b/projects/agenticos/standards/CLAUDE.md
@@ -1,118 +1,42 @@
-# CLAUDE.md — AgenticOS Development
+# CLAUDE.md — AgenticOS Standards
 
-## MANDATORY: Recording Protocol
+## Canonical Location Note
 
-> This is an AgenticOS project. All session activity MUST be recorded.
-> Recording is not optional — it is the core function of this system.
+This directory is the only canonical location for ongoing AgenticOS standards work.
 
-### During Session
+- live standards path: `projects/agenticos/standards/`
+- retired standalone snapshot: `archive/standalone-agentic-os-development-2026-03-23/`
 
-After completing any meaningful unit of work (feature, fix, design decision, analysis), call `agenticos_record`:
-
-```
-agenticos_record({
-  summary: "what happened",
-  decisions: ["decision 1", ...],
-  outcomes: ["outcome 1", ...],
-  pending: ["next step 1", ...],
-  current_task: { title: "task name", status: "in_progress" }
-})
-```
-
-### Before Session Ends
-
-When the user signals session end (says goodbye, thanks, done, or stops responding), you MUST:
-
-1. Call `agenticos_record` with a complete session summary
-2. Call `agenticos_save` to commit to Git
-
-**If you skip this step, all context from this session is permanently lost.**
-
----
+For current live status, prefer `.context/quick-start.md`, `.context/state.yaml`, and current `knowledge/` documents in this directory.
 
 ## Session Start Protocol
 
-When you open this project in a new session, **immediately do the following**:
+When you enter this standards area:
 
-1. Read the "Current State" section below
-2. Greet the user with a brief status report in this format:
+1. Read `.project.yaml`
+2. Read `.context/quick-start.md`
+3. Read `.context/state.yaml`
+4. Read only the specific `knowledge/` documents needed for the current issue
 
-```
-📍 项目：AgenticOS Development
-📌 上次进展：[current_task title + status]
-🎯 当前待办：[top pending items]
-💡 建议下一步：[recommended next action]
+Do not treat archived standalone records as the live source of truth.
 
-继续上次的工作，还是有新的方向？
-```
+## Execution Rules
 
-3. Wait for the user's direction before proceeding
-
----
-
-## Project DNA
-
-**一句话定位**: Agent-first 的项目管理操作系统，让 AI Agent 能自主管理项目状态、跨会话恢复上下文、跨工具协作。
-
-**核心设计原则**:
-- **Agent First**: AI 是主要用户，一切结构为 AI 理解优化
-- **完整记录**: 所有决策、对话、变更完整留痕
-- **跨工具兼容**: Claude Code / Cursor / Codex 均可使用
-- **可移植性**: Git 备份，路径相对化存储，跨机器可用
-
-**三层架构**:
-1. **通用层** (Universal): `.project.yaml` + `.context/state.yaml` + `knowledge/` + `tasks/` — 纯文本+结构化数据，无工具依赖
-2. **MCP 层**: `agenticos-mcp` npm 包，9 个工具 (init/switch/list/status/record/save/preflight/branch_bootstrap/pr_scope_check) + 1 个资源
-3. **Agent 适配层**: `CLAUDE.md` / `CURSOR.md` — 每个工具的专用配置和行为指令
-
-**技术栈**: TypeScript, Node.js (ES2022), MCP SDK, YAML, Git
-
-**关键设计约束**:
-- 路径在 YAML 中存储为相对路径，运行时解析为绝对路径
-- Registry 位于 `~/.agent-workspace/registry.yaml`（AgenticOS Home 下）
-- Git 操作从 workspace root 执行（整个 AgenticOS 是一个仓库）
-
----
-
-## Current State
-
-<!-- AGENT_CONTEXT_START -->
-**Last Updated**: 2026-03-21T05:49:33.899Z
-
-**Current Task**: Homebrew Tap + Agent-friendly README (status: completed)
-
-**Active Items**:
-- E2E manual verification: opencli 360teams docs, opencli 360teams calendar — 需要 360Teams 运行中
-- 如果需要，创建 docs-parser.test.js（但 docs.js 目前无可测试的导出函数）
-
-**Recent Decisions**:
-- tests/helpers.test.js 中 T5T helper 函数应从 helpers.js 导入（非 t5t.js），因为 helpers.js 包含完整数据转换函数，t5t.js 只导出 innerText 解析函数
-- parseCalendarDayFromText 需要 null guard 防止 null 输入导致 TypeError
-- docs.js 由于跨域 iframe 限制，仅实现 status 动作，这是已知技术约束而非设计缺陷
-
-**Next Action**: E2E manual verification: opencli 360teams docs, opencli 360teams calendar — 需要 360Teams 运行中
-<!-- AGENT_CONTEXT_END -->
-
----
+1. Standards work is part of the main AgenticOS product repository and must follow the same issue-first, branch, worktree, PR flow.
+2. Durable standards decisions belong in `knowledge/`, not only in chat.
+3. Keep active guidance focused on the main standards area; historical documents may mention older paths, but live entry files must not.
+4. Prefer reusable templates and kit assets under:
+   - `projects/agenticos/.meta/templates/`
+   - `projects/agenticos/.meta/standard-kit/`
+5. Treat the archive as read-only provenance.
 
 ## Navigation
 
-| 目录/文件 | 用途 |
-|-----------|------|
-| `.project.yaml` | 项目元信息（名称、ID、版本、技术栈） |
-| `.context/state.yaml` | 当前会话状态、工作记忆、待办事项 |
-| `.context/quick-start.md` | 人类可读的项目概览 |
-| `.context/conversations/` | 历史对话记录 |
-| `knowledge/` | 持久化知识：架构设计、决策记录、权衡分析 |
-| `knowledge/architecture.md` | 核心架构设计（三层架构详解） |
-| `knowledge/design-decisions.md` | 5 个关键设计决策及理由 |
-| `knowledge/complete-design.md` | 完整系统设计文档 |
-| `tasks/` | 任务追踪 |
-| `artifacts/` | 产出物 |
-| `changelog.md` | 变更日志 |
-
-**获取更多上下文**:
-- 架构全貌 → `knowledge/architecture.md`
-- 为什么选 MCP 而非 CLI → `knowledge/cli-vs-mcp-analysis.md`
-- 设计权衡 → `knowledge/trade-offs.md`
-- MCP Server 源码 → `../../mcp-server/src/`
+| Path | Purpose |
+|------|---------|
+| `.project.yaml` | Standards area identity and entry points |
+| `.context/quick-start.md` | Human-readable current status |
+| `.context/state.yaml` | Structured resumable state |
+| `knowledge/` | Canonical standards reasoning and execution records |
+| `archive/` | Retired standalone standards snapshot |
+| `changelog.md` | Historical change log |

--- a/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/.context/conversations/2026-03-16.md
+++ b/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/.context/conversations/2026-03-16.md
@@ -1,0 +1,130 @@
+# Session 2026-03-16
+
+## Session Info
+- Date: 2026-03-16
+- Agent: Claude Sonnet 4.6
+- Session ID: session-2026-03-16-001
+
+## Conversation Log
+
+### 04:25 - AgenticOS 概念诞生
+
+**User**: 在 dev 目录创建 AI Projects 文件夹，用于管理 AI 协作项目
+
+**Context**: 用户希望建立一个系统来：
+- 记录与 AI Agent 协作的项目
+- 持久化项目上下文
+- 支持项目切换
+- 建立协作规范
+
+**AI**: 提出初步设计方案
+- 目录结构
+- 协作规范
+- 工具脚本
+
+### 04:27 - Agent First 设计理念
+
+**User**: 要求 Agent First、Agent Friendly 的设计
+
+**AI**: 重新设计，强调：
+- 结构化数据（YAML/JSON）优于自由文本
+- 分层上下文加载（essential/important/optional）
+- 状态持久化（state.yaml）
+- Agent 自主管理内容
+
+**Key Insight**: 设计应该优先考虑 AI 如何理解和使用，而不是人类
+
+### 04:30 - Agent 驱动的演进
+
+**User**: 希望通过 Agent 交互来管理内容演进，而不是人工维护
+
+**AI**: 调整设计理念：
+- AI 自己创建和维护项目结构
+- 动态的、自适应的组织方式
+- AI 自动维护项目状态
+
+**User**: 将系统命名为 AIOS (Agentic OS)
+
+**Rationale**: 这不只是项目管理，而是一个 AI-native 的协作操作系统
+
+### 04:32 - 跨 Agent 兼容性
+
+**User**: 考虑 Claude Code、Gemini CLI 等不同 Agent 的兼容性
+
+**AI**: 设计分层规范：
+- **通用层**: .project.yaml + quick-start.md（所有 Agent）
+- **Agent 增强层**: CLAUDE.md、GEMINI.md（特定 Agent）
+
+**Design Decision**:
+- 最小兼容性保证（通用层）
+- Agent 特定增强（专用层）
+- 灵活可扩展
+
+### 04:35 - 完整记录机制
+
+**User**: 要求记录所有想法、对话、项目日志，便于追溯和 Agent 切换
+
+**Requirements**:
+1. 原始对话操作
+2. 用户的记忆和洞察
+3. 从对话中学习到的知识
+4. 项目演进的时间线
+
+**AI**: 建立多层记录系统：
+- `.context/conversations/` - 对话日志
+- `knowledge/user-insights.md` - 用户洞察
+- `.context/changelog.md` - 项目日志
+- `.context/memory.jsonl` - 结构化事件流
+
+### 04:38 - GitHub 版本控制
+
+**User**: 上传到 GitHub 做版本备份，追踪演变进程
+
+**Actions**:
+- 初始化 Git 仓库
+- 创建 GitHub 仓库：AgenticOS
+- 推送初始版本
+
+**User**: 将目录名统一改为 AgenticOS
+
+**Action**: 重命名 ~/dev/AIOS → ~/dev/AgenticOS
+
+### 04:40 - 元项目创建
+
+**User**: 将"打造完善 AgenticOS"作为一个项目管理
+
+**Decision**: 放在 projects/ 下（自举设计）
+- 项目名: agentic-os-development
+- 用 AgenticOS 管理 AgenticOS 本身的开发
+
+## Key Decisions
+
+- **Agent First 设计**: 优先考虑 AI 的使用体验
+- **分层规范**: 通用层 + Agent 专用层
+- **完整记录**: 对话、洞察、日志、记忆流
+- **版本控制**: Git + GitHub
+- **自举设计**: 用 AgenticOS 管理自己
+
+## Technical Insights
+
+1. **跨 Agent 兼容性**
+   - 使用标准文件格式（YAML、Markdown）
+   - 分层规范设计
+   - Agent 特定文件（CLAUDE.md、GEMINI.md）
+
+2. **状态持久化**
+   - state.yaml 记录当前工作状态
+   - memory.jsonl 记录事件流
+   - 支持会话恢复
+
+3. **记录系统**
+   - 对话日志（自然语言）
+   - 项目日志（时间线）
+   - 记忆流（结构化）
+   - 用户洞察（知识提取）
+
+## Next Steps
+
+- 设计自动备份机制
+- 开发项目管理工具（ai-init, ai-switch）
+- 完善跨 Agent 兼容性测试

--- a/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/.context/conversations/2026-03-20.md
+++ b/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/.context/conversations/2026-03-20.md
@@ -1,0 +1,82 @@
+# Sessions — 2026-03-20
+
+### 14:42 — Session Record
+
+**Summary**: 通过 CDP 直接连接 360Teams 页面成功获取了 T5T 历史记录的完整内容，包括 5 周的数据（2026年3月第3周、2周、1周，以及2月第4周、第2周）。所有内容已保存到 Week-2026-03-01/history/ 目录。
+
+关键发现：
+- T5T 页面在 CDP 中是 page 类型而不是 webview 类型
+- 需要先导航到 T5T URL (https://im.360teams.com/miniapps/t5t/home)
+- 页面完全加载后可以获取完整的 innerText 内容
+
+**Outcomes**:
+- T5T 历史记录完整获取功能实现
+- 解决了 T5T webview 找不到的问题
+- 创建了 5 个周目录，每个目录包含 t5t.md 文件
+- 更新了 t5t-history-raw.md 包含完整历史汇总
+
+**Decisions**:
+- 通过 CDP 导航到 T5T URL 而不是查找 webview target
+- T5T 页面类型是 page 而不是 webview
+- 直接用 page target 的 Runtime.evaluate 获取 innerText 获取完整内容
+
+**Pending**:
+- T5T 内容读取功能增强 - 已完成
+- T5T 提交功能 - 自动化填写并提交 T5T
+
+
+### 14:46 — Session Record
+
+**Summary**: 成功通过 bb-browser site okr/get 获取了 2026 年年度 OKR 完整内容，并保存到 T5T 项目 knowledge 目录和 OKR-Management 项目中。OKR 包含 4 个 Objective，O1（DeepBank）、O2（降本增效）、O3（交付稳定性）、O4（组织建设）。
+
+**Outcomes**:
+- 2026年年度 OKR 完整内容获取成功
+- OKR 保存到 T5T 项目 knowledge 目录
+- OKR-Management 项目的 2026年年度OKR.md 已更新为最新版本
+
+**Decisions**:
+- 使用 bb-browser site okr/get 2026年年度 --json 获取 OKR 数据
+- 将 OKR 保存为参考材料到 T5T 项目的 knowledge/2026-annual-okr.md
+
+**Pending**:
+- T5T 提交功能 - 自动化填写并提交 T5T
+
+
+### 15:31 — Session Record
+
+**Summary**: Fixed T5T history parser - the number pattern /^[1１]$/ only matched "1" but not "2","3","4","5". Also fixed field name mapping from {title,time,content} to {Week,SubmitTime,Content}. CLI now correctly shows 5 weeks of T5T history.
+
+**Outcomes**:
+- t5t history now returns 5 weeks of records with correct content
+- t5t status continues to work correctly
+
+**Decisions**:
+- Regex bug: /^[1１]$/ only matched number 1, needed /^[1-5１-５]$/ to match all T5T item numbers
+- Field mapping: parseWeekBlock returns {title,time,content} but opencli columns are {Week,SubmitTime,Content} - needed explicit mapping in history action
+
+**Pending**:
+- T5T content parsing: names like 彭新荣,郭高升 still appearing in content (noise filter issue)
+- Write T5T content for 2026年3月第4周
+
+
+### 16:47 — Session Record
+
+**Summary**: T5T 自动填写功能实现完成
+
+修改内容：
+1. t5t.js 新增 --content 参数（5条内容用 ||| 分隔）
+2. 添加 truncateContent 辅助函数（限制80字/条）
+3. write action 自动填充5个textarea并点击提交按钮
+4. SKILL.md 更新 CLI 用法文档
+
+**Outcomes**:
+- T5T 自动填写 CLI 功能已完成
+- SKILL.md Step 3a 已更新
+
+**Decisions**:
+- 使用 ||| 作为5条内容的分隔符
+- 添加80字截断保护（网站限制）
+- 点击'提交'按钮完成自动提交
+
+**Pending**:
+- 测试完整流程

--- a/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/.context/conversations/2026-03-21.md
+++ b/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/.context/conversations/2026-03-21.md
@@ -1,0 +1,220 @@
+# Sessions — 2026-03-21
+
+### 04:24 — Session Record
+
+**Summary**: 研究 Ghostty + tmux + Zsh 集成方案，基于多篇技术文章和社区最佳实践，创建了一键部署的 bootstrap 脚本和完整配置文件集。
+
+**Outcomes**:
+- 创建 resources/ghostty-tmux-zsh-research.md 研究文档
+- 创建 setup/bootstrap.sh 一键初始化脚本
+- 创建 setup/configs/ghostty-config (tmux 兼容版)
+- 创建 setup/configs/tmux.conf (Ctrl+Space prefix, TPM 插件)
+- 创建 setup/configs/starship.toml (简洁 prompt)
+- 创建 setup/configs/zshrc-append (插件加载 + tmux 快捷函数)
+
+**Decisions**:
+- 三层架构: Ghostty(渲染) + tmux(会话管理) + Zsh(Shell)，互补而非替代
+- tmux prefix 设为 Ctrl+Space，并通过 Ghostty keybind 映射 Cmd 快捷键
+- copy-on-select = false 避免 Ghostty 与 tmux copy-mode 冲突
+- Zsh 插件走 Homebrew 安装而非 oh-my-zsh，更轻量
+- bootstrap.sh 采用备份-部署模式，不会覆盖现有配置
+- zshrc 用追加模式带标记，支持幂等执行
+
+**Pending**:
+- 用户测试 bootstrap.sh 在当前机器上的效果
+- 验证 Ghostty keybind → tmux prefix 映射是否正常工作
+- 考虑添加 Linux 支持（目前仅 macOS）
+- 可选: 添加 Neovim 集成到方案中
+- Grok 对话原文内容待用户手动补充
+
+
+### 04:29 — Session Record
+
+**Summary**: 基于用户实际环境重构了部署方案。用户已有 Ghostty + oh-my-zsh + Starship 配置，tmux 是新增组件。采用兼容模式：不覆盖已有配置，只补充缺失部分。备份了当前机器的所有配置（已脱敏）。
+
+**Outcomes**:
+- 完成当前机器配置快照（4个文件，已脱敏）
+- 重写 bootstrap.sh 为兼容模式
+- 创建 apply-tmux-compat.sh 单项调整脚本
+- 创建 setup/README.md 部署文档
+- 更新 ghostty-config 和 zshrc-append 配置模板
+
+**Decisions**:
+- bootstrap.sh 采用兼容模式：已有配置不覆盖，只补充缺失
+- zshrc 用追加模式带标记，不干扰 oh-my-zsh 等现有配置
+- 敏感信息（API key）脱敏后存入 backup-snapshot
+- 新增 --dry-run 选项允许预览变更
+- Ghostty copy-on-select 改为独立脚本 apply-tmux-compat.sh，不强制修改
+
+**Pending**:
+- 用户测试 bootstrap.sh --dry-run 确认无问题
+- 实际运行 bootstrap.sh 安装 tmux
+- 验证 tmux 与现有 Starship/oh-my-zsh 的兼容性
+- Grok 对话原文内容待用户补充
+- 考虑将项目推送到 Git 远程仓库供跨机器拉取
+
+
+### 04:34 — Session Record
+
+**Summary**: 方向修正：从 Ghostty+tmux+Zsh 改为 Ghostty+Cmux+Zed（Ben's Bites 推荐的 AI 编程栈）。清理了 tmux 方案，重新研究 Cmux 和 Zed，构建了完整的部署方案。
+
+**Outcomes**:
+- 删除 tmux.conf、旧 zshrc-append、starship.toml 模板等 tmux 方案文件
+- 创建 resources/cmux-zed-research.md 研究文档
+- 重写 bootstrap.sh 为 Cmux+Zed 安装脚本
+- 创建 zed-settings.json 配置模板
+- 创建 cmux-notify-hook.sh 通知 hook
+- 创建新 zshrc-append（Cmux/Zed 集成）
+- 更新 setup/README.md
+
+**Decisions**:
+- 技术栈确认: Cmux(内置libghostty) + Zed 编辑器，不用 tmux
+- Cmux 直接读取 Ghostty 配置，无需单独维护
+- Zed 补齐 Cmux 缺少的文件浏览/编辑功能
+- 保留 backup-snapshot 目录存放当前机器配置快照
+- 新增 cmux-notify-hook.sh 用于 Claude Code 任务通知
+- zshrc 追加内容改为 Cmux/Zed 快捷函数（cw/cc/cb/z）
+
+**Pending**:
+- 用户测试 bootstrap.sh --dry-run
+- 验证 Cmux brew 安装是否顺利
+- 验证现有 Ghostty 配置与 Cmux 的兼容性
+- 配置 Cmux workspace 模板 (.vscode/terminals.json)
+- Zed AI Agent Panel 配置（模型选择、MCP Server）
+- 将项目推送到 Git 远程仓库供跨机器拉取
+
+
+### 04:48 — Session Record
+
+**Summary**: 开源协作开发流程建设：完成深度研究（GStack、Claude Code GitHub Actions、AGENTS.md 最佳实践），创建 Issue #5 和 PR #6（9个基础文件），但发现 CLAUDE.md/AGENTS.md 定位错误需修订。识别出 4 个核心问题：子 Agent 上下文断裂、文件定位混乱、设计产出物未持久化、DRY 原则缺失。
+
+**Outcomes**:
+- Issue #5 已创建：https://github.com/madlouse/AgenticOS/issues/5
+- PR #6 已创建：https://github.com/madlouse/AgenticOS/pull/6（待修订 CLAUDE.md 和 AGENTS.md）
+- 研究报告已保存：knowledge/open-source-workflow-research.md
+- 会话反思已保存：knowledge/session-retrospective-2026-03-21.md
+- 识别出 AgenticOS 自身的上下文恢复机制在子 Agent 场景下的断裂问题
+
+**Decisions**:
+- AGENTS.md 应作为规范来源（canonical source），CLAUDE.md 引用它并添加 Claude Code 特有扩展
+- 采用渐进式披露：第一层（CLAUDE.md/AGENTS.md）快速启动，第二层（CONTRIBUTING.md）详细规范，第三层（knowledge/）深度知识
+- 重要研究和设计产出物必须持久化到 knowledge/ 或 artifacts/，对话中只保留文件引用
+- 子 Agent spawn 前必须先读取 knowledge/ 关键文件并注入上下文
+
+**Pending**:
+- 修订 PR #6 中的 CLAUDE.md（改为快速启动配置，引用 AGENTS.md）
+- 修订 PR #6 中的 AGENTS.md（作为 canonical source，遵循渐进式披露）
+- 设计 CLAUDE.md 引用 AGENTS.md 的具体机制
+- 将'子 Agent 上下文注入'和'产出物持久化'写入开发规范
+- Phase 2: CI 流水线（Issue #6）
+- Phase 3: Agentic 自动化（Issue #7）
+
+
+### 05:35 — Session Record
+
+**Summary**: 执行 bootstrap.sh 完成部署。安装了 zsh-autosuggestions，部署了 Zed 配置、Cmux hooks，追加了 .zshrc。同步将 Ghostty copy-on-select 改为 false。
+
+**Outcomes**:
+- zsh-autosuggestions 安装完成
+- Zed 配置部署到 ~/.config/zed/settings.json
+- Cmux hooks 部署到 ~/.claude/hooks/cmux-notify-hook.sh
+- .zshrc 备份到 ~/.config-backup/ghostty-opt-20260321-133433/zshrc.bak
+- Shell 快捷函数追加完成 (cw/cc/cb/z.)
+- Ghostty copy-on-select 改为 false
+
+**Decisions**:
+- bootstrap.sh 实际执行: 全部成功，无报错
+- Ghostty copy-on-select 改为 false (sed 直接修改)
+
+**Pending**:
+- Cmux hooks 需要在 Claude Code settings.json 中配置触发
+- Cmux workspace 模板配置 (.vscode/terminals.json)
+- Zed AI Agent Panel + MCP Server 配置
+- 重启终端/shell 使 zsh-autosuggestions 和新 .zshrc 生效
+
+
+### 05:38 — Session Record
+
+**Summary**: Issue #7 模板版本化功能已完成并创建 PR #8。识别出 AgenticOS 当前一个重要的产品能力缺陷：worktree 嵌套在 repo 内导致 git commit 总是打到 main，而非 worktree 分支。
+
+**Outcomes**:
+- PR #8 已创建：https://github.com/madlouse/AgenticOS/pull/8（模板版本化）
+- distill.ts 新增：CURRENT_TEMPLATE_VERSION、extractTemplateVersion()、upgradeClaudeMd()、ensureVersionMarker()
+- project.ts 新增：switchProject 时检测版本并自动升级（保留用户内容）
+- 两个 worktree 坑：1) repo 内部 worktree 导致 commit 打 main 2) reset --hard 会 revert 未提交的文件
+
+**Decisions**:
+- Worktree 应建立在 repo 外部而非内部，否则 git 命令会混淆
+- commit 到错误分支后用 `git reset --hard HEAD~1` 撤销，但会同时 revert 文件——需重新应用变更
+- 最终方案：在 repo 外建立独立 worktree 目录
+
+**Pending**:
+- Merge PR #6（基础设施）
+- Merge PR #8（模板版本化）
+- Phase 2: CI 流水线（Issue #6）
+- Phase 3: Agentic 自动化（Issue #7）
+
+
+### 05:42 — Session Record
+
+**Summary**: Phase 2 完成：Issue #9 CI 流水线。package.json 添加 lint/test 脚本，PR #10 已创建。CI workflow 文件因 OAuth token scope 限制（缺少 workflow 权限）无法通过 gh cli 推送，已在 PR body 中提供完整内容供手动添加。
+
+**Outcomes**:
+- PR #6 已创建：基础设施（CLAUDE.md/AGENTS.md 修订、模板、LICENSE）
+- PR #8 已创建：MCP Server 模板版本化机制
+- PR #10 已创建：CI lint/test 脚本准备（workflow 文件需手动添加）
+
+**Decisions**:
+- CI workflow 文件通过 GitHub API 推送需要 workflow scope，OAuth token 不够
+- 解决方案：在 PR body 中提供 workflow 文件完整内容，用户手动添加
+
+**Pending**:
+- Merge PR #6 → main
+- Merge PR #8 → main
+- 手动添加 .github/workflows/ci.yml（token scope 限制）
+- Merge PR #10 → main
+- 配置 GitHub Branch Protection
+- Phase 3: Agentic 自动化
+
+
+### 05:47 — Session Record
+
+**Summary**: 完成 Homebrew Tap 创建和 README Agent-friendly 改造。两个仓库分工明确：ghostty-optimization 存放配置源码，homebrew-ghostty 作为安装入口。
+
+**Outcomes**:
+- 创建 homebrew-ghostty 仓库 (https://github.com/madlouse/homebrew-ghostty)
+- ghostty-cmux.rb Formula 完成，SHA256 已验证
+- README.md 重写为 Agent-friendly 版本并推送
+- brew tap madlouse/ghostty 测试成功，formula 正常解析
+
+**Decisions**:
+- 双仓库架构: ghostty-optimization(配置) + homebrew-ghostty(安装入口)
+- Formula: ghostty-cmux.rb，自动安装 Cmux/Zed/starship 等 + 克隆配置仓库 + 运行 bootstrap
+- README 改为 Agent-friendly：明确安装命令、架构图、文件结构、开发状态
+- Cmux 通过 manaflow-ai/cmux/cmux tap 安装，非直接 cask
+
+**Pending**:
+- Cmux 通过 manaflow-ai/cmux tap 安装，需确认该 tap 可用
+- 在另一台电脑上验证完整安装流程
+- Cmux workspace 模板配置
+- Zed MCP Server 完整配置
+
+
+### 05:49 — Session Record
+
+**Summary**: 完成了 360Teams 云文档和日程会议 CLI 化（Phase 0-3）。关键工作：(1) 修复了测试文件 import 错误（tests/helpers.test.js 从 t5t.js 导入 T5T 函数改为从 helpers.js）；(2) 在 calendar.js 添加 null guard；(3) 更新 SKILL.md（v2.3→v2.5，新增 docs/calendar 命令）；(4) 更新 DEVELOPMENT.md（新增文件、miniapp 表格、测试数量 87→175）；(5) 新增 calendar-parser.test.js（43 tests）。全部 175 测试通过。
+
+**Outcomes**:
+- 175 tests pass across 4 test files
+- SKILL.md v2.5.0 with docs + calendar commands
+- DEVELOPMENT.md updated with miniapp-cdp.js, docs.js, calendar.js, calendar-parser.test.js
+- calendar-parser.test.js: 43 tests for calendar.js exported functions
+
+**Decisions**:
+- tests/helpers.test.js 中 T5T helper 函数应从 helpers.js 导入（非 t5t.js），因为 helpers.js 包含完整数据转换函数，t5t.js 只导出 innerText 解析函数
+- parseCalendarDayFromText 需要 null guard 防止 null 输入导致 TypeError
+- docs.js 由于跨域 iframe 限制，仅实现 status 动作，这是已知技术约束而非设计缺陷
+
+**Pending**:
+- E2E manual verification: opencli 360teams docs, opencli 360teams calendar — 需要 360Teams 运行中
+- 如果需要，创建 docs-parser.test.js（但 docs.js 目前无可测试的导出函数）

--- a/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/.context/conversations/2026-03-22.md
+++ b/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/.context/conversations/2026-03-22.md
@@ -1,0 +1,1334 @@
+# Sessions — 2026-03-22
+
+### 06:36 — Session Record
+
+**Summary**: 修复 docs.js 云文档读取功能，验证通过。修复了 3 个 bug：refreshIframeContext 使用了错误的 frameTree.frameTree（应为 frameTree.childFrames）、readDocContent 有语法错误、window.location.href 导航导致 context 在返回值前被销毁。新增 canvas 文档检测（sheets 类型返回提示）。docs --action read 对文字文档（docs/ 路径）验证成功。
+
+**Outcomes**:
+- [
+- "
+- d
+- o
+- c
+- s
+-  
+- -
+- -
+- a
+- c
+- t
+- i
+- o
+- n
+-  
+- s
+- h
+- a
+- r
+- e
+- d
+-  
+- 正
+- 常
+- 列
+- 出
+-  
+- 2
+- 0
+-  
+- 份
+- 文
+- 档
+- "
+- ,
+-  
+- "
+- d
+- o
+- c
+- s
+-  
+- -
+- -
+- a
+- c
+- t
+- i
+- o
+- n
+-  
+- r
+- e
+- a
+- d
+-  
+- 对
+- 文
+- 字
+- 文
+- 档
+- （
+- d
+- o
+- c
+- s
+- /
+-  
+- 和
+-  
+- d
+- o
+- c
+- x
+- /
+-  
+- 路
+- 径
+- ）
+- 成
+- 功
+- 读
+- 取
+- 内
+- 容
+- "
+- ,
+-  
+- "
+- C
+- a
+- n
+- v
+- a
+- s
+-  
+- 表
+- 格
+- （
+- s
+- h
+- e
+- e
+- t
+- s
+- /
+- ）
+- 返
+- 回
+- 明
+- 确
+- 提
+- 示
+- ，
+- 不
+- 再
+- 报
+-  
+- D
+- o
+- c
+- u
+- m
+- e
+- n
+- t
+-  
+- n
+- o
+- t
+-  
+- f
+- o
+- u
+- n
+- d
+- "
+- ,
+-  
+- "
+- 固
+- 定
+- 了
+-  
+- ~
+- /
+- .
+- o
+- p
+- e
+- n
+- c
+- l
+- i
+- /
+- c
+- l
+- i
+- s
+- /
+- 3
+- 6
+- 0
+- t
+- e
+- a
+- m
+- s
+- /
+-  
+- 与
+- 项
+- 目
+-  
+- c
+- l
+- i
+- s
+- /
+-  
+- 不
+- 同
+- 步
+- 的
+- 问
+- 题
+- "
+- ]
+
+**Decisions**:
+- [
+- "
+- r
+- e
+- f
+- r
+- e
+- s
+- h
+- I
+- f
+- r
+- a
+- m
+- e
+- C
+- o
+- n
+- t
+- e
+- x
+- t
+-  
+- 从
+-  
+- m
+- i
+- n
+- i
+- a
+- p
+- p
+- -
+- c
+- d
+- p
+- .
+- j
+- s
+-  
+- 导
+- 入
+- 而
+- 非
+- 本
+- 地
+- 定
+- 义
+- ，
+- 避
+- 免
+- 重
+- 复
+- 代
+- 码
+- 和
+-  
+- b
+- u
+- g
+- "
+- ,
+-  
+- "
+- c
+- a
+- n
+- v
+- a
+- s
+-  
+- 文
+- 档
+- 返
+- 回
+- 特
+- 定
+- 提
+- 示
+- 而
+- 非
+- 报
+- 错
+- ，
+- 保
+- 持
+- 命
+- 令
+- 稳
+- 定
+- 性
+- "
+- ,
+-  
+- "
+- 导
+- 航
+- 使
+- 用
+-  
+- s
+- e
+- t
+- T
+- i
+- m
+- e
+- o
+- u
+- t
+-  
+- 推
+- 迟
+-  
+- 5
+- 0
+- m
+- s
+- ，
+- 避
+- 免
+-  
+- c
+- o
+- n
+- t
+- e
+- x
+- t
+-  
+- 在
+- 返
+- 回
+- 前
+- 被
+- 销
+- 毁
+- "
+- ,
+-  
+- "
+- i
+- f
+- r
+- a
+- m
+- e
+-  
+- 导
+- 航
+- 使
+- 用
+-  
+- p
+- a
+- r
+- e
+- n
+- t
+-  
+- f
+- r
+- a
+- m
+- e
+-  
+- 的
+-  
+- i
+- f
+- r
+- a
+- m
+- e
+- .
+- s
+- r
+- c
+-  
+- 设
+- 置
+- ，
+- 绕
+- 过
+- 跨
+- 域
+- 限
+- 制
+- "
+- ]
+
+**Pending**:
+- [
+- "
+- S
+- y
+- n
+- t
+- a
+- x
+- E
+- r
+- r
+- o
+- r
+- :
+-  
+- U
+- n
+- e
+- x
+- p
+- e
+- c
+- t
+- e
+- d
+-  
+- t
+- o
+- k
+- e
+- n
+-  
+- '
+- )
+- '
+-  
+- 的
+- 来
+- 源
+- 待
+- 查
+- （
+- 每
+- 次
+- 命
+- 令
+- 末
+- 尾
+- 出
+- 现
+- ，
+- 可
+- 能
+- 是
+-  
+- o
+- p
+- e
+- n
+- c
+- l
+- i
+-  
+- 某
+- 处
+- 代
+- 码
+- 问
+- 题
+- ）
+- "
+- ,
+-  
+- "
+- C
+- a
+- n
+- v
+- a
+- s
+-  
+- 表
+- 格
+- 内
+- 容
+- 读
+- 取
+-  
+- —
+-  
+- 考
+- 虑
+- 通
+- 过
+-  
+- S
+- h
+- e
+- e
+- t
+- s
+-  
+- A
+- P
+- I
+-  
+- 或
+- 其
+- 他
+- 方
+- 式
+- 支
+- 持
+- "
+- ,
+-  
+- "
+- d
+- o
+- c
+- s
+-  
+- -
+- -
+- a
+- c
+- t
+- i
+- o
+- n
+-  
+- r
+- e
+- a
+- d
+-  
+- 调
+- 用
+- 两
+- 次
+- 时
+- 的
+-  
+- c
+- o
+- n
+- t
+- e
+- x
+- t
+-  
+- 失
+- 效
+- 问
+- 题
+- 需
+- 要
+- 加
+- 健
+- 壮
+- 性
+- （
+- w
+- a
+- i
+- t
+- F
+- o
+- r
+- D
+- o
+- c
+- s
+- L
+- o
+- a
+- d
+-  
+- 应
+-  
+- c
+- a
+- t
+- c
+- h
+-  
+- 错
+- 误
+- ）
+- "
+- ]
+
+
+### 07:15 — Session Record
+
+**Summary**: 清理积压 PR/Issues，发布 v0.2.1，更新 CONTRIBUTING.md 和 AGENTS.md
+
+**Outcomes**:
+- [
+- "
+- 合
+- 并
+-  
+- P
+- R
+-  
+- #
+- 1
+- 9
+- （
+- v
+- i
+- t
+- e
+- s
+- t
+-  
+- 单
+- 测
+- ）
+- 和
+-  
+- P
+- R
+-  
+- #
+- 2
+- 1
+- （
+- C
+- I
+-  
+- 修
+- 复
+- ）
+- "
+- ,
+- "
+- 关
+- 闭
+-  
+- I
+- s
+- s
+- u
+- e
+-  
+- #
+- 1
+-  
+- #
+- 2
+-  
+- #
+- 3
+-  
+- #
+- 1
+- 3
+-  
+- #
+- 1
+- 4
+-  
+- #
+- 1
+- 5
+-  
+- #
+- 1
+- 6
+- （
+- 全
+- 部
+- 清
+- 零
+- ）
+- "
+- ,
+- "
+- 发
+- 布
+-  
+- v
+- 0
+- .
+- 2
+- .
+- 1
+- ：
+- 包
+- 含
+- 单
+- 测
+- 套
+- 件
+-  
+- +
+-  
+- C
+- I
+-  
+- 修
+- 复
+- "
+- ,
+- "
+- 更
+- 新
+-  
+- H
+- o
+- m
+- e
+- b
+- r
+- e
+- w
+-  
+- F
+- o
+- r
+- m
+- u
+- l
+- a
+-  
+- s
+- h
+- a
+- 2
+- 5
+- 6
+-  
+- 为
+-  
+- v
+- 0
+- .
+- 2
+- .
+- 1
+-  
+- 实
+- 际
+- 值
+- "
+- ,
+- "
+- 更
+- 新
+-  
+- C
+- O
+- N
+- T
+- R
+- I
+- B
+- U
+- T
+- I
+- N
+- G
+- .
+- m
+- d
+- ：
+- G
+- i
+- t
+- H
+- u
+- b
+-  
+- F
+- l
+- o
+- w
+-  
+- 规
+- 范
+- 、
+- 发
+- 布
+- 流
+- 程
+- 、
+- 常
+- 见
+- 陷
+- 阱
+- "
+- ,
+- "
+- 更
+- 新
+-  
+- A
+- G
+- E
+- N
+- T
+- S
+- .
+- m
+- d
+- ：
+- 同
+- 步
+-  
+- G
+- i
+- t
+-  
+- F
+- l
+- o
+- w
+-  
+- 规
+- 范
+- "
+- ]
+
+**Decisions**:
+- [
+- "
+- 使
+- 用
+-  
+- G
+- i
+- t
+- H
+- u
+- b
+-  
+- F
+- l
+- o
+- w
+- （
+- 单
+-  
+- m
+- a
+- i
+- n
+-  
+- 分
+- 支
+- ）
+- 替
+- 代
+-  
+- G
+- i
+- t
+-  
+- F
+- l
+- o
+- w
+- ，
+- 适
+- 合
+- 单
+- 人
+- /
+- A
+- I
+- -
+- a
+- g
+- e
+- n
+- t
+-  
+- 协
+- 作
+- 项
+- 目
+- "
+- ,
+- "
+- b
+- r
+- a
+- n
+- c
+- h
+-  
+- p
+- r
+- o
+- t
+- e
+- c
+- t
+- i
+- o
+- n
+-  
+- 去
+- 掉
+-  
+- r
+- e
+- q
+- u
+- i
+- r
+- e
+- d
+-  
+- r
+- e
+- v
+- i
+- e
+- w
+- s
+- （
+- G
+- i
+- t
+- H
+- u
+- b
+-  
+- 不
+- 允
+- 许
+- 自
+- 审
+- ）
+- ，
+- 只
+- 保
+- 留
+-  
+- C
+- I
+-  
+- r
+- e
+- q
+- u
+- i
+- r
+- e
+- d
+- "
+- ,
+- "
+- 所
+- 有
+-  
+- w
+- o
+- r
+- k
+- f
+- l
+- o
+- w
+-  
+- 用
+-  
+- n
+- p
+- m
+-  
+- i
+- n
+- s
+- t
+- a
+- l
+- l
+-  
+- 替
+- 换
+-  
+- n
+- p
+- m
+-  
+- c
+- i
+- ，
+- 避
+- 免
+-  
+- l
+- o
+- c
+- k
+-  
+- f
+- i
+- l
+- e
+-  
+- 不
+- 同
+- 步
+- 问
+- 题
+- "
+- ,
+- "
+- H
+- o
+- m
+- e
+- b
+- r
+- e
+- w
+-  
+- f
+- o
+- r
+- m
+- u
+- l
+- a
+-  
+- s
+- h
+- a
+- 2
+- 5
+- 6
+-  
+- 必
+- 须
+- 在
+- 每
+- 次
+-  
+- r
+- e
+- l
+- e
+- a
+- s
+- e
+-  
+- 后
+- 立
+- 即
+- 更
+- 新
+- ，
+- 不
+- 留
+-  
+- p
+- l
+- a
+- c
+- e
+- h
+- o
+- l
+- d
+- e
+- r
+- "
+- ]
+
+**Pending**:
+- [
+- "
+- H
+- o
+- m
+- e
+- b
+- r
+- e
+- w
+-  
+- t
+- a
+- p
+-  
+- 是
+- 否
+- 需
+- 要
+- 独
+- 立
+- 仓
+- 库
+- 发
+- 布
+- （
+- 目
+- 前
+- 在
+- 主
+-  
+- r
+- e
+- p
+- o
+-  
+- 内
+- ）
+- "
+- ,
+- "
+- N
+- o
+- d
+- e
+- .
+- j
+- s
+-  
+- 2
+- 0
+-  
+- a
+- c
+- t
+- i
+- o
+- n
+- s
+-  
+- d
+- e
+- p
+- r
+- e
+- c
+- a
+- t
+- i
+- o
+- n
+-  
+- 警
+- 告
+- （
+- 2
+- 0
+- 2
+- 6
+- -
+- 0
+- 6
+- -
+- 0
+- 2
+-  
+- 前
+- 需
+- 升
+- 级
+- 到
+-  
+- N
+- o
+- d
+- e
+-  
+- 2
+- 4
+- ）
+- "
+- ]
+
+
+### 07:34 — Session Record
+
+**Summary**: Fixed docs --action read for Sheets/canvas documents and resolved opencli 360teams registration issue. Root cause of registration failure: local node_modules/@jackwener/opencli in ~/.opencli/clis/360teams/ created a split registry singleton — user CLI files registered into the local copy while opencli binary used the global one. Fix: symlinked global install into local node_modules. Also fixed waitForDocsLoad context invalidation crash, and moved non-CLI test files (check-event.mjs, check-event-test.js) to scripts/ subdirectory to prevent opencli from trying to load them. All 12 360teams commands now load cleanly. Sheets document read via Shimo API returns correct cell values.
+
+**Outcomes**:
+- opencli 360teams commands now register correctly from any working directory
+- docs --action read works for Sheets documents via Shimo API (/api/files/{id}/content)
+- docs --action read returns 20 cell values from '人行查询原因字段排查' Sheets doc
+- No more SyntaxError warning on stderr — test files moved out of CLI discovery path
+- waitForDocsLoad no longer crashes on context invalidation
+
+**Decisions**:
+- Use symlink ~/.opencli/clis/360teams/node_modules/@jackwener/opencli -> global install to ensure single registry instance
+- Move non-CLI utility scripts to scripts/ subdirectory to prevent opencli discovery from loading them
+- waitForDocsLoad wraps evaluate in try/catch to survive Shimo SPA internal navigation context invalidation
+
+**Pending**:
+- Document the @jackwener/opencli symlink pattern in DEVELOPMENT.md as a known pitfall for opencli adapter development
+- Consider adding npm postinstall hook to auto-symlink global opencli when running npm install in ~/.opencli/clis/360teams/
+
+
+### 23:34 — Session Record
+
+**Summary**: Re-read the AgenticOS Development project docs and historical conversations to clarify the product's actual role. Confirmed with the user that this project is the standards and product-definition project for AgenticOS itself, not just another downstream project. Recorded a durable design review covering the intended product outcome, the downstream inheritance model, and five structural design problems that should drive future optimization.
+
+**Outcomes**:
+- Created `knowledge/product-positioning-and-design-review-2026-03-22.md`
+- Reframed `.context/quick-start.md` around the standards-project role instead of unrelated downstream execution details
+- Updated `.context/state.yaml` to reflect the current product-design task and near-term pending work
+- Preserved the user's clarified goals: durable human-agent context, sustainable evolution, and cross-agent collaboration
+
+**Decisions**:
+- Treat `agentic-os-development` as the canonical standards project whose norms should shape important downstream projects
+- Future design work should make `Agent First` and `Agent Friendly` executable through explicit rules, schemas, or pseudocode-level contracts
+- The next optimization phase should focus on tightening the product contract rather than adding more features first
+
+**Pending**:
+- Convert the five structural design problems into concrete issue candidates
+- Define executable rules for Agent First and Agent Friendly
+- Define canonical contracts for project boundaries, memory layers, and sub-agent context inheritance
+- Define how Issue-first and GitHub Actions based evolution should be standardized for AgenticOS projects
+
+
+### 23:48 — Session Record
+
+**Summary**: Investigated why switching to the AgenticOS project did not work naturally in Codex. Found that Codex had no user-level `agenticos` MCP entry before this session. Also confirmed the user was right that Claude Code had prior successful AgenticOS MCP tool usage, but the explicit configuration source was not easy to locate, which is itself an operability problem. Added explicit user-level MCP configuration for Codex and Claude, and recorded cross-agent bootstrap consistency plus CLI+Skills fallback as product-level design questions.
+
+**Outcomes**:
+- Installed `agenticos-mcp` globally and verified the binary is available
+- Added a global Codex MCP server entry for `agenticos`
+- Added an explicit user-level Claude MCP config file for `agenticos`
+- Updated product design notes to include the cross-agent bootstrap gap and MCP vs CLI+Skills fallback question
+
+**Decisions**:
+- Treat cross-agent bootstrap consistency as a first-class product requirement
+- Separate the problems of tool transport, intent recognition, and configuration visibility instead of treating them as one issue
+- Keep MCP as the primary integration mode for now, but evaluate CLI+Skills as a formal fallback/compatibility mode
+
+**Pending**:
+- Verify the new Codex and Claude MCP entries after the respective tools restart
+- Turn the bootstrap gap, config-source opacity, and fallback-mode questions into concrete issue candidates
+- Define a per-agent bootstrap standard and verification checklist
+
+
+### 23:58 — Session Record
+
+**Summary**: Extended the diagnosis to Homebrew distribution. Confirmed that Homebrew installation currently delivers the `agenticos-mcp` binary, but does not yet complete the per-agent MCP/bootstrap path for Claude Code, Codex, Gemini CLI, and other supported agents. Updated product notes and install documentation so the limitation is explicit and so each supported agent has a documented bootstrap path.
+
+**Outcomes**:
+- Updated the main README with explicit Homebrew limitation notes and per-agent MCP bootstrap steps
+- Updated the Homebrew tap README and Formula caveats to mention Claude Code, Codex, and Gemini CLI setup after install
+- Updated the MCP server README installation protocol to distinguish binary installation from agent bootstrap
+- Recorded Homebrew bootstrap as a product-level gap in the AgenticOS standards project
+
+**Decisions**:
+- Treat Homebrew post-install behavior as part of the AgenticOS product contract, not only package distribution
+- If Homebrew cannot safely auto-edit agent configs yet, the post-install output and docs must state the remaining manual steps clearly
+- The long-term goal should be safe per-agent bootstrap, verification, and reminder behavior after install
+
+**Pending**:
+- Define whether Homebrew should auto-configure supported agents or run in reminder-only mode
+- Turn the Homebrew bootstrap gap into a concrete issue candidate
+- Add a verification checklist for Claude Code, Codex, Gemini CLI, and other supported agents after install
+
+
+### 00:06 — Session Record
+
+**Summary**: Converted the current design findings into a first batch of issue drafts under `tasks/issue-drafts/`. The batch covers the main product-contract, isolation, memory, bootstrap, Homebrew, and integration-strategy gaps so they can be published and worked through one by one.
+
+**Outcomes**:
+- Created `tasks/issue-drafts/README.md` with a recommended execution order
+- Added issue drafts for boundary enforcement, memory-layer contracts, executable agent protocol, sub-agent context inheritance, cross-agent bootstrap, Homebrew bootstrap, MCP vs CLI+Skills, and issue-first GitHub Actions workflow
+- Updated project quick-start and state to point future sessions at the issue-draft batch
+
+**Decisions**:
+- Use `tasks/issue-drafts/` as the staging area before publishing formal GitHub Issues
+- Prioritize core product contracts before integration and workflow expansion
+- Start with boundary enforcement and memory-layer contracts, then move outward to bootstrap and tooling
+
+**Pending**:
+- Review the issue drafts with the user
+- Publish the highest-priority drafts as GitHub Issues
+- Refine the first issue before implementation starts
+
+
+### 00:12 — Session Record
+
+**Summary**: Refined the first issue draft, `01-fix-project-boundary-enforcement.md`, into a publish-ready version. Added explicit implementation scope, trust-boundary analysis, non-goals, verification plan, and stronger acceptance criteria based on the current MCP server write path.
+
+**Outcomes**:
+- Clarified that the current risk sits around `registry.active_project` as the primary trust anchor for writes
+- Added concrete implementation scope covering `project.ts`, `record.ts`, `context.ts`, and registry helpers
+- Added fail-closed behavior and write-time identity validation as the intended direction
+- Updated project state to point at issue 01 as the active refinement target
+
+**Decisions**:
+- Refine issue drafts one by one before publishing them
+- Use issue 01 to establish the product contract for boundary safety before tackling higher-level memory or protocol work
+- Ground issue drafts in current implementation details, not just abstract product concerns
+
+**Pending**:
+- Review the refined issue 01 with the user
+- Publish issue 01 when the wording is accepted
+- Move next to issue 02: memory-layer contracts
+
+
+### 00:14 — Session Record
+
+**Summary**: Refined the second issue draft, `02-define-memory-layer-contracts.md`, into a publish-ready version. Connected it to the current implementation in `record.ts` and `distill.ts`, clarified source-of-truth vs derived layers, and added concrete contract dimensions such as mutability, append-only behavior, and forbidden content per layer.
+
+**Outcomes**:
+- Expanded issue 02 from a conceptual draft into a concrete specification task
+- Added a proposed first-pass contract for `.project.yaml`, `quick-start.md`, `state.yaml`, `conversations/`, `knowledge/`, `tasks/`, and `artifacts/`
+- Added implementation scope, non-goals, verification plan, and stronger acceptance criteria
+- Updated project state to point at issue 02 as the active refinement target
+
+**Decisions**:
+- Use issue 02 to define the memory model that later protocol and validation work will build on
+- Distinguish canonical memory layers from derived views explicitly
+- Keep this issue focused on contracts first, not full automation in the first pass
+
+**Pending**:
+- Review the refined issue 02 with the user
+- Publish issues 01 and 02 when wording is accepted
+- Move next to issue 03: executable agent protocol
+
+
+### 00:18 — Session Record
+
+**Summary**: User flagged a protocol violation: changes were made directly in the active workspace rather than via a dedicated issue branch/worktree. Confirmed that the root repository standard already documents Issue-First and isolated worktrees, but the behavior was not enforced in practice. Recorded this as a separate issue draft focused on agent workflow compliance and worktree/branch enforcement.
+
+**Outcomes**:
+- Created `tasks/issue-drafts/09-enforce-agent-worktree-branch-compliance.md`
+- Updated the issue-draft index to include the new workflow-compliance item
+- Clarified that this is not only a Git workflow concern, but an agent-control concern
+
+**Decisions**:
+- Treat workflow-compliance failures by agents as evidence that the standard is not yet operationally enforceable
+- Separate the generic workflow standard from the agent-execution enforcement layer
+- Keep the new issue focused on preflight gating, branch/worktree rules, and enforcement behavior
+
+**Pending**:
+- Review the new issue 09 draft with the user
+- Decide how strongly docs-only work should be exempted from branch/worktree requirements
+- Continue refining remaining issue drafts

--- a/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/.context/conversations/2026-03-23.md
+++ b/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/.context/conversations/2026-03-23.md
@@ -1,0 +1,760 @@
+# Session Record - 2026-03-23
+
+## Summary
+
+This session continued the standards work around AgenticOS workflow and agent behavior.
+The main outcome was to move from abstract workflow principles into a more executable protocol layer.
+
+## Key Outcomes
+
+- clarified that AgenticOS should keep **GitHub Flow** as the branch lifecycle model
+- clarified that `git worktree` is a workspace-isolation mechanism, not the branching model itself
+- defined the operating direction as:
+  `Issue -> branch -> isolated worktree -> implementation -> verification -> PR -> merge -> automation`
+- created a first concrete draft of an **Agent Preflight and Execution Protocol**
+- defined task classification categories:
+  - `discussion_only`
+  - `analysis_or_doc`
+  - `implementation`
+  - `bootstrap`
+- tied branch/worktree enforcement to task classification instead of treating it as a detached git rule
+- required multi-pass design/critique loops for non-trivial work before implementation
+- required executable acceptance criteria before implementation
+- clarified differentiated verification:
+  - code work -> tests/build/lint/typecheck/changed-scope coverage target
+  - non-code work -> rubric-based evaluation with explicit evidence
+
+## New Files
+
+- `knowledge/workflow-model-review-2026-03-23.md`
+- `knowledge/agent-execution-loop-2026-03-23.md`
+- `knowledge/agent-preflight-and-execution-protocol-2026-03-23.md`
+- `tasks/templates/agent-preflight-checklist.yaml`
+- `tasks/templates/issue-design-brief.md`
+- `tasks/templates/non-code-evaluation-rubric.yaml`
+- `tasks/templates/submission-evidence.md`
+
+## Updated Files
+
+- `tasks/issue-drafts/03-define-executable-agent-protocol.md`
+- `tasks/issue-drafts/08-standardize-issue-first-github-actions-workflow.md`
+- `tasks/issue-drafts/09-enforce-agent-worktree-branch-compliance.md`
+- `AGENTS.md`
+- `CLAUDE.md`
+- `.context/quick-start.md`
+- `.context/state.yaml`
+
+## GitHub Sync
+
+Updated GitHub issues:
+- #27 `feat: define executable agent protocol for Agent First and Agent Friendly`
+- #32 `feat: standardize issue-first and GitHub Actions based evolution workflow`
+- #33 `feat: enforce agent compliance with issue-first branch and worktree workflow`
+
+## Current Position
+
+The project now has:
+- product positioning
+- workflow model judgment
+- initial executable protocol drafts
+- reusable templates for downstream adoption
+
+The next phase should shift from "define the protocol" to "package and enforce the protocol":
+- convert the protocol into a standard package or canonical template set
+- define how downstream projects inherit it
+- define how helper commands or automation enforce it
+
+## Follow-up Expansion
+
+The session then pushed the next phase one step further:
+
+- defined a downstream standard package direction in `knowledge/downstream-standard-package-plan-2026-03-23.md`
+- created three new issue drafts for:
+  - downstream standard kit packaging
+  - runtime preflight guardrail and worktree helper
+  - baseline bootstrap protocol for newborn repos
+
+This keeps the protocol-definition phase separate from the future implementation/enforcement phase.
+
+Published GitHub issues:
+- #34 `feat: define baseline bootstrap protocol for new AgenticOS project repositories`
+- #35 `feat: package executable agent protocol as a downstream standard kit`
+- #36 `feat: build agent preflight guardrail and worktree bootstrap helper`
+
+## Bootstrap Protocol Refinement
+
+The next step focused on issue #34.
+
+Key refinement:
+- a repository with `No commits yet on main` must be explicitly classified as `bootstrap`
+- bootstrap is a narrow baseline-establishing state, not a general workflow exemption
+- bootstrap allows only baseline files and the first baseline commit
+- after bootstrap exit, normal issue-first branch/worktree rules apply immediately
+
+New document:
+- `knowledge/baseline-bootstrap-protocol-2026-03-23.md`
+
+## Repository Layering Review
+
+The session then revisited the larger portability question at the top-level `AgenticOS` repository.
+
+Main conclusion:
+- the current root repository mixes standards, implementation, workspace projects, and runtime artifacts
+
+Classification judgment:
+- `mcp-server/`, `homebrew-tap/`, `.meta/`, `.github/`, `tools/` -> product implementation/source
+- `projects/agentic-os-development/` -> standards/meta-project content
+- ordinary `projects/*` -> workspace project content
+- `.claude/worktrees/` -> runtime/ephemeral artifacts
+- `.agent-workspace/registry.yaml` -> workspace metadata
+
+New document:
+- `knowledge/repository-layering-and-portability-plan-2026-03-23.md`
+
+Published GitHub issue:
+- #37 `feat: separate product source, workspace, and runtime layers`
+
+Immediate operational rule added:
+- AgenticOS source repo and live `AGENTICOS_HOME` workspace should be separate
+- runtime artifacts like `.claude/worktrees/` should be excluded from product source control where possible
+
+## Workspace Migration Plan
+
+The session then moved from layering analysis into migration planning.
+
+Main conclusion:
+- ordinary tracked projects under `projects/` should be treated as runtime workspace projects by default
+- `projects/agentic-os-development` remains the standards/meta project
+- the remaining tracked runtime projects should be extracted from the product source repo over time
+
+New document:
+- `knowledge/workspace-migration-plan-2026-03-23.md`
+
+Published GitHub issue:
+- #38 `feat: extract runtime workspace projects from the product source repository`
+
+## Self-Hosting Model Evaluation
+
+The session then evaluated a stronger alternative:
+- make the current top-level `AgenticOS` directory the runtime workspace
+- move the AgenticOS product source itself into `projects/` as a managed project
+
+Main conclusion:
+- this model is conceptually coherent and cleaner in the long term
+- but it is a structural migration, not a small cleanup
+
+New document:
+- `knowledge/self-hosting-workspace-model-2026-03-23.md`
+
+Published GitHub issue:
+- #39 `feat: evaluate self-hosting workspace model for the AgenticOS product`
+
+## Self-Hosting Migration Plan
+
+The session then advanced from evaluation into migration planning.
+
+Main conclusion:
+- if self-hosting is chosen, the migration must be phased
+- standards relocation, product source relocation, runtime relocation, and path rewrites should not be mixed into one blind move
+
+New document:
+- `knowledge/self-hosting-migration-plan-2026-03-23.md`
+
+Published GitHub issue:
+- #40 `feat: plan the self-hosting migration sequence for AgenticOS`
+
+## Migration Resolution Draft
+
+The session then clarified one important migration constraint:
+- existing runtime projects should remain largely unaffected
+- the main migration target is the AgenticOS host product itself
+
+New document:
+- `knowledge/self-hosting-migration-resolution-draft-2026-03-23.md`
+
+## Formal Resolution v1
+
+The session then froze the target self-hosting model into a formal v1 resolution.
+
+Frozen target points:
+- top-level `AgenticOS` directory becomes workspace home
+- canonical managed product project path becomes `projects/agenticos`
+- standards move under `projects/agenticos/standards/`
+- runtime-only artifacts move under `.runtime/`
+
+New document:
+- `knowledge/self-hosting-migration-resolution-v1-2026-03-23.md`
+
+## Phase 2 Relocation Checklist
+
+The session then entered Phase 2 planning.
+
+Main output:
+- a concrete relocation checklist for root product-source paths
+- a concrete relocation checklist for standards paths
+- an initial reference rewrite inventory for docs, packaging, and workflow paths
+
+New document:
+- `knowledge/phase2-path-relocation-checklist-2026-03-23.md`
+
+## Phase 3 Execution Sequence
+
+The session then converted the migration plan into a verification-first execution sequence.
+
+Main rule:
+- every step must define preconditions, immediate verification, and a local rollback boundary
+
+New document:
+- `knowledge/phase3-execution-sequence-2026-03-23.md`
+
+## Command-Level Playbook
+
+The session then lowered the migration plan to a command-level playbook.
+
+Important baseline finding:
+- `mcp-server` still builds from the current root
+- but the top-level product repository worktree is not clean, so baseline isolation must happen before real structural moves
+
+New document:
+- `knowledge/command-level-migration-playbook-v1-2026-03-23.md`
+
+## Baseline Isolation Plan
+
+The session then split out one final execution prerequisite:
+- the current root worktree is not clean enough for direct migration execution
+
+Main conclusion:
+- migration execution must happen in a fresh dedicated worktree after the current dirty state is preserved
+
+New document:
+- `knowledge/baseline-isolation-plan-2026-03-23.md`
+
+Published GitHub issue:
+- #41 `feat: define baseline isolation procedure before self-hosting migration`
+
+## Operator Checklist v1
+
+The session then turned the isolation plan into an operator-ready checklist.
+
+Frozen operator inputs:
+- base commit: `fc401332bea49fdecdc2f4e489e30545d5061043`
+- migration branch: `feat/self-hosting-migration`
+- external worktree: `/Users/jeking/worktrees/agenticos-self-hosting`
+
+New document:
+- `knowledge/operator-checklist-v1-2026-03-23.md`
+
+## Baseline Isolation Execution
+
+The session then began the first real execution of baseline isolation using the frozen operator inputs.
+
+Executed operator inputs:
+- base commit: `fc401332bea49fdecdc2f4e489e30545d5061043`
+- migration branch: `feat/self-hosting-migration`
+- external worktree: `/Users/jeking/worktrees/agenticos-self-hosting`
+
+Execution outcomes:
+- exported dirty-state preservation artifacts to `/Users/jeking/worktrees/agenticos-self-hosting-baseline/2026-03-23`
+- created external worktree `/Users/jeking/worktrees/agenticos-self-hosting`
+- verified the new worktree was clean on branch `feat/self-hosting-migration`
+- verified the new worktree HEAD was `fc401332bea49fdecdc2f4e489e30545d5061043`
+- stopped migration when `npm ci` failed in `mcp-server` because `package.json` and `package-lock.json` are not in sync
+
+New document:
+- `knowledge/baseline-isolation-execution-report-2026-03-23.md`
+
+Published GitHub issue:
+- #43 `fix: restore reproducible mcp-server clean install baseline before self-hosting migration`
+
+## #43 Clean-Baseline Repair
+
+The session then fixed the newly discovered reproducibility blocker as a separate issue-first change instead of mixing it into migration work.
+
+Repair actions:
+- confirmed the drift was limited to `mcp-server/package-lock.json`
+- switched the external worktree onto a dedicated branch:
+  - `fix/43-mcp-server-clean-install-baseline`
+- synchronized the lockfile
+- committed the repair as:
+  - `4aada96 fix(mcp-server): restore clean install lockfile baseline (#43)`
+
+Validation results:
+- `npm ci` passed
+- `npm run build` passed
+- `npm test` passed
+
+Main conclusion:
+- the clean-baseline blocker is resolved locally
+- self-hosting migration still remains paused until the `#43` fix is landed and the migration baseline is recreated
+
+## PR Creation for #43
+
+The session then pushed the dedicated repair branch and opened a pull request.
+
+Published PR:
+- #44 `fix(mcp-server): restore clean install lockfile baseline (#43)`
+
+Result:
+- the `#43` fix is now in normal review/merge flow
+- self-hosting migration still remains paused until PR #44 lands
+
+## Replacement PR for #43
+
+The session then discovered that PR #44 had been cut from a local branch ahead of `origin/main`, so it accidentally included unrelated commits.
+
+Correction:
+- closed PR #44
+- created replacement PR #45 directly from `origin/main`
+- merged PR #45 to restore the clean-install baseline properly
+
+## Self-Hosting Migration Execution
+
+With the clean baseline restored, the session then executed the self-hosting migration on a fresh clean worktree.
+
+Main execution outcomes:
+- moved standards content to `projects/agenticos/standards/`
+- moved product source to `projects/agenticos/`
+- moved agent command assets to `projects/agenticos/.claude/commands/`
+- kept `.github/` at repository root after verifying GitHub Actions workflow discovery is root-scoped
+- verified the relocated product from `projects/agenticos/mcp-server` with install, build, and test
+
+Published PR:
+- #46 `refactor(repo): self-host AgenticOS under projects/agenticos (#40)`
+
+Final result:
+- PR #46 merged
+- issue #40 closed
+
+New document:
+- `knowledge/self-hosting-migration-execution-report-2026-03-23.md`
+
+## Post Self-Hosting Follow-Up
+
+After the host-product migration landed, the session then shifted from migration execution to follow-up prioritization.
+
+Main conclusions:
+- self-hosting is no longer a speculative target; it is now the operational baseline
+- the next highest-value work is guardrails, downstream standards packaging, and runtime project extraction
+- execution exposed concrete guardrail requirements around wrong-base branches and root-scoped infrastructure exceptions
+- the downstream standards kit must now be defined from the landed path `projects/agenticos/standards/`
+
+New document:
+- `knowledge/post-self-hosting-follow-up-plan-2026-03-23.md`
+
+Updated GitHub issues:
+- #35 downstream standards kit
+- #36 preflight guardrails and helper command
+- #37 product/workspace/runtime layering
+- #38 runtime project extraction
+
+## Guardrail v1 Tightening
+
+The session then focused on `#36` and converted the guardrail direction into a more executable model.
+
+Main outcomes:
+- defined a four-layer guardrail model:
+  - task gate
+  - repository gate
+  - scope gate
+  - reproducibility gate
+- made remote-base ancestry against `origin/main` an explicit machine-checkable requirement
+- made PR diff-scope checks a first-class guardrail concern
+- made root-scoped infrastructure exceptions such as `.github/` part of the guardrail contract
+- expanded the preflight checklist template to include these fields
+
+New document:
+- `knowledge/agent-guardrail-design-v1-2026-03-23.md`
+
+Updated template:
+- `tasks/templates/agent-preflight-checklist.yaml`
+
+Updated GitHub issue:
+- #36 preflight guardrails and helper command
+
+## Guardrail Command Contracts
+
+The session then pushed `#36` one step further from design into explicit command contracts.
+
+Main outcomes:
+- defined command I/O contracts for:
+  - `agenticos_preflight`
+  - `agenticos_branch_bootstrap`
+  - `agenticos_pr_scope_check`
+- fixed `PASS` / `BLOCK` / `REDIRECT` semantics for guardrail outcomes
+- separated checker responsibilities from mutating helper responsibilities
+
+New document:
+- `knowledge/agent-guardrail-command-contracts-v1-2026-03-23.md`
+
+Updated GitHub issue:
+- #36 preflight guardrails and helper command
+
+## First Executable Guardrail Slice Landed
+
+The session then moved from standards design into implementation and merged the first real guardrail command.
+
+Main outcomes:
+- implemented `agenticos_preflight` in `projects/agenticos/mcp-server`
+- standardized machine-readable guardrail outcomes:
+  - `PASS`
+  - `BLOCK`
+  - `REDIRECT`
+- enforced checks for:
+  - repo identity
+  - implementation-work issue binding
+  - declared target scope
+  - worktree/main-workspace redirection
+  - remote-base ancestry
+  - structural-move exceptions such as `.github/`
+  - reproducibility gate declaration
+- validated the slice in an isolated worktree with:
+  - `npm install`
+  - `npm run build`
+  - `npm test`
+- merged the change as PR #47
+
+New document:
+- `knowledge/guardrail-preflight-implementation-report-2026-03-23.md`
+
+Updated GitHub issue:
+- #36 preflight guardrails and helper command
+
+## Guardrail Command Trio Landed
+
+The session then continued from the first guardrail slice and finished the initial command trio for issue `#36`.
+
+Main outcomes:
+- implemented `agenticos_branch_bootstrap` and merged it as PR #48
+- implemented `agenticos_pr_scope_check` and merged it as PR #49
+- completed the first executable guardrail command trio:
+  - `agenticos_preflight`
+  - `agenticos_branch_bootstrap`
+  - `agenticos_pr_scope_check`
+- validated each slice in its own isolated worktree before PR creation
+- kept checker and mutating-helper responsibilities separate in implementation
+
+New document:
+- `knowledge/guardrail-command-trio-implementation-report-2026-03-23.md`
+
+Updated GitHub issue:
+- #36 preflight guardrails and helper command
+
+## Guardrail Flow Wiring Landed
+
+The session then completed the last planned v1 step for issue `#36` by wiring the guardrail commands into the product-facing execution flow.
+
+Main outcomes:
+- updated root `AGENTS.md` and `CLAUDE.md` to require the guardrail sequence for implementation work
+- updated `projects/agenticos/.claude/commands/develop.md` and `review.md` to reference `agenticos_preflight`, `agenticos_branch_bootstrap`, and `agenticos_pr_scope_check`
+- added reusable templates under `projects/agenticos/.meta/templates/`
+- upgraded `distill.ts` to template version `v3` so generated `AGENTS.md` and `CLAUDE.md` inherit the guardrail protocol
+- updated README files to document the expanded MCP toolset and the expected implementation flow
+- validated the change in an isolated worktree and merged it as PR #50
+- reached a completion point where `#36` can be treated as complete for guardrail v1
+
+New document:
+- `knowledge/guardrail-flow-wiring-report-2026-03-23.md`
+
+Updated GitHub issue:
+- #36 preflight guardrails and helper command
+
+## Downstream Standard Kit Landed
+
+The session then shifted to issue `#35` and implemented the first reusable downstream standard package.
+
+Main outcomes:
+- added `projects/agenticos/.meta/standard-kit/` in the main product repository
+- defined a versioned manifest for canonical generated files, copied templates, root-scoped exclusions, and upgrade rules
+- added inheritance rules and a downstream adoption checklist
+- marked older `.meta` guidance as legacy when it conflicts with the new standard kit
+- merged the package model as PR #51
+- reached a completion point where `#35` can be treated as complete for the initial packaging milestone
+
+New document:
+- `knowledge/downstream-standard-kit-implementation-report-2026-03-23.md`
+
+Updated GitHub issue:
+- #35 downstream standard kit
+
+## Runtime Project Extraction Planning Landed
+
+The session then moved to issue `#38` and landed the planning milestone for extracting tracked runtime projects from the product source repository.
+
+Main outcomes:
+- added a machine-readable classification manifest at `projects/agenticos/.meta/runtime-project-classification.yaml`
+- classified `projects/agenticos` as the only canonical host-product project under `projects/`
+- classified `2026okr`, `360teams`, `agentic-devops`, `ghostty-optimization`, `okr-management`, and `t5t` as runtime projects
+- classified `test-project` as a fixture/example candidate
+- added a concrete extraction and de-tracking plan in `projects/agenticos/standards/knowledge/runtime-project-extraction-plan-2026-03-23.md`
+- updated root docs to reflect that non-`agenticos` tracked `projects/*` entries are legacy runtime or fixture content pending extraction
+- merged the planning milestone as PR #52
+
+New document:
+- `knowledge/runtime-project-extraction-planning-report-2026-03-23.md`
+
+Updated GitHub issue:
+- #38 runtime project extraction
+
+## Runtime Extraction Execution Follow-Up
+
+The session then cleaned up the issue structure after the planning milestone.
+
+Main outcomes:
+- created a new execution issue:
+  - #53 actual runtime-project extraction from the product source repository
+- closed the broader layer-definition issue:
+  - #37 product source / workspace / runtime layer model
+- kept planning and execution as separate work items so later filesystem migration does not get mixed with architectural definition work
+
+New document:
+- `knowledge/runtime-project-extraction-execution-follow-up-2026-03-23.md`
+
+
+### 01:51 — Session Record
+
+**Summary**: 补全了 360Teams calendar create 的参与人选择和自动提交能力。成功创建了日程"讨论 Agentic DevOps 的技术方案"（2026-03-23 14:00-15:00），自动提交成功。参与人搜索（倪思勇）受网络延迟影响无法获取搜索结果，已在 calendar.js 的 sleep(2000) 处添加 TODO 注释，标记后续需改为 waitFor 轮询方式。
+
+**Outcomes**:
+- calendar.js create action 新增 --attendees 和 --submit 参数支持
+- 添加参与人流程完整实现：button.add-user-button → .selectPerson-wrapper → 搜索 → checkbox → 确定
+- 自动提交功能实现：dispatchMouseEvent 点击 drawer 内 确定/保存/提交 按钮
+- 成功创建日程 Status: Created
+- 在搜索 sleep(2000) 处添加 TODO 注释，说明需改为 waitFor 轮询
+
+**Decisions**:
+- attendee 搜索结果不显示判断为网络异步加载问题，当前 sleep(2000) 不足以等待，后续用 waitFor 替代
+- dispatchMouseEvent 是 Element UI 组件点击的唯一可靠方式
+- button.add-user-button 通过 querySelector 动态查找，比文字匹配或坐标硬编码更可靠
+
+**Pending**:
+- TODO: calendar.js 参与人搜索 sleep(2000) 改为 waitFor 轮询 input[type=checkbox] 出现（6000ms timeout），解决网络延迟导致搜索结果未加载问题
+
+## Runtime Extraction Wave 1
+
+The session then moved from extraction planning into the first real execution wave for issue `#53`.
+
+Main outcomes:
+- confirmed the live workspace root as `/Users/jeking/AgenticOS`
+- verified that `projects/2026okr` and `projects/360teams` had no existing destination collision under the live workspace
+- copied both projects into:
+  - `/Users/jeking/AgenticOS/projects/2026okr`
+  - `/Users/jeking/AgenticOS/projects/360teams`
+- verified both copied projects before any source-repo de-tracking:
+  - destination paths exist
+  - `.project.yaml` and `.context/state.yaml` parse successfully
+  - `2026okr` matched directly under tree comparison
+  - `360teams` matched under post-copy `rsync --dry-run --itemize-changes` and key-file SHA comparison
+- updated `/Users/jeking/AgenticOS/.agent-workspace/registry.yaml` so `2026okr` and `360teams` now point to the live workspace paths
+- created a dedicated source-repo execution commit in isolated worktree `/Users/jeking/worktrees/agenticos-runtime-extraction-53`
+  - branch: `feat/53-runtime-project-extraction`
+  - commit: `9638a99`
+  - message: `feat(meta): execute runtime extraction wave 1 (#53)`
+
+Deferred classes discovered during execution:
+- `agentic-devops` and `ghostty-optimization` are split-brain cases with existing external directories
+- `okr-management` and `t5t` are gitlink residues without valid `.gitmodules` mappings
+
+Publication blocker:
+- local commit is ready
+- `gh auth status` is healthy
+- but `git push` over HTTPS fails with `LibreSSL SSL_connect: SSL_ERROR_SYSCALL`
+- SSH push also fails because no GitHub public key is configured in this environment
+
+New document:
+- `knowledge/runtime-project-extraction-wave1-report-2026-03-23.md`
+
+## Runtime Extraction Publication Recovery
+
+After the local wave-1 execution commit was created, publication initially failed:
+- `git push` over HTTPS returned `LibreSSL SSL_connect: SSL_ERROR_SYSCALL`
+- SSH push also failed because no GitHub public key was configured in this environment
+
+The session then investigated the transport problem and identified the root cause:
+- Git had global `http.proxy` and `https.proxy` set to `http://127.0.0.1:7897`
+- plain `curl https://github.com` succeeded
+- `git -c http.proxy= -c https.proxy= ls-remote https://github.com/madlouse/AgenticOS.git HEAD` also succeeded immediately
+- this isolated the failure to Git's proxied HTTPS path rather than to GitHub availability
+
+Publication was then recovered without changing global Git config:
+- used a one-shot direct connection (`-c http.proxy= -c https.proxy=`)
+- used a temporary non-interactive askpass wrapper backed by `gh auth token`
+- pushed branch `feat/53-runtime-project-extraction`
+- opened PR `#54`
+
+GitHub issue updates:
+- issue `#53` now has a comment recording the local wave-1 execution
+- issue `#53` also has a follow-up comment recording the proxy root cause and PR link
+
+Final outcome of the publication step:
+- PR `#54` merged successfully
+- issue `#53` intentionally remained open because wave 1 only covered `2026okr` and `360teams`
+- the next extraction wave is still required for:
+  - split-brain projects: `agentic-devops`, `ghostty-optimization`
+  - gitlink residues: `okr-management`, `t5t`
+
+## Runtime Extraction Wave 2
+
+The session then executed the second runtime-extraction wave for the split-brain projects.
+
+Main outcomes:
+- created `/Users/jeking/AgenticOS/projects/agentic-devops` from:
+  - external project content at `/Users/jeking/agentic-devops`
+  - plus the source metadata shadow from `projects/agentic-devops`
+- created `/Users/jeking/AgenticOS/projects/ghostty-optimization` from:
+  - the external standalone repo at `/Users/jeking/dev/ghostty-optimization`
+  - plus the source-only shadow artifacts from `projects/ghostty-optimization`
+- updated `/Users/jeking/AgenticOS/.agent-workspace/registry.yaml` so both projects now point to the workspace paths
+- verified:
+  - both workspace copies parse for `.project.yaml` and `.context/state.yaml`
+  - the workspace `ghostty-optimization` copy remains a valid and clean Git worktree
+- opened and merged PR `#55`
+
+New document:
+- `knowledge/runtime-project-extraction-wave2-report-2026-03-23.md`
+
+## Gitlink Residue Investigation
+
+After wave 2, the session investigated the remaining paths:
+- `projects/okr-management`
+- `projects/t5t`
+
+Findings:
+- they are mode `160000` gitlink entries in `git ls-tree HEAD`
+- current checked-out directories are empty
+- `git submodule status --recursive` fails because there is no valid `.gitmodules` mapping
+- no canonical runtime root with actual content was found locally
+- direct `gh repo view` checks also did not find standalone repos `madlouse/okr-management` or `madlouse/t5t`
+
+Conclusion:
+- these are orphaned gitlink residues, not normal runtime-project directories
+- they should not be handled by the normal extraction flow
+
+GitHub follow-up:
+- created issue `#56` to repair the orphaned gitlink residues
+- left issue `#53` open, but with the remaining work now blocked on `#56`
+
+## Gitlink Residue Repair And Program Closure
+
+The session then executed the dedicated repair issue `#56`.
+
+Main outcomes:
+- created an isolated repair worktree and branch for `#56`
+- removed the orphaned gitlink residues:
+  - `projects/okr-management`
+  - `projects/t5t`
+- updated runtime classification so these paths are no longer treated as tracked runtime projects
+- cleaned the live workspace registry so it no longer contains broken entries for `okr-management` and `t5t`
+- opened and merged PR `#57`
+
+Final verification on a clean `origin/main` checkout:
+- `projects/` now contains only:
+  - `agenticos`
+  - `test-project`
+- `git submodule status --recursive` no longer fails
+
+Program closure:
+- issue `#56` closed
+- issue `#53` closed
+
+New document:
+- `knowledge/runtime-project-extraction-closure-report-2026-03-23.md`
+
+## Git Transport Fallback Documentation
+
+After the runtime-extraction program closed, the session codified the GitHub publication workaround that had previously only existed in execution notes.
+
+Main outcomes:
+- created issue `#58` to document the Git proxy and credential fallback
+- opened PR `#59`
+- landed safer repository guidance in:
+  - `README.md`
+  - `AGENTS.md`
+  - `CONTRIBUTING.md`
+- removed the old guidance that embedded GitHub tokens directly into remote URLs
+- replaced it with a canonical operator procedure based on:
+  - command-scoped `-c http.proxy= -c https.proxy=`
+  - a temporary `GIT_ASKPASS` helper
+
+Verification:
+- CI passed for PR `#59`
+- PR `#59` merged
+- issue `#58` closed
+
+## HTTP/1.1 Compatibility Follow-Up
+
+The PR-59 publication step exposed one remaining transport nuance:
+
+- direct `ls-remote` with no-proxy overrides worked
+- `git push` with only no-proxy + `GIT_ASKPASS` still failed once with `LibreSSL SSL_connect: SSL_ERROR_SYSCALL`
+- adding command-scoped `-c http.version=HTTP/1.1` allowed the push to succeed
+
+Conclusion:
+- the new documentation is materially better and now canonical
+- but it is still incomplete for this machine's exact Git transport behavior
+
+GitHub follow-up:
+- created issue `#60` to refine the transport fallback docs with the `HTTP/1.1` compatibility note
+
+New document:
+- `knowledge/git-transport-fallback-documentation-report-2026-03-23.md`
+
+## HTTP/1.1 Compatibility Refinement
+
+The session then completed the follow-up issue created at the end of the previous transport-documentation step.
+
+Main outcomes:
+- created a fresh docs worktree from `origin/main`
+- updated:
+  - `README.md`
+  - `AGENTS.md`
+  - `CONTRIBUTING.md`
+- refined the canonical operator procedure so it now explicitly says:
+  - first retry with command-scoped no-proxy + temporary `GIT_ASKPASS`
+  - if push still fails with `LibreSSL SSL_connect: SSL_ERROR_SYSCALL`, retry with command-scoped `-c http.version=HTTP/1.1`
+
+Verification:
+- pushed branch `docs/60-git-transport-http11` successfully with the documented `HTTP/1.1` compatibility override
+- CI passed for PR `#61`
+- PR `#61` merged
+- issue `#60` closed
+
+Conclusion:
+- the Git transport fallback is now documented at the level actually required by this machine's observed behavior
+
+New document:
+- `knowledge/git-transport-http11-refinement-report-2026-03-23.md`
+
+## Guardrail Evidence Persistence
+
+The session then implemented the next follow-up after guardrail v1 and transport fallback stabilization.
+
+Main outcomes:
+- created issue `#62`
+- implemented automatic persistence for:
+  - `agenticos_preflight`
+  - `agenticos_branch_bootstrap`
+  - `agenticos_pr_scope_check`
+- added a dedicated helper:
+  - `projects/agenticos/mcp-server/src/utils/guardrail-evidence.ts`
+- persisted evidence now lands in a bounded `guardrail_evidence` section inside project `.context/state.yaml`
+- the persistence path now resolves the target project by:
+  - registered AgenticOS project path first
+  - nearest on-disk `.project.yaml` plus `.context/state.yaml` root second
+
+Validation:
+- `npm install`
+- `npm run build`
+- targeted guardrail persistence tests passed
+- full test suite passed
+- final validation state: `60 passed | 3 skipped`
+
+GitHub result:
+- initial PR attempts `#63` and `#64` were closed during transport/retry handling and branch cleanup
+- final PR `#65` merged successfully
+- issue `#62` closed
+
+Conclusion:
+- guardrail execution is now durably visible to later sessions through normal state loading rather than only through terminal output or chat history
+
+New document:
+- `knowledge/guardrail-evidence-persistence-implementation-report-2026-03-23.md`

--- a/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/.context/quick-start.md
+++ b/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/.context/quick-start.md
@@ -1,0 +1,81 @@
+# AgenticOS Development - Quick Start
+
+## Project Overview
+AgenticOS Development is the standards and product-definition project for AgenticOS itself. Its purpose is to evolve the canonical project structure, context model, agent behavior rules, and collaboration workflow that future important projects should follow, so any compatible agent can switch into a project, recover context quickly, and continue the work safely.
+
+## Current Status
+- Status: Active
+- Product positioning has been clarified: this is the meta-project and standards project for the AgenticOS ecosystem
+- Core goals are stable: durable human-agent context, sustainable evolution, and cross-agent collaboration
+- A new design review has been recorded in `knowledge/product-positioning-and-design-review-2026-03-22.md`
+- A concrete preflight/execution protocol draft is now being developed for agents
+- Reusable protocol templates now exist in `tasks/templates/` for preflight, design briefs, evaluation, and submission evidence
+- A downstream standard-package direction has been defined for packaging these templates and protocols into inheritable assets
+- A bootstrap protocol is being defined for newborn repositories that do not yet have an initial commit
+- A repository-layering review is being developed to separate standards, implementation, workspace data, and runtime byproducts
+- The immediate practical rule is emerging: AgenticOS source repo and live AGENTICOS_HOME workspace should be separate
+- A workspace migration plan is being defined for already tracked runtime projects under `projects/`
+- A self-hosting migration plan is being defined in case the top-level AgenticOS directory becomes the workspace home
+- A resolution draft now favors self-hosting while keeping other runtime projects largely unaffected
+- A formal migration resolution v1 now freezes `projects/agenticos`, `projects/agenticos/standards/`, and `.runtime/` as the target model
+- A Phase 2 path relocation checklist is being prepared for concrete root-path and standards-path moves
+- A Phase 3 execution sequence is being prepared with verification-first checkpoints and rollback boundaries
+- A command-level migration playbook v1 is being prepared, including exact verification commands and stop conditions
+- A baseline isolation plan is being defined because the current root worktree is not clean enough for direct migration execution
+- An operator checklist v1 now proposes a concrete base commit, migration branch, and external worktree path
+- Baseline isolation was executed, the `#43` clean-install blocker was repaired, and the corrected replacement PR was merged as PR #45
+- The self-hosting migration has now been executed and merged as PR #46
+- The landed repository model now uses `projects/agenticos/` and `projects/agenticos/standards/`
+- Execution refined the model with one important exception: `.github/` must remain at repository root for GitHub Actions workflow discovery
+- `knowledge/self-hosting-migration-execution-report-2026-03-23.md` records the landed migration and the `.github` exception
+- `knowledge/post-self-hosting-follow-up-plan-2026-03-23.md` now captures the next priorities after self-hosting landed
+- The highest-value next work is now: guardrails, downstream standards packaging, and runtime project extraction
+- `knowledge/agent-guardrail-design-v1-2026-03-23.md` now defines a concrete guardrail model driven by real execution failures
+- `knowledge/agent-guardrail-command-contracts-v1-2026-03-23.md` now defines fixed I/O contracts for the first guardrail commands
+- `knowledge/guardrail-preflight-implementation-report-2026-03-23.md` records the first landed guardrail implementation slice
+- `knowledge/guardrail-command-trio-implementation-report-2026-03-23.md` records the landed implementation of the first three guardrail commands
+- `knowledge/guardrail-flow-wiring-report-2026-03-23.md` records the merge that wired the guardrail trio into the main execution flow
+- `knowledge/downstream-standard-kit-implementation-report-2026-03-23.md` records the landed downstream packaging artifact for reusable standards
+- `knowledge/runtime-project-extraction-planning-report-2026-03-23.md` records the landed runtime-project classification and extraction-planning milestone
+- `knowledge/runtime-project-extraction-execution-follow-up-2026-03-23.md` records the new execution issue that follows the planning milestone
+- `tasks/templates/agent-preflight-checklist.yaml` has been expanded to include remote-base ancestry, PR scope, and reproducibility gates
+- `agenticos_preflight` has now landed in the main product repository through PR #47
+- `agenticos_branch_bootstrap` has now landed in the main product repository through PR #48
+- `agenticos_pr_scope_check` has now landed in the main product repository through PR #49
+- the first guardrail command trio is now executable in MCP and wired into product-facing workflow entry points through PR #50
+- guardrail issue #36 is now functionally complete for v1
+- downstream standard kit issue #35 has now landed through PR #51
+- `projects/agenticos/.meta/standard-kit/` is now the canonical downstream packaging surface for reusable workflow standards
+- runtime project extraction planning issue #38 has now landed through PR #52
+- `projects/agenticos/.meta/runtime-project-classification.yaml` is now the machine-readable classification source for tracked `projects/*`
+- layer-model issue #37 is now closed as a completed definition milestone
+- runtime-project extraction execution now has its own follow-up issue: #53
+- runtime extraction wave 1 for `2026okr` and `360teams` has now been executed locally and recorded in `knowledge/runtime-project-extraction-wave1-report-2026-03-23.md`
+- the live workspace registry now points `2026okr` and `360teams` to `/Users/jeking/AgenticOS/projects/*`
+- the source-repo extraction commit `9638a99` is now published on branch `feat/53-runtime-project-extraction`
+- PR `#54` has now been merged for runtime extraction wave 1
+- runtime extraction wave 2 for `agentic-devops` and `ghostty-optimization` has now been merged as PR `#55`
+- the live workspace registry now also points `agentic-devops` and `ghostty-optimization` to `/Users/jeking/AgenticOS/projects/*`
+- `knowledge/runtime-project-extraction-wave2-report-2026-03-23.md` records the split-brain extraction wave and the remaining blocker
+- issue `#53` is now closed
+- issue `#56` is now also closed after removing the orphaned gitlink residues `okr-management` and `t5t`
+- `knowledge/runtime-project-extraction-closure-report-2026-03-23.md` records the final completed state of the extraction program
+- the publication blocker was traced to Git's global HTTPS proxy path (`127.0.0.1:7897`) rather than to GitHub availability itself
+- issue `#58` has now landed and been merged as PR `#59`
+- `knowledge/git-transport-fallback-documentation-report-2026-03-23.md` records the new canonical operator procedure for GitHub transport failure diagnosis and fallback
+- issue `#60` has now also landed and been merged as PR `#61`
+- `knowledge/git-transport-http11-refinement-report-2026-03-23.md` records the final `HTTP/1.1` compatibility refinement for this machine's Git HTTPS behavior
+- issue `#62` has now landed and been merged as PR `#65`
+- `knowledge/guardrail-evidence-persistence-implementation-report-2026-03-23.md` records the automatic persistence of bounded guardrail execution evidence into project state
+- no real runtime projects remain tracked under `projects/`; only `projects/agenticos` and fixture candidate `projects/test-project` remain
+- A first batch of issue drafts has been created in `tasks/issue-drafts/`
+- The largest current risks are project-boundary pollution, weak context-loading guarantees, and overly abstract agent-behavior principles
+- A new cross-agent bootstrap gap has been identified: MCP and intent-recognition are not yet consistently wired across Claude Code and Codex
+- Homebrew installation is also incomplete as a product experience: binary install works, but per-agent MCP/bootstrap still requires explicit follow-up
+
+## Next Steps
+1. Review and refine the issue drafts in `tasks/issue-drafts/`
+2. Publish the highest-priority drafts as GitHub Issues
+3. Decide whether downstream standard-kit adoption and upgrade should become first-class commands
+4. Decide whether standards-repo records should now be cleaned up and committed under the same issue-first flow
+5. Decide whether quick-start/status surfaces should summarize the latest persisted guardrail evidence more explicitly

--- a/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/.context/state.yaml
+++ b/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/.context/state.yaml
@@ -1,0 +1,176 @@
+session:
+  id: session-2026-03-22-001
+  started: 2026-03-22T06:00:00.000Z
+  agent: codex
+  last_backup: 2026-03-23T03:42:30.000Z
+
+current_task:
+  title: record completion of guardrail execution evidence persistence after issue #62 landed
+  status: in_progress
+  updated: 2026-03-23T10:03:00.000Z
+
+working_memory:
+  facts:
+    - agentic-os-development is the standards and product-definition project for AgenticOS itself
+    - AgenticOS should remain one main product and one main source repository
+    - agentic-os-development should be treated as the standards or meta area inside the broader AgenticOS product effort
+    - mcp-server belongs to the product implementation layer, not to the standards project
+    - the top-level AgenticOS repository currently mixes standards, implementation, runtime workspace projects, and runtime byproducts
+    - ordinary projects under projects/ should be treated as runtime workspace projects by default
+    - projects/agentic-os-development should remain distinct from ordinary runtime projects
+    - .claude/worktrees should be treated as runtime or ephemeral state, not canonical source
+    - .agent-workspace/registry.yaml should be treated as workspace metadata
+    - the immediate practical rule is that the AgenticOS source repo and live AGENTICOS_HOME workspace should be separate
+    - GitHub issue #37 tracks the separation of product source, workspace, and runtime layers
+    - GitHub issue #38 tracks extraction of tracked runtime workspace projects from the product source repository
+    - GitHub issue #39 tracks evaluation of a self-hosting workspace model where AgenticOS itself becomes a managed project under projects/
+    - GitHub issue #40 tracks planning the phased self-hosting migration sequence
+    - GitHub issue #41 tracks the baseline isolation procedure before self-hosting migration execution
+    - GitHub issue #42 tracks the operator checklist for self-hosting migration baseline isolation
+    - a self-hosting migration needs phased execution, path rewrites, verification gates, and rollback boundaries
+    - the migration should primarily target the AgenticOS host product while keeping existing runtime projects largely unaffected
+    - self-hosting resolution v1 freezes projects/agenticos as the canonical managed product project path
+    - self-hosting resolution v1 freezes projects/agenticos/standards as the target standards location
+    - self-hosting resolution v1 freezes .runtime/ as the target runtime-only root
+    - Phase 2 now requires an explicit path relocation checklist for product-source paths, standards paths, and reference rewrites
+    - Phase 3 must be verification-first: each step needs preconditions, immediate verification, and a local rollback boundary
+    - current root build baseline is green for mcp-server, but the top-level repository worktree is not clean
+    - baseline isolation is required before any real structural move because the current main worktree mixes unrelated changes
+    - operator checklist v1 proposes base commit fc401332bea49fdecdc2f4e489e30545d5061043, branch feat/self-hosting-migration, and external worktree /Users/jeking/worktrees/agenticos-self-hosting
+    - baseline backups were exported to /Users/jeking/worktrees/agenticos-self-hosting-baseline/2026-03-23 before migration execution
+    - a clean external worktree now exists at /Users/jeking/worktrees/agenticos-self-hosting on branch feat/self-hosting-migration
+    - the isolated worktree is clean and points at fc401332bea49fdecdc2f4e489e30545d5061043
+    - the clean reproducibility gate failed in the isolated worktree because mcp-server/package.json and package-lock.json are out of sync
+    - npm ci failed in the isolated worktree with missing vitest-related lock entries
+    - GitHub issue #43 tracks restoration of a reproducible clean-install baseline before self-hosting migration resumes
+    - the initial #43 PR (#44) was closed because it was based on a local branch ahead of origin/main and included unrelated commits
+    - the corrected #43 replacement PR (#45) was cut directly from origin/main and merged
+    - self-hosting migration was then re-established on a fresh clean worktree and merged as PR #46
+    - the landed repository layout now uses projects/agenticos as the product-source project path
+    - the landed repository layout now uses projects/agenticos/standards as the standards path
+    - execution proved that .github must remain at repository root because GitHub Actions workflow discovery is root-scoped
+    - the relocated product still builds and tests successfully from projects/agenticos/mcp-server
+    - post-self-hosting follow-up work is now centered on guardrails, downstream standards packaging, and runtime project extraction
+    - GitHub issues #35, #36, #37, and #38 were updated with execution-backed corrections after self-hosting landed
+    - guardrail v1 is now documented as a four-layer machine-checkable model: task, repository, scope, and reproducibility gates
+    - the preflight checklist template has been expanded to include remote-base ancestry checks, scope-control fields, and clean reproducibility gates
+    - guardrail command contracts now exist for agenticos_preflight, agenticos_branch_bootstrap, and agenticos_pr_scope_check
+    - the first executable guardrail slice has now landed as PR #47 in the main AgenticOS repository
+    - agenticos_preflight is now implemented in projects/agenticos/mcp-server and returns PASS, BLOCK, or REDIRECT
+    - the landed preflight slice validates repo identity, worktree state, remote-base ancestry, scope declaration, structural-move exceptions, and reproducibility-gate declaration
+    - the isolated implementation worktree for the guardrail slice passed npm install, npm run build, and npm test before PR #47 merged
+    - agenticos_branch_bootstrap has now landed as PR #48 in the main AgenticOS repository
+    - agenticos_branch_bootstrap creates an issue branch and isolated worktree from the intended remote base and blocks when branch or worktree targets already exist unexpectedly
+    - agenticos_pr_scope_check has now landed as PR #49 in the main AgenticOS repository
+    - agenticos_pr_scope_check validates commit subjects and changed files against the intended issue scope relative to the remote base
+    - PR #50 wired the first guardrail command trio into root repo guidance, Claude command entry points, reusable templates, and distill-generated project templates
+    - the distillation template version is now v3 and includes the guardrail protocol
+    - guardrail issue #36 is complete for v1 because command implementation and execution-flow wiring now both exist
+    - PR #51 added a downstream standard kit under projects/agenticos/.meta/standard-kit/
+    - the downstream standard kit now defines canonical generated files, copied templates, root-scoped exclusions, and upgrade rules
+    - issue #35 is complete for the initial downstream packaging milestone
+    - PR #52 added a machine-readable runtime project classification manifest and a concrete extraction plan
+    - runtime projects under projects/ are now explicitly classified instead of implicitly mixed with product source
+    - issue #38 is complete for the planning milestone, but actual filesystem extraction remains follow-up execution work
+    - GitHub issue #53 now tracks the actual runtime-project extraction execution step
+    - GitHub issue #37 is now closed because the product/workspace/runtime layer model has been explicitly defined
+    - issue #53 wave 1 has copied projects/2026okr into /Users/jeking/AgenticOS/projects/2026okr
+    - issue #53 wave 1 has copied projects/360teams into /Users/jeking/AgenticOS/projects/360teams
+    - the live workspace registry now points 2026okr and 360teams to /Users/jeking/AgenticOS/projects/*
+    - the issue #53 execution worktree is /Users/jeking/worktrees/agenticos-runtime-extraction-53 on branch feat/53-runtime-project-extraction
+    - the local wave-1 extraction commit is 9638a99 feat(meta): execute runtime extraction wave 1 (#53)
+    - PR #54 has been merged and origin/main is now ahead to a6929dfb4508db0abbf22e47f732c0139a41e08b
+    - PR #55 has been merged for the wave-2 extraction of agentic-devops and ghostty-optimization
+    - the live workspace registry now points agentic-devops and ghostty-optimization to /Users/jeking/AgenticOS/projects/*
+    - PR #57 has been merged to remove the orphaned gitlink residues okr-management and t5t
+    - okr-management and t5t were verified to be empty mode-160000 gitlink residues with no valid .gitmodules mapping and no canonical content source
+    - GitHub issue #56 is now closed
+    - GitHub issue #53 is now closed
+    - clean origin/main now contains only projects/agenticos and projects/test-project under projects/
+    - clean origin/main no longer fails git submodule status --recursive because of okr-management or t5t
+    - the live workspace registry no longer contains entries for okr-management or t5t
+    - the original Git publication failure was caused by Git using the globally configured http/https proxy at 127.0.0.1:7897
+    - GitHub itself was reachable; git -c http.proxy= -c https.proxy= ls-remote to the repository succeeded immediately
+    - SSH push is still unavailable in this environment because git@github.com does not have configured public-key access here
+    - PR #59 has been merged to document the GitHub transport fallback in the main product repository
+    - GitHub issue #58 is now closed
+    - the main repository now documents a command-scoped no-proxy plus temporary GIT_ASKPASS operator procedure instead of token-in-URL push guidance
+    - publishing PR #59 still required command-scoped -c http.version=HTTP/1.1 to avoid LibreSSL SSL_ERROR_SYSCALL during git push
+    - PR #61 has been merged to refine the Git transport fallback with the HTTP/1.1 compatibility retry
+    - GitHub issue #60 is now closed
+    - the main repository now documents the full observed operator sequence for this machine: no-proxy, temporary GIT_ASKPASS, and command-scoped http.version=HTTP/1.1 when needed
+    - PR #65 has been merged to persist bounded guardrail execution evidence into project context
+    - GitHub issue #62 is now closed
+    - guardrail command results are now persisted into a dedicated state.yaml section: guardrail_evidence
+    - guardrail evidence now resolves target projects first by registered managed path and then by nearest on-disk .project.yaml plus .context/state.yaml root
+    - repeated guardrail runs now overwrite latest evidence per command instead of appending unbounded logs into working memory
+  decisions:
+    - keep AgenticOS as one main product with internal work domains rather than splitting it into separate products
+    - separate product source, user workspace, and runtime artifacts as a portability requirement
+    - exclude runtime artifacts from product source control where possible
+    - create a dedicated migration plan for already tracked runtime projects
+    - if self-hosting is adopted, migrate in phases instead of mixing source relocation, standards relocation, and runtime relocation in one step
+    - keep the public product identity as AgenticOS while using projects/agenticos as the canonical managed product project path
+    - freeze the target model before structural moves begin so later planning does not re-open the same naming and role questions
+    - split Phase 2 into path classification, reference rewrite inventory, and later execution sequencing
+    - prioritize verification over move speed during migration planning and execution
+    - require baseline isolation before any real structural move begins
+    - use a fresh dedicated external worktree for migration execution rather than the current root worktree
+    - freeze concrete operator inputs before execution so migration does not improvise branch names or worktree paths
+    - stop structural migration immediately if clean-checkout reproducibility fails in the isolated worktree
+    - use npm ci rather than npm install for the clean-baseline verification gate in mcp-server
+    - keep the lockfile repair on its own issue branch rather than mixing it into the migration branch
+    - keep .github at repository root as repo-automation infrastructure even after self-hosting migration lands
+    - use the landed self-hosting model as the baseline for future standards packaging and runtime extraction work
+    - treat wrong-base branch ancestry and PR diff-scope leakage as first-class guardrail problems
+    - separate checker commands from mutating helper commands in the guardrail layer
+    - implement guardrails incrementally, starting with preflight checks before moving to branch bootstrap and PR scope enforcement
+    - keep #36 open after the command trio lands until invocation and workflow integration rules are executable
+    - treat automatic persistence of guardrail execution evidence as a follow-up enhancement rather than a blocker for closing #36
+    - treat the initial standard-kit package model as sufficient to close #35 even before adoption/upgrade automation exists
+    - treat #38 as complete for planning once classification, extraction sequence, and de-tracking strategy are explicitly landed
+    - split runtime-project extraction into a closed planning issue and a separate execution issue so later filesystem changes have their own guardrailed work item
+    - codify the Git proxy and credential workaround as a repository-level operator procedure rather than leaving it only in execution notes
+    - keep transport troubleshooting guidance command-scoped and diagnostic rather than turning it into blanket global Git configuration advice
+    - keep guardrail execution evidence in a dedicated state section instead of mixing it into working_memory
+  pending:
+    - decide how Git history and repo boundaries are preserved during relocation
+    - decide whether projects/test-project should be kept as a fixture/example or extracted as runtime content
+    - define migration steps for already tracked runtime workspace projects in the top-level product repository
+    - define how Homebrew initialization should create a clean workspace separate from the product source checkout
+    - update the canonical migration and layering documents to reflect the root-level .github exception
+    - continue downstream packaging, guardrails, boundary enforcement, and memory-layer contract work
+    - decide whether standard-kit adoption and upgrade should become first-class commands
+    - decide whether the standards-repo history should now be cleaned up and committed under its own issue-first flow
+    - decide whether project status surfaces should summarize the latest guardrail evidence in a more human-readable way
+
+loaded_context:
+  - .project.yaml
+  - .context/quick-start.md
+  - knowledge/product-positioning-and-design-review-2026-03-22.md
+  - knowledge/repository-layering-and-portability-plan-2026-03-23.md
+  - knowledge/self-hosting-workspace-model-2026-03-23.md
+  - knowledge/self-hosting-migration-plan-2026-03-23.md
+  - knowledge/self-hosting-migration-resolution-v1-2026-03-23.md
+  - knowledge/phase2-path-relocation-checklist-2026-03-23.md
+  - knowledge/phase3-execution-sequence-2026-03-23.md
+  - knowledge/command-level-migration-playbook-v1-2026-03-23.md
+  - knowledge/baseline-isolation-plan-2026-03-23.md
+  - knowledge/operator-checklist-v1-2026-03-23.md
+  - knowledge/baseline-isolation-execution-report-2026-03-23.md
+  - knowledge/self-hosting-migration-execution-report-2026-03-23.md
+  - knowledge/post-self-hosting-follow-up-plan-2026-03-23.md
+  - knowledge/agent-guardrail-design-v1-2026-03-23.md
+  - knowledge/agent-guardrail-command-contracts-v1-2026-03-23.md
+  - knowledge/guardrail-preflight-implementation-report-2026-03-23.md
+  - knowledge/guardrail-command-trio-implementation-report-2026-03-23.md
+  - knowledge/guardrail-flow-wiring-report-2026-03-23.md
+  - knowledge/downstream-standard-kit-implementation-report-2026-03-23.md
+  - knowledge/runtime-project-extraction-planning-report-2026-03-23.md
+  - knowledge/runtime-project-extraction-execution-follow-up-2026-03-23.md
+  - knowledge/runtime-project-extraction-wave1-report-2026-03-23.md
+  - knowledge/runtime-project-extraction-wave2-report-2026-03-23.md
+  - knowledge/runtime-project-extraction-closure-report-2026-03-23.md
+  - knowledge/git-transport-fallback-documentation-report-2026-03-23.md
+  - knowledge/git-transport-http11-refinement-report-2026-03-23.md
+  - knowledge/guardrail-evidence-persistence-implementation-report-2026-03-23.md

--- a/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/.project.yaml
+++ b/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/.project.yaml
@@ -1,0 +1,9 @@
+meta:
+  name: agentic-os-development
+  id: agentic-os-development
+  description: ""
+  created: 2026-03-20
+  version: 1.0.0
+agent_context:
+  quick_start: .context/quick-start.md
+  current_state: .context/state.yaml

--- a/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/AGENTS.md
+++ b/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/AGENTS.md
@@ -1,0 +1,80 @@
+# AGENTS.md — AgenticOS Development
+
+## Recording Protocol (MANDATORY)
+
+This project uses AgenticOS for persistent context management.
+All session activity MUST be recorded via MCP tools.
+
+### How to Record
+
+Call the MCP tool `agenticos_record` with:
+- `summary` (required): What happened in this session
+- `decisions`: Key decisions made
+- `outcomes`: What was accomplished
+- `pending`: What remains to be done
+- `current_task`: { title, status } to update current task
+
+### When to Record
+
+1. After completing any meaningful unit of work
+2. Before ending the session (MANDATORY — context is lost otherwise)
+
+After recording, call `agenticos_save` to commit to this project's Git repo.
+
+## Git Boundary
+
+This directory is a standalone Git repository.
+Do not use the parent `AgenticOS` repository as the Git root for work in `agentic-os-development`.
+
+## Agent Execution Protocol (MANDATORY)
+
+Before acting on any non-trivial task, load and follow:
+1. `knowledge/agent-preflight-and-execution-protocol-2026-03-23.md`
+2. `knowledge/workflow-model-review-2026-03-23.md`
+
+Execution rules:
+- Do not react only to the user's literal last sentence; synthesize fragmented intent into a coherent objective.
+- Do not jump from issue reading straight to implementation.
+- Classify the task as `discussion_only`, `analysis_or_doc`, `implementation`, or `bootstrap`.
+- For `implementation`, branch + isolated worktree are mandatory.
+- For non-trivial work, complete a design -> critique -> redesign loop before implementation.
+- Define executable acceptance criteria before editing files.
+- Verify before claiming completion.
+
+Reusable templates:
+- `tasks/templates/agent-preflight-checklist.yaml`
+- `tasks/templates/issue-design-brief.md`
+- `tasks/templates/non-code-evaluation-rubric.yaml`
+- `tasks/templates/submission-evidence.md`
+
+### Session Start
+
+On session start, read these files for context:
+1. `.project.yaml` — Project metadata
+2. `.context/state.yaml` — Current state and working memory
+3. `.context/quick-start.md` — Project overview
+4. `.context/conversations/` — Previous session records
+5. `knowledge/product-positioning-and-design-review-2026-03-22.md` — Current product framing
+
+Then greet the user with: project name, last progress, current pending items, suggested next step.
+
+## Project
+
+**Name**: AgenticOS Development
+**Description**: Agent-first project management OS — AI Agent autonomously manages project state, cross-session context recovery, and cross-tool collaboration.
+
+## Directory Structure
+
+| Path | Purpose |
+|------|---------|
+| `.project.yaml` | Project metadata |
+| `.context/state.yaml` | Session state and working memory |
+| `.context/conversations/` | Session records (auto-generated) |
+| `knowledge/` | Persistent knowledge: architecture, decisions, trade-offs |
+| `knowledge/architecture.md` | Three-layer architecture design |
+| `knowledge/design-decisions.md` | 5 key design decisions with rationale |
+| `knowledge/complete-design.md` | Complete system design document |
+| `tasks/` | Task tracking |
+| `tasks/templates/` | Reusable execution and evaluation templates |
+| `artifacts/` | Outputs and deliverables |
+| `changelog.md` | Project changelog |

--- a/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/CLAUDE.md
+++ b/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/CLAUDE.md
@@ -1,0 +1,138 @@
+<!-- agenticos-template: v2 -->
+# CLAUDE.md — AgenticOS Development
+
+## MANDATORY: Recording Protocol
+
+> This is an AgenticOS project. All session activity MUST be recorded.
+> Recording is not optional — it is the core function of this system.
+
+### During Session
+
+After completing any meaningful unit of work (feature, fix, design decision, analysis), call `agenticos_record`:
+
+```
+agenticos_record({
+  summary: "what happened",
+  decisions: ["decision 1", ...],
+  outcomes: ["outcome 1", ...],
+  pending: ["next step 1", ...],
+  current_task: { title: "task name", status: "in_progress" }
+})
+```
+
+### Before Session Ends
+
+When the user signals session end (says goodbye, thanks, done, or stops responding), you MUST:
+
+1. Call `agenticos_record` with a complete session summary
+2. Call `agenticos_save` to commit to this project's Git repo
+
+**If you skip this step, all context from this session is permanently lost.**
+
+---
+
+## Session Start Protocol
+
+When you open this project in a new session, **immediately do the following**:
+
+1. Read `.context/quick-start.md`
+2. Read `.context/state.yaml`
+3. Read `knowledge/product-positioning-and-design-review-2026-03-22.md`
+4. Read `knowledge/agent-preflight-and-execution-protocol-2026-03-23.md`
+2. Greet the user with a brief status report in this format:
+
+```
+📍 项目：AgenticOS Development
+📌 上次进展：[current_task title + status]
+🎯 当前待办：[top pending items]
+💡 建议下一步：[recommended next action]
+
+继续上次的工作，还是有新的方向？
+```
+
+3. Wait for the user's direction before proceeding
+
+---
+
+## Project DNA
+
+**一句话定位**: AgenticOS 的规范项目和产品定义项目，用来演进项目上下文结构、Agent 行为协议和协作工作流标准。
+
+**核心设计原则**:
+- **Agent First**: AI 是主要用户，一切结构为 AI 理解优化
+- **Executable Protocols**: 原则必须落成规则、检查单、伪代码和可验证标准
+- **完整记录**: 所有决策、对话、变更完整留痕
+- **跨工具兼容**: Claude Code / Cursor / Codex 均可使用
+- **可移植性**: Git 备份，路径相对化存储，跨机器可用
+
+**三层架构**:
+1. **通用层** (Universal): `.project.yaml` + `.context/state.yaml` + `knowledge/` + `tasks/` — 纯文本+结构化数据，无工具依赖
+2. **MCP 层**: `agenticos-mcp` npm 包，5 个工具 (init/switch/list/record/save) + 1 个资源
+3. **Agent 适配层**: `CLAUDE.md` / `CURSOR.md` — 每个工具的专用配置和行为指令
+
+**技术栈**: TypeScript, Node.js (ES2022), MCP SDK, YAML, Git
+
+**关键设计约束**:
+- 路径在 YAML 中存储为相对路径，运行时解析为绝对路径
+- Registry 位于 `~/.agent-workspace/registry.yaml`（AgenticOS Home 下）
+- Git 操作从当前项目根目录执行（`projects/agentic-os-development/` 是独立仓库，不依赖上层 `AgenticOS` 仓库）
+
+---
+
+## Mandatory Execution Rules
+
+Before implementation or non-trivial doc/protocol changes:
+- classify the task using `knowledge/agent-preflight-and-execution-protocol-2026-03-23.md`
+- complete preflight before editing
+- for `implementation`, use a dedicated branch and isolated worktree
+- define executable acceptance criteria before editing
+- complete at least one design/critique loop for non-trivial doc/protocol work
+
+Reusable templates:
+- `tasks/templates/agent-preflight-checklist.yaml`
+- `tasks/templates/issue-design-brief.md`
+- `tasks/templates/non-code-evaluation-rubric.yaml`
+- `tasks/templates/submission-evidence.md`
+
+## Current State
+
+<!-- AGENT_CONTEXT_START -->
+**Last Updated**: 2026-03-23T01:51:19.639Z
+
+**Current Task**: calendar create 能力补全 (status: completed)
+
+**Active Items**:
+- TODO: calendar.js 参与人搜索 sleep(2000) 改为 waitFor 轮询 input[type=checkbox] 出现（6000ms timeout），解决网络延迟导致搜索结果未加载问题
+
+**Recent Decisions**:
+- attendee 搜索结果不显示判断为网络异步加载问题，当前 sleep(2000) 不足以等待，后续用 waitFor 替代
+- dispatchMouseEvent 是 Element UI 组件点击的唯一可靠方式
+- button.add-user-button 通过 querySelector 动态查找，比文字匹配或坐标硬编码更可靠
+
+**Next Action**: TODO: calendar.js 参与人搜索 sleep(2000) 改为 waitFor 轮询 input[type=checkbox] 出现（6000ms timeout），解决网络延迟导致搜索结果未加载问题
+<!-- AGENT_CONTEXT_END -->
+
+---
+
+## Navigation
+
+| 目录/文件 | 用途 |
+|-----------|------|
+| `.project.yaml` | 项目元信息（名称、ID、版本、技术栈） |
+| `.context/state.yaml` | 当前会话状态、工作记忆、待办事项 |
+| `.context/quick-start.md` | 人类可读的项目概览 |
+| `.context/conversations/` | 历史对话记录 |
+| `knowledge/` | 持久化知识：架构设计、决策记录、权衡分析 |
+| `knowledge/architecture.md` | 核心架构设计（三层架构详解） |
+| `knowledge/design-decisions.md` | 5 个关键设计决策及理由 |
+| `knowledge/complete-design.md` | 完整系统设计文档 |
+| `tasks/` | 任务追踪 |
+| `tasks/templates/` | 可执行模板：preflight、design brief、rubric、submission evidence |
+| `artifacts/` | 产出物 |
+| `changelog.md` | 变更日志 |
+
+**获取更多上下文**:
+- 架构全貌 → `knowledge/architecture.md`
+- 为什么选 MCP 而非 CLI → `knowledge/cli-vs-mcp-analysis.md`
+- 设计权衡 → `knowledge/trade-offs.md`
+- MCP Server 源码 → `../../mcp-server/src/`

--- a/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/README.md
+++ b/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/README.md
@@ -1,0 +1,37 @@
+# Retired Standalone Standards Snapshot
+
+This directory is a legacy snapshot of the standalone repository:
+
+- `projects/agentic-os-development`
+
+It is preserved for traceability during the standards consolidation process.
+
+## What This Snapshot Contains
+
+- retired `.context/` raw context and conversation history
+- local `tasks/issue-drafts/` history from before GitHub became the canonical issue tracker
+- root entry files from the standalone repo:
+  - `.project.yaml`
+  - `AGENTS.md`
+  - `CLAUDE.md`
+  - `changelog.md`
+
+## What This Snapshot Is Not
+
+This snapshot is not:
+
+- the live canonical standards source
+- the place to record new standards work
+- the authoritative current project state
+
+## Canonical Location
+
+All future AgenticOS standards work should be recorded in:
+
+- `projects/agenticos/standards/`
+
+Use this archive only when:
+
+- tracing migration history
+- checking whether an older standalone artifact still needs to be merged
+- understanding why a legacy document existed before the standards repo was retired

--- a/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/changelog.md
+++ b/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/changelog.md
@@ -1,0 +1,82 @@
+# AgenticOS Development Changelog
+
+## 2026-03-16
+
+### 08:46 - MCP Server 架构设计与实现
+
+**实现内容**:
+- 创建 `agenticos-mcp` MCP Server 项目
+- 实现 4 个核心工具（init、switch、list、save）
+- 实现资源系统（agenticos://context/current）
+- Registry 管理系统
+- TypeScript 构建成功
+
+**设计决策**:
+- 选择 MCP Server 而非 CLI 工具
+- 原因：Agent First 原则，结构化返回，跨工具兼容
+
+**文档更新**:
+- 创建 `architecture.md` - 完整架构设计
+- 创建 `cli-vs-mcp-analysis.md` - 方案对比分析
+- 创建 `complete-design.md` - 系统性设计文档
+- 更新 `design-decisions.md` - 添加 Decision 5
+- 更新 `evolution.md` - 记录 MCP Server 里程碑
+
+### 04:42 - 统一命名为 AgenticOS
+
+**变更**:
+- AIOS → AgenticOS
+- 与 GitHub 仓库名称一致
+
+### 04:40 - 自举设计
+
+**实现**:
+- 创建元项目管理 AgenticOS 本身
+- 用 AgenticOS 管理 AgenticOS
+
+### 04:38 - GitHub 版本控制
+
+**实现**:
+- 推送到 GitHub
+- 建立版本备份机制
+
+### 04:35 - 完整记录机制
+
+**实现**:
+- 对话日志（conversations/）
+- 项目日志（changelog.md）
+- 记忆流（memory.jsonl）
+- 知识库（knowledge/）
+
+### 04:32 - 命名为 AIOS
+
+**概念升华**:
+- Agentic Operating System
+- AI-native 协作操作系统
+
+### 04:30 - Agent 驱动理念
+
+**确立**:
+- AI 自主管理内容
+- 动态演进机制
+
+### 04:27 - Agent First 转向
+
+**重大转变**:
+- 从 Human First 转向 Agent First
+- 重新设计为结构化、分层系统
+
+### 04:25 - 概念诞生
+
+**初始想法**:
+- 建立 AI 协作项目管理系统
+- 初步设计目录结构
+
+---
+
+## 待办事项
+
+- [ ] 测试 MCP Server
+- [ ] 配置到 Claude Code
+- [ ] 验证跨工具兼容性
+- [ ] 发布到 npm

--- a/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/tasks/issue-drafts/01-fix-project-boundary-enforcement.md
+++ b/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/tasks/issue-drafts/01-fix-project-boundary-enforcement.md
@@ -1,0 +1,103 @@
+---
+name: Bug Report
+about: Fix cross-project context pollution in AgenticOS
+title: "fix: enforce project boundary isolation in recorded context"
+labels: bug
+---
+
+## Description
+
+AgenticOS projects are supposed to maintain durable, project-specific context.
+In practice, the standards project `agentic-os-development` accumulated unrelated execution details from downstream projects such as `360teams`.
+
+This breaks one of the core product promises: a project should recover its own context, not a contaminated mixture of nearby work.
+
+## Steps to Reproduce
+
+1. Work in project A.
+2. Later switch to project B.
+3. Record progress, update quick-start, or update state.
+4. Observe that project B may now contain facts, pending items, or summaries that belong to project A.
+
+## Expected Behavior
+
+Each project should only contain:
+- its own quick-start summary
+- its own state and working memory
+- its own conversations and knowledge
+
+## Actual Behavior
+
+Project-level context can be polluted by unrelated project execution history.
+
+## Problem Statement
+
+Without strong boundary enforcement, AgenticOS cannot serve as a reliable project operating system.
+If context pollution is possible, downstream recovery and cross-agent collaboration become unsafe.
+
+At the moment, the core write path trusts `registry.active_project` too much:
+- `agenticos_switch` sets the active project in the registry
+- `recordSession` resolves the target path from that single active-project pointer
+- the tool then writes to `.context/conversations/`, `.context/state.yaml`, `.context/.last_record`, and `CLAUDE.md` without an additional identity check
+
+This means that if project selection, agent context, or user intent drift even slightly, the wrong project can be mutated.
+
+## Proposed Solution
+
+Define and enforce project-boundary rules for:
+- `.context/quick-start.md`
+- `.context/state.yaml`
+- `.context/conversations/`
+- `knowledge/`
+
+Potential implementation directions:
+- always resolve and validate the active project before `record` and `save`
+- reject writes when project identity is ambiguous
+- introduce project-id checks in state updates
+- add automated tests for cross-project isolation
+
+Suggested implementation scope:
+- `mcp-server/src/tools/project.ts`
+  Harden project switching and make active-project transitions easier to inspect
+- `mcp-server/src/tools/record.ts`
+  Add project-identity validation before all writes
+- `mcp-server/src/resources/context.ts`
+  Ensure context reads clearly identify the active project being loaded
+- registry helpers
+  Make active-project provenance and transitions more explicit
+
+Possible product/technical safeguards:
+- include canonical project identity in `state.yaml`
+- include a write-time validation step that compares registry project id, project path, and local `.project.yaml`
+- fail closed if project identity cannot be proven
+- optionally support an explicit `project` parameter for record/save in future, rather than relying only on global active state
+
+## Non-Goals
+
+- This issue should not redesign the entire memory model
+- This issue should not solve sub-agent inheritance by itself
+- This issue should not change Git workflow or bootstrap strategy unless required for boundary validation
+
+## Alternatives Considered
+
+- Rely on agent discipline only
+- Detect contamination after the fact using lint-like checks
+- Keep `active_project` as the only trust anchor and accept occasional manual cleanup
+
+## Verification Plan
+
+- Create a test fixture with at least two projects
+- Switch from project A to project B
+- Record a session in project B
+- Verify that only project B files changed
+- Repeat with stale context and ambiguous situations to confirm the tool fails safely instead of writing to the wrong project
+- Manually validate that `agentic-os-development` no longer picks up downstream-project state during normal use
+
+## Acceptance Criteria
+
+- Recording to one project never mutates another project's quick-start, state, or conversations
+- Write paths validate project identity before mutating files
+- Ambiguous or invalid project identity produces an explicit error instead of best-effort writes
+- Automated tests cover project switching and recording across multiple projects
+- The standards project no longer contains unrelated downstream project state after validation
+- The issue leaves behind a clear project-boundary contract that later issues can build on

--- a/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/tasks/issue-drafts/02-define-memory-layer-contracts.md
+++ b/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/tasks/issue-drafts/02-define-memory-layer-contracts.md
@@ -1,0 +1,140 @@
+---
+name: Feature Request
+about: Define strict contracts for AgenticOS memory layers
+title: "feat: define canonical contracts for quick-start, state, conversations, and knowledge"
+labels: enhancement
+---
+
+## Problem Statement
+
+AgenticOS already has multiple memory layers, but their roles are not strict enough.
+That creates overlap, noise, and unreliable recovery.
+
+The unclear boundaries are especially visible between:
+- `.context/quick-start.md`
+- `.context/state.yaml`
+- `.context/conversations/`
+- `knowledge/`
+- `tasks/`
+
+Current implementation already writes across several layers:
+- `recordSession` appends to `conversations/`
+- `recordSession` mutates `state.yaml`
+- `recordSession` may enrich `quick-start.md` when it detects boilerplate
+- `updateClaudeMdState` mirrors part of state into `CLAUDE.md`
+
+This means the memory model is already operational, but still underspecified.
+Without a strict contract, agents can write the wrong kind of information to the wrong layer and later sessions will recover low-signal or misleading context.
+
+## Proposed Solution
+
+Define a canonical contract for each layer:
+
+- `quick-start.md`
+  A short, project-level orientation summary for fast session entry
+
+- `state.yaml`
+  Structured working memory, current task, decisions, pending items, and loaded context
+
+- `conversations/`
+  Session-level historical record, append-only
+
+- `knowledge/`
+  Durable synthesized insights, architecture, decisions, and research
+
+- `tasks/`
+  Explicit work items, issue drafts, execution plans, and task decomposition
+
+The contract should specify:
+- canonical vs derived content
+- append-only vs mutable content
+- project-level vs session-level content
+- human-readable vs machine-oriented content
+- what should never be written into each file type
+
+The contract should also answer:
+- which layer is read first on session start
+- which layer is safe to rewrite automatically
+- which layer must remain append-only
+- which layer should hold raw history vs synthesized knowledge
+- which layer is the source of truth when two layers overlap
+
+Suggested output format for this issue:
+- a memory-layer specification document
+- a file-by-file contract matrix
+- example entries for each layer
+- write rules for agents and MCP tools
+
+Suggested first-pass contract direction:
+
+- `.project.yaml`
+  Stable project identity and metadata. Canonical. Rarely changed.
+
+- `.context/quick-start.md`
+  Short orientation summary for fast session entry. Human-readable. Mutable, but should remain concise and project-level.
+
+- `.context/state.yaml`
+  Structured current working state: current task, pending items, working memory, loaded context pointers. Mutable. Operational source for current state, not full history.
+
+- `.context/conversations/`
+  Session-by-session append-only history. Raw record, not the place for synthesis.
+
+- `knowledge/`
+  Durable synthesis: architecture, decisions, research, product judgments. Canonical for learned understanding, not raw conversation logs.
+
+- `tasks/`
+  Actionable work artifacts: issue drafts, plans, decompositions, checklists. Future-facing execution layer, not historical narrative.
+
+- `artifacts/`
+  Concrete outputs and deliverables, not memory or planning by default.
+
+Suggested implementation scope:
+- `mcp-server/src/tools/record.ts`
+  Constrain what gets written automatically into each memory layer
+- `mcp-server/src/utils/distill.ts`
+  Clarify which parts of `CLAUDE.md` are derived views of state vs user-authored content
+- project templates and generated docs
+  Align initial files with the new contracts
+- documentation
+  Reflect the layer model consistently in README, AGENTS, and project templates
+
+## Non-Goals
+
+- This issue should not fully solve project-boundary enforcement by itself
+- This issue should not redesign the MCP transport layer
+- This issue should not decide all cross-agent bootstrap behavior
+- This issue should not require immediate automation for every rule on day one
+
+## Alternatives Considered
+
+- Keep the current loose conventions and rely on agent judgment
+- Collapse several layers into fewer files
+- Make everything append-only and rely on later summarization
+- Make `state.yaml` the single source for everything, including long-term knowledge
+
+## Additional Context
+
+This issue is foundational because multiple later problems are downstream of weak memory contracts.
+
+It is also the bridge between issue 01 and later protocol issues:
+- issue 01 defines where writes are allowed
+- this issue defines what each location is allowed to contain
+
+## Verification Plan
+
+- Create a contract table for all memory-related paths
+- Test current examples against the contract and identify mismatches
+- Verify that the standards project files can be classified cleanly under the new model
+- Define at least one invalid example per layer to make the boundaries explicit
+- Confirm that future issues can reference this contract without redefining the same concepts
+
+## Acceptance Criteria
+
+- A written spec exists for each memory layer
+- The spec identifies source-of-truth vs derived layers
+- The spec defines append-only vs mutable behavior per layer
+- The spec defines what must never be written into each layer
+- Templates and docs reflect the new contracts
+- Example content is provided for each file type
+- The spec is strong enough to drive future validation or linting
+- The spec is usable as an input to later agent-protocol and boundary-enforcement work

--- a/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/tasks/issue-drafts/03-define-executable-agent-protocol.md
+++ b/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/tasks/issue-drafts/03-define-executable-agent-protocol.md
@@ -1,0 +1,93 @@
+---
+name: Feature Request
+about: Turn Agent First and Agent Friendly into executable rules
+title: "feat: define executable agent protocol for Agent First and Agent Friendly"
+labels: enhancement
+---
+
+## Problem Statement
+
+`Agent First` and `Agent Friendly` are meaningful product principles, but they are still too abstract to guarantee predictable behavior across different models and tools.
+
+Without executable rules, different agents will interpret the same principle differently.
+
+## Proposed Solution
+
+Create an explicit agent protocol that defines:
+- how the agent synthesizes fragmented user input into a coherent objective
+- how the agent classifies the task before acting
+- what an agent must read first
+- what counts as enough context to begin acting
+- how an issue should be framed against project-level goals and existing design
+- how many design/critique iterations are required before implementation
+- when the agent must ask for confirmation
+- how executable acceptance criteria are defined before implementation
+- what must be recorded after meaningful work
+- what verification is required before claiming completion
+- how project boundaries must be preserved
+- how to handle uncertainty, ambiguity, and missing state
+
+The protocol should be expressed in a form agents can follow consistently:
+- rules
+- decision trees
+- pseudocode
+- schemas
+- validation checkpoints
+- reusable templates for preflight, design briefs, evaluation rubrics, and submission evidence
+
+The protocol should explicitly define an execution loop such as:
+- intent synthesis
+- task classification
+- context loading
+- preflight
+- task framing
+- design
+- critique
+- redesign
+- acceptance definition
+- implementation
+- verification
+- submission
+
+## Alternatives Considered
+
+- Keep principles as narrative guidance only
+- Add more prose to `AGENTS.md` without formalizing execution logic
+
+## Additional Context
+
+This is the key issue for turning AgenticOS from a philosophy into an operating standard.
+
+It should also clarify that issue execution is not a one-shot generation act.
+Agents should normally go through two to three design/critique passes before implementation for non-trivial work.
+
+The protocol should include concrete pass/fail gates for:
+- `discussion_only`
+- `analysis_or_doc`
+- `implementation`
+- `bootstrap`
+
+Verification should distinguish between:
+- **code deliverables**: automated tests plus coverage expectations for the changed scope
+- **non-code deliverables**: rubric-based LLM evaluation or equivalent goal-oriented assessment
+
+The intent is to make completion claims auditable rather than purely conversational.
+
+Potential outputs should include:
+- a canonical preflight checklist schema
+- an issue design brief template
+- a non-code evaluation rubric template
+- a submission evidence template
+
+## Acceptance Criteria
+
+- A written protocol exists with concrete execution rules
+- The protocol distinguishes mandatory steps from optional heuristics
+- The protocol defines how fragmented user intent is synthesized into a task objective
+- The protocol defines task classification and preflight gates before editing
+- The protocol defines a multi-pass design/critique loop before implementation
+- The protocol requires executable acceptance criteria before implementation
+- The protocol distinguishes code verification from non-code verification
+- The protocol has reusable template artifacts that downstream projects can adopt
+- The protocol can be referenced by Claude, Codex, and other agent-specific guides
+- The protocol is specific enough that future linting or auto-checks are plausible

--- a/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/tasks/issue-drafts/04-define-sub-agent-context-inheritance.md
+++ b/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/tasks/issue-drafts/04-define-sub-agent-context-inheritance.md
@@ -1,0 +1,43 @@
+---
+name: Feature Request
+about: Ensure spawned agents inherit and verify project context
+title: "feat: define sub-agent context inheritance and verification rules"
+labels: enhancement
+---
+
+## Problem Statement
+
+`agenticos_switch` can restore context for the main session, but spawned/sub agents may still start effectively context-blind.
+
+This creates waste, inconsistency, and design drift.
+
+## Proposed Solution
+
+Define a standard for sub-agent startup:
+- what files the main agent must read before spawning
+- what minimum context must be injected into the sub-agent prompt
+- how the sub-agent should verify it understands the project before working
+- how the sub-agent should persist important outputs back into project files
+
+Potential required context:
+- project identity
+- current task
+- key constraints
+- relevant knowledge files
+- relevant task or issue draft
+
+## Alternatives Considered
+
+- Let every agent infer context independently
+- Depend on the parent agent to free-form summarize context ad hoc
+
+## Additional Context
+
+This was already identified internally as a major product gap.
+
+## Acceptance Criteria
+
+- A standard sub-agent inheritance protocol is documented
+- The protocol specifies required inputs and required verification behavior
+- The protocol is reflected in agent-facing docs
+- A downstream test scenario or simulation is defined

--- a/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/tasks/issue-drafts/05-define-cross-agent-bootstrap-standard.md
+++ b/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/tasks/issue-drafts/05-define-cross-agent-bootstrap-standard.md
@@ -1,0 +1,52 @@
+---
+name: Feature Request
+about: Standardize AgenticOS bootstrap across Claude Code, Codex, Cursor, Gemini, and others
+title: "feat: define per-agent bootstrap standard for AgenticOS integration"
+labels: enhancement
+---
+
+## Problem Statement
+
+Cross-agent compatibility is a core product promise, but actual bootstrap behavior is inconsistent.
+
+One agent may have:
+- MCP configured
+- trigger logic configured
+- user-level config visible
+
+Another may have:
+- no MCP entry
+- unclear config source
+- no project-intent recognition
+
+## Proposed Solution
+
+Define a per-agent bootstrap standard covering:
+- config location
+- MCP server registration method
+- trigger/intention recognition mechanism
+- restart requirements
+- post-install verification steps
+- debugging steps when switching/creation commands do not trigger correctly
+
+Start with:
+- Claude Code
+- Codex
+- Cursor
+- Gemini CLI
+
+## Alternatives Considered
+
+- Keep agent integrations loosely documented in separate places
+- Let each agent integration evolve independently
+
+## Additional Context
+
+Without a bootstrap standard, "works across agents" is difficult to verify or maintain.
+
+## Acceptance Criteria
+
+- Each supported agent has a documented bootstrap path
+- Each path includes verification and debugging instructions
+- The standard distinguishes MCP transport from project-intent routing
+- Docs and install output reference the same bootstrap contract

--- a/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/tasks/issue-drafts/06-homebrew-post-install-bootstrap.md
+++ b/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/tasks/issue-drafts/06-homebrew-post-install-bootstrap.md
@@ -1,0 +1,46 @@
+---
+name: Feature Request
+about: Improve Homebrew install so AgenticOS is actually ready after install
+title: "feat: define Homebrew post-install bootstrap for supported agents"
+labels: enhancement
+---
+
+## Problem Statement
+
+Homebrew currently installs the `agenticos-mcp` binary and workspace, but does not ensure that supported agents are actually bootstrapped afterward.
+
+This creates a gap between:
+- package installation
+- real product activation
+
+## Proposed Solution
+
+Define the Homebrew post-install product contract.
+
+At minimum, Homebrew install should:
+- clearly state what was installed
+- clearly state what remains manual
+- point to exact config paths or commands for each supported agent
+- remind the user to restart the AI tool
+- explain how to verify activation
+
+Longer term, evaluate safe automation options:
+- auto-create missing config directories
+- auto-merge MCP entries where safe
+- opt-in bootstrap command after install
+
+## Alternatives Considered
+
+- Keep Homebrew as binary-only distribution and rely on docs
+- Attempt fully automatic config mutation immediately
+
+## Additional Context
+
+This is both a packaging issue and a product-activation issue.
+
+## Acceptance Criteria
+
+- Homebrew caveats/post-install output cover Claude Code, Codex, and Gemini CLI explicitly
+- The main README and tap README describe the same limitation and next steps
+- A clear decision exists on reminder-only vs auto-bootstrap behavior
+- Verification steps after install are documented

--- a/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/tasks/issue-drafts/07-define-mcp-vs-cli-skills-integration-matrix.md
+++ b/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/tasks/issue-drafts/07-define-mcp-vs-cli-skills-integration-matrix.md
@@ -1,0 +1,48 @@
+---
+name: Feature Request
+about: Evaluate fallback and compatibility modes beyond MCP
+title: "feat: define integration matrix for MCP-native and CLI+Skills fallback modes"
+labels: enhancement
+---
+
+## Problem Statement
+
+MCP is the primary integration model for AgenticOS, but practical agent compatibility may require fallback paths.
+
+Some agents or environments may have:
+- weak MCP support
+- hard-to-debug MCP behavior
+- missing bootstrap automation
+- strong prompt/skill support but weaker MCP ergonomics
+
+## Proposed Solution
+
+Define an integration matrix for AgenticOS, for example:
+- MCP-native mode
+- CLI-wrapper mode
+- Skills-only routing mode
+- mixed mode
+
+For each mode, document:
+- supported capabilities
+- limitations
+- debugging ergonomics
+- portability
+- maintenance cost
+- when the mode should be used
+
+## Alternatives Considered
+
+- Keep MCP as the only supported mode
+- Add ad hoc fallbacks without a product model
+
+## Additional Context
+
+This should be treated as a product design choice, not just a transport implementation detail.
+
+## Acceptance Criteria
+
+- A formal comparison exists for MCP and fallback modes
+- A product decision is made on primary vs fallback integration modes
+- The decision is reflected in docs and roadmap
+- Any fallback mode has a clear scope and non-goals

--- a/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/tasks/issue-drafts/08-standardize-issue-first-github-actions-workflow.md
+++ b/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/tasks/issue-drafts/08-standardize-issue-first-github-actions-workflow.md
@@ -1,0 +1,73 @@
+---
+name: Feature Request
+about: Turn issue-driven evolution into a reusable AgenticOS standard
+title: "feat: standardize issue-first and GitHub Actions based evolution workflow"
+labels: enhancement
+---
+
+## Problem Statement
+
+AgenticOS already points toward an open-source workflow:
+Issue -> branch/worktree -> PR -> review -> merge -> automation
+
+But this workflow is not yet fully productized as a reusable standard for downstream projects.
+
+This issue is about the reusable workflow model itself:
+- what branch lifecycle AgenticOS projects should use
+- how issues, PRs, and GitHub Actions fit together
+- what downstream projects should inherit by default
+
+It should be explicit that `git worktree` is a workspace-isolation mechanism, not by itself the branching model.
+
+## Proposed Solution
+
+Define a reusable evolution workflow standard for AgenticOS-managed projects.
+
+Recommended direction:
+- adopt **GitHub Flow** as the canonical branch lifecycle
+- require short-lived issue-linked branches
+- require PR-based merge back to `main`
+- define how GitHub Actions participates in validation, release, and automation
+- define how this model is inherited by downstream AgenticOS projects
+
+The standard should cover:
+- when to create an issue
+- how to link tasks and issue drafts
+- how to create branches/worktrees safely
+- how to structure PRs
+- how GitHub Actions should participate
+- what verification is required before merge
+- what release/tagging path is expected after merge
+
+Potential outputs:
+- workflow spec
+- downstream checklist
+- issue/PR template guidance
+- automation hooks or bootstrap helpers
+
+## Alternatives Considered
+
+- Keep workflow guidance only in repository docs
+- Let each downstream project invent its own process
+
+## Additional Context
+
+This issue matters because sustainable evolution is one of the main product goals.
+
+It is intentionally separate from the agent-enforcement layer:
+- issue 08 defines the reusable workflow standard
+- issue 09 defines how agents are forced to comply with it before editing
+
+This issue should also clarify why AgenticOS uses GitHub Flow rather than full GitFlow:
+- lower operational overhead
+- better fit for continuous, agent-assisted iteration
+- simpler downstream inheritance and automation
+
+## Acceptance Criteria
+
+- A documented workflow standard exists
+- The standard explicitly names the canonical branch model used by AgenticOS
+- The workflow references issue-first behavior explicitly
+- GitHub Actions responsibilities are defined
+- The standard is reusable by downstream AgenticOS projects
+- The boundary between workflow model and agent-enforcement layer is clear

--- a/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/tasks/issue-drafts/09-enforce-agent-worktree-branch-compliance.md
+++ b/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/tasks/issue-drafts/09-enforce-agent-worktree-branch-compliance.md
@@ -1,0 +1,113 @@
+---
+name: Feature Request
+about: Enforce issue-first branch/worktree workflow for code agents
+title: "feat: enforce agent compliance with issue-first branch and worktree workflow"
+labels: enhancement
+---
+
+## Problem Statement
+
+AgenticOS already documents an issue-first, branch-based workflow and, in the main repository, explicit worktree isolation for development.
+
+However, this session showed that the protocol is still not reliably enforced in agent behavior:
+- changes were made directly in the active workspace
+- work did not begin from a dedicated branch/worktree
+- the workflow was not treated as a hard gate before editing
+
+This means the current standard is still descriptive, not operationally enforceable.
+
+## Why This Matters
+
+If a code agent can read the rules and still edit directly on `main` or on the active workspace, then:
+- the standard is not strong enough
+- cross-session trust decreases
+- running systems are exposed to accidental mutation
+- issue-first collaboration cannot scale reliably
+
+This is not only a workflow issue. It is an agent-control issue.
+
+## Current State
+
+Today the documented guidance is split:
+- repository-level `AGENTS.md` defines Issue-First, feature branches, and no direct work on `main`
+- repository-level `CLAUDE.md` adds worktree isolation for Claude Code
+- project-level documents do not always restate or enforce these rules
+- there is no hard preflight check that blocks edits when the workflow contract is not satisfied
+- some independent project repos may still be on an unborn `main` branch with no initial commit, which means normal branch/worktree flow cannot even start cleanly yet
+
+## Proposed Solution
+
+Turn workflow compliance into an explicit agent preflight protocol.
+
+The intended workflow model should be:
+
+- **GitHub Flow** for branch lifecycle
+- **mandatory isolated worktrees** for implementation work
+- **issue-first preflight** before implementation begins
+
+This issue should build on the executable agent protocol from issue 03 rather than invent a separate workflow logic.
+In particular, worktree enforcement should be attached to task classification:
+- `discussion_only` does not require a worktree
+- `analysis_or_doc` may remain in the main workspace only when implementation-affecting files are untouched
+- `implementation` requires branch + isolated worktree
+- `bootstrap` allows a narrow baseline exception until the repo can support normal flow
+
+This issue is not about choosing release branches. It is about making the chosen workflow executable by agents.
+
+Before any code-editing task begins, the agent should verify:
+- an issue exists or an issue draft has been accepted
+- the current repo is not the protected `main` working tree for active development
+- a dedicated branch or isolated worktree exists for the task
+- the write target is appropriate for the current repo and task
+
+Potential enforcement directions:
+- add an agent preflight checklist to canonical agent docs
+- add a helper command or bootstrap script that creates the issue branch/worktree correctly
+- add guardrails that refuse code edits when running on `main`
+- add repository checks that surface a warning or hard failure when editing on the wrong branch/worktree
+- distinguish clearly between "discussion/doc drafting allowed on main" and "implementation changes require branch/worktree"
+- define how the protocol behaves when the repo has no initial baseline commit yet
+- provide reusable preflight and submission templates so worktree compliance is not purely conversational
+
+## Scope
+
+This issue should define:
+- when a branch/worktree is mandatory
+- whether docs-only work is exempt or not
+- how independent subproject repos should inherit the same rule
+- what minimum baseline state is required before branch/worktree workflow becomes mandatory
+- how agents should behave if the correct branch/worktree does not exist yet
+- how this protocol differs between Claude Code, Codex, and other supported agents
+- what counts as an "implementation-affecting" change versus a "discussion-only" change
+- how worktree enforcement composes with the broader agent execution protocol
+
+## Non-Goals
+
+- This issue should not redesign the whole Git workflow model
+- This issue should not decide release branching strategy
+- This issue should not replace issue 08; it should provide the agent-execution enforcement layer that issue 08 depends on
+
+## Alternatives Considered
+
+- Rely on written guidance only
+- Let users manually catch workflow violations
+- Enforce workflow only socially through code review
+
+## Verification Plan
+
+- Define a preflight checklist and test it against real agent tasks
+- Simulate a code-edit task on `main` and confirm the agent is redirected to create/use a branch or worktree
+- Verify that documentation-only tasks and implementation tasks are treated according to the new rules
+- Verify that the standard is visible to downstream projects and not only the root repository
+- Verify behavior for repos with no initial commit yet
+- Verify that task classification cannot silently downgrade implementation work into a docs-only exception
+
+## Acceptance Criteria
+
+- A documented agent preflight workflow exists for issue-first and branch/worktree compliance
+- The standard explicitly treats worktree as mandatory isolation for implementation work under GitHub Flow
+- The standard defines whether docs-only and implementation tasks are treated differently
+- The standard defines how task classification drives branch/worktree requirements
+- The standard covers both the root repository and independent AgenticOS-managed project repos
+- The standard is concrete enough to support future guardrails or automation
+- Later agent sessions should not modify active `main` workspaces for implementation tasks by default

--- a/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/tasks/issue-drafts/10-package-executable-agent-protocol-for-downstream-projects.md
+++ b/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/tasks/issue-drafts/10-package-executable-agent-protocol-for-downstream-projects.md
@@ -1,0 +1,56 @@
+---
+name: Feature Request
+about: Package the executable agent protocol and templates for downstream AgenticOS projects
+title: "feat: package executable agent protocol as a downstream standard kit"
+labels: enhancement
+---
+
+## Problem Statement
+
+AgenticOS now has protocol drafts and reusable templates for:
+- agent preflight
+- design briefs
+- non-code evaluation
+- submission evidence
+
+But these assets still live only inside the standards project.
+
+Downstream projects do not yet have a clear, versioned, inheritable package that makes this protocol operational by default.
+
+After self-hosting migration landed, these standards are now anchored at:
+
+- `projects/agenticos/standards/`
+
+That means the packaging problem is no longer abstract. It now needs to define how a real product repository exports inheritable standards while keeping repository-root exceptions separate.
+
+## Proposed Solution
+
+Define a downstream standard kit for the executable agent protocol.
+
+It should specify:
+- which files are canonical templates
+- which files are generated per project
+- which files are customizable
+- how version markers are applied
+- how later upgrades are propagated safely
+- which assets are project-scoped standards versus root-scoped repository infrastructure
+- how downstream projects consume standards without inheriting root-only exceptions like `.github/`
+
+Potential outputs:
+- a standard package layout
+- inheritance rules
+- template versioning rules
+- downstream adoption checklist
+
+## Why This Matters
+
+Without a standard kit, the protocol remains local knowledge rather than a reusable operating standard.
+
+## Acceptance Criteria
+
+- A documented downstream package model exists
+- Canonical versus customizable files are defined
+- Template upgrade/versioning rules are defined
+- A downstream project can adopt the protocol without relying on the original chat history
+- The package model is consistent with the landed self-hosting layout under `projects/agenticos/standards/`
+- Repository-root exceptions are explicitly excluded or handled separately

--- a/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/tasks/issue-drafts/11-build-agent-preflight-guardrail-and-helper-command.md
+++ b/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/tasks/issue-drafts/11-build-agent-preflight-guardrail-and-helper-command.md
@@ -1,0 +1,81 @@
+---
+name: Feature Request
+about: Add guardrails and helper commands so agent workflow rules are enforced rather than only documented
+title: "feat: build agent preflight guardrail and worktree bootstrap helper"
+labels: enhancement
+---
+
+## Problem Statement
+
+AgenticOS now has stronger workflow and execution protocol definitions, but they are still mostly documentary.
+
+An agent can still skip:
+- task classification
+- issue-first checks
+- worktree checks
+- acceptance definition
+- verification planning
+
+if there is no runtime guardrail.
+
+Real execution added two concrete failure modes that must now be treated as first-class guardrail targets:
+
+- opening a PR from a branch cut from a local `main` ahead of `origin/main`
+- assuming repository-root infrastructure such as `.github/` can be relocated like ordinary product-source content
+
+## Proposed Solution
+
+Design and implement a guardrail layer that can:
+- run preflight checks before implementation starts
+- fail closed when issue/branch/worktree prerequisites are missing
+- help bootstrap the correct branch/worktree when possible
+- surface clear reasons when work is blocked
+
+Potential outputs:
+- a helper command for issue branch + worktree setup
+- a machine-checkable preflight command
+- refusal or warning behavior in protected contexts
+- integration points for Claude, Codex, and other supported agents
+- remote-base ancestry checks before branch creation or PR opening
+- diff-scope checks that detect unrelated commits relative to the intended remote base
+- a root-scoped infrastructure exception list used during repository-structure operations
+
+Guardrail v1 should cover four machine-checkable layers:
+
+1. task gate
+   - classify discussion/doc/implementation/bootstrap correctly
+2. repository gate
+   - verify repo identity, branch, worktree type, remote base, and branch ancestry
+3. scope gate
+   - verify declared target files, PR diff scope, and root-scoped infrastructure exceptions
+4. reproducibility gate
+   - verify clean install/build/test expectations before structure-changing work
+
+Suggested commands:
+- `agenticos_preflight`
+- `agenticos_branch_bootstrap`
+- `agenticos_pr_scope_check`
+
+Related design artifact:
+- `knowledge/agent-guardrail-design-v1-2026-03-23.md`
+- `knowledge/agent-guardrail-command-contracts-v1-2026-03-23.md`
+
+Related machine-checkable schema:
+- `tasks/templates/agent-preflight-checklist.yaml`
+
+## Why This Matters
+
+The project has already observed that written rules alone do not reliably control agent behavior.
+
+## Acceptance Criteria
+
+- A concrete guardrail design exists
+- Preflight can be evaluated in a machine-checkable way
+- Missing issue/branch/worktree prerequisites can block or redirect implementation work
+- A helper path exists to create the required branch/worktree correctly
+- The guardrail can detect when a branch is based on the wrong baseline relative to `origin/main`
+- The guardrail can detect or encode root-scoped infrastructure exceptions such as `.github/`
+- The guardrail can distinguish `BLOCK` from `REDIRECT` when helper automation can safely repair setup
+- A machine-readable preflight schema includes remote-base ancestry, scope checks, and reproducibility gates
+- Command contracts exist for `agenticos_preflight`, `agenticos_branch_bootstrap`, and `agenticos_pr_scope_check`
+- The command contracts separate checker responsibilities from mutating helper responsibilities

--- a/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/tasks/issue-drafts/12-define-baseline-bootstrap-protocol-for-new-project-repos.md
+++ b/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/tasks/issue-drafts/12-define-baseline-bootstrap-protocol-for-new-project-repos.md
@@ -1,0 +1,79 @@
+---
+name: Feature Request
+about: Define how new or unborn AgenticOS project repos enter the normal issue/branch/worktree workflow
+title: "feat: define baseline bootstrap protocol for new AgenticOS project repositories"
+labels: enhancement
+---
+
+## Problem Statement
+
+Some AgenticOS-managed project repositories may still have no initial commit.
+
+In that state:
+- normal branch creation is not meaningful
+- normal worktree flow cannot start cleanly
+- issue-first branch/worktree rules become self-contradictory
+
+This is not hypothetical.
+The `agentic-os-development` standards project itself is currently such a repo, which makes this issue immediately relevant.
+
+## Proposed Solution
+
+Define a baseline bootstrap protocol for newborn project repos.
+
+It should specify:
+- the minimum baseline files required
+- whether bootstrap work needs a special issue type
+- when bootstrap is considered complete
+- when the repo transitions into normal issue/branch/worktree flow
+- what actions remain forbidden even during bootstrap
+- how bootstrap composes with the broader task-classification protocol
+
+Recommended direction:
+- treat `bootstrap` as a narrow repository state, not a broad exemption
+- allow only baseline-establishing work during bootstrap
+- require the first baseline commit on `main`
+- require normal issue/branch/worktree rules immediately after bootstrap exit
+
+Potential outputs:
+- bootstrap state definition
+- minimum baseline file set
+- bootstrap issue template guidance
+- exit criteria
+- guardrail pseudocode for blocking non-baseline work before bootstrap is complete
+
+## Why This Matters
+
+Without a bootstrap protocol, the standard cannot cleanly apply to newly initialized projects, including the standards project itself.
+
+Without a clean bootstrap rule, downstream projects can misuse "new repo" status as a loophole around the normal workflow.
+
+## Scope
+
+This issue should define:
+- how a repo is classified as `bootstrap`
+- what exact files or conditions form the minimum baseline
+- what is allowed and forbidden during bootstrap
+- when bootstrap ends
+- how the repo transitions into normal issue-first branch/worktree flow
+
+## Non-Goals
+
+- This issue should not define the entire downstream project template package
+- This issue should not implement runtime guardrails by itself
+- This issue should not weaken branch/worktree rules for normal repositories
+
+## Verification Plan
+
+- Verify the protocol against a real unborn repository state
+- Verify that non-baseline work would be blocked during bootstrap
+- Verify that after the first baseline commit, normal branch/worktree flow becomes applicable
+- Verify that the bootstrap state cannot remain indefinitely without explicit reason
+
+## Acceptance Criteria
+
+- A documented bootstrap phase exists for repos with no initial commit
+- Minimum baseline requirements are defined
+- Exit criteria from bootstrap into normal workflow are defined
+- The protocol prevents bootstrap from becoming a loophole for unrelated work
+- The protocol is concrete enough to classify the current standards project correctly

--- a/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/tasks/issue-drafts/13-separate-product-source-workspace-and-runtime-layers.md
+++ b/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/tasks/issue-drafts/13-separate-product-source-workspace-and-runtime-layers.md
@@ -1,0 +1,52 @@
+---
+name: Feature Request
+about: Separate AgenticOS product source, user workspace, and runtime layers for portability and clarity
+title: "feat: separate product source, workspace, and runtime layers"
+labels: enhancement
+---
+
+## Problem Statement
+
+The current top-level AgenticOS repository mixes:
+- standards/specification assets
+- product implementation
+- user workspace projects
+- runtime byproducts such as agent worktrees
+
+This makes it unclear:
+- what Homebrew should install
+- what should live in the product source repository
+- what should be portable across machines
+- what should be treated as runtime-only and excluded from canonical source
+
+## Proposed Solution
+
+Define and adopt a layered model:
+
+- **product source**: standards, implementation, packaging, release assets
+- **workspace**: managed projects and portable workspace metadata
+- **runtime**: temporary worktrees, caches, ephemeral execution state
+
+The issue should define:
+- which current paths belong to which layer
+- which paths should move or be reclassified
+- how `agentic-os-development` should be positioned
+- how Homebrew initialization should create a clean workspace without mixing product source and runtime state
+
+After self-hosting migration landed, this layering issue now has one important execution-backed correction:
+
+- `.github/` is repository-root infrastructure and must remain at root even when product source is self-hosted under `projects/agenticos/`
+
+## Why This Matters
+
+Without this separation, portability, migration, and agent predictability all suffer.
+
+It also creates repeated confusion about whether implementation code like `mcp-server` belongs inside the standards project.
+
+## Acceptance Criteria
+
+- A documented layer model exists for product source, workspace, and runtime
+- Current top-level paths are classified into those layers
+- The intended position of `agentic-os-development` is defined
+- The intended relationship between Homebrew install, product source, workspace, and runtime is defined
+- Repository-root infrastructure exceptions such as `.github/` are explicitly classified and handled

--- a/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/tasks/issue-drafts/14-extract-runtime-workspace-projects-from-product-source-repo.md
+++ b/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/tasks/issue-drafts/14-extract-runtime-workspace-projects-from-product-source-repo.md
@@ -1,0 +1,60 @@
+---
+name: Feature Request
+about: Extract tracked runtime workspace projects out of the AgenticOS product source repository
+title: "feat: extract runtime workspace projects from the product source repository"
+labels: enhancement
+---
+
+## Problem Statement
+
+The current AgenticOS product source repository still tracks multiple real runtime projects under `projects/`.
+
+This creates coupling between:
+- AgenticOS standards and implementation development
+- real user project workspace data
+
+As long as runtime projects remain tracked in the product source repository:
+- repository boundaries remain unclear
+- migration stays messy
+- standards work can be polluted by runtime history
+- AgenticOS source development can interfere with the live workspace model
+
+## Proposed Solution
+
+Extract runtime workspace projects from the product source repository into a separate live workspace rooted at `AGENTICOS_HOME`.
+
+This issue should define:
+- which current `projects/*` entries are runtime projects
+- which entries are standards/meta content
+- which entries are fixtures/examples
+- the extraction sequence
+- the de-tracking strategy in the source repo
+- the documentation and bootstrap updates required afterward
+
+Initial recommended extraction targets:
+- `projects/2026okr`
+- `projects/360teams`
+- `projects/agentic-devops`
+- `projects/ghostty-optimization`
+- `projects/okr-management`
+- `projects/t5t`
+
+## Why This Matters
+
+Without extraction, AgenticOS remains both a product source repo and a live workspace at the same time.
+
+That weakens portability and makes Agent behavior less predictable.
+
+Self-hosting migration has now fixed the host-product positioning, so this issue has become more concrete:
+
+- `projects/agenticos/` is now the host product project
+- the remaining non-`agenticos` entries under `projects/` are much easier to classify as runtime, standards, or fixture content
+
+## Acceptance Criteria
+
+- Runtime workspace projects are classified explicitly
+- A migration sequence exists for moving them into a separate workspace
+- A de-tracking strategy exists for the product source repository
+- `agentic-os-development` is kept distinct from ordinary runtime projects
+- The resulting source repo no longer needs to act as the live default workspace
+- The extraction plan is consistent with `projects/agenticos/` already being the landed host-product project

--- a/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/tasks/issue-drafts/15-evaluate-self-hosting-workspace-model-for-agenticos.md
+++ b/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/tasks/issue-drafts/15-evaluate-self-hosting-workspace-model-for-agenticos.md
@@ -1,0 +1,41 @@
+---
+name: Feature Request
+about: Evaluate moving the AgenticOS product itself under projects/ so the workspace self-hosts the main product
+title: "feat: evaluate self-hosting workspace model for the AgenticOS product"
+labels: enhancement
+---
+
+## Problem Statement
+
+The current setup still leaves ambiguity between:
+- the AgenticOS product source repository
+- the AgenticOS runtime workspace
+- the standards/meta project used to evolve the rules
+
+One possible resolution is to make the top-level AgenticOS directory the runtime workspace, and move the AgenticOS product itself under `projects/` as a managed project.
+
+That would make AgenticOS develop itself under its own project rules.
+
+## Proposed Solution
+
+Evaluate a self-hosting model where:
+- the top-level AgenticOS directory becomes workspace home
+- the AgenticOS product source becomes a managed project under `projects/`
+- standards and implementation are unified inside that managed product project
+
+The evaluation should define:
+- target directory layout
+- what happens to `agentic-os-development`
+- migration impact on CI, releases, Homebrew, and docs
+- whether this is better than keeping the current source-first model
+
+## Why This Matters
+
+This model may be the cleanest way to ensure that AgenticOS itself is developed under AgenticOS project governance.
+
+## Acceptance Criteria
+
+- A documented comparison exists between source-first and self-hosting models
+- The target structure for a self-hosting model is defined
+- The role of `agentic-os-development` is clarified under that model
+- Migration cost and risk are explicitly assessed

--- a/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/tasks/issue-drafts/16-plan-self-hosting-migration-sequence.md
+++ b/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/tasks/issue-drafts/16-plan-self-hosting-migration-sequence.md
@@ -1,0 +1,59 @@
+---
+name: Feature Request
+about: Plan the migration sequence if AgenticOS adopts the self-hosting workspace model
+title: "feat: plan the self-hosting migration sequence for AgenticOS"
+labels: enhancement
+---
+
+## Problem Statement
+
+The self-hosting model is conceptually coherent, but adoption requires a structural migration.
+
+Without a staged migration plan, AgenticOS risks:
+- path breakage
+- CI and release breakage
+- confusion about where standards live
+- accidental mixing of old and new models
+
+## Proposed Solution
+
+Define a phased migration sequence for adopting the self-hosting workspace model.
+
+Assume the frozen target model for planning is:
+- top-level `AgenticOS` directory becomes workspace home
+- canonical managed product project path becomes `projects/agenticos`
+- current standards content moves under `projects/agenticos/standards/`
+- runtime-only artifacts move under `.runtime/`
+
+The plan should specify:
+- target directory layout
+- where the AgenticOS product project will live
+- where standards will live
+- how runtime artifacts will move
+- which current root paths move into `projects/agenticos`
+- which current standards paths move into `projects/agenticos/standards`
+- what paths need rewriting
+- how to preserve or manage Git history
+- what verification must pass after each phase
+
+Execution planning should be verification-first:
+- each step defines preconditions
+- each step has immediate post-change verification
+- each step has a local rollback boundary
+- later steps do not begin until earlier verification passes
+- the plan should be precise enough to become a command-level playbook
+
+## Why This Matters
+
+A self-hosting model only helps if the transition to it is controlled and reversible.
+
+## Acceptance Criteria
+
+- A phased migration plan exists
+- The target model is explicit enough to plan against without re-opening the naming decision each time
+- A concrete path relocation checklist exists for both product-source paths and standards paths
+- Path rewrite scope is identified
+- Verification gates are defined
+- A verification-first execution order exists
+- A command-level playbook exists or is directly derivable from the plan
+- Rollback boundaries are defined

--- a/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/tasks/issue-drafts/17-define-baseline-isolation-before-self-hosting-migration.md
+++ b/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/tasks/issue-drafts/17-define-baseline-isolation-before-self-hosting-migration.md
@@ -1,0 +1,45 @@
+---
+name: Feature Request
+about: Define how to isolate a clean migration baseline before any self-hosting execution begins
+title: "feat: define baseline isolation procedure before self-hosting migration"
+labels: enhancement
+---
+
+## Problem Statement
+
+The current AgenticOS root worktree is not clean enough to serve as a trustworthy migration starting point.
+
+It currently mixes:
+- unstaged root product-source changes
+- staged deletions related to the standards subproject split
+- unrelated runtime project changes
+
+If self-hosting migration starts from this state, verification and rollback become ambiguous.
+
+## Proposed Solution
+
+Define a baseline isolation procedure that:
+- preserves the current dirty state safely
+- creates a dedicated migration branch
+- creates a fresh isolated worktree
+- verifies the clean baseline before any structural move begins
+
+The procedure should define:
+- branch naming
+- worktree location rules
+- preservation commands for current dirty state
+- clean-worktree verification gates
+- stop conditions if isolation fails
+
+## Why This Matters
+
+Migration quality depends on starting from a clean and reviewable baseline.
+
+Without isolation, even a good migration plan can fail operationally.
+
+## Acceptance Criteria
+
+- A documented baseline isolation procedure exists
+- Dirty-state preservation requirements are explicit
+- A clean migration branch/worktree strategy is defined
+- Verification gates exist before the first structural move

--- a/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/tasks/issue-drafts/18-prepare-operator-checklist-for-self-hosting-migration.md
+++ b/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/tasks/issue-drafts/18-prepare-operator-checklist-for-self-hosting-migration.md
@@ -1,0 +1,40 @@
+---
+name: Feature Request
+about: Prepare an operator-ready checklist with exact commands for baseline isolation before self-hosting migration
+title: "feat: prepare operator checklist for self-hosting migration baseline isolation"
+labels: enhancement
+---
+
+## Problem Statement
+
+The migration planning stack now includes:
+- target model
+- relocation checklist
+- verification-first execution sequence
+- baseline isolation plan
+
+But an operator still needs one final artifact:
+- the exact command checklist to establish the migration baseline safely
+
+Without that, execution may still drift or improvise.
+
+## Proposed Solution
+
+Prepare an operator-ready checklist that freezes:
+- exact base commit
+- exact migration branch name
+- exact external worktree path
+- exact preservation commands for current dirty state
+- exact isolation verification commands
+- exact isolation rollback commands
+
+## Why This Matters
+
+This is the final bridge between planning and safe execution.
+
+## Acceptance Criteria
+
+- An execution-ready operator checklist exists
+- Exact commands are listed for preservation, worktree creation, and verification
+- Exact stop conditions are defined
+- Exact isolation rollback commands are defined

--- a/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/tasks/issue-drafts/19-restore-clean-mcp-server-baseline-before-migration.md
+++ b/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/tasks/issue-drafts/19-restore-clean-mcp-server-baseline-before-migration.md
@@ -1,0 +1,48 @@
+---
+name: Bug Report
+about: Restore a reproducible clean-install baseline for mcp-server before self-hosting migration continues
+title: "fix: restore reproducible mcp-server clean install baseline before self-hosting migration"
+labels: bug
+---
+
+## Problem Statement
+
+The first real baseline-isolation execution for self-hosting migration succeeded in creating a clean external worktree, but failed at the reproducibility gate:
+
+```bash
+cd /Users/jeking/worktrees/agenticos-self-hosting/mcp-server
+npm ci
+```
+
+`npm ci` failed because `package.json` and `package-lock.json` are out of sync. The missing lock entries include `vitest` and related packages.
+
+That means the current migration baseline commit cannot be reproduced from a clean checkout.
+
+## Proposed Solution
+
+Restore a reproducible baseline for `mcp-server` by:
+- bringing `package-lock.json` back into sync with `package.json`
+- verifying `npm ci` succeeds in a fresh clean worktree
+- verifying `npm run build` succeeds after the clean install
+- documenting the clean-baseline verification step as a hard migration gate
+
+## Why This Matters
+
+Self-hosting migration cannot safely continue from a baseline that is not reproducible from a clean checkout.
+
+If this is left unresolved:
+- migration verification becomes unreliable
+- future agents may continue from a false green baseline
+- rollback and reproducibility claims become weak
+
+## Non-Goals
+
+- This issue does not execute the structural self-hosting migration itself
+- This issue does not redesign the broader migration plan
+
+## Acceptance Criteria
+
+- `mcp-server/package.json` and `mcp-server/package-lock.json` are in sync
+- `npm ci` succeeds in a fresh clean isolated worktree
+- `npm run build` succeeds immediately after that clean install
+- the baseline isolation and operator-checklist docs reflect `npm ci` as the canonical clean-baseline install gate

--- a/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/tasks/issue-drafts/20-execute-runtime-project-extraction-from-source-repo.md
+++ b/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/tasks/issue-drafts/20-execute-runtime-project-extraction-from-source-repo.md
@@ -1,0 +1,66 @@
+---
+name: Feature Request
+about: Execute the runtime-project extraction from the AgenticOS product source repository into the live workspace
+title: "feat: execute runtime project extraction from the product source repository"
+labels: enhancement
+---
+
+## Problem Statement
+
+Issue `#38` completed the planning milestone for runtime-project extraction:
+- runtime projects are now explicitly classified
+- fixture/example content is identified
+- an extraction and de-tracking sequence exists
+
+But the real runtime projects are still physically tracked in the product source repository.
+
+That means AgenticOS still has a gap between:
+- the intended source/workspace boundary
+- the actual filesystem and Git-tracking reality
+
+## Proposed Solution
+
+Execute the first real extraction wave for the tracked runtime projects.
+
+Initial execution targets:
+- `projects/2026okr`
+- `projects/360teams`
+- `projects/agentic-devops`
+- `projects/ghostty-optimization`
+- `projects/okr-management`
+- `projects/t5t`
+
+This issue should:
+- prepare or confirm the separate live workspace root
+- copy the runtime projects into that workspace
+- verify that copied project state and project-local Git repositories remain intact
+- de-track the runtime project directories from the product source repository only after verification
+- leave `projects/agenticos` untouched as product source
+- decide whether `projects/test-project` stays as fixture/example or is removed separately
+
+## Why This Matters
+
+Without the execution step, the source repo remains polluted by live runtime project content even though the intended architecture is now clear.
+
+## Non-Goals
+
+- redesigning the self-hosting model
+- changing the canonical host-product path `projects/agenticos`
+- moving repository-root infrastructure such as `.github/`
+- silently deleting runtime project data before copied workspace verification passes
+
+## Acceptance Criteria
+
+- A live workspace destination for extracted runtime projects is confirmed
+- The first-wave runtime projects are copied out and verified
+- The product source repository de-tracks those runtime projects after verification
+- Root docs reflect that the source repo no longer carries the extracted runtime projects
+- `projects/agenticos` remains the only canonical product-source project under `projects/`
+
+## Verification Plan
+
+- verify the extracted project directories exist in the live workspace
+- verify project-local `.git` directories or repositories still work where present
+- verify project-local `.context/` state remains readable
+- verify `git diff --stat origin/main...HEAD` in the source repo contains only the intended de-tracking and documentation changes
+- verify root docs and root guidance describe the new boundary correctly

--- a/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/tasks/issue-drafts/README.md
+++ b/projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/tasks/issue-drafts/README.md
@@ -1,0 +1,33 @@
+# AgenticOS Issue Drafts
+
+> Date: 2026-03-22
+> Purpose: convert current design findings into issue-first work items for systematic iteration
+
+## Recommended Order
+
+1. `01-fix-project-boundary-enforcement.md`
+2. `02-define-memory-layer-contracts.md`
+3. `03-define-executable-agent-protocol.md`
+4. `04-define-sub-agent-context-inheritance.md`
+5. `05-define-cross-agent-bootstrap-standard.md`
+6. `06-homebrew-post-install-bootstrap.md`
+7. `07-define-mcp-vs-cli-skills-integration-matrix.md`
+8. `08-standardize-issue-first-github-actions-workflow.md`
+9. `09-enforce-agent-worktree-branch-compliance.md`
+10. `10-package-executable-agent-protocol-for-downstream-projects.md`
+11. `11-build-agent-preflight-guardrail-and-helper-command.md`
+12. `12-define-baseline-bootstrap-protocol-for-new-project-repos.md`
+13. `13-separate-product-source-workspace-and-runtime-layers.md`
+14. `14-extract-runtime-workspace-projects-from-product-source-repo.md`
+15. `15-evaluate-self-hosting-workspace-model-for-agenticos.md`
+16. `16-plan-self-hosting-migration-sequence.md`
+17. `17-define-baseline-isolation-before-self-hosting-migration.md`
+18. `18-prepare-operator-checklist-for-self-hosting-migration.md`
+19. `19-restore-clean-mcp-server-baseline-before-migration.md`
+20. `20-execute-runtime-project-extraction-from-source-repo.md`
+
+## Notes
+
+- These drafts are the local source material for the corresponding GitHub issues.
+- Each draft is written so it can be copied or synced into the repository's issue template with minimal editing.
+- The order above is intentional: fix core product contracts first, then integration, workflow, packaging, and enforcement layers.

--- a/projects/agenticos/standards/knowledge/agent-execution-loop-2026-03-23.md
+++ b/projects/agenticos/standards/knowledge/agent-execution-loop-2026-03-23.md
@@ -1,0 +1,151 @@
+# AgenticOS Agent Execution Loop
+
+> Date: 2026-03-23
+> Purpose: convert fragmented user intent and issue-driven work into an executable agent workflow
+
+## 1. Core Principle
+
+User input may be fragmented, incomplete, or partially solution-shaped.
+
+An AgenticOS-compatible agent should not respond only to the literal last sentence.
+It should:
+- synthesize fragmented inputs into a coherent objective
+- infer the likely end goal, constraints, and quality bar
+- propose the most suitable solution when the user's plan is incomplete
+- improve the user's proposed solution when it is directionally correct but underspecified
+
+This is a required behavior, not a style preference.
+
+## 2. Issue Execution Must Start With Context
+
+When an agent picks up an issue, it must not jump straight into implementation.
+
+It must first load enough project context to answer:
+- what is the project's long-term objective
+- what system or product contract already exists
+- what the current issue is trying to change
+- how this issue interacts with adjacent decisions or risks
+
+Minimum context loading should include:
+- project quick-start and state
+- relevant knowledge/design documents
+- relevant issue and PR history
+- agent-specific rules for the current repository
+
+## 3. Required Execution Loop
+
+For non-trivial tasks, the agent should follow this loop:
+
+1. **Intent synthesis**
+   Infer the user's real objective from fragmented input.
+2. **Context loading**
+   Read enough project material to understand the whole system.
+3. **Task framing**
+   Define the current problem, constraints, non-goals, and desired outcome.
+4. **Design pass 1**
+   Produce an initial design or solution path.
+5. **Design critique**
+   Challenge the initial design, identify weak assumptions, missing edge cases, and tradeoffs.
+6. **Design pass 2**
+   Produce a refined design.
+7. **Optional design pass 3**
+   Required for high-risk, architectural, or protocol-defining work.
+8. **Acceptance definition**
+   Define executable acceptance criteria before implementation.
+9. **Implementation**
+   Change code, docs, or other artifacts.
+10. **Verification**
+    Run the required checks.
+11. **Only then submit**
+    Commit, open/update MR or PR, and link verification evidence.
+
+This is a `design -> critique -> redesign -> verify` workflow, not a one-shot generation workflow.
+
+## 4. Acceptance Criteria Must Be Executable
+
+Acceptance criteria should not remain purely narrative.
+
+They must be written in an executable or operational form:
+- code checks
+- pseudocode-level protocol checks
+- lint/test/build rules
+- evaluation rubrics
+- machine-checkable file or schema expectations
+
+Bad example:
+- "Agent should understand the project better"
+
+Better example:
+- "Before implementation, the agent must read `quick-start`, `state.yaml`, and at least one issue-relevant knowledge file, then restate project goal, issue goal, and implementation scope"
+
+## 5. Verification Rules
+
+### Code deliverables
+
+For code changes, verification should include:
+- build/lint/typecheck as applicable
+- automated tests for changed behavior
+- coverage for the changed scope
+
+Operational recommendation:
+- require **100% coverage for the changed scope or changed logic surface**
+- if exact 100% cannot be achieved, require an explicit documented exception with reason and residual risk
+
+This is a better operational interpretation than demanding arbitrary repository-wide 100% coverage on every issue.
+
+### Non-code deliverables
+
+For documentation, protocol, design, or analysis outputs, verification should use rubric-based evaluation.
+
+Possible mechanisms:
+- LLM-as-judge prompts against explicit rubrics
+- multiple evaluator prompts or evaluator models
+- checklist-based self-evaluation plus independent LLM evaluation
+- comparison against issue acceptance criteria and source context
+
+The key requirement is not "use an LLM somehow".
+It is:
+- evaluation criteria must be explicit
+- evaluation should check goal satisfaction, not only writing quality
+- the result should be recorded as evidence before submission
+
+## 6. Suggested Pseudocode
+
+```text
+function execute_issue(issue, user_input, repo):
+  objective = synthesize_intent(user_input, issue)
+  context = load_project_context(repo, issue)
+  task = frame_task(objective, context)
+
+  design_v1 = draft_design(task)
+  critique_v1 = challenge_design(design_v1, context)
+  design_v2 = refine_design(design_v1, critique_v1)
+
+  if task.is_high_risk or task.is_architectural:
+    critique_v2 = challenge_design(design_v2, context)
+    final_design = refine_design(design_v2, critique_v2)
+  else:
+    final_design = design_v2
+
+  acceptance = define_executable_acceptance(final_design)
+
+  implementation = implement(final_design)
+  verification = verify(implementation, acceptance)
+
+  if not verification.passed:
+    return iterate_again()
+
+  return submit_with_evidence(implementation, verification)
+```
+
+## 7. Product Implication
+
+This protocol should shape:
+- issue templates
+- AGENTS.md and CLAUDE.md style agent instructions
+- future automation and linting
+- downstream project inheritance
+
+Without this loop, "Agent First" stays aspirational.
+
+With this loop, AgenticOS can begin to standardize predictable agent behavior.

--- a/projects/agenticos/standards/knowledge/agent-guardrail-command-contracts-v1-2026-03-23.md
+++ b/projects/agenticos/standards/knowledge/agent-guardrail-command-contracts-v1-2026-03-23.md
@@ -1,0 +1,248 @@
+# AgenticOS Guardrail Command Contracts v1
+
+> Date: 2026-03-23
+> Status: draft command-contract candidate
+> Purpose: define executable input/output contracts for the first guardrail commands
+
+## 1. Why Command Contracts Are Needed
+
+The guardrail design is not actionable enough until the command boundaries are fixed.
+
+These contracts should answer:
+- what each command consumes
+- what each command returns
+- what it is allowed to fix automatically
+- what it must block instead of mutating
+
+## 2. Contract Set
+
+Guardrail v1 should expose three commands:
+
+1. `agenticos_preflight`
+2. `agenticos_branch_bootstrap`
+3. `agenticos_pr_scope_check`
+
+## 3. `agenticos_preflight`
+
+### Responsibility
+
+Evaluate whether the current task is allowed to proceed into implementation.
+
+### Required input
+
+```yaml
+issue_id: "36"
+task_type: implementation
+repo_path: "/abs/path/to/repo"
+remote_base_branch: "origin/main"
+declared_target_files:
+  - "projects/agenticos/mcp-server/src/..."
+structural_move: false
+worktree_required: true
+```
+
+### Optional input
+
+```yaml
+risk_level: high
+root_scoped_exceptions:
+  - ".github/"
+clean_reproducibility_gate:
+  - "npm ci"
+  - "npm run build"
+  - "npm test"
+issue_relevant_knowledge_files:
+  - "projects/agenticos/standards/knowledge/..."
+```
+
+### Required checks
+
+- repo identity
+- issue linkage
+- task classification
+- current workspace type
+- remote-base ancestry
+- target-file declaration
+- root-scoped exception check if `structural_move == true`
+- verification-plan presence
+
+### Output shape
+
+```yaml
+status: PASS | BLOCK | REDIRECT
+summary: ""
+repo_identity_confirmed: true
+branch_ancestry_verified: true
+branch_based_on_intended_remote: true
+worktree_ok: true
+scope_ok: true
+reproducibility_gate_defined: true
+block_reasons: []
+redirect_actions: []
+evidence:
+  current_branch: ""
+  current_head: ""
+  remote_base_branch: ""
+  branch_fork_point: ""
+```
+
+### Status semantics
+
+#### `PASS`
+
+Use only if:
+- no hard gate failed
+- current branch/worktree/base are acceptable
+- implementation may continue
+
+#### `BLOCK`
+
+Use if:
+- branch is based on wrong remote ancestry
+- issue/worktree alignment is missing and cannot be repaired safely in place
+- structural move ignores root-scoped exceptions
+- clean reproducibility gate is required but undefined
+
+#### `REDIRECT`
+
+Use if:
+- work can proceed only after safe setup automation
+- example: issue exists, but correct branch/worktree is missing and can be created by helper
+
+### Non-goals
+
+`agenticos_preflight` should not:
+- mutate repository structure
+- silently create branches
+- silently rewrite task scope
+
+It is a checker, not an executor.
+
+## 4. `agenticos_branch_bootstrap`
+
+### Responsibility
+
+Create the correct issue branch and isolated worktree from the intended remote base.
+
+### Required input
+
+```yaml
+issue_id: "36"
+branch_type: "feat"
+slug: "guardrail-helper"
+repo_path: "/abs/path/to/repo"
+remote_base_branch: "origin/main"
+worktree_root: "/abs/path/to/worktrees"
+```
+
+### Output shape
+
+```yaml
+status: CREATED | BLOCK
+branch_name: "feat/36-guardrail-helper"
+base_commit: ""
+worktree_path: ""
+notes: []
+```
+
+### Hard rules
+
+- must derive the branch from the intended remote base, not the local current branch
+- must record the exact base commit used
+- must fail if target branch or worktree path already exists unexpectedly
+
+### Allowed mutation
+
+- create branch
+- create worktree
+- record setup metadata
+
+### Disallowed mutation
+
+- applying user code changes
+- rebasing unrelated local work
+- deleting existing worktrees automatically
+
+## 5. `agenticos_pr_scope_check`
+
+### Responsibility
+
+Validate that the current branch diff is scoped to the intended issue relative to the intended remote base.
+
+### Required input
+
+```yaml
+issue_id: "36"
+repo_path: "/abs/path/to/repo"
+remote_base_branch: "origin/main"
+declared_target_files:
+  - "projects/agenticos/..."
+expected_issue_scope: "single_guardrail_feature"
+```
+
+### Required checks
+
+- commit range relative to remote base
+- changed files relative to declared target files
+- unrelated commit subject detection
+- optional heuristic on suspicious extra scope
+
+### Output shape
+
+```yaml
+status: PASS | BLOCK
+summary: ""
+commit_count: 0
+changed_files: []
+unexpected_files: []
+unrelated_commit_subjects: []
+```
+
+### Fail conditions
+
+Block if:
+- unrelated commits exist in the branch range
+- changed files escape the declared target scope without explicit justification
+- current branch is not comparable to the intended remote base
+
+### Non-goal
+
+This command should not merge, rebase, or prune commits.
+
+It is a scope validator only.
+
+## 6. Shared Result Rules
+
+All guardrail commands should:
+- return machine-readable status first
+- include concrete evidence fields, not only prose
+- explain block reasons as actionable statements
+
+Recommended top-level invariant:
+
+```text
+no implementation command should proceed if the latest guardrail result is BLOCK
+```
+
+## 7. Minimum Implementation Order
+
+Recommended order:
+
+1. `agenticos_preflight`
+2. `agenticos_branch_bootstrap`
+3. `agenticos_pr_scope_check`
+
+Reason:
+- preflight defines the gates
+- bootstrap fixes safe setup gaps
+- PR scope check protects submission
+
+## 8. Minimum v1 Acceptance
+
+The command-contract layer is ready for implementation if:
+
+1. each command has fixed required inputs
+2. each command has fixed status values
+3. mutating versus non-mutating responsibilities are separated
+4. wrong-base ancestry and root-scoped exceptions are represented explicitly
+5. `BLOCK` versus `REDIRECT` semantics are unambiguous

--- a/projects/agenticos/standards/knowledge/agent-guardrail-design-v1-2026-03-23.md
+++ b/projects/agenticos/standards/knowledge/agent-guardrail-design-v1-2026-03-23.md
@@ -1,0 +1,224 @@
+# AgenticOS Agent Guardrail Design v1
+
+> Date: 2026-03-23
+> Status: draft design candidate
+> Purpose: turn the agent preflight protocol into a machine-checkable guardrail model informed by real execution failures
+
+## 1. Guardrail Goal
+
+The guardrail layer exists to stop an agent from entering implementation incorrectly.
+
+It should not rely on:
+- the model "remembering" process rules
+- branch naming alone
+- informal human review after the fact
+
+It should produce a concrete pass/fail result before implementation or PR creation proceeds.
+
+## 2. Why v1 Is Needed
+
+Real execution exposed concrete failure modes that documentation alone did not prevent:
+
+1. a PR branch can be cut from a local `main` that is ahead of `origin/main`
+2. the resulting PR can accidentally include unrelated commits
+3. a repository structure plan can incorrectly try to relocate root-scoped infrastructure such as `.github/`
+4. structural work can start before clean reproducibility is proven
+
+These are now design inputs, not hypotheticals.
+
+## 3. Guardrail Scope
+
+Guardrail v1 should cover four layers.
+
+### Layer A: task gate
+
+Checks:
+- task type classified
+- implementation versus docs-only distinguished
+- high-risk/protocol work identified
+
+Purpose:
+- decide whether strict branch/worktree enforcement applies
+
+### Layer B: repository gate
+
+Checks:
+- repo identity known
+- current branch known
+- current worktree type known
+- target remote base known
+- branch ancestry against remote base known
+
+Purpose:
+- prevent implementation from starting on the wrong baseline
+
+### Layer C: scope gate
+
+Checks:
+- target files identified before editing
+- executable standards versus ordinary docs distinguished
+- root-scoped infrastructure exceptions recognized
+- PR diff contains only issue-relevant commits
+
+Purpose:
+- prevent accidental broadening of scope
+
+### Layer D: reproducibility gate
+
+Checks:
+- clean install/build/test gate defined where applicable
+- baseline reproducibility proven before structural changes
+- verification plan exists before edits
+
+Purpose:
+- prevent structurally correct work from resting on a false baseline
+
+## 4. Root-Scoped Infrastructure Exceptions
+
+Guardrail v1 needs an explicit exception list.
+
+Initial required entries:
+- `.github/`
+
+Rule:
+- these paths are repository-scoped infrastructure
+- they must not be blindly treated as product-project paths during relocation logic
+
+Example:
+
+```text
+if operation == "relocate product source":
+  keep ".github/" at repo root
+  rewrite workflow working-directory instead
+```
+
+This exception list should be versioned and auditable.
+
+## 5. Remote-Base Ancestry Gate
+
+This is the most important new hard gate from execution.
+
+### Required checks
+
+For implementation work:
+
+1. determine intended remote base, default `origin/main`
+2. determine branch fork point
+3. verify branch ancestry is compatible with intended remote base
+4. verify extra commits are only issue-relevant
+
+### Fail condition
+
+Example:
+
+```text
+if branch contains commits not intended for current issue relative to origin/main:
+  preflight_passed = false
+  block_reason = "branch includes unrelated commits relative to remote base"
+```
+
+### Consequence
+
+The agent must not:
+- open the PR
+- continue implementation on that branch
+- claim issue isolation is satisfied
+
+The agent should instead:
+- cut a fresh branch/worktree from the correct remote base
+- re-apply only the intended change
+
+## 6. PR-Scope Gate
+
+Branch ancestry alone is not enough.
+
+The guardrail should also check:
+- changed files versus declared target files
+- commit count versus expected issue scope
+- unrelated commit headlines in the PR range
+
+Example heuristic:
+
+```text
+if implementation issue expects one scoped fix
+and PR range contains multiple unrelated commit subjects
+then block PR creation
+```
+
+This can begin as heuristic rather than perfect static proof.
+
+## 7. Structural-Change Gate
+
+If the task changes repository structure, the guardrail must require:
+- explicit path inventory
+- root-scoped infrastructure exception check
+- immediate post-move verification plan
+
+Example:
+
+```text
+if task_category == "implementation" and structural_move == true:
+  require root_scoped_exception_check == true
+  require post_move_build_gate_defined == true
+```
+
+## 8. Suggested Helper Commands
+
+Guardrail v1 should likely separate helper and checker responsibilities.
+
+### `agenticos_preflight`
+
+Role:
+- evaluate machine-checkable preflight
+- output pass/fail plus reasons
+
+Possible outputs:
+- `PASS`
+- `BLOCK`
+- `REDIRECT`
+
+### `agenticos_branch_bootstrap`
+
+Role:
+- create issue branch from intended remote base
+- create isolated worktree
+- record base commit and worktree path
+
+### `agenticos_pr_scope_check`
+
+Role:
+- compare current branch against intended remote base
+- detect unrelated commits or out-of-scope files
+
+## 9. Suggested Decision Model
+
+```text
+function run_guardrail(task, repo):
+  classify_task(task)
+  check_repo_identity(repo)
+  check_issue_link(task)
+  check_workspace_type(repo)
+  check_remote_base(repo, default="origin/main")
+  check_branch_ancestry(repo)
+  check_scope_declared(task)
+  check_root_scoped_exceptions(task)
+  check_verification_plan(task)
+
+  if any hard gate fails:
+    return BLOCK
+
+  if helper can resolve setup gap safely:
+    return REDIRECT
+
+  return PASS
+```
+
+## 10. Minimum v1 Acceptance Criteria
+
+Guardrail v1 is good enough to advance if:
+
+1. it can block implementation when no issue/branch/worktree alignment exists
+2. it can detect wrong-base branch ancestry relative to `origin/main`
+3. it can detect declared structural moves that ignore root-scoped exceptions such as `.github/`
+4. it can require an explicit clean reproducibility gate before structure-changing work
+5. it emits a machine-readable result, not just prose guidance

--- a/projects/agenticos/standards/knowledge/agent-preflight-and-execution-protocol-2026-03-23.md
+++ b/projects/agenticos/standards/knowledge/agent-preflight-and-execution-protocol-2026-03-23.md
@@ -1,0 +1,289 @@
+# AgenticOS Agent Preflight and Execution Protocol
+
+> Date: 2026-03-23
+> Status: draft standard candidate
+> Purpose: define a concrete preflight and execution contract that downstream agents can follow and future automation can enforce
+
+## 1. Protocol Goal
+
+This protocol exists to make agent work predictable, reviewable, and safe.
+
+It defines:
+- what an agent must understand before acting
+- when an agent is allowed to edit files
+- when branch/worktree isolation is mandatory
+- what design loop must occur before implementation
+- what verification must pass before submission
+
+## 2. Task Classification
+
+An agent must classify the task before acting.
+
+### `discussion_only`
+
+Allowed actions:
+- analyze
+- explain
+- compare options
+- propose designs
+
+Disallowed actions:
+- editing repository files
+- creating implementation artifacts that change shipped behavior
+
+### `analysis_or_doc`
+
+Allowed actions:
+- create or edit knowledge docs
+- write issue drafts
+- refine plans and protocols
+- update non-runtime documentation
+
+Constraints:
+- may run in the main workspace only if no implementation-affecting files are touched
+- still requires issue or accepted direction for non-trivial changes
+
+### `implementation`
+
+Examples:
+- code changes
+- workflow files
+- scripts
+- templates that downstream projects execute or inherit
+- runtime-affecting documentation coupled to shipped behavior
+
+Constraints:
+- requires issue-first preflight
+- requires task branch
+- requires isolated worktree
+- requires explicit verification before submission
+
+### `bootstrap`
+
+Applies when:
+- repo has no initial commit
+- branch/worktree flow cannot yet start normally
+
+Constraints:
+- only minimum baseline creation is allowed
+- bootstrap scope must be explicit
+- once baseline exists, normal implementation rules apply
+
+## 3. Required Preflight
+
+Before any file edits, the agent must produce a pass/fail result for this checklist.
+
+### Repository checks
+
+- repo identity known
+- current branch known
+- repo baseline state known
+- active issue or accepted issue draft known
+
+### Context checks
+
+- project goal understood
+- issue goal understood
+- relevant constraints understood
+- adjacent risks or related decisions reviewed
+
+### Task checks
+
+- task classified into one of the protocol types
+- target files identified
+- implementation impact assessed
+- whether worktree is mandatory determined
+
+### Execution checks
+
+- acceptance criteria drafted before implementation
+- verification method selected before implementation
+- record/update obligations identified
+
+If any required check fails, the agent must not proceed to implementation.
+
+## 4. Mandatory Behavior by Task Type
+
+### For `discussion_only`
+
+The agent must:
+- synthesize user intent
+- load enough context to avoid local optimization
+- keep outputs as analysis, options, or critique
+
+The agent must not:
+- silently transition into implementation
+
+### For `analysis_or_doc`
+
+The agent must:
+- synthesize fragmented input into a coherent objective
+- relate the task back to project-level goals
+- perform at least one design-and-critique loop for non-trivial docs or protocol work
+- define evaluation criteria before claiming completion
+
+The agent must not:
+- treat documentation edits as exempt if they change executable standards or downstream generated behavior without proper review
+
+### For `implementation`
+
+The agent must:
+- confirm issue linkage
+- create or use the correct branch
+- work in an isolated worktree
+- perform at least two design passes with critique in between for non-trivial work
+- define executable acceptance criteria before editing
+- verify before submission
+
+The agent must not:
+- implement directly in the protected active workspace
+- implement directly on `main`
+- skip verification because the change "looks small"
+
+### For `bootstrap`
+
+The agent must:
+- keep scope to the minimum baseline needed for the repo to enter normal workflow
+- identify what baseline files or commit are required
+- stop treating the repo as bootstrap once the baseline exists
+
+The agent must not:
+- use bootstrap as an excuse to bypass the normal workflow for unrelated work
+
+## 5. Design Loop Requirements
+
+### Trivial work
+
+One design pass may be acceptable only if:
+- the change is local
+- the risk is low
+- no project-level contract is being changed
+
+### Non-trivial work
+
+Minimum required loop:
+
+1. design pass 1
+2. critique pass 1
+3. design pass 2
+4. executable acceptance definition
+
+### High-risk or protocol work
+
+Minimum required loop:
+
+1. design pass 1
+2. critique pass 1
+3. design pass 2
+4. critique pass 2
+5. design pass 3
+6. executable acceptance definition
+
+High-risk includes:
+- workflow rules
+- standards and templates
+- persistence logic
+- context loading behavior
+- branching or worktree rules
+- security or data integrity sensitive code
+
+## 6. Acceptance Criteria Format
+
+Acceptance criteria should be written as checks, not adjectives.
+
+Preferred forms:
+- `if/then` behavioral rules
+- pseudocode assertions
+- command-based verification steps
+- schema or file-state assertions
+- rubric rows with pass/fail thresholds
+
+### Example
+
+Instead of:
+- "Agent should load enough context"
+
+Use:
+- "Before implementation, the agent must read `quick-start`, `state.yaml`, and at least one issue-relevant knowledge file, then restate project goal, issue scope, and non-goals"
+
+## 7. Verification Requirements
+
+### Code changes
+
+Required where applicable:
+- build
+- lint
+- typecheck
+- automated tests
+- coverage for changed scope
+
+Policy target:
+- 100% coverage for changed logic surface
+
+If the target is not met:
+- record an explicit exception
+- state why
+- state residual risk
+- do not claim full completion
+
+### Non-code changes
+
+Required:
+- explicit evaluation rubric
+- at least one structured evaluation pass
+- evidence recorded in the task output, issue, or related artifact
+
+Suitable evaluation methods:
+- LLM-as-judge with rubric
+- multi-pass evaluator prompts
+- criteria checklist against acceptance rules
+
+## 8. Submission Gate
+
+An agent may submit or claim completion only if:
+- preflight passed
+- required design loop completed
+- acceptance criteria existed before implementation
+- verification evidence exists
+- unresolved risks are disclosed
+
+If any of the above is false, the correct output is not "done".
+The correct output is a blocked or partial-completion state.
+
+## 9. Suggested Pseudocode
+
+```text
+function run_agent_task(input, repo, issue):
+  objective = synthesize_fragmented_input(input, issue)
+  task_type = classify_task(objective, repo)
+  preflight = run_preflight(repo, issue, task_type)
+
+  if not preflight.passed:
+    return blocked("preflight_failed", preflight.missing_items)
+
+  design = draft_design(objective, repo, issue)
+  critique = critique_design(design, repo, issue)
+  design = refine_design(design, critique)
+
+  if task_type in ["implementation", "protocol", "high_risk"]:
+    critique_2 = critique_design(design, repo, issue)
+    design = refine_design(design, critique_2)
+
+  acceptance = define_executable_acceptance(design, task_type)
+
+  result = implement(design)
+  verification = verify_result(result, acceptance, task_type)
+
+  if not verification.passed:
+    return blocked("verification_failed", verification.failures)
+
+  return submit(result, verification)
+```
+
+## 10. Downstream Implication
+
+This protocol should eventually become:
+- part of the canonical AgenticOS standard
+- reflected in issue templates
+- reflected in AGENTS.md and agent-specific overlays
+- enforceable through helper commands, scripts, or guardrails

--- a/projects/agenticos/standards/knowledge/baseline-bootstrap-protocol-2026-03-23.md
+++ b/projects/agenticos/standards/knowledge/baseline-bootstrap-protocol-2026-03-23.md
@@ -1,0 +1,128 @@
+# AgenticOS Baseline Bootstrap Protocol
+
+> Date: 2026-03-23
+> Purpose: define how a newborn AgenticOS project repository enters the normal issue/branch/worktree workflow
+
+## 1. Why Bootstrap Exists
+
+Normal AgenticOS workflow assumes:
+- the repository already has an initial commit
+- `main` exists as a meaningful baseline
+- feature branches can be created from that baseline
+- isolated worktrees can be attached to those branches
+
+For a newborn repository, those assumptions are false.
+
+So a bootstrap phase is required before normal issue-first branch/worktree rules can fully apply.
+
+## 2. Bootstrap Trigger
+
+A repository is in `bootstrap` state if any of the following is true:
+- `git status --branch` reports `No commits yet on main`
+- there is no baseline commit to branch from
+- canonical AgenticOS starter files have not been established yet
+
+## 3. Bootstrap Goal
+
+Bootstrap is not "early development".
+Bootstrap is a narrow phase whose only purpose is to create a stable baseline so normal workflow can begin.
+
+Its goal is to produce:
+- a valid initial repository baseline
+- canonical project identity files
+- enough context files for future agents to start correctly
+- a first commit on `main`
+
+## 4. Minimum Baseline Scope
+
+Bootstrap may include only baseline-establishing assets such as:
+- `.project.yaml`
+- `.context/quick-start.md`
+- `.context/state.yaml`
+- `AGENTS.md`
+- agent-specific overlay such as `CLAUDE.md`
+- `knowledge/` starter files
+- `tasks/` starter files
+- `.gitignore`
+- minimal README or changelog if part of the standard
+
+Bootstrap must not include unrelated feature work, product implementation, or opportunistic cleanup.
+
+## 5. Bootstrap Issue Handling
+
+Bootstrap should still be issue-driven.
+
+Recommended rule:
+- use a dedicated bootstrap issue type or clearly marked issue
+- scope the issue explicitly to baseline creation only
+
+Example framing:
+- `bootstrap: establish initial AgenticOS project baseline`
+
+## 6. Allowed and Forbidden Actions During Bootstrap
+
+### Allowed
+
+- create canonical baseline files
+- define initial project metadata
+- define initial quick-start and state
+- create the first baseline commit
+- record the bootstrap rationale and exit condition
+
+### Forbidden
+
+- unrelated feature implementation
+- policy expansion unrelated to baseline creation
+- bundling multiple future issues into the baseline commit
+- treating bootstrap as a permanent exemption from worktree rules
+
+## 7. Bootstrap Exit Criteria
+
+A repository exits bootstrap only when all of the following are true:
+
+1. an initial commit exists on `main`
+2. canonical starter files exist
+3. project identity is established
+4. session-start context is loadable
+5. future work can branch from the baseline cleanly
+
+Once these conditions are true, the repository is no longer in bootstrap state.
+
+## 8. Transition to Normal Workflow
+
+After bootstrap exit:
+- normal issue-first workflow applies
+- implementation work must use branch + isolated worktree
+- bootstrap exception is no longer available for ordinary work
+
+The transition rule should be strict.
+Otherwise every new repo can remain permanently "special".
+
+## 9. Suggested Pseudocode
+
+```text
+function classify_repo_state(repo):
+  if repo.has_no_initial_commit():
+    return "bootstrap"
+  return "normal"
+
+function allow_task(repo, task):
+  state = classify_repo_state(repo)
+
+  if state == "bootstrap":
+    if task.scope_is_baseline_only():
+      return allow_with_bootstrap_constraints()
+    return block("repo_bootstrap_not_complete")
+
+  return enforce_normal_issue_branch_worktree_protocol()
+```
+
+## 10. Current Relevance
+
+This standards project is itself an example of why this protocol is needed.
+
+At the time of writing:
+- `/Users/jeking/dev/AgenticOS/projects/agentic-os-development`
+- is still on `No commits yet on main`
+
+So the project currently cannot cleanly claim full branch/worktree compliance until baseline bootstrap is formally completed.

--- a/projects/agenticos/standards/knowledge/baseline-isolation-execution-report-2026-03-23.md
+++ b/projects/agenticos/standards/knowledge/baseline-isolation-execution-report-2026-03-23.md
@@ -1,0 +1,123 @@
+# AgenticOS Baseline Isolation Execution Report
+
+> Date: 2026-03-23
+> Purpose: record the first real execution of baseline isolation before self-hosting migration
+
+## 1. Operator Inputs Used
+
+- source repo path: `/Users/jeking/dev/AgenticOS`
+- base commit: `fc401332bea49fdecdc2f4e489e30545d5061043`
+- migration branch: `feat/self-hosting-migration`
+- migration worktree path: `/Users/jeking/worktrees/agenticos-self-hosting`
+
+## 2. Baseline Preservation Result
+
+The current dirty root state was preserved outside the repository at:
+
+```text
+/Users/jeking/worktrees/agenticos-self-hosting-baseline/2026-03-23
+```
+
+Artifacts captured:
+- `status.txt`
+- `worktrees.txt`
+- `unstaged.patch`
+- `staged.patch`
+- `untracked.txt`
+- `base-commit.txt`
+
+## 3. Isolation Result
+
+Isolation itself succeeded.
+
+Executed outcome:
+- created branch `feat/self-hosting-migration`
+- created external worktree `/Users/jeking/worktrees/agenticos-self-hosting`
+- verified the fresh worktree was clean
+- verified the fresh worktree HEAD was `fc401332bea49fdecdc2f4e489e30545d5061043`
+
+## 4. Clean Baseline Validation Result
+
+The clean reproducibility gate failed.
+
+Command used:
+
+```bash
+cd /Users/jeking/worktrees/agenticos-self-hosting/mcp-server
+npm ci
+```
+
+Observed result:
+- `npm ci` failed immediately with `EUSAGE`
+- npm reported that `package.json` and `package-lock.json` were not in sync
+- the missing lock entries included `vitest` and related packages
+
+This means the selected baseline commit is **not reproducible from a clean checkout** for `mcp-server`.
+
+## 5. Operational Conclusion
+
+The baseline isolation procedure is only partially complete:
+
+- preservation: passed
+- external worktree creation: passed
+- clean worktree verification: passed
+- clean install reproducibility: failed
+
+Structural self-hosting migration must **not** continue from this baseline until the clean-install drift is resolved.
+
+## 6. What This Changes
+
+This execution introduces a new hard rule:
+
+- migration execution is blocked not only by dirty source state
+- it is also blocked by any clean-checkout reproducibility failure in the isolated worktree
+
+For `mcp-server`, the reproducibility gate should use:
+
+```bash
+npm ci
+npm run build
+```
+
+not a weaker install path that could hide lock drift.
+
+## 7. Immediate Next Action
+
+Create and track a dedicated issue to restore a reproducible clean `mcp-server` baseline before self-hosting migration resumes.
+
+## 8. Follow-Up Resolution in Isolated Worktree
+
+The clean-install blocker was then fixed in the isolated worktree without resuming structural migration.
+
+Fix scope:
+- updated `mcp-server/package-lock.json` only
+- switched the external worktree onto a dedicated issue branch:
+  - `fix/43-mcp-server-clean-install-baseline`
+- committed the fix as:
+  - `4aada96 fix(mcp-server): restore clean install lockfile baseline (#43)`
+
+Validation after the lockfile sync:
+
+```bash
+cd /Users/jeking/worktrees/agenticos-self-hosting/mcp-server
+npm ci
+npm run build
+npm test
+```
+
+Observed result:
+- `npm ci` passed
+- `npm run build` passed
+- `npm test` passed with 43 tests passing and 3 skipped
+
+## 9. Updated Operational Conclusion
+
+The original reproducibility blocker is now resolved locally on the dedicated `#43` fix branch.
+
+However, self-hosting migration should still remain paused until:
+- the `#43` fix is reviewed and landed
+- the migration baseline is re-established from the corrected source state
+
+The fix has now been pushed and opened as:
+
+- PR #44 `fix(mcp-server): restore clean install lockfile baseline (#43)`

--- a/projects/agenticos/standards/knowledge/baseline-isolation-plan-2026-03-23.md
+++ b/projects/agenticos/standards/knowledge/baseline-isolation-plan-2026-03-23.md
@@ -1,0 +1,179 @@
+# AgenticOS Baseline Isolation Plan
+
+> Date: 2026-03-23
+> Purpose: define how to establish a clean, verifiable starting point before any self-hosting migration execution begins
+
+## 1. Why Isolation Is Required
+
+The current top-level AgenticOS repository is not in a clean execution state.
+
+Observed conditions:
+- unstaged product-source changes exist at root
+- staged deletions exist for `projects/agentic-os-development` in the parent repo
+- unrelated runtime project changes and untracked files also exist
+
+That means the current main worktree is not a trustworthy migration baseline.
+
+If migration starts from this state:
+- verification results become ambiguous
+- rollback becomes unsafe
+- unrelated changes can be mixed into structural migration
+
+## 2. Isolation Goal
+
+Before any real file moves begin, create a migration environment that is:
+- clean
+- isolated from unrelated work
+- reproducible
+- easy to verify
+- easy to abandon or recreate
+
+## 3. Current Dirty-State Categories
+
+### A. Root product-source modifications
+
+Examples currently visible:
+- `.gitignore`
+- `AGENTS.md`
+- `README.md`
+- `homebrew-tap/Formula/agenticos.rb`
+- `homebrew-tap/README.md`
+- `mcp-server/README.md`
+- `mcp-server/package-lock.json`
+
+### B. Parent-repo staged deletions for the standards subproject
+
+These staged deletions reflect the earlier split of `projects/agentic-os-development` from the parent repo.
+
+They should not be mixed into self-hosting migration execution.
+
+### C. Runtime project noise
+
+Examples:
+- `projects/360teams/*`
+- `projects/agentic-devops/*`
+- `projects/test-project/*`
+- other runtime project deltas
+
+These are not part of the host-product migration itself.
+
+## 4. Recommended Isolation Strategy
+
+Use a **fresh dedicated worktree** outside the current root working tree.
+
+Recommended model:
+
+1. preserve the current dirty state without destroying it
+2. create a dedicated migration branch from a known commit
+3. create a fresh external worktree for that branch
+4. verify the new worktree is clean
+5. execute migration work only there
+
+## 5. Recommended Branch and Worktree Model
+
+### Branch
+
+Use a dedicated branch such as:
+
+```text
+feat/self-hosting-migration
+```
+
+### Worktree location
+
+Use an external path, not inside runtime worktree directories:
+
+```text
+~/worktrees/agenticos-self-hosting
+```
+
+Avoid:
+- the current root worktree
+- `.claude/worktrees/`
+- any runtime-only temp path that may be cleaned automatically
+
+## 6. Baseline Preservation Before Isolation
+
+Before creating the migration worktree, preserve the current state in one of these forms:
+
+### Preferred
+
+- a dedicated checkpoint branch or commit for the current planning state
+
+### Acceptable fallback
+
+- explicit patch exports for staged and unstaged changes
+
+At minimum, capture:
+
+```bash
+git status --short --branch
+git diff > /safe/path/agenticos-root-working.patch
+git diff --cached > /safe/path/agenticos-root-staged.patch
+git rev-parse HEAD
+```
+
+The goal is not to clean the current worktree destructively.
+The goal is to make it recoverable and ignorable.
+
+## 7. Verification Gates for Isolation
+
+### Gate 1: Baseline captured
+
+Required evidence:
+- `git status --short --branch` recorded
+- current HEAD recorded
+- patch or checkpoint mechanism recorded
+
+### Gate 2: Fresh migration worktree created
+
+Required commands should succeed:
+
+```bash
+git worktree add /target/path -b feat/self-hosting-migration <base-commit>
+cd /target/path
+git status --short --branch
+```
+
+Pass condition:
+- new worktree is clean
+- branch name is correct
+
+### Gate 3: Build baseline verified inside isolated worktree
+
+Required command:
+
+```bash
+cd /target/path/mcp-server
+npm ci
+npm run build
+```
+
+Pass condition:
+- clean install and build both succeed from the isolated worktree before any migration move
+
+## 8. Stop Conditions
+
+Stop before migration execution if:
+- the fresh worktree is not clean
+- the base commit is unclear
+- the current dirty state has not been preserved
+- clean install does not pass in the isolated worktree
+- build does not pass in the isolated worktree
+
+## 9. Rollback Principle
+
+Isolation rollback is simple:
+- abandon the migration worktree
+- keep the preserved patches or checkpoint branch
+- do not "repair" the original dirty main worktree as part of migration execution
+
+This is why isolation should happen first.
+
+## 10. Immediate Next Action
+
+Turn this isolation plan into an execution checklist with:
+- exact base commit choice
+- exact branch name
+- exact worktree path
+- exact preservation commands

--- a/projects/agenticos/standards/knowledge/command-level-migration-playbook-v1-2026-03-23.md
+++ b/projects/agenticos/standards/knowledge/command-level-migration-playbook-v1-2026-03-23.md
@@ -1,0 +1,294 @@
+# AgenticOS Command-Level Migration Playbook v1
+
+> Date: 2026-03-23
+> Purpose: define a command-level, verification-first playbook for self-hosting migration planning
+
+## 1. Important Status Before Execution
+
+Current baseline observations:
+
+- `mcp-server` builds successfully from the current root
+- the top-level product repository worktree is **not clean**
+
+So the first execution gate is not "move files".
+It is:
+
+- isolate migration work from unrelated changes
+- capture a clean baseline snapshot
+
+Without that, later verification signals are not trustworthy.
+
+## 2. Execution Rule
+
+For every step below:
+
+1. run pre-check commands
+2. confirm pass conditions
+3. perform one bounded change
+4. run post-check commands immediately
+5. if any post-check fails, stop and rollback that step only
+
+## 3. Step 0: Baseline Isolation
+
+### Goal
+
+Create a clean, reviewable migration baseline before any structural move.
+
+### Pre-check
+
+```bash
+git status --short --branch
+git rev-parse HEAD
+```
+
+### Required pass condition
+
+- unrelated changes are understood
+- migration work will not be mixed with them silently
+- a dedicated migration branch/worktree plan exists
+
+### If fail
+
+- stop
+- do not start file relocation
+
+## 4. Step 1: Build Baseline Verification
+
+### Commands
+
+```bash
+cd /path/to/AgenticOS/mcp-server
+npm install
+npm run build
+```
+
+### Pass condition
+
+- TypeScript build succeeds from the current root layout
+
+### Rollback
+
+- none; this is a read-only verification gate
+
+## 5. Step 2: Path Inventory Verification
+
+### Commands
+
+```bash
+cd /path/to/AgenticOS
+find . -maxdepth 1 -mindepth 1 | sort
+find projects/agentic-os-development -maxdepth 2 -mindepth 1 | sort
+rg -n "projects/agentic-os-development|mcp-server/|homebrew-tap/|\\.meta/|\\.github/|tools/|\\.claude/worktrees|AGENTICOS_HOME" .
+```
+
+### Pass condition
+
+- current path assumptions are enumerated
+- standards references are known
+- moved product-source references are known
+
+### Rollback
+
+- none; read-only verification gate
+
+## 6. Step 3: Runtime Split Preparation
+
+### Intended change
+
+- prepare `.runtime/`
+- ensure `.claude/worktrees/` is documented and ignored as runtime-only
+
+### Pre-check
+
+```bash
+rg -n "\\.claude/worktrees|\\.runtime" .gitignore README.md AGENTS.md CLAUDE.md
+```
+
+### Post-check
+
+```bash
+git diff -- .gitignore README.md AGENTS.md CLAUDE.md
+rg -n "\\.claude/worktrees|\\.runtime" .gitignore README.md AGENTS.md CLAUDE.md
+```
+
+### Pass condition
+
+- runtime paths are ignored or documented correctly
+- no product-source docs still frame worktrees as canonical source
+
+### Rollback
+
+```bash
+git diff -- .gitignore README.md AGENTS.md CLAUDE.md
+```
+
+If incorrect, revert only those file changes in the migration branch/worktree.
+
+## 7. Step 4: Standards Relocation
+
+### Intended change
+
+- move `projects/agentic-os-development/*` into `projects/agenticos/standards/`
+
+### Pre-check
+
+```bash
+test -d projects/agentic-os-development
+test ! -e projects/agenticos/standards
+rg -n "projects/agentic-os-development" .
+```
+
+### Post-check
+
+```bash
+test -d projects/agenticos/standards
+find projects/agenticos/standards -maxdepth 2 -mindepth 1 | sort
+rg -n "projects/agentic-os-development" .
+```
+
+### Pass condition
+
+- standards content exists at the new target path
+- expected files are present
+- old-path references are either gone or explicitly transitional
+
+### Rollback
+
+- revert standards move only
+- rerun the same three post-check commands until the old state is restored cleanly
+
+## 8. Step 5: Agent Command Asset Relocation
+
+### Intended change
+
+- move `.claude/commands/` into `projects/agenticos/.claude/commands/`
+
+### Pre-check
+
+```bash
+test -d .claude/commands
+find .claude/commands -maxdepth 2 -type f | sort
+```
+
+### Post-check
+
+```bash
+test -d projects/agenticos/.claude/commands
+find projects/agenticos/.claude/commands -maxdepth 2 -type f | sort
+test ! -d .claude/commands
+```
+
+### Pass condition
+
+- command assets exist in the new product-project path
+- runtime worktrees remain outside product-source semantics
+
+### Rollback
+
+- revert command asset relocation only
+
+## 9. Step 6: Product-Source Directory Relocation
+
+### Intended change
+
+- move `mcp-server`, `homebrew-tap`, `.meta`, `.github`, and `tools` into `projects/agenticos`
+
+### Pre-check
+
+```bash
+for p in mcp-server homebrew-tap .meta .github tools; do test -e "$p" || exit 1; done
+```
+
+### Post-check
+
+```bash
+for p in mcp-server homebrew-tap .meta .github tools; do test -e "projects/agenticos/$p" || exit 1; done
+find projects/agenticos -maxdepth 2 -mindepth 1 | sort
+```
+
+### Pass condition
+
+- all required product-source directories now exist under `projects/agenticos`
+
+### Rollback
+
+- revert directory relocation only
+- rerun the post-checks against the original root layout
+
+## 10. Step 7: Root Document Relocation and Rewrite
+
+### Intended change
+
+- move product docs into `projects/agenticos/`
+- rewrite path references
+
+### Pre-check
+
+```bash
+for f in README.md AGENTS.md CLAUDE.md CONTRIBUTING.md CHANGELOG.md ROADMAP.md LICENSE; do test -e "$f" || exit 1; done
+```
+
+### Post-check
+
+```bash
+for f in README.md AGENTS.md CLAUDE.md CONTRIBUTING.md CHANGELOG.md ROADMAP.md LICENSE; do test -e "projects/agenticos/$f" || exit 1; done
+rg -n "projects/agentic-os-development|mcp-server/|homebrew-tap/|\\.meta/|\\.github/|tools/" projects/agenticos
+```
+
+### Pass condition
+
+- moved docs exist in the product project
+- rewritten references point at valid paths or are explicitly transitional
+
+### Rollback
+
+- revert doc moves and doc rewrites only
+
+## 11. Step 8: Build Verification From New Product Path
+
+### Commands
+
+```bash
+cd /path/to/AgenticOS/projects/agenticos/mcp-server
+npm install
+npm run build
+```
+
+### Pass condition
+
+- product implementation still builds from the relocated product-project path
+
+### If fail
+
+- stop immediately
+- revert the most recent relocation or rewrite step
+
+## 12. Step 9: Workspace Root Verification
+
+### Commands
+
+```bash
+cd /path/to/AgenticOS
+find projects -maxdepth 1 -mindepth 1 | sort
+find .runtime -maxdepth 2 -mindepth 1 | sort
+rg -n "workspace home|AGENTICOS_HOME|projects/agenticos|projects/agenticos/standards" .
+```
+
+### Pass condition
+
+- root now reads as workspace home
+- managed projects remain visible
+- runtime root exists and is semantically separate
+
+## 13. Stop Conditions
+
+Stop immediately if:
+- build verification fails
+- moved paths are missing after a relocation step
+- stale references cannot be reconciled within the current step
+- unrelated repository changes make verification ambiguous
+
+## 14. Immediate Next Action
+
+Before any real migration starts, produce one more artifact:
+- a step-by-step move script or operator checklist tied exactly to this playbook

--- a/projects/agenticos/standards/knowledge/downstream-standard-kit-implementation-report-2026-03-23.md
+++ b/projects/agenticos/standards/knowledge/downstream-standard-kit-implementation-report-2026-03-23.md
@@ -1,0 +1,88 @@
+# Downstream Standard Kit Implementation Report - 2026-03-23
+
+## Summary
+
+GitHub issue `#35` has now landed as a real packaging artifact in the main AgenticOS product repository.
+
+Merged pull request:
+- `#51 feat(meta): package downstream workflow standard kit (#35)`
+
+Merged commit:
+- `11f2d81335dd26bf718311278c92a55e8aca9f8d`
+
+## What Landed
+
+A versioned downstream standard kit now exists at:
+
+- `projects/agenticos/.meta/standard-kit/`
+
+The kit currently includes:
+- `README.md`
+- `manifest.yaml`
+- `inheritance-rules.md`
+- `adoption-checklist.md`
+
+## Package Model
+
+The landed package explicitly defines:
+- canonical generated files:
+  - `AGENTS.md`
+  - `CLAUDE.md`
+- canonical copied templates:
+  - `.project.yaml`
+  - `.context/quick-start.md`
+  - `.context/state.yaml`
+  - `tasks/templates/agent-preflight-checklist.yaml`
+  - `tasks/templates/issue-design-brief.md`
+  - `tasks/templates/submission-evidence.md`
+- root-scoped exclusions:
+  - `.github/`
+  - `.runtime/`
+  - `.claude/worktrees/`
+- upgrade rules for generated files versus copied templates
+
+## Boundary Clarification
+
+The package also makes one important repository-contract decision explicit:
+
+- `.meta/standard-kit/` is now the canonical downstream packaging surface
+- older `.meta/agent-guide.md` and `.meta/rules.md` are legacy references if they conflict with the standard kit
+
+This reduces ambiguity between historical AIOS guidance and the current self-hosted AgenticOS model.
+
+## Validation
+
+Validation was executed in an isolated worktree before merge.
+
+Validation commands:
+
+```bash
+ruby -e 'require "yaml"; data = YAML.load_file("/Users/jeking/worktrees/agenticos-standard-kit-35/projects/agenticos/.meta/standard-kit/manifest.yaml"); puts data["kit_id"]'
+```
+
+```bash
+ruby -e 'require "yaml"; root="/Users/jeking/worktrees/agenticos-standard-kit-35"; data=YAML.load_file(root+"/projects/agenticos/.meta/standard-kit/manifest.yaml"); sources=[]; data["layers"].each_value{|layer| next unless layer["entries"]; layer["entries"].each{|entry| src=entry["canonical_source"]; sources << src if src}}; missing=sources.reject{|src| File.exist?(File.join(root, src))}; abort("missing canonical sources: #{missing.join(", ")}") unless missing.empty?; puts "canonical sources ok"'
+```
+
+Validation result:
+- manifest YAML parsed successfully
+- all declared canonical sources resolved successfully
+
+## Completion Judgment
+
+Issue `#35` can now be treated as complete for the initial packaging milestone.
+
+Its core acceptance intent is satisfied:
+- a documented downstream package model exists
+- canonical versus customizable files are defined
+- template upgrade and inheritance rules are defined
+- downstream adoption no longer depends on the original standards conversation history
+
+## Follow-Up
+
+Future work can extend this packaging layer with automation.
+
+Likely follow-up:
+1. an adoption command that materializes the standard kit into a downstream project
+2. an upgrade command that compares local project-owned files against canonical templates
+3. stronger deprecation cleanup for older `.meta` guidance files

--- a/projects/agenticos/standards/knowledge/downstream-standard-package-plan-2026-03-23.md
+++ b/projects/agenticos/standards/knowledge/downstream-standard-package-plan-2026-03-23.md
@@ -1,0 +1,63 @@
+# AgenticOS Downstream Standard Package Plan
+
+> Date: 2026-03-23
+> Purpose: define what should be packaged so downstream projects can inherit the executable agent protocol consistently
+
+## 1. Problem
+
+The project now has protocol documents and templates, but they still live as knowledge assets inside the standards project.
+
+That is not enough for downstream adoption.
+
+Downstream projects need a standard package that answers:
+- which files are copied or generated
+- which files are canonical versus customizable
+- which templates are required for issue execution
+- which guardrails or helper commands should accompany those templates
+
+## 2. Package Goal
+
+The standard package should make a downstream project operationally ready for:
+- context loading
+- issue-first execution
+- design/critique loops
+- worktree isolation for implementation
+- executable acceptance and verification
+
+## 3. Proposed Package Layers
+
+### Layer 1: Canonical docs
+
+- `AGENTS.md` baseline standard
+- agent-specific overlay such as `CLAUDE.md`
+- `.context/quick-start.md`
+- `.context/state.yaml` contract
+
+### Layer 2: Execution templates
+
+- preflight checklist
+- issue design brief
+- non-code evaluation rubric
+- submission evidence template
+
+### Layer 3: Optional helper tooling
+
+- preflight command
+- branch/worktree bootstrap helper
+- evaluation helper for non-code outputs
+
+### Layer 4: Inheritance rules
+
+- what downstream projects must keep unchanged
+- what downstream projects may extend
+- how template upgrades are propagated later
+
+## 4. Recommended Packaging Direction
+
+AgenticOS should eventually support a reusable standard package with:
+- canonical template files
+- version markers
+- upgrade path
+- helper commands for adoption and enforcement
+
+This is the missing bridge between "we designed the protocol" and "another project can actually use it".

--- a/projects/agenticos/standards/knowledge/git-transport-fallback-documentation-report-2026-03-23.md
+++ b/projects/agenticos/standards/knowledge/git-transport-fallback-documentation-report-2026-03-23.md
@@ -1,0 +1,59 @@
+# Git Transport Fallback Documentation Report - 2026-03-23
+
+## Summary
+
+Issue `#58` was completed in the main `AgenticOS` product repository to document a canonical operator procedure for GitHub publication failures caused by broken Git proxy and credential plumbing.
+
+The landed documentation replaced the earlier unsafe guidance that embedded tokens directly in remote URLs.
+
+## Landed Changes
+
+Merged PR:
+
+- `#59` `docs: document git transport fallback (#58)`
+
+Closed issue:
+
+- `#58` `docs: document GitHub transport fallback when Git proxy and credential plumbing break`
+
+Main repository docs now:
+
+- diagnose GitHub publication failures before changing global config
+- check `gh auth status`
+- inspect global `http.proxy` / `https.proxy`
+- verify direct Git reachability with command-scoped `-c http.proxy= -c https.proxy=`
+- use a temporary `GIT_ASKPASS` helper for non-interactive HTTPS push
+- explicitly avoid embedding tokens in remote URLs
+
+Files changed in the product repository:
+
+- `README.md`
+- `AGENTS.md`
+- `CONTRIBUTING.md`
+
+## Verification
+
+Verified outcomes:
+
+- branch `docs/58-git-transport-fallback` pushed successfully
+- PR `#59` merged successfully
+- issue `#58` closed automatically through `Closes #58`
+
+## New Follow-Up
+
+During publication of PR `#59`, one more compatibility nuance appeared:
+
+- `git -c http.proxy= -c https.proxy= ls-remote ...` succeeded immediately
+- `git push` with only no-proxy + `GIT_ASKPASS` still failed once with:
+  - `LibreSSL SSL_connect: SSL_ERROR_SYSCALL`
+- adding command-scoped `-c http.version=HTTP/1.1` allowed the push to succeed
+
+This means the newly landed documentation is directionally correct but still incomplete for this machine's exact transport behavior.
+
+To capture that residual gap, issue `#60` was opened:
+
+- `docs: refine GitHub transport fallback with HTTP/1.1 compatibility note`
+
+## Conclusion
+
+The repository now has a canonical and much safer GitHub transport fallback procedure than before, but there is still one machine-specific transport compatibility refinement to document.

--- a/projects/agenticos/standards/knowledge/git-transport-http11-refinement-report-2026-03-23.md
+++ b/projects/agenticos/standards/knowledge/git-transport-http11-refinement-report-2026-03-23.md
@@ -1,0 +1,50 @@
+# Git Transport HTTP/1.1 Refinement Report - 2026-03-23
+
+## Summary
+
+Issue `#60` completed the follow-up refinement that remained after the initial GitHub transport fallback documentation landed in issue `#58`.
+
+The main gap was that the first documented fallback still was not sufficient for this machine's exact Git HTTPS behavior. During publication of PR `#59`, the push only succeeded after adding command-scoped `-c http.version=HTTP/1.1`.
+
+## Landed Changes
+
+Merged PR:
+
+- `#61` `docs: refine git transport fallback (#60)`
+
+Closed issue:
+
+- `#60` `docs: refine GitHub transport fallback with HTTP/1.1 compatibility note`
+
+Repository docs now explicitly distinguish:
+
+- proxy-path failures
+- credential-path failures
+- Git HTTPS transport-compatibility failures
+
+The documented operator sequence now includes:
+
+1. verify GitHub reachability and auth state
+2. retry with command-scoped `-c http.proxy= -c https.proxy=`
+3. supply credentials with temporary `GIT_ASKPASS`
+4. if push still fails with `LibreSSL SSL_connect: SSL_ERROR_SYSCALL`, retry with:
+   - `-c http.version=HTTP/1.1`
+
+## Files Updated In Product Repository
+
+- `README.md`
+- `AGENTS.md`
+- `CONTRIBUTING.md`
+
+## Verification
+
+Verified outcomes:
+
+- branch `docs/60-git-transport-http11` pushed successfully with the documented `HTTP/1.1` compatibility override
+- CI passed for PR `#61`
+- PR `#61` merged successfully
+- issue `#60` closed automatically through `Closes #60`
+
+## Conclusion
+
+The GitHub transport fallback is now documented at the level actually required by this machine's observed behavior. Future agents should no longer stop at the earlier no-proxy + `GIT_ASKPASS` step if the remaining failure is really a Git HTTPS transport compatibility issue.

--- a/projects/agenticos/standards/knowledge/guardrail-command-trio-implementation-report-2026-03-23.md
+++ b/projects/agenticos/standards/knowledge/guardrail-command-trio-implementation-report-2026-03-23.md
@@ -1,0 +1,91 @@
+# Guardrail Command Trio Implementation Report - 2026-03-23
+
+## Summary
+
+The first executable guardrail command trio for GitHub issue `#36` has landed in the main AgenticOS product repository.
+
+Merged pull requests:
+- `#47 feat(mcp-server): add agenticos_preflight guardrail tool (#36)`
+- `#48 feat(mcp-server): add agenticos_branch_bootstrap helper (#36)`
+- `#49 feat(mcp-server): add agenticos_pr_scope_check tool (#36)`
+
+## Landed Commands
+
+### `agenticos_preflight`
+
+Machine-checkable preflight before implementation or PR creation.
+
+Current coverage:
+- repository identity
+- branch and worktree state
+- remote-base ancestry
+- issue binding for implementation work
+- declared target file scope
+- structural-move exceptions such as `.github/`
+- reproducibility gate declaration
+
+Possible outcomes:
+- `PASS`
+- `BLOCK`
+- `REDIRECT`
+
+### `agenticos_branch_bootstrap`
+
+Mutating helper command for safe issue setup.
+
+Current coverage:
+- derive a branch from the intended remote base
+- create an isolated worktree
+- record the exact base commit in the result
+- block when the branch or worktree path already exists unexpectedly
+
+Possible outcomes:
+- `CREATED`
+- `BLOCK`
+
+### `agenticos_pr_scope_check`
+
+Scope validator before PR submission.
+
+Current coverage:
+- compare commit subjects against the intended issue id
+- compare changed files against declared target paths
+- verify the branch is comparable to the intended remote base
+
+Possible outcomes:
+- `PASS`
+- `BLOCK`
+
+## Validation
+
+Each slice was implemented and validated in its own isolated worktree before PR creation.
+
+Validation command pattern:
+
+```bash
+cd /Users/jeking/worktrees/<slice-worktree>/projects/agenticos/mcp-server
+npm install
+npm run build
+npm test
+```
+
+Final validation state after the third slice:
+- build passed
+- full test suite passed
+- `54 passed | 3 skipped`
+
+## What Is Now True
+
+- guardrail behavior is now partially executable in MCP, not only documented in standards files
+- checker commands and mutating helper commands are separated in implementation, not only in design
+- remote-base ancestry and PR-scope drift are now machine-checkable
+- wrong-branch or wrong-worktree starts can now be redirected to a safe helper path
+
+## Remaining Follow-Up
+
+Issue `#36` should remain open until the commands are wired into the expected execution flow.
+
+Remaining work:
+1. integrate these commands into the expected agent workflow and templates
+2. decide how Agents should invoke preflight consistently before implementation work
+3. decide whether command outputs should also update structured execution evidence automatically

--- a/projects/agenticos/standards/knowledge/guardrail-evidence-persistence-implementation-report-2026-03-23.md
+++ b/projects/agenticos/standards/knowledge/guardrail-evidence-persistence-implementation-report-2026-03-23.md
@@ -1,0 +1,81 @@
+# Guardrail Evidence Persistence Implementation Report - 2026-03-23
+
+## Summary
+
+GitHub issue `#62` completed the follow-up enhancement that was intentionally deferred after guardrail v1 landed in issue `#36`.
+
+Merged pull request:
+
+- `#65` `feat: persist guardrail execution evidence (#62)`
+
+Closed issue:
+
+- `#62` `feat: persist guardrail execution evidence into project context`
+
+## What Landed
+
+The three guardrail commands no longer return their execution results only to the terminal.
+
+They now persist bounded structured evidence into project `.context/state.yaml`:
+
+- `agenticos_preflight`
+- `agenticos_branch_bootstrap`
+- `agenticos_pr_scope_check`
+
+The implementation added a dedicated helper:
+
+- `projects/agenticos/mcp-server/src/utils/guardrail-evidence.ts`
+
+## Persistence Model
+
+Evidence is stored in a dedicated top-level state section rather than mixed into `working_memory`.
+
+Implemented shape:
+
+- `guardrail_evidence.updated_at`
+- `guardrail_evidence.last_command`
+- `guardrail_evidence.preflight`
+- `guardrail_evidence.branch_bootstrap`
+- `guardrail_evidence.pr_scope_check`
+
+The storage model is bounded:
+
+- each command overwrites its own latest evidence entry
+- repeated runs do not append unbounded logs into project state
+
+## Project Resolution Behavior
+
+Evidence persistence now resolves the target project in two stages:
+
+1. prefer the registered AgenticOS project whose path contains `repo_path`
+2. if registry resolution fails, walk upward from `repo_path` to find the nearest on-disk project root containing:
+   - `.project.yaml`
+   - `.context/state.yaml`
+
+This makes evidence persistence work both for:
+
+- normal managed workspace projects
+- source checkouts and isolated worktrees that still carry the project metadata locally
+
+## Validation
+
+Validation executed in isolated worktree:
+
+```bash
+cd /Users/jeking/worktrees/agenticos-guardrail-62/projects/agenticos/mcp-server
+npm install
+npm run build
+npm test -- --run src/utils/__tests__/guardrail-evidence.test.ts src/tools/__tests__/preflight.test.ts src/tools/__tests__/branch-bootstrap.test.ts src/tools/__tests__/pr-scope-check.test.ts
+npm test
+```
+
+Validation result:
+
+- build passed
+- targeted tests passed
+- full test suite passed
+- `60 passed | 3 skipped`
+
+## Conclusion
+
+Guardrail compliance is now more durable than before because later sessions can recover whether preflight, branch bootstrap, and PR scope validation actually ran, and what their last structured results were, without depending only on chat history.

--- a/projects/agenticos/standards/knowledge/guardrail-flow-wiring-report-2026-03-23.md
+++ b/projects/agenticos/standards/knowledge/guardrail-flow-wiring-report-2026-03-23.md
@@ -1,0 +1,93 @@
+# Guardrail Flow Wiring Report - 2026-03-23
+
+## Summary
+
+GitHub issue `#36` has now progressed from design, to command implementation, to workflow wiring in the main AgenticOS product repository.
+
+Merged pull request:
+- `#50 feat(workflow): wire guardrail commands into agent flow (#36)`
+
+Merged commit:
+- `690e23321a57fd3a20fc39e52c32add5477dbcda`
+
+## What Landed
+
+The first guardrail command trio is now wired into the expected execution flow instead of existing only as standalone MCP commands.
+
+Wiring landed in:
+- root `AGENTS.md`
+- root `CLAUDE.md`
+- `projects/agenticos/.claude/commands/develop.md`
+- `projects/agenticos/.claude/commands/review.md`
+- `projects/agenticos/.meta/templates/`
+- `projects/agenticos/mcp-server/src/utils/distill.ts`
+- root and MCP README files
+
+## Behavioral Change
+
+The intended implementation workflow is now explicit in product-facing instructions:
+
+1. run `agenticos_preflight`
+2. if the result is `REDIRECT`, run `agenticos_branch_bootstrap`
+3. implement only in the compliant isolated worktree
+4. run `agenticos_pr_scope_check` before PR submission or merge
+
+This moved the guardrail layer from:
+- implemented but optional
+
+to:
+- implemented and referenced by the primary execution entry points
+
+## Template Impact
+
+The product now ships reusable templates for:
+- `agent-preflight-checklist.yaml`
+- `issue-design-brief.md`
+- `submission-evidence.md`
+
+The distillation layer was upgraded to template version `v3`, so future generated `AGENTS.md` and `CLAUDE.md` files can inherit the guardrail protocol.
+
+## Validation
+
+Validation was executed in an isolated worktree before merge.
+
+Validation commands:
+
+```bash
+cd /Users/jeking/worktrees/agenticos-guardrail-36-wiring/projects/agenticos/mcp-server
+npm install
+npm run build
+npm test
+```
+
+Additional validation:
+
+```bash
+ruby -e 'require "yaml"; YAML.load_file("/Users/jeking/worktrees/agenticos-guardrail-36-wiring/projects/agenticos/.meta/templates/agent-preflight-checklist.yaml")'
+```
+
+Validation result:
+- build passed
+- full test suite passed
+- `56 passed | 3 skipped`
+- preflight checklist template parsed successfully
+
+## Completion Judgment
+
+Issue `#36` can now be treated as complete for guardrail v1.
+
+Its original acceptance criteria are satisfied:
+- concrete guardrail design exists
+- machine-checkable preflight exists
+- missing issue/branch/worktree prerequisites can block or redirect work
+- a helper path exists to create branch/worktree correctly
+- command contracts and initial integration points now exist in the actual execution flow
+
+## Follow-Up
+
+Further improvements should be treated as follow-up work, not as blockers for `#36`.
+
+Possible future work:
+1. automatically persist guardrail execution evidence
+2. integrate guardrail expectations into additional agent adapters beyond the current documented entry points
+3. package the standards kit for downstream reuse

--- a/projects/agenticos/standards/knowledge/guardrail-preflight-implementation-report-2026-03-23.md
+++ b/projects/agenticos/standards/knowledge/guardrail-preflight-implementation-report-2026-03-23.md
@@ -1,0 +1,63 @@
+# Guardrail Preflight Implementation Report - 2026-03-23
+
+## Summary
+
+The first executable guardrail slice for GitHub issue `#36` has landed in the main AgenticOS product repository.
+
+Merged pull request:
+- `#47 feat(mcp-server): add agenticos_preflight guardrail tool (#36)`
+
+Merged commit:
+- `00b4d5a98e0ffa09d532da71a4df77f5b6f37aff`
+
+## What Landed
+
+The MCP server now includes an initial `agenticos_preflight` tool under `projects/agenticos/mcp-server`.
+
+This first slice implements machine-checkable preflight behavior for:
+- repository identity
+- branch and worktree state
+- remote-base ancestry
+- issue binding for implementation work
+- declared target file scope
+- structural-move exceptions such as `.github/`
+- reproducibility gate declaration for structural changes
+
+The tool returns machine-readable JSON and standardizes three outcomes:
+- `PASS`
+- `BLOCK`
+- `REDIRECT`
+
+## Validation
+
+Validation was executed in an isolated implementation worktree before PR creation.
+
+Validation command:
+
+```bash
+cd /Users/jeking/worktrees/agenticos-guardrail-36/projects/agenticos/mcp-server
+npm install
+npm run build
+npm test
+```
+
+Validation result:
+- build passed
+- test suite passed
+- `46 passed | 3 skipped`
+
+## Lessons Reinforced
+
+- guardrails must check the real remote base, not only local branch naming
+- mutating helper commands must stay separate from checker commands
+- structural repository moves require explicit root-scoped infrastructure exceptions
+- clean reproducibility gates must be part of the preflight contract, not an informal reminder
+
+## Remaining Follow-Up
+
+Issue `#36` is only partially complete.
+
+The next implementation slices are:
+1. `agenticos_branch_bootstrap`
+2. `agenticos_pr_scope_check`
+3. integration of preflight checks into the expected agent execution flow

--- a/projects/agenticos/standards/knowledge/operator-checklist-v1-2026-03-23.md
+++ b/projects/agenticos/standards/knowledge/operator-checklist-v1-2026-03-23.md
@@ -1,0 +1,177 @@
+# AgenticOS Operator Checklist v1
+
+> Date: 2026-03-23
+> Purpose: provide an execution-ready checklist for baseline isolation before self-hosting migration
+
+## 1. Frozen Baseline Inputs
+
+At planning time, the current baseline values are:
+
+- source repo path: `/Users/jeking/dev/AgenticOS`
+- current branch: `main`
+- upstream branch: `origin/main`
+- current HEAD: `fc401332bea49fdecdc2f4e489e30545d5061043`
+- recommended migration branch: `feat/self-hosting-migration`
+- recommended external worktree path: `/Users/jeking/worktrees/agenticos-self-hosting`
+
+## 2. Scope of This Checklist
+
+This checklist does **not** perform the structural migration yet.
+
+It only prepares a safe execution baseline by:
+- preserving current dirty state
+- creating a dedicated migration branch/worktree
+- verifying a clean isolated baseline
+
+## 3. Operator Checklist
+
+### Step 0: Record current state
+
+Run:
+
+```bash
+cd /Users/jeking/dev/AgenticOS
+git status --short --branch
+git rev-parse HEAD
+git rev-parse --abbrev-ref --symbolic-full-name @{upstream}
+```
+
+Pass condition:
+- output matches the expected planning baseline closely enough to trust the checklist
+
+Stop if:
+- repo identity is not the expected product source repo
+- current HEAD is not the intended baseline commit and no deliberate update was approved
+
+### Step 1: Preserve unstaged and staged changes
+
+Run:
+
+```bash
+mkdir -p /Users/jeking/worktrees/agenticos-migration-backups
+cd /Users/jeking/dev/AgenticOS
+git diff > /Users/jeking/worktrees/agenticos-migration-backups/root-working.patch
+git diff --cached > /Users/jeking/worktrees/agenticos-migration-backups/root-staged.patch
+git status --short --branch > /Users/jeking/worktrees/agenticos-migration-backups/root-status.txt
+git rev-parse HEAD > /Users/jeking/worktrees/agenticos-migration-backups/root-head.txt
+```
+
+Pass condition:
+- all four backup files exist
+
+Verify:
+
+```bash
+ls -l /Users/jeking/worktrees/agenticos-migration-backups
+```
+
+Stop if:
+- any backup artifact is missing
+
+### Step 2: Create external worktree parent if needed
+
+Run:
+
+```bash
+mkdir -p /Users/jeking/worktrees
+```
+
+Pass condition:
+- `/Users/jeking/worktrees` exists
+
+### Step 3: Create migration worktree
+
+Run:
+
+```bash
+cd /Users/jeking/dev/AgenticOS
+git worktree add /Users/jeking/worktrees/agenticos-self-hosting -b feat/self-hosting-migration fc401332bea49fdecdc2f4e489e30545d5061043
+```
+
+Pass condition:
+- worktree add succeeds
+
+Stop if:
+- branch already exists unexpectedly
+- worktree path is already occupied unexpectedly
+
+### Step 4: Verify clean migration worktree
+
+Run:
+
+```bash
+cd /Users/jeking/worktrees/agenticos-self-hosting
+git status --short --branch
+git rev-parse HEAD
+```
+
+Pass condition:
+- branch is `feat/self-hosting-migration`
+- HEAD is `fc401332bea49fdecdc2f4e489e30545d5061043`
+- worktree is clean
+
+Stop if:
+- any tracked or untracked change appears in the fresh worktree unexpectedly
+
+### Step 5: Verify build baseline in isolated worktree
+
+Run:
+
+```bash
+cd /Users/jeking/worktrees/agenticos-self-hosting/mcp-server
+npm ci
+npm run build
+```
+
+Pass condition:
+- clean install and build both succeed in the isolated worktree before any migration move
+
+Stop if:
+- `npm ci` fails
+- build fails
+
+### Step 6: Freeze execution starting point
+
+Run:
+
+```bash
+cd /Users/jeking/worktrees/agenticos-self-hosting
+git status --short --branch > /Users/jeking/worktrees/agenticos-migration-backups/migration-worktree-status.txt
+git rev-parse HEAD > /Users/jeking/worktrees/agenticos-migration-backups/migration-worktree-head.txt
+```
+
+Pass condition:
+- migration worktree status and head snapshots are written
+
+At this point:
+- migration planning can move into structural execution
+
+## 4. Rollback for Isolation Step
+
+If isolation setup itself must be abandoned:
+
+```bash
+git -C /Users/jeking/dev/AgenticOS worktree remove /Users/jeking/worktrees/agenticos-self-hosting
+git -C /Users/jeking/dev/AgenticOS branch -D feat/self-hosting-migration
+```
+
+Only do this if:
+- the worktree was created but should be discarded
+- no intentional migration work needs to be preserved there
+
+## 5. Operator Notes
+
+- Do not run structural move commands in `/Users/jeking/dev/AgenticOS`
+- Do not use `.claude/worktrees/` as the migration worktree path
+- Do not destroy the original dirty state while preparing isolation
+
+## 6. Next Action After This Checklist
+
+Once all steps above pass, execute the self-hosting migration only from:
+
+- `/Users/jeking/worktrees/agenticos-self-hosting`
+
+and then follow:
+
+- `knowledge/phase3-execution-sequence-2026-03-23.md`
+- `knowledge/command-level-migration-playbook-v1-2026-03-23.md`

--- a/projects/agenticos/standards/knowledge/phase2-path-relocation-checklist-2026-03-23.md
+++ b/projects/agenticos/standards/knowledge/phase2-path-relocation-checklist-2026-03-23.md
@@ -1,0 +1,165 @@
+# AgenticOS Phase 2 Path Relocation Checklist
+
+> Date: 2026-03-23
+> Purpose: enumerate the concrete path moves and reference rewrites needed for the self-hosting migration
+
+## 1. Phase 2 Objective
+
+Prepare the self-hosting migration by freezing:
+- which current root paths move into `projects/agenticos`
+- which current standards paths move into `projects/agenticos/standards`
+- which root paths remain at workspace level
+- which references must be rewritten afterward
+
+This phase is still planning.
+It does not execute the file moves yet.
+
+## 2. Root-Level Path Classification
+
+### Move into `projects/agenticos`
+
+These are current product-source paths and should become part of the canonical managed product project:
+
+| Current Path | Target Path |
+|--------------|-------------|
+| `mcp-server/` | `projects/agenticos/mcp-server/` |
+| `homebrew-tap/` | `projects/agenticos/homebrew-tap/` |
+| `.meta/` | `projects/agenticos/.meta/` |
+| `tools/` | `projects/agenticos/tools/` |
+| `README.md` | `projects/agenticos/README.md` |
+| `AGENTS.md` | `projects/agenticos/AGENTS.md` |
+| `CLAUDE.md` | `projects/agenticos/CLAUDE.md` |
+| `CONTRIBUTING.md` | `projects/agenticos/CONTRIBUTING.md` |
+| `CHANGELOG.md` | `projects/agenticos/CHANGELOG.md` |
+| `ROADMAP.md` | `projects/agenticos/ROADMAP.md` |
+| `LICENSE` | `projects/agenticos/LICENSE` |
+
+### Split rather than move directly
+
+These paths need role separation rather than a blind move:
+
+| Current Path | Action |
+|--------------|--------|
+| `.gitignore` | split into workspace-level ignore and product-project ignore |
+| `.claude/` | split commands/config assets vs runtime worktrees |
+| `.github/` | remain at repository root; rewrite workflow working directories to `projects/agenticos/` |
+
+Recommended split:
+- `.claude/commands/` -> `projects/agenticos/.claude/commands/`
+- `.claude/worktrees/` -> `.runtime/worktrees/`
+
+### Remain at workspace root
+
+These belong to the workspace role:
+
+| Path | Reason |
+|------|--------|
+| `.agent-workspace/` | workspace metadata |
+| `projects/` | managed project container |
+| `.runtime/` | runtime-only state root |
+
+## 3. Standards Relocation Map
+
+Current standards project:
+- `projects/agentic-os-development/`
+
+Target standards area:
+- `projects/agenticos/standards/`
+
+Recommended subtree mapping:
+
+| Current Path | Target Path |
+|--------------|-------------|
+| `projects/agentic-os-development/.project.yaml` | `projects/agenticos/standards/.project.yaml` |
+| `projects/agentic-os-development/.context/` | `projects/agenticos/standards/.context/` |
+| `projects/agentic-os-development/knowledge/` | `projects/agenticos/standards/knowledge/` |
+| `projects/agentic-os-development/tasks/` | `projects/agenticos/standards/tasks/` |
+| `projects/agentic-os-development/artifacts/` | `projects/agenticos/standards/artifacts/` |
+| `projects/agentic-os-development/AGENTS.md` | `projects/agenticos/standards/AGENTS.md` |
+| `projects/agentic-os-development/CLAUDE.md` | `projects/agenticos/standards/CLAUDE.md` |
+| `projects/agentic-os-development/changelog.md` | `projects/agenticos/standards/changelog.md` |
+
+## 4. Existing Runtime Projects
+
+These should remain managed projects under the workspace and are **not** the main migration target:
+
+- `projects/2026okr`
+- `projects/360teams`
+- `projects/agentic-devops`
+- `projects/ghostty-optimization`
+- `projects/okr-management`
+- `projects/t5t`
+
+Still undecided:
+- `projects/test-project`
+
+## 5. Reference Rewrite Inventory
+
+The following files already contain path assumptions that will break after relocation.
+
+### Product root docs and instructions
+
+- `AGENTS.md`
+- `CLAUDE.md`
+- `CONTRIBUTING.md`
+- `README.md`
+
+### Build, release, and packaging paths
+
+- `.github/workflows/*`
+- `homebrew-tap/Formula/agenticos.rb`
+
+Execution correction:
+- `.github/workflows/*` remain at repository root
+- workflow `working-directory` values must point into `projects/agenticos/`
+
+### Standards references
+
+Current root files reference:
+- `projects/agentic-os-development/knowledge/...`
+
+These will need to point to the new standards location under:
+- `projects/agenticos/standards/...`
+
+### Product implementation references
+
+Current root files reference:
+- `mcp-server/...`
+- `homebrew-tap/...`
+- `.meta/...`
+- `tools/...`
+
+These will need to point to:
+- `projects/agenticos/mcp-server/...`
+- `projects/agenticos/homebrew-tap/...`
+- `projects/agenticos/.meta/...`
+- `projects/agenticos/tools/...`
+
+## 6. Git and Repository Boundary Questions
+
+Before physical moves happen, these must be answered explicitly:
+
+1. Will the current Git history be preserved inside `projects/agenticos`?
+2. Will the top-level workspace root itself remain under Git?
+3. If the root remains under Git temporarily, what is tracked there after the product repo is relocated?
+
+These are execution-phase decisions, but they must be answered before actual relocation.
+
+## 7. Verification Checklist After Relocation
+
+After the moves, verify:
+
+- main product build commands still work
+- CI workflow paths still resolve
+- Homebrew references still resolve
+- AGENTS and CLAUDE docs point to valid paths
+- standards content is reachable under `projects/agenticos/standards`
+- runtime worktrees are no longer treated as canonical source
+- other runtime projects remain intact
+
+## 8. Immediate Next Action
+
+Use this checklist to produce the first execution-facing move plan:
+- exact move order
+- exact path rewrite order
+- exact verification commands after each step

--- a/projects/agenticos/standards/knowledge/phase3-execution-sequence-2026-03-23.md
+++ b/projects/agenticos/standards/knowledge/phase3-execution-sequence-2026-03-23.md
@@ -1,0 +1,211 @@
+# AgenticOS Phase 3 Execution Sequence
+
+> Date: 2026-03-23
+> Purpose: define the execution order, verification-first checkpoints, and rollback boundaries for self-hosting migration
+
+## 1. Execution Principle
+
+Every migration step must follow this pattern:
+
+1. verify the preconditions
+2. perform one bounded change
+3. verify immediately
+4. stop if verification fails
+5. keep rollback local to the step
+
+Do not batch multiple structural moves before verification.
+
+## 2. Global Preconditions
+
+Before Phase 3 starts, verify:
+
+- the target model is frozen
+- the path relocation checklist exists
+- the current product still builds from the current root
+- the current tracked runtime projects are intact
+- a clean migration branch/worktree exists
+- the current root Git state is snapshotted or otherwise recoverable
+
+Suggested baseline checks:
+
+```bash
+git status --short --branch
+git rev-parse HEAD
+cd mcp-server && npm install && npm run build
+```
+
+## 3. Step Order
+
+### Step 1: Prepare runtime root without relocating product source
+
+Change:
+- create `.runtime/` semantics and decide runtime subpaths
+- ensure `.claude/worktrees/` is treated as runtime-only
+
+Verification:
+- `.gitignore` excludes runtime paths
+- no canonical docs still describe worktrees as product source
+
+Rollback boundary:
+- revert only runtime-path documentation and ignore changes
+
+### Step 2: Relocate standards area first
+
+Change:
+- move `projects/agentic-os-development` content into `projects/agenticos/standards/`
+- do not move product source root yet
+
+Why first:
+- standards references are currently explicit and easier to isolate
+- this reduces ambiguity before moving implementation code
+
+Verification:
+- standards docs are readable at the new path
+- root docs updated to the new standards path still resolve
+- no references remain to the old standards path unless intentionally transitional
+
+Suggested verification:
+
+```bash
+rg -n "projects/agentic-os-development" .
+```
+
+Rollback boundary:
+- revert only standards relocation and standards-path rewrites
+
+### Step 3: Move agent command assets
+
+Change:
+- move `.claude/commands/` into `projects/agenticos/.claude/commands/`
+- keep runtime worktrees separate
+
+Verification:
+- agent command docs still exist at the expected product-project path
+- no runtime worktrees are accidentally pulled into product source
+
+Rollback boundary:
+- revert only command asset relocation
+
+### Step 4: Move product-source directories
+
+Change:
+- move `mcp-server/`, `homebrew-tap/`, `.meta/`, and `tools/` into `projects/agenticos/`
+- keep `.github/` at repository root and retarget workflows to the relocated product path
+
+Verification:
+- product tree structure matches the target layout
+- no required product-source directory remains stranded at root unless explicitly transitional
+
+Suggested verification:
+
+```bash
+find projects/agenticos -maxdepth 2 -mindepth 1 | sort
+```
+
+Rollback boundary:
+- revert only product-source directory moves
+
+### Step 5: Rewrite root-relative references
+
+Change:
+- update README, AGENTS, CLAUDE, CONTRIBUTING, workflows, formulas, and scripts to the new paths
+- preserve root `.github/workflows` while rewriting their working directories and moved-path references
+
+Verification:
+- `rg` finds no stale root-relative references for moved paths
+- docs point to valid locations
+- workflow and formula paths resolve
+
+Suggested verification:
+
+```bash
+rg -n "projects/agentic-os-development|mcp-server/|homebrew-tap/|\\.meta/|\\.github/|tools/" .
+```
+
+Rollback boundary:
+- revert only reference rewrites
+
+### Step 6: Verify product build from new location
+
+Change:
+- no new move; this is a verification gate
+
+Verification:
+
+```bash
+cd projects/agenticos/mcp-server && npm install && npm run build
+```
+
+Also verify:
+- release docs still make sense
+- Homebrew formula references still point to valid assets
+
+Rollback boundary:
+- if build fails, revert the immediately preceding move/rewrite step first
+
+### Step 7: Verify workspace semantics at root
+
+Change:
+- confirm the top-level root is now described and treated as workspace home
+
+Verification:
+- top-level docs describe workspace role clearly
+- `projects/*` semantics are now consistent
+- runtime projects remain intact
+
+Suggested verification:
+
+```bash
+find projects -maxdepth 1 -mindepth 1 | sort
+```
+
+Rollback boundary:
+- revert workspace-role documentation if needed without undoing the whole migration
+
+## 4. Verification Priority Rules
+
+### Rule 1
+
+Do not proceed to the next step if the current step is not verified.
+
+### Rule 2
+
+Prefer verification commands that can be re-run cheaply and deterministically.
+
+### Rule 3
+
+When a step changes both structure and references, verify structure first, then references.
+
+### Rule 4
+
+If one verification fails, stop and fix that layer before touching another layer.
+
+## 5. Minimum Verification Matrix
+
+| Step | Required Verification |
+|------|------------------------|
+| 1 | runtime ignore rules and docs |
+| 2 | standards path resolution and stale-reference scan |
+| 3 | command asset relocation and runtime separation |
+| 4 | expected directory layout under `projects/agenticos` |
+| 5 | stale-reference scan and path validity |
+| 6 | build verification from relocated product source |
+| 7 | workspace-root semantic verification |
+
+## 6. Rollback Strategy
+
+Rollback should be local to the most recent verified step.
+
+Do not respond to a late failure by manually improvising across multiple layers.
+
+Preferred rollback behavior:
+- revert last bounded move
+- rerun verification
+- only continue when green again
+
+## 7. Immediate Next Action
+
+Convert this execution sequence into:
+- exact shell-safe move order
+- exact `rg` verification command set
+- exact per-step success/failure checklist

--- a/projects/agenticos/standards/knowledge/post-self-hosting-follow-up-plan-2026-03-23.md
+++ b/projects/agenticos/standards/knowledge/post-self-hosting-follow-up-plan-2026-03-23.md
@@ -1,0 +1,104 @@
+# AgenticOS Post Self-Hosting Follow-Up Plan
+
+> Date: 2026-03-23
+> Purpose: capture the concrete next-priority work after the self-hosting migration landed
+
+## 1. What Is Now Settled
+
+The following is no longer speculative:
+
+- AgenticOS now self-hosts under `projects/agenticos/`
+- standards now live under `projects/agenticos/standards/`
+- the relocated product build works from `projects/agenticos/mcp-server`
+- the clean-install baseline problem was real and required a separate fix before migration could proceed
+
+These are no longer design assumptions.
+They are execution-backed facts.
+
+## 2. What Execution Taught Us
+
+### Lesson 1: repository automation is not just another product directory
+
+`.github/` cannot be treated like ordinary product-source content.
+
+It must remain at repository root because GitHub Actions workflow discovery is root-scoped.
+
+Implication:
+- future layering and relocation rules need an explicit root-scoped infrastructure exception
+
+### Lesson 2: issue-first is not enough without base-branch guardrails
+
+The first `#43` PR was incorrectly based on a local branch ahead of `origin/main`, so it accidentally included unrelated commits.
+
+Implication:
+- future guardrails must check remote base ancestry, not only branch naming
+- PR scope validation needs to detect accidental extra commits before opening or merging
+
+### Lesson 3: clean reproducibility is a real migration gate
+
+Migration did not fail because of path rewrites first.
+It failed because `npm ci` exposed a lockfile drift.
+
+Implication:
+- baseline reproducibility checks must remain mandatory before structural work
+- `npm ci` should stay the canonical clean-checkout gate where reproducibility matters
+
+### Lesson 4: self-hosting solved one ambiguity but not the whole workspace problem
+
+The host product is now positioned correctly, but real runtime projects still remain tracked under `projects/`.
+
+Implication:
+- runtime extraction and workspace separation remain open follow-up work
+- self-hosting was a major prerequisite, not the final portability state
+
+## 3. Highest-Value Next Priorities
+
+### Priority A: guardrails
+
+Now that the repository model is real, the next weak point is execution correctness.
+
+Most valuable guardrails:
+- verify current branch is cut from the intended remote base
+- verify PR diff does not include unrelated commits
+- verify issue/branch/worktree alignment before implementation begins
+- verify root-scoped infrastructure exceptions such as `.github/`
+
+### Priority B: downstream standards kit
+
+The standards are now anchored in a real product layout.
+
+The next packaging step should define:
+- what downstream projects inherit from `projects/agenticos/standards/`
+- what remains repository-specific
+- what is root-scoped infrastructure versus project-scoped standards
+
+### Priority C: runtime extraction
+
+The root repository still tracks real runtime projects.
+
+The next portability step should:
+- classify which `projects/*` entries are runtime
+- define extraction and de-tracking order
+- define the relationship between the product source repo and the live `AGENTICOS_HOME` workspace
+
+## 4. Suggested Immediate Sequencing
+
+Recommended order after self-hosting:
+
+1. strengthen guardrails from real execution failures
+2. package the standards into a reusable downstream kit
+3. execute runtime workspace extraction from the product source repo
+
+This order matters:
+- guardrails reduce the chance of repeating execution mistakes
+- packaging stabilizes what downstream projects should inherit
+- extraction should happen after the target operational model is clearer
+
+## 5. Canonical Follow-Up Questions
+
+The next iteration should answer these precisely:
+
+1. Which paths are root-scoped infrastructure exceptions and can never be blindly relocated?
+2. How should an agent prove its branch is based on the correct remote base before implementation starts?
+3. What exact files make up the downstream standards kit from `projects/agenticos/standards/`?
+4. Which current `projects/*` entries are runtime projects versus fixtures or examples?

--- a/projects/agenticos/standards/knowledge/product-positioning-and-design-review-2026-03-22.md
+++ b/projects/agenticos/standards/knowledge/product-positioning-and-design-review-2026-03-22.md
@@ -1,0 +1,255 @@
+# AgenticOS Development: Product Positioning and Design Review
+
+> Date: 2026-03-22
+> Source: current session synthesis from project docs, historical conversations, and user clarification
+> Purpose: preserve the product framing and current design assessment as a stable reference for later optimization work
+
+## 1. Canonical Positioning
+
+`agentic-os-development` is the standards and product-definition project for AgenticOS itself.
+
+It is not just "one project under AgenticOS". It is the place where AgenticOS:
+- defines its canonical project metadata and project structure
+- evolves the rules for cross-session context recovery
+- evolves the rules for multi-agent collaboration
+- evolves the rules for durable recording, knowledge capture, and Git-backed persistence
+- defines the templates and behavior contracts that downstream projects should inherit
+
+In other words, this project is the meta-project and standards project for the whole AgenticOS ecosystem.
+
+## 2. Intended Outcome
+
+The long-term outcome is not only better project notes. The target system is:
+
+1. Human-Agent collaboration context becomes durable and portable.
+   Human intent, decisions, rationale, and working knowledge should become persistent project context that future agents can reload and continue from.
+
+2. The system can evolve continuously.
+   The standards themselves should be improved through issue-driven, Git-backed, reviewable changes rather than ad hoc conversation-only updates.
+
+3. Any compatible agent can participate.
+   Different models and tools should be able to switch into a project, recover the same context, follow the same constraints, and contribute safely.
+
+## 3. What This Implies for Downstream Projects
+
+Important downstream projects should follow the AgenticOS project specification produced here.
+
+That means each important project should eventually have:
+- stable project metadata
+- durable context files
+- explicit agent-facing norms
+- durable design and decision records
+- Git-backed persistence
+- issue-driven and reviewable evolution when appropriate
+
+This project therefore defines the "shape" of project memory and agent behavior that other projects should inherit.
+
+## 4. Product Principles Refined
+
+The session clarified that some current principles are too abstract. In particular:
+
+- `Agent First` cannot remain a slogan.
+- `Agent Friendly` cannot remain a descriptive adjective.
+
+If these principles are expected to guide heterogeneous agents reliably, they need to become executable norms:
+- explicit rules
+- decision criteria
+- loading order
+- required validations
+- record/update obligations
+- escalation paths
+- preferably code, schemas, or pseudocode-level behavior contracts
+
+The goal is not philosophical consistency. The goal is predictable agent behavior across models and tools.
+
+## 5. Current Design: What Is Working
+
+The current design still has a strong core:
+
+- The product is aimed at the correct problem: durable agent context, not generic task management.
+- The three-layer structure is directionally sound: universal files, MCP enhancement, agent-specific adaptation.
+- The system correctly treats project knowledge as something that should survive conversation compression.
+- The project already recognizes the need for issue-first, PR-based, reviewable evolution rather than purely conversational evolution.
+
+These are strong foundations worth preserving.
+
+## 6. Current Design: Structural Problems
+
+The current implementation and process still show five important problems.
+
+### Problem 1: Project boundary pollution
+
+This standards project currently contains execution history and state that clearly belong to other projects.
+
+That means the system is not yet enforcing clean project isolation. If the standards project itself cannot maintain boundary integrity, downstream projects will drift and contaminate each other too.
+
+### Problem 2: Context pointer != context understanding
+
+`agenticos_switch` and related flows can expose file pointers, but this does not guarantee that an agent actually reads and internalizes the right knowledge before acting.
+
+This is especially visible with spawned/sub agents.
+
+### Problem 3: Memory layers are not strict enough
+
+The intended layers exist, but their contract is not yet sharp enough:
+- what belongs in `quick-start`
+- what belongs in `state.yaml`
+- what belongs in `conversations`
+- what belongs in `knowledge`
+- what is ephemeral versus canonical
+
+Without a strict contract, records become noisy and later sessions recover the wrong things.
+
+### Problem 4: Agent behavior rules are under-specified
+
+The system has principles, but not enough executable rules for:
+- what an agent must read first
+- what must be recorded
+- when to ask for confirmation
+- how to verify understanding
+- how to maintain project boundaries
+- how child agents inherit context
+
+This limits predictability.
+
+### Problem 5: Open-source evolution model is only partially productized
+
+The project already points toward Issue -> branch/worktree -> PR -> review -> merge -> automation.
+
+But this workflow is not yet fully turned into a first-class product contract that downstream projects can adopt consistently, including GitHub Actions as part of the operating model.
+
+## 7. Design Judgment
+
+The overall direction is correct, but the product contract is still too soft.
+
+Current status:
+- The architecture is plausible.
+- The product positioning is strong.
+- The knowledge strategy is directionally correct.
+- The behavior specification is still too implicit.
+- The isolation and recovery contracts are still too weak.
+
+So the next phase should not start with "more features".
+
+It should start with tightening the product contract:
+- define project boundary rules
+- define memory-layer contracts
+- define executable agent behavior rules
+- define sub-agent context inheritance rules
+- define issue-driven evolution workflow as part of the standard
+
+## 8. Recommended Optimization Themes
+
+The next optimization rounds should likely focus on these themes:
+
+1. Standards model
+   Define which files are canonical, derived, ephemeral, and agent-facing.
+
+2. Executable agent protocol
+   Convert "Agent First / Friendly" into rules, pseudocode, schemas, and validation checkpoints.
+
+3. Context isolation
+   Prevent cross-project pollution in `quick-start`, `state.yaml`, and recorded history.
+
+4. Collaboration workflow
+   Formalize Issue-first and GitHub Actions based evolution as a reusable downstream pattern.
+
+5. Inheritance model
+   Define which parts of this standards project flow into downstream projects as templates, policies, or generated files.
+
+## 9. Immediate Follow-up Candidates
+
+These can become future issues:
+
+- Define the canonical contract for `.project.yaml`, `.context/quick-start.md`, `.context/state.yaml`, `knowledge/`, and `tasks/`
+- Define executable rules for "Agent First" and "Agent Friendly"
+- Define sub-agent context injection and verification rules
+- Define project-boundary enforcement rules
+- Define how issue-driven and GitHub Actions based evolution should work for AgenticOS projects
+- Define which standards are inherited automatically versus customized per project
+
+## 10. New Diagnosis: Cross-Agent Bootstrap Gap
+
+This session exposed an additional product gap when switching from Claude Code to Codex.
+
+### Observation
+
+The user asked to switch to the AgenticOS project, but the agent did not behave as if AgenticOS were an already integrated operating layer.
+
+### Likely Causes
+
+1. The MCP server may not be installed or connected for the current agent.
+2. The MCP server may exist, but project-intent recognition may not be wired into the current agent's startup rules.
+3. Configuration may exist in one agent, but not in another, creating inconsistent cross-agent behavior.
+4. Configuration may work, but its source may be opaque, making it hard to maintain and debug.
+
+### Concrete Findings From This Session
+
+- Claude Code had historical evidence of successful `mcp__agenticos__...` tool usage, so AgenticOS was active there at least in prior sessions.
+- However, the explicit user-level MCP declaration was not easy to locate, which is itself an operability problem.
+- Codex did not have a user-level `agenticos` MCP entry before this session.
+- Codex now has a global MCP server entry for `agenticos`, and Claude now also has an explicit user-level MCP config file.
+
+### Product Implication
+
+AgenticOS needs a first-class bootstrap standard per agent, not only a server implementation.
+
+That bootstrap standard should define:
+- where MCP is configured for each agent
+- how project-intent recognition is configured for each agent
+- how to verify the integration is actually active
+- how to debug misrouting or missing project-switch behavior
+
+Without this, "cross-agent compatibility" remains theoretical.
+
+### Homebrew Distribution Gap
+
+Homebrew distribution currently installs the binary successfully, but does not yet guarantee that Claude Code, Codex, Gemini CLI, or other supported agents are actually bootstrapped afterward.
+
+That means installation and activation are still split:
+- install binary
+- configure agent MCP
+- configure intent recognition
+- restart tool
+- verify integration
+
+This gap should be treated as a product issue, not as documentation polish only.
+
+## 11. MCP vs CLI+Skills Fallback
+
+This session also surfaced a useful fallback question: if MCP is unavailable, unreliable, or too inconsistent across agents, should AgenticOS support a CLI + Skills mode?
+
+### Why This Matters
+
+AgenticOS currently treats MCP as the primary integration protocol, which is directionally correct.
+But product reliability may require a compatibility mode when:
+- an agent does not support MCP well
+- MCP configuration is difficult to maintain
+- intent routing is weak even when tools are available
+- the team needs a more inspectable integration path
+
+### Working Framing
+
+- **Primary mode**: MCP
+  Best for structured tools, resources, and long-term agent-native integration.
+
+- **Fallback mode**: CLI + Skills
+  Potentially better for universal reach, debuggability, and explicit invocation.
+
+### Open Product Question
+
+AgenticOS may need a formal integration matrix:
+- MCP-native mode
+- CLI-wrapper mode
+- Skills-only prompt/routing mode
+- mixed mode for agents with uneven capabilities
+
+This should be treated as a product design question, not only as an implementation detail.
+
+## 12. Working Conclusion
+
+AgenticOS should be treated as a durable project-context operating standard for human-agent and agent-agent collaboration.
+
+`agentic-os-development` is the canonical project where that standard is defined, tested, criticized, and evolved.
+
+The next design work should focus on making the standard more explicit, more executable, and more enforceable.

--- a/projects/agenticos/standards/knowledge/repository-layering-and-portability-plan-2026-03-23.md
+++ b/projects/agenticos/standards/knowledge/repository-layering-and-portability-plan-2026-03-23.md
@@ -1,0 +1,260 @@
+# AgenticOS Repository Layering and Portability Plan
+
+> Date: 2026-03-23
+> Purpose: clarify which parts of the current AgenticOS repository are runtime data, which are standards, which are implementation, and how to improve portability
+
+## 1. Core Diagnosis
+
+The current top-level `AgenticOS` repository mixes four different concerns:
+
+1. **standards and specifications**
+2. **product implementation**
+3. **user workspace and managed projects**
+4. **agent runtime byproducts**
+
+That mixed model makes it hard to answer:
+- what should be installed by Homebrew
+- what should be versioned as product source
+- what should be portable across machines
+- what should never be committed because it is runtime-only
+
+This is the main source of confusion around whether `agentic-os-development` belongs inside the top-level repo, whether `.claude` is product data, and whether `mcp-server` should move into the standards project.
+
+## 2. Classification of Current Top-Level Content
+
+### A. Standards / specification assets
+
+These define the rules, templates, and contracts that downstream projects should follow.
+
+Examples:
+- `projects/agentic-os-development/`
+- `.meta/templates/`
+- `.meta/rules.md`
+- `.meta/agent-guide.md`
+- top-level guidance such as `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`
+
+These are **not runtime data**.
+They are part of the product standard and should be versioned deliberately.
+
+### B. Product implementation assets
+
+These are the actual implementation of AgenticOS as a tool.
+
+Examples:
+- `mcp-server/`
+- `homebrew-tap/`
+- `tools/`
+- `.github/`
+
+These are also **not runtime data**.
+They are the code and packaging machinery that implement the standard.
+
+`mcp-server` belongs here.
+It should **not** be moved into the standards project.
+
+Reason:
+- the standards project defines the contracts
+- the MCP server implements those contracts
+- mixing the implementation back into the standards project would collapse specification and implementation into one layer again
+
+### C. Workspace / managed project data
+
+These are the projects managed by AgenticOS for real user work.
+
+Examples:
+- `projects/360teams`
+- `projects/ghostty-optimization`
+- `projects/agentic-devops`
+- `projects/test-project`
+
+These are neither core implementation nor global runtime temp data.
+They are user workspace content.
+
+They may be portable and optionally backed up in Git, but they should not be confused with product source code.
+
+### D. Runtime / ephemeral agent data
+
+These are produced while the system is running and should usually not be treated as canonical product content.
+
+Examples:
+- `.claude/worktrees/`
+- temporary worktree copies
+- local caches
+- lock files or temp execution traces
+- active session pointers that can be regenerated
+
+These should be treated as **runtime state**, not product source.
+
+In the current repo, `.claude` is mixed:
+- `.claude/commands/` is closer to agent integration assets
+- `.claude/worktrees/` is runtime byproduct
+
+That mixed directory is a design smell and should be split conceptually.
+
+### E. Borderline workspace metadata
+
+Examples:
+- `.agent-workspace/registry.yaml`
+
+This is not pure runtime trash, but it is also not core implementation source.
+
+It is **workspace metadata**.
+It should be portable, but it should not be confused with the product's own source repo.
+
+## 3. Recommendation: Three-Layer Model
+
+AgenticOS should move toward a cleaner three-layer model.
+
+### Layer 1: Product source repository
+
+This is the GitHub repository for AgenticOS itself.
+
+It should contain:
+- standards/specification assets
+- implementation code
+- packaging and release assets
+- example or fixture content only when intentional
+
+It should not contain:
+- user-specific managed projects as live mutable workspace state
+- runtime worktree copies
+- user-local ephemeral execution traces
+
+### Layer 2: User workspace
+
+This is what Homebrew or the install flow prepares for the user.
+
+It should contain:
+- managed projects
+- portable workspace metadata
+- project context and knowledge
+
+It may optionally be committed by the user for backup and migration.
+
+This is where `projects/` belongs in the long term.
+
+### Layer 3: Runtime state
+
+This should hold:
+- temporary worktrees
+- session-local caches
+- generated temp execution state
+- lock files
+- tool-specific runtime artifacts
+
+This layer should be excluded from normal source control and should be safe to rebuild.
+
+## 4. Practical Interpretation for Current Paths
+
+### Keep as product source
+
+- `mcp-server/`
+- `homebrew-tap/`
+- `.meta/`
+- `.github/`
+- `tools/`
+- root docs
+
+### Keep as standards content, but treat carefully
+
+- `projects/agentic-os-development/`
+
+This project is a standards/meta-project.
+It can remain conceptually part of the product-definition layer, but it should not be mistaken for ordinary user workspace content.
+
+Long-term, it likely deserves one of these forms:
+- a dedicated `standards/agentic-os-development/` area inside the product source repo
+- or a dedicated standalone repository if you want full lifecycle separation
+
+### Move out of product source or stop treating as canonical source
+
+- ordinary managed projects under `projects/`
+- `.claude/worktrees/`
+
+These belong to workspace/runtime, not to the core source repository.
+
+### Split or redesign
+
+- `.claude/`
+  - keep reusable agent command assets in product source
+  - move worktree/runtime artifacts into a runtime-only location
+
+- `.agent-workspace/registry.yaml`
+  - keep as workspace metadata, not as product source of truth
+
+## 5. Portability-Oriented Target State
+
+If a user installs AgenticOS on a new machine via Homebrew, the ideal model is:
+
+1. Homebrew installs the product implementation.
+2. AgenticOS initializes a clean user workspace.
+3. The workspace contains managed projects and portable project metadata.
+4. Runtime temp data is kept separate from portable workspace content.
+
+That means "new machine migration" should move:
+- workspace projects
+- project context
+- portable workspace metadata
+
+But it should not need to move:
+- temp worktrees
+- agent-specific runtime residue
+
+## 6. Recommendation on MCP Server
+
+`mcp-server` should stay in the product implementation layer.
+
+It should not be moved into the standards project.
+
+The right relationship is:
+- standards project defines the protocol
+- `mcp-server` implements the protocol
+- installer/bootstrap machinery distributes and activates the implementation
+
+If anything should move closer to the standards project, it is:
+- canonical templates
+- protocol schemas
+- guardrail definitions
+
+not the server implementation itself.
+
+## 7. Recommended Structural Direction
+
+The most coherent direction is:
+
+1. Keep `madlouse/AgenticOS` as the **product source repository**
+2. Treat `mcp-server`, `homebrew-tap`, `.meta`, `.github`, and root docs as product source
+3. Gradually stop using the product source repo as the user's live workspace
+4. Move runtime artifacts like `.claude/worktrees/` out of source control semantics
+5. Treat `agentic-os-development` as the canonical standards/meta-project, but decide explicitly whether it lives:
+   - inside product source as a standards area, or
+   - as a standalone repository with its own remote
+6. Treat ordinary downstream projects as workspace projects, not product source
+
+### Immediate Practical Rule
+
+Until the larger migration is complete, use this operational rule:
+
+- develop AgenticOS source in the product repo checkout
+- run real AgenticOS-managed projects from a separate `AGENTICOS_HOME`
+- do not treat the source repo checkout as the default live workspace
+- exclude runtime artifacts from product source control wherever possible
+
+## 8. Final Judgment
+
+The main problem is not whether one folder is "wrong".
+
+The main problem is that the current top-level repository is simultaneously acting as:
+- source repo
+- package repo
+- standards repo
+- workspace home
+- runtime scratch space
+
+That is too many roles for one tree.
+
+For portability, maintainability, and predictable agent behavior, AgenticOS should explicitly separate:
+- **standard**
+- **implementation**
+- **workspace**
+- **runtime**

--- a/projects/agenticos/standards/knowledge/self-hosting-migration-execution-report-2026-03-23.md
+++ b/projects/agenticos/standards/knowledge/self-hosting-migration-execution-report-2026-03-23.md
@@ -1,0 +1,81 @@
+# AgenticOS Self-Hosting Migration Execution Report
+
+> Date: 2026-03-23
+> Purpose: record the real execution and landing of the self-hosting migration for the AgenticOS product repository
+
+## 1. Outcome
+
+The self-hosting migration has now been executed and merged in the main AgenticOS repository.
+
+Merged PR:
+- PR #46 `refactor(repo): self-host AgenticOS under projects/agenticos (#40)`
+
+Related issue:
+- Issue #40 is now closed
+
+## 2. What Landed
+
+The merged migration established the following repository layout:
+
+- AgenticOS product source now lives under `projects/agenticos/`
+- standards content now lives under `projects/agenticos/standards/`
+- agent command assets now live under `projects/agenticos/.claude/commands/`
+- product implementation now lives under:
+  - `projects/agenticos/mcp-server/`
+  - `projects/agenticos/homebrew-tap/`
+  - `projects/agenticos/.meta/`
+  - `projects/agenticos/tools/`
+
+## 3. Runtime and Workspace Semantics
+
+The root repository now acts as the workspace home more explicitly.
+
+Runtime-only areas were clarified as:
+- `.runtime/`
+- `.claude/worktrees/`
+
+These are not canonical product source.
+
+## 4. Important Design Correction
+
+Execution revealed one important constraint that required correcting the original migration model:
+
+- `.github` cannot move under `projects/agenticos/`
+
+Reason:
+- GitHub Actions workflow discovery remains repository-root scoped
+
+So the landed model keeps:
+- `.github/` at repository root
+
+This means the final self-hosting model is slightly different from the earlier frozen draft:
+- product source is self-hosted under `projects/agenticos/`
+- but repository automation remains at root
+
+## 5. Verification Evidence
+
+The migration was verified from the relocated product path:
+
+```bash
+cd /Users/jeking/worktrees/agenticos-self-hosting-v2/projects/agenticos/mcp-server
+npm install
+npm run build
+npm test
+```
+
+Observed result:
+- install passed
+- build passed
+- test passed
+
+CI on PR #46 also passed before merge.
+
+## 6. Follow-Up Implication for Standards
+
+The standards project should now treat the self-hosting model as:
+
+- accepted
+- executed
+- slightly refined by the `.github` root-level exception
+
+Future planning documents should avoid assuming that all product-source-adjacent directories can be nested under `projects/agenticos/`.

--- a/projects/agenticos/standards/knowledge/self-hosting-migration-plan-2026-03-23.md
+++ b/projects/agenticos/standards/knowledge/self-hosting-migration-plan-2026-03-23.md
@@ -1,0 +1,184 @@
+# AgenticOS Self-Hosting Migration Plan
+
+> Date: 2026-03-23
+> Purpose: define a concrete migration path if AgenticOS adopts the self-hosting workspace model
+
+## 1. Migration Goal
+
+Adopt the self-hosting model by changing roles as follows:
+
+- current top-level `AgenticOS` directory becomes the **workspace home**
+- the AgenticOS product source becomes a managed project under `projects/agenticos`
+- `agentic-os-development` stops being a sibling runtime project and becomes the standards area inside the AgenticOS product project
+
+## 2. Target Structure
+
+```text
+~/AgenticOS/
+  .agent-workspace/
+  .runtime/
+    worktrees/
+    caches/
+  projects/
+    agenticos/
+      .git/
+      standards/
+      mcp-server/
+      homebrew-tap/
+      .github/
+      .meta/
+      tools/
+      README.md
+      AGENTS.md
+      CLAUDE.md
+      CONTRIBUTING.md
+      CHANGELOG.md
+      ROADMAP.md
+    360teams/
+    2026okr/
+    agentic-devops/
+    ghostty-optimization/
+    okr-management/
+    t5t/
+```
+
+## 3. Main Structural Decisions
+
+### Product project name
+
+Use:
+- `projects/agenticos`
+
+Reason:
+- aligns with the product name
+- avoids overloading `agentic-os-development`
+- makes the main product project obviously canonical
+
+### Standards location
+
+Absorb current `projects/agentic-os-development` into:
+- `projects/agenticos/standards/`
+
+This keeps:
+- one main product project
+- one standards area inside it
+
+### Runtime location
+
+Move temporary runtime artifacts under:
+- `.runtime/worktrees/`
+- `.runtime/caches/`
+
+This avoids mixing them with reusable agent command/config assets.
+
+## 4. Migration Phases
+
+### Phase 1: Freeze the target model
+
+Outputs:
+- approved target structure
+- approved naming
+- approved treatment of `agentic-os-development`
+- approved runtime path rules
+
+No physical moves yet.
+
+### Phase 2: Prepare product project relocation
+
+Tasks:
+- choose the future canonical repo root inside `projects/agenticos`
+- identify all root-relative paths in CI, docs, release scripts, and formulas
+- identify all references to `projects/agentic-os-development`
+- identify all references to `.claude/worktrees`
+
+Outputs:
+- relocation checklist
+- path rewrite checklist
+
+### Phase 3: Move standards into the product project
+
+Tasks:
+- move `projects/agentic-os-development` content into `projects/agenticos/standards/`
+- preserve history carefully if desired
+- update references in docs and templates
+
+Outputs:
+- one main product project with an internal standards area
+
+### Phase 4: Relocate product source
+
+Tasks:
+- move current root product source content into `projects/agenticos/`
+- ensure Git history is preserved in the product project
+- update CI/release/Homebrew/docs paths
+
+Outputs:
+- top-level root no longer acts as product source repo
+
+### Phase 5: Convert top-level root into workspace home
+
+Tasks:
+- keep workspace metadata at top level
+- keep runtime state in `.runtime/`
+- ensure `projects/*` are managed project directories
+
+Outputs:
+- root is now clearly a workspace, not a mixed source/runtime tree
+
+### Phase 6: Extract or reclassify remaining tracked runtime projects
+
+Tasks:
+- keep actual runtime projects under `projects/`
+- decide which are fixtures/examples versus real managed projects
+- ensure source-only content no longer lives at root
+
+## 5. Path Rewrite Scope
+
+The following path families will need updates:
+
+- CI workflow paths under `.github/workflows`
+- Homebrew formula references
+- README and install documentation
+- AGENTS and CLAUDE references to standards files
+- release and build commands
+- any scripts assuming root contains `mcp-server` directly
+
+## 6. Git Strategy
+
+This migration should not be done as one blind file move.
+
+Recommended Git strategy:
+
+1. finalize target model
+2. create a dedicated migration issue/branch
+3. move standards first
+4. update references
+5. move product source
+6. verify CI/docs/build/release paths
+7. only then declare self-hosting active
+
+## 7. Verification Requirements
+
+Before the migration is considered complete:
+
+- the main AgenticOS product project can still build
+- MCP server paths still work
+- Homebrew docs and formulas still point to valid locations
+- agent startup docs still point to valid standards files
+- runtime worktrees are no longer treated as canonical source
+- the root workspace role is unambiguous
+
+## 8. Rollback Principle
+
+Each migration phase should be reversible.
+
+Do not combine:
+- standards relocation
+- product source relocation
+- runtime relocation
+
+into one irreversible step.
+
+## 9. Recommended Next Action
+
+Create a dedicated execution issue for self-hosting migration planning and sequencing.

--- a/projects/agenticos/standards/knowledge/self-hosting-migration-resolution-v1-2026-03-23.md
+++ b/projects/agenticos/standards/knowledge/self-hosting-migration-resolution-v1-2026-03-23.md
@@ -1,0 +1,113 @@
+# AgenticOS Self-Hosting Migration Resolution v1
+
+> Date: 2026-03-23
+> Status: draft resolution v1
+> Purpose: freeze the target model for AgenticOS self-hosting migration before structural moves begin
+
+## 1. Resolution
+
+AgenticOS will move toward a self-hosting workspace model.
+
+The frozen target model for v1 is:
+
+1. The public product identity remains `AgenticOS`.
+2. The current top-level `AgenticOS` directory becomes the workspace home.
+3. The canonical managed product project path becomes `projects/agenticos`.
+4. Current standards content should move under `projects/agenticos/standards/`.
+5. Runtime-only artifacts should move under `.runtime/`.
+
+## 2. Rationale
+
+This model resolves the current ambiguity between:
+- product source
+- standards/meta project
+- runtime workspace
+- runtime byproducts
+
+It also makes AgenticOS self-hosting explicit:
+- AgenticOS becomes one managed project inside its own workspace
+- standards and implementation are unified inside that product project
+
+## 3. Scope of This Resolution
+
+This resolution freezes the intended target model.
+
+It does **not** yet execute:
+- directory moves
+- Git history migration
+- CI path rewrites
+- Homebrew path rewrites
+- runtime project extraction
+
+Those remain separate execution phases.
+
+## 4. Impact Boundary
+
+The migration should primarily target the AgenticOS host product itself.
+
+That means:
+- existing runtime projects should remain largely unaffected unless they need minimal path or workspace adjustments
+- the migration should not become a forced redesign of all existing managed projects
+
+## 5. Naming and Roles
+
+### Workspace root
+
+- current top-level `AgenticOS/`
+- role: workspace home
+
+### Main product project
+
+- path: `projects/agenticos`
+- role: canonical managed product project
+
+### Standards area
+
+- path: `projects/agenticos/standards/`
+- role: home for current `agentic-os-development` content
+
+### Runtime root
+
+- path: `.runtime/`
+- role: worktrees, caches, and other runtime-only artifacts
+
+## 6. Non-Goals
+
+This resolution does not imply:
+- renaming the public product away from `AgenticOS`
+- immediately moving every existing runtime project
+- collapsing all projects into the main product project
+- skipping phased verification and rollback boundaries
+
+## 7. Required Follow-Up
+
+The next implementation-facing work should:
+
+1. enumerate exact paths that move into `projects/agenticos`
+2. enumerate exact standards paths that move into `projects/agenticos/standards/`
+3. enumerate root-relative paths that need rewriting
+4. define phase-by-phase verification and rollback gates
+
+## 8. Working Consequence
+
+From this point on, planning should assume:
+- `projects/agenticos` is the target canonical product project path
+- `projects/agenticos/standards/` is the target standards location
+- `.runtime/` is the target runtime-only location
+
+Any alternative target model should now be treated as a deliberate change request, not as the default assumption.
+
+## 9. Execution Correction
+
+Real execution later established one important repository-level exception:
+
+- `.github/` must remain at repository root
+
+Reason:
+- GitHub Actions workflow discovery is root-scoped
+
+So the executed self-hosting model is:
+- product source under `projects/agenticos/`
+- standards under `projects/agenticos/standards/`
+- runtime-only state under `.runtime/`
+- repository automation under root `.github/`

--- a/projects/agenticos/standards/knowledge/self-hosting-workspace-model-2026-03-23.md
+++ b/projects/agenticos/standards/knowledge/self-hosting-workspace-model-2026-03-23.md
@@ -1,0 +1,167 @@
+# AgenticOS Self-Hosting Workspace Model
+
+> Date: 2026-03-23
+> Purpose: evaluate whether the current `AgenticOS` directory can become the runtime workspace, with the AgenticOS product itself becoming a managed project inside `projects/`
+
+## 1. Proposed Model
+
+The proposal is:
+
+- treat the current top-level `AgenticOS` directory as the **runtime workspace**
+- move the AgenticOS product source itself into `projects/` as a managed project
+- make AgenticOS evolve itself under its own project rules
+
+This is a valid architectural direction.
+
+It creates a **self-hosting** model:
+- AgenticOS runs as a workspace
+- one of its managed projects is the AgenticOS product itself
+- standards and implementation changes are then performed inside that managed project
+
+## 2. Why This Model Is Attractive
+
+It solves a real conceptual problem:
+
+- the AgenticOS product should itself be developed under AgenticOS project rules
+- standards and implementation can then live inside one managed product project
+- the top-level runtime workspace becomes a neutral container, not a mixed source/runtime tree
+
+This is cleaner than keeping the current root simultaneously as:
+- product source repo
+- runtime workspace
+- standards repo
+- package repo
+
+## 3. Required Role Change
+
+This model works only if the current top-level `AgenticOS` directory changes role.
+
+Today it is effectively treated as the product source repository.
+
+Under the self-hosting model, it would become:
+- **workspace home**
+
+That means the actual GitHub product source repository would need to move under:
+- `projects/agenticos`
+- or a similar canonical project path
+
+So the rule is:
+
+**the same directory cannot continue to be both the product source repo and the runtime workspace root**
+
+One role must win.
+
+## 4. Recommended Internal Structure
+
+If you adopt this model, the target shape should look like:
+
+```text
+~/AgenticOS/
+  .agent-workspace/
+  projects/
+    agenticos/
+      .git/
+      standards/
+      mcp-server/
+      homebrew-tap/
+      .github/
+      .meta/
+      tools/
+      README.md
+    360teams/
+    2026okr/
+    ghostty-optimization/
+  .runtime/
+    worktrees/
+    caches/
+```
+
+Key point:
+- the AgenticOS product becomes one managed project among others
+- but it remains the special, canonical product project
+
+## 5. What Happens to `agentic-os-development`
+
+Under this model, `agentic-os-development` should probably stop being a separate sibling project.
+
+It becomes part of the AgenticOS product project, for example:
+- `projects/agenticos/standards/`
+- or `projects/agenticos/knowledge/standards/`
+
+This would remove the ambiguity between:
+- "the main AgenticOS project"
+- and "the standards project"
+
+There would instead be:
+- one product project: `agenticos`
+- with internal areas such as `standards` and `implementation`
+
+## 6. Benefits
+
+- self-hosting becomes explicit
+- AgenticOS development itself follows AgenticOS rules
+- top-level workspace is cleaner conceptually
+- runtime projects and the main product project share the same management model
+- standards and implementation can be versioned together inside one product project
+
+## 7. Risks and Costs
+
+This is not a no-op rename.
+
+It has real migration cost:
+- the current root GitHub repo would need to be relocated into `projects/agenticos`
+- release tooling paths would need updating
+- Homebrew formulas and CI paths may need changes
+- current docs and commands assume the root repo is the product source
+- nested repo and workspace semantics must be handled deliberately
+
+So this is coherent, but it is a **structural migration**, not a small cleanup.
+
+## 8. Judgment
+
+### Conceptually
+
+Yes, this model is coherent and arguably cleaner.
+
+It matches your goal that:
+- AgenticOS should itself be managed as a project under its own standard
+
+### Operationally
+
+It should be adopted only if you are willing to:
+- redefine the current root as workspace home
+- move the product source repo under `projects/`
+- update release, bootstrap, and documentation assumptions
+
+## 9. Recommended Decision
+
+Two viable options remain:
+
+### Option A: Source-first model
+
+- keep current root as product source repo
+- keep runtime workspace elsewhere
+- keep `agentic-os-development` as the standards/meta area inside the product effort
+
+Lower migration cost.
+
+### Option B: Self-hosting workspace model
+
+- make current root the workspace home
+- move the AgenticOS product source into `projects/agenticos`
+- absorb `agentic-os-development` into that product project as a standards area
+
+Higher migration cost, but conceptually cleaner.
+
+## 10. Recommendation
+
+If your priority is **conceptual clarity and self-hosting**, Option B is the stronger long-term model.
+
+If your priority is **lower disruption right now**, Option A is the safer short-term model.
+
+My judgment is:
+
+- long-term: Option B is better
+- short-term: do not partially mix the two
+
+If you choose Option B, do it as an explicit migration project, not as incremental accidental drift.

--- a/projects/agenticos/standards/knowledge/standalone-standards-first-consolidation-wave-2026-03-23.md
+++ b/projects/agenticos/standards/knowledge/standalone-standards-first-consolidation-wave-2026-03-23.md
@@ -1,0 +1,83 @@
+# Standalone Standards First Consolidation Wave - 2026-03-23
+
+## Summary
+
+Issue `#68` executes the first real consolidation wave after the standalone-standards audit.
+
+This wave does three bounded things:
+
+1. backfills missing high-signal standards knowledge into the main repository
+2. archives the retired standalone repo's raw context and local issue-draft history
+3. rewrites live standards entry files so future work starts from the canonical main-repo standards area
+
+## What Was Merged
+
+The main standards knowledge area now includes previously missing execution-backed documents from the retired standalone repository, including:
+
+- product positioning and design review
+- workflow-model review
+- self-hosting model, migration plan, resolution, and execution report
+- agent execution protocol and guardrail design/contract reports
+- baseline bootstrap and isolation reports
+- Git transport fallback reports
+- downstream standard-kit planning and implementation reports
+
+This creates one canonical standards knowledge surface under:
+
+- `projects/agenticos/standards/knowledge/`
+
+## What Was Archived
+
+The retired standalone repo snapshot is preserved under:
+
+- `projects/agenticos/standards/archive/standalone-agentic-os-development-2026-03-23/`
+
+The archive contains:
+
+- raw `.context/` state and conversation history
+- local `tasks/issue-drafts/` history
+- old root entry files such as `.project.yaml`, `AGENTS.md`, `CLAUDE.md`, and `changelog.md`
+
+The archive is read-only provenance, not the live standards surface.
+
+## Live Guidance Cleanup
+
+Active entry files were rewritten so they no longer treat the standalone repo as canonical:
+
+- `.project.yaml`
+- `AGENTS.md`
+- `CLAUDE.md`
+- `.context/quick-start.md`
+- `.context/state.yaml`
+
+These now point future work to:
+
+- the main standards area
+- the main reusable template surface under `projects/agenticos/.meta/templates/`
+- the main downstream standard-kit under `projects/agenticos/.meta/standard-kit/`
+
+## Additional Template Recovery
+
+This consolidation wave also restores:
+
+- `projects/agenticos/.meta/templates/non-code-evaluation-rubric.yaml`
+
+The downstream standard-kit manifest and adoption checklist were updated so this template is part of the canonical reusable surface.
+
+## Verification
+
+Verification for this wave should confirm:
+
+1. selected standards reports exist under `projects/agenticos/standards/knowledge/`
+2. the archive snapshot exists under `projects/agenticos/standards/archive/`
+3. live entry files point only to the main standards area as canonical
+4. the recovered rubric exists under `projects/agenticos/.meta/templates/`
+5. the updated standard-kit manifest parses cleanly
+
+## Follow-up
+
+After this first consolidation wave lands, the remaining decision is narrower:
+
+- whether any archived standalone artifacts still deserve a second canonical merge wave
+
+All new standards work should continue only inside the main AgenticOS repository.

--- a/projects/agenticos/standards/knowledge/workflow-model-review-2026-03-23.md
+++ b/projects/agenticos/standards/knowledge/workflow-model-review-2026-03-23.md
@@ -1,0 +1,180 @@
+# AgenticOS Workflow Model Review
+
+> Date: 2026-03-23
+> Purpose: clarify whether AgenticOS should use GitHub Flow or GitFlow, and define how worktree isolation fits into the operating model
+
+## 1. Core Clarification
+
+The main decision is not "GitHub Flow vs GitFlow" in isolation.
+
+The real product question is:
+
+- what collaboration model downstream AgenticOS projects should follow
+- what must happen before an agent is allowed to edit code
+- how to isolate active implementation work from the currently running or trusted workspace
+
+`git worktree` is not itself a branching strategy.
+It is a workspace-isolation mechanism.
+
+So these decisions should be separated:
+
+1. **Branching and release model**
+   How changes move from idea to merged code.
+2. **Workspace isolation model**
+   Where agents are allowed to make those changes.
+
+## 2. GitHub Flow vs GitFlow
+
+### GitHub Flow
+
+Characteristics:
+- one long-lived `main` branch
+- short-lived feature/fix/docs branches
+- changes merge back through PRs
+- releases usually come from `main`
+
+Strengths:
+- simple
+- low coordination overhead
+- works well for continuous delivery
+- easier for solo maintainers and agent-driven iteration
+
+Weaknesses:
+- less explicit release stabilization structure
+- teams with long QA/release hardening phases may want more branching ceremony
+
+### GitFlow
+
+Characteristics:
+- multiple long-lived branches such as `main` and `develop`
+- release branches and hotfix branches are first-class
+- a more staged model between development and release
+
+Strengths:
+- useful when releases are infrequent, coordinated, and need explicit hardening windows
+- clearer separation between ongoing development and release preparation
+
+Weaknesses:
+- materially more process overhead
+- higher branch-management burden for agents
+- easier for automation and sub-agents to drift or target the wrong branch
+- usually overkill for fast-moving repositories that already rely on CI and PR checks
+
+## 3. Recommendation for AgenticOS
+
+AgenticOS should use **GitHub Flow as the primary branch model**, not GitFlow.
+
+Reasoning:
+- the project is agent-heavy and iteration-heavy
+- the current repo already documents a single-`main` model
+- automation and issue-first PR flow fit GitHub Flow naturally
+- the main operational risk is not lack of release branches, but lack of enforced isolation before edits
+
+So the correct refinement is:
+
+**GitHub Flow + mandatory worktree isolation for implementation work**
+
+This gives:
+- low cognitive overhead
+- simple downstream inheritance
+- strong isolation from the active workspace
+- compatibility with issue-first and PR-based evolution
+
+## 4. What Worktree Actually Solves
+
+Worktree should be treated as a protection mechanism, not as a release strategy.
+
+It helps solve:
+- accidental edits in the active workspace
+- branch confusion during parallel agent work
+- unsafe mixing of multiple issue implementations
+- reduced trust when agents touch the same checkout repeatedly
+
+It does **not** solve:
+- release planning
+- semantic versioning policy
+- PR review rules
+- issue taxonomy
+
+## 5. Proposed AgenticOS Workflow Contract
+
+### Primary model
+
+For AgenticOS-managed repositories with a valid git baseline:
+
+`Issue -> branch -> isolated worktree -> implementation -> verification -> PR -> merge -> automation`
+
+### Mandatory rules
+
+For implementation tasks:
+- a GitHub Issue must exist or an accepted issue draft must be linked
+- the agent must not implement directly in the protected active workspace
+- the agent must use a task branch
+- the agent must use a dedicated worktree for that branch
+
+For discussion and analysis tasks:
+- issue drafting, knowledge capture, and product analysis may happen without a feature worktree if no shipped code or runtime-sensitive files are being changed
+- this exception should be explicit and narrow
+
+### Required preflight
+
+Before editing implementation files, the agent should verify:
+- current repository identity
+- current branch name
+- whether the repo has an initial baseline commit
+- whether a task issue exists
+- whether the current workspace is an isolated worktree
+- whether the target files are implementation-affecting or documentation-only
+
+## 6. Independent Project Repos
+
+This session exposed an important edge case:
+
+some AgenticOS-managed subproject repos may still be on an unborn `main` branch with no initial commit.
+
+In that state, normal branch/worktree flow is not fully available.
+
+So the standard should define a bootstrap phase:
+
+### Repository bootstrap phase
+
+If a project repo has no initial commit yet:
+- create the minimum baseline commit first
+- establish canonical files and branch identity
+- only then require branch/worktree isolation for implementation work
+
+Without this bootstrap rule, the protocol becomes self-contradictory.
+
+## 7. Suggested Product Framing
+
+AgenticOS should avoid saying only:
+- "we use GitHub Flow"
+
+It should say:
+
+- "AgenticOS uses GitHub Flow for branch lifecycle"
+- "AgenticOS requires isolated worktrees for implementation work"
+- "AgenticOS uses issue-first preflight before agent execution"
+
+This is more precise and operationally useful than arguing over GitHub Flow vs GitFlow alone.
+
+## 8. Recommended Changes to the Standard
+
+1. Keep GitHub Flow as the canonical branch model.
+2. Add a hard agent preflight protocol before implementation.
+3. Make worktree isolation mandatory for implementation changes.
+4. Define a narrow exception policy for docs/analysis-only work.
+5. Require issue execution to begin with context loading and at least one design/critique loop before implementation.
+6. Define executable acceptance criteria before implementation starts.
+7. Define a bootstrap rule for repos that do not yet have an initial commit.
+8. Add downstream templates and helper commands so the rule is easy to follow.
+
+## 9. Working Conclusion
+
+The main problem is not that AgenticOS picked the wrong named Git model.
+
+The main problem is that the current workflow standard is not yet executable enough to stop agents from working in the wrong place.
+
+So the next optimization target should be:
+
+**turn GitHub Flow + worktree isolation + issue-first preflight into an enforceable agent protocol**


### PR DESCRIPTION
## Summary
- backfill missing high-signal standards knowledge from the retired standalone repo into `projects/agenticos/standards/knowledge/`
- archive the retired standalone `.context`, issue-draft history, and entry files under `projects/agenticos/standards/archive/`
- retarget live standards entry files and the downstream standard-kit surface to the main repo canonical standards area

## Verification
- `ruby -e 'require "yaml"; YAML.load_file("projects/agenticos/standards/.context/state.yaml"); YAML.load_file("projects/agenticos/.meta/standard-kit/manifest.yaml"); YAML.load_file("projects/agenticos/.meta/templates/non-code-evaluation-rubric.yaml"); puts "yaml ok"'`
- verified archive snapshot does not contain `.git`, `.DS_Store`, or archived `.last_record`
- verified live standards guidance now points to the main standards area as canonical

Closes #68
