### PR TITLE
docs(standards): finalize standalone retirement resolution (#70)

### DIFF
--- a/projects/agenticos/standards/.context/quick-start.md
+++ b/projects/agenticos/standards/.context/quick-start.md
@@ -14,12 +14,14 @@ Its job is to define and evolve:
 ## Current Status
 
 - canonical standards location has been frozen in the main repo by issue `#66` / PR `#67`
-- the old standalone `projects/agentic-os-development` repo is now treated as a retired transitional snapshot
-- issue `#68` is the first real consolidation wave
+- the old standalone `projects/agentic-os-development` repo is now treated as a retired archive-only snapshot
+- issue `#68` has already landed as PR `#69`
 - selected high-signal standards reports from the retired standalone repo have been backfilled into `knowledge/`
+- `knowledge/runtime-project-extraction-closure-report-2026-03-23.md` has now also been restored as the final remaining high-signal closure report
 - the retired standalone `.context/`, issue-draft history, and entry files are now preserved under:
   - `archive/standalone-agentic-os-development-2026-03-23/`
 - live standards guidance now points only to this main-repo standards area
+- `knowledge/standalone-standards-retirement-resolution-2026-03-23.md` now records the final decision that no second broad merge wave is needed
 - reusable downstream templates are canonically surfaced under:
   - `projects/agenticos/.meta/templates/`
   - `projects/agenticos/.meta/standard-kit/`
@@ -31,14 +33,14 @@ Start here:
 
 1. `knowledge/standalone-standards-repo-consolidation-audit-2026-03-23.md`
 2. `knowledge/standalone-standards-first-consolidation-wave-2026-03-23.md`
-3. `knowledge/product-positioning-and-design-review-2026-03-22.md`
-4. `knowledge/agent-preflight-and-execution-protocol-2026-03-23.md`
-5. `knowledge/guardrail-flow-wiring-report-2026-03-23.md`
-6. `knowledge/downstream-standard-kit-implementation-report-2026-03-23.md`
+3. `knowledge/standalone-standards-retirement-resolution-2026-03-23.md`
+4. `knowledge/product-positioning-and-design-review-2026-03-22.md`
+5. `knowledge/agent-preflight-and-execution-protocol-2026-03-23.md`
+6. `knowledge/guardrail-flow-wiring-report-2026-03-23.md`
 
 ## Next Steps
 
-1. Land issue `#68` so the main repo becomes the only place where live standards work is updated
-2. Decide whether any archived standalone artifacts still deserve a second canonical merge wave
-3. Decide whether standard-kit adoption and upgrade should become first-class commands
-4. Decide whether status surfaces should summarize latest guardrail evidence more explicitly
+1. Stop writing new canonical standards records into the retired standalone repo
+2. Decide whether standard-kit adoption and upgrade should become first-class commands
+3. Decide whether status surfaces should summarize latest guardrail evidence more explicitly
+4. Only open a new selective-merge issue if one specific archived artifact is later proven to fill a real canonical gap

--- a/projects/agenticos/standards/.context/state.yaml
+++ b/projects/agenticos/standards/.context/state.yaml
@@ -5,38 +5,42 @@ session:
   last_backup: 2026-03-23T10:35:00.000Z
 
 current_task:
-  title: execute the first consolidation wave for the retired standalone standards repo inside the main AgenticOS repository
+  title: finalize retirement of the standalone standards repo after the first consolidation wave
   status: in_progress
-  updated: 2026-03-23T10:35:00.000Z
+  updated: 2026-03-23T12:45:00.000Z
 
 working_memory:
   facts:
     - projects/agenticos/standards is now the only canonical location for ongoing AgenticOS standards work
-    - the standalone repo projects/agentic-os-development is now a retired transitional snapshot, not an active canonical repo
+    - the standalone repo projects/agentic-os-development is now a retired archive-only snapshot, not an active canonical repo
     - issue #66 was merged as PR #67 to freeze the canonical standards location and define merge/archive/discard rules
-    - issue #68 tracks the first real consolidation wave after the audit
-    - the first consolidation wave backfills missing high-signal standards knowledge documents into the main standards knowledge area
+    - issue #68 was merged as PR #69 to execute the first real consolidation wave after the audit
+    - the first consolidation wave backfilled missing high-signal standards knowledge documents into the main standards knowledge area
     - the retired standalone raw context, conversations, entry files, and local issue drafts are archived under archive/standalone-agentic-os-development-2026-03-23/
     - active standards entry files must point only to the main standards area, not to the retired standalone repo
     - reusable downstream templates are canonically surfaced under projects/agenticos/.meta/templates/
     - reusable downstream packaging rules are canonically surfaced under projects/agenticos/.meta/standard-kit/
     - non-code-evaluation-rubric.yaml has been restored into the main template surface as part of issue #68
+    - runtime-project-extraction-closure-report-2026-03-23.md is the last remaining high-signal standalone-only report worth canonical merge
+    - the remaining standalone-only runtime extraction reports are superseded by canonical main-repo planning and execution documents
+    - self-hosting-migration-resolution-draft-2026-03-23.md is superseded by self-hosting-migration-resolution-v1-2026-03-23.md
   decisions:
     - keep one main AgenticOS product repository and one canonical standards area inside it
     - merge durable standards knowledge into the main repo, but archive raw standalone context/history instead of treating it as live state
     - keep the archive read-only and use it only for provenance or later selective recovery
     - preserve the live .context/.last_record marker because current tooling still uses it
+    - no second broad merge wave is needed for the retired standalone standards repo
   pending:
-    - commit, push, and open the first consolidation-wave PR for issue #68
-    - decide whether archived standalone material needs a second merge wave or can remain archive-only
     - decide whether standard-kit adoption and upgrade should become first-class commands
     - decide whether live status surfaces should summarize the latest guardrail evidence more explicitly
+    - stop treating the standalone repo as a live writable standards source
 
 loaded_context:
   - .project.yaml
   - .context/quick-start.md
   - knowledge/standalone-standards-repo-consolidation-audit-2026-03-23.md
   - knowledge/standalone-standards-first-consolidation-wave-2026-03-23.md
+  - knowledge/standalone-standards-retirement-resolution-2026-03-23.md
   - knowledge/product-positioning-and-design-review-2026-03-22.md
   - knowledge/agent-preflight-and-execution-protocol-2026-03-23.md
   - knowledge/guardrail-flow-wiring-report-2026-03-23.md

--- a/projects/agenticos/standards/knowledge/runtime-project-extraction-closure-report-2026-03-23.md
+++ b/projects/agenticos/standards/knowledge/runtime-project-extraction-closure-report-2026-03-23.md
@@ -1,0 +1,60 @@
+# Runtime Project Extraction Closure Report - 2026-03-23
+
+## Summary
+
+The runtime-project extraction program has now fully completed.
+
+Closed issues:
+- `#53` runtime-project extraction program
+- `#56` orphaned gitlink residue repair
+
+Merged PR sequence:
+- `#54` wave 1: `2026okr`, `360teams`
+- `#55` wave 2: `agentic-devops`, `ghostty-optimization`
+- `#57` residue repair: `okr-management`, `t5t`
+
+## Final State
+
+### Product source repository
+
+Clean `origin/main` now has:
+- `projects/agenticos`
+- `projects/test-project`
+
+Meaning:
+- `projects/agenticos` is the only canonical product-source project
+- `projects/test-project` remains the explicit fixture/example candidate
+- no real runtime projects remain tracked under `projects/`
+
+### Live workspace
+
+Verified live runtime roots now include:
+- `/Users/jeking/AgenticOS/projects/2026okr`
+- `/Users/jeking/AgenticOS/projects/360teams`
+- `/Users/jeking/AgenticOS/projects/agentic-devops`
+- `/Users/jeking/AgenticOS/projects/ghostty-optimization`
+
+The live workspace registry no longer contains broken entries for:
+- `okr-management`
+- `t5t`
+
+## Verification Highlights
+
+Final clean-main verification:
+- `git ls-tree origin/main:projects` shows only `agenticos` and `test-project`
+- `git submodule status --recursive` no longer fails on a clean `origin/main` checkout
+
+This means the product/workspace boundary is now implemented rather than only documented.
+
+## Why This Matters
+
+Before this sequence:
+- real runtime projects were still physically tracked in the product source repo
+- split-brain project shadows existed
+- empty orphaned gitlinks made the repository structurally misleading
+
+After this sequence:
+- real runtime projects live in `AGENTICOS_HOME/projects/*`
+- product source remains in `projects/agenticos`
+- fixture content is explicit
+- the repository no longer carries false runtime-project placeholders

--- a/projects/agenticos/standards/knowledge/standalone-standards-retirement-resolution-2026-03-23.md
+++ b/projects/agenticos/standards/knowledge/standalone-standards-retirement-resolution-2026-03-23.md
@@ -1,0 +1,91 @@
+# Standalone Standards Retirement Resolution - 2026-03-23
+
+## Summary
+
+After the first consolidation wave landed in PR `#69`, the remaining delta between:
+
+- retired standalone repo: `projects/agentic-os-development`
+- canonical standards area: `projects/agenticos/standards`
+
+was audited again.
+
+Final judgment:
+
+- one remaining high-signal closure report deserved canonical merge
+- all other remaining standalone-only artifacts should remain archive-only
+- no second broad canonical merge wave is needed
+
+## Remaining Standalone-Only Artifacts After PR #69
+
+Standalone-only files that still existed after the first consolidation wave:
+
+- `runtime-project-extraction-closure-report-2026-03-23.md`
+- `runtime-project-extraction-execution-follow-up-2026-03-23.md`
+- `runtime-project-extraction-planning-report-2026-03-23.md`
+- `runtime-project-extraction-wave1-report-2026-03-23.md`
+- `runtime-project-extraction-wave2-report-2026-03-23.md`
+- `self-hosting-migration-resolution-draft-2026-03-23.md`
+
+## Classification
+
+### Canonical merge
+
+Keep and merge:
+
+- `runtime-project-extraction-closure-report-2026-03-23.md`
+
+Reason:
+- it captures the final completed state of the runtime extraction program
+- it provides a concise outcome summary not otherwise preserved in one dedicated report
+
+### Archive-only
+
+Keep archived, but do not merge as canonical:
+
+- `runtime-project-extraction-execution-follow-up-2026-03-23.md`
+- `runtime-project-extraction-planning-report-2026-03-23.md`
+- `runtime-project-extraction-wave1-report-2026-03-23.md`
+- `runtime-project-extraction-wave2-report-2026-03-23.md`
+- `self-hosting-migration-resolution-draft-2026-03-23.md`
+
+Reasons:
+
+- the runtime extraction planning and wave reports are superseded by canonical main-repo documents:
+  - `knowledge/runtime-project-extraction-plan-2026-03-23.md`
+  - `knowledge/runtime-project-extraction-wave1-execution-2026-03-23.md`
+  - `knowledge/runtime-project-extraction-wave2-execution-2026-03-23.md`
+  - `knowledge/orphaned-gitlink-residue-repair-2026-03-23.md`
+- the self-hosting draft resolution is superseded by:
+  - `knowledge/self-hosting-migration-resolution-v1-2026-03-23.md`
+
+## Retirement Decision
+
+The standalone repo should now be treated as:
+
+- retired
+- archive-only
+- non-canonical
+
+That means:
+
+- do not create new standards records there
+- do not treat its `.context/state.yaml` as live state
+- do not plan a second broad merge wave unless a specific archived artifact is later found to fill a real canonical gap
+
+## Result
+
+The intended durable model is now fully stable:
+
+1. the main AgenticOS repository is the only active repository for ongoing standards work
+2. `projects/agenticos/standards/` is the only canonical standards area
+3. `archive/standalone-agentic-os-development-2026-03-23/` is retained only for provenance
+
+## Follow-Up
+
+Future follow-up, if any, should be narrowly scoped:
+
+- identify one specific archived artifact
+- justify why current canonical records are insufficient
+- merge only that artifact in a dedicated issue
+
+Until then, the retired standalone repo should remain untouched.


### PR DESCRIPTION
## Summary
- restore the final runtime-project extraction closure report into the canonical standards knowledge area
- record the final retirement resolution for the old standalone standards repo after the first consolidation wave
- update live standards quick-start and state so the retired standalone repo is treated as archive-only

## Verification
- `ruby -e 'require "yaml"; YAML.load_file("projects/agenticos/standards/.context/state.yaml"); puts "state ok"'`
- verified remaining standalone-only artifacts were classified as either superseded or still worthy of one final canonical merge
- verified live standards guidance now says no second broad merge wave is needed

Closes #70
