### PR TITLE
feat(mcp-server): add standard-kit adopt and upgrade-check tools (#72)

### DIFF
--- a/projects/agenticos/.meta/standard-kit/README.md
+++ b/projects/agenticos/.meta/standard-kit/README.md
@@ -56,6 +56,16 @@ See:
 - `inheritance-rules.md`
 - `adoption-checklist.md`
 
+## Operational Commands
+
+The standard kit is also exposed through first-class MCP commands:
+
+- `agenticos_standard_kit_adopt`
+- `agenticos_standard_kit_upgrade_check`
+
+Use `agenticos_standard_kit_adopt` to materialize the kit into a downstream project.
+Use `agenticos_standard_kit_upgrade_check` to compare an adopted project against the current canonical kit without mutating project-owned templates.
+
 ## Packaging Rule
 
 If there is a conflict between older `.meta` guidance and this package:

--- a/projects/agenticos/.meta/standard-kit/adoption-checklist.md
+++ b/projects/agenticos/.meta/standard-kit/adoption-checklist.md
@@ -4,6 +4,7 @@ Use this checklist when adopting the AgenticOS workflow standard in a downstream
 
 ## Project Files
 
+- [ ] run `agenticos_standard_kit_adopt` or follow its equivalent workflow
 - [ ] copy `.project.yaml` from the canonical template
 - [ ] create `.context/quick-start.md`
 - [ ] create `.context/state.yaml`
@@ -33,6 +34,7 @@ Use this checklist when adopting the AgenticOS workflow standard in a downstream
 
 ## Upgrade Readiness
 
+- [ ] run `agenticos_standard_kit_upgrade_check` to inspect drift against the canonical kit
 - [ ] copied templates are treated as project-owned after adoption
 - [ ] generated files are allowed to upgrade through template version changes
 - [ ] any future standard-kit upgrade is reviewed against local customizations

--- a/projects/agenticos/mcp-server/src/index.ts
+++ b/projects/agenticos/mcp-server/src/index.ts
@@ -34,7 +34,7 @@ import {
   ListResourcesRequestSchema,
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { initProject, switchProject, listProjects, getStatus, saveState, recordSession, runPreflight, runBranchBootstrap, runPrScopeCheck } from './tools/index.js';
+import { initProject, switchProject, listProjects, getStatus, saveState, recordSession, runPreflight, runBranchBootstrap, runPrScopeCheck, runStandardKitAdopt, runStandardKitUpgradeCheck } from './tools/index.js';
 import { getProjectContext } from './resources/index.js';
 
 const server = new Server(
@@ -189,6 +189,30 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         required: ['issue_id', 'repo_path', 'declared_target_files'],
       },
     },
+    {
+      name: 'agenticos_standard_kit_adopt',
+      description: 'Adopt the canonical AgenticOS downstream standard kit into a project by creating missing copied templates and generated guidance.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          project_path: { type: 'string', description: 'Absolute target project path. If omitted, uses the active project from the registry.' },
+          project_name: { type: 'string', description: 'Project name to use when creating missing .project.yaml or generated guidance.' },
+          project_description: { type: 'string', description: 'Optional project description used for generated guidance.' },
+        },
+      },
+    },
+    {
+      name: 'agenticos_standard_kit_upgrade_check',
+      description: 'Check a project against the canonical AgenticOS downstream standard kit and report missing, stale, or diverged files without mutating them.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          project_path: { type: 'string', description: 'Absolute target project path. If omitted, uses the active project from the registry.' },
+          project_name: { type: 'string', description: 'Optional project name override used for reporting when .project.yaml is missing.' },
+          project_description: { type: 'string', description: 'Optional project description override used for reporting.' },
+        },
+      },
+    },
   ],
 }));
 
@@ -215,6 +239,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       return { content: [{ type: 'text', text: await runBranchBootstrap(args ?? {}) }] };
     case 'agenticos_pr_scope_check':
       return { content: [{ type: 'text', text: await runPrScopeCheck(args ?? {}) }] };
+    case 'agenticos_standard_kit_adopt':
+      return { content: [{ type: 'text', text: await runStandardKitAdopt(args ?? {}) }] };
+    case 'agenticos_standard_kit_upgrade_check':
+      return { content: [{ type: 'text', text: await runStandardKitUpgradeCheck(args ?? {}) }] };
     default:
       throw new Error(`Unknown tool: ${name}`);
   }

--- a/projects/agenticos/mcp-server/src/tools/__tests__/standard-kit.test.ts
+++ b/projects/agenticos/mcp-server/src/tools/__tests__/standard-kit.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtemp, mkdir, readFile, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import yaml from 'yaml';
+import { runStandardKitAdopt, runStandardKitUpgradeCheck } from '../standard-kit.js';
+
+async function setupKitHome(): Promise<{ home: string; projectRoot: string }> {
+  const home = await mkdtemp(join(tmpdir(), 'agenticos-standard-kit-'));
+  const productRoot = join(home, 'projects', 'agenticos');
+  const kitRoot = join(productRoot, '.meta', 'standard-kit');
+  const templateRoot = join(productRoot, '.meta', 'templates');
+  const projectRoot = join(home, 'projects', 'sample-project');
+
+  await mkdir(kitRoot, { recursive: true });
+  await mkdir(templateRoot, { recursive: true });
+  await mkdir(projectRoot, { recursive: true });
+
+  const manifest = {
+    kit_id: 'downstream-standard-kit',
+    kit_version: '0.1.0',
+    layers: {
+      generated_files: {
+        entries: [
+          { path: 'AGENTS.md', canonical_source: 'projects/agenticos/mcp-server/src/utils/distill.ts' },
+          { path: 'CLAUDE.md', canonical_source: 'projects/agenticos/mcp-server/src/utils/distill.ts' },
+        ],
+      },
+      copied_templates: {
+        entries: [
+          { path: '.project.yaml', canonical_source: 'projects/agenticos/.meta/templates/.project.yaml' },
+          { path: '.context/quick-start.md', canonical_source: 'projects/agenticos/.meta/templates/quick-start.md' },
+          { path: '.context/state.yaml', canonical_source: 'projects/agenticos/.meta/templates/state.yaml' },
+          { path: 'tasks/templates/agent-preflight-checklist.yaml', canonical_source: 'projects/agenticos/.meta/templates/agent-preflight-checklist.yaml' },
+          { path: 'tasks/templates/issue-design-brief.md', canonical_source: 'projects/agenticos/.meta/templates/issue-design-brief.md' },
+          { path: 'tasks/templates/non-code-evaluation-rubric.yaml', canonical_source: 'projects/agenticos/.meta/templates/non-code-evaluation-rubric.yaml' },
+          { path: 'tasks/templates/submission-evidence.md', canonical_source: 'projects/agenticos/.meta/templates/submission-evidence.md' },
+        ],
+      },
+    },
+    adoption: {
+      required_files: [
+        'AGENTS.md',
+        'CLAUDE.md',
+        '.project.yaml',
+        '.context/quick-start.md',
+        '.context/state.yaml',
+        'tasks/templates/agent-preflight-checklist.yaml',
+        'tasks/templates/issue-design-brief.md',
+        'tasks/templates/non-code-evaluation-rubric.yaml',
+        'tasks/templates/submission-evidence.md',
+      ],
+    },
+  };
+
+  await writeFile(join(kitRoot, 'manifest.yaml'), yaml.stringify(manifest), 'utf-8');
+  await writeFile(join(templateRoot, '.project.yaml'), `meta:\n  name: "Project Name"\n  id: "project-id"\n  version: "1.0.0"\n  created: "YYYY-MM-DD"\nstatus:\n  phase: "planning"\n  last_updated: "YYYY-MM-DD"\n`, 'utf-8');
+  await writeFile(join(templateRoot, 'quick-start.md'), '# Quick Start\n\n- **Project**: [Project Name]\n- **Goal**: [Main objective]\n- **Status**: [Current phase]\n- **Last Action**: [What was done last]\n- **Next Step**: [What to do next]\n', 'utf-8');
+  await writeFile(join(templateRoot, 'state.yaml'), 'session:\n  id: "session-001"\n  started: "YYYY-MM-DDTHH:MM:SSZ"\n  agent: "claude-sonnet-4.6"\ncurrent_task:\n  id: null\n  title: null\n  status: "pending"\n  next_step: null\nworking_memory:\n  facts: []\n  decisions: []\n  pending: []\nloaded_context:\n  - ".project.yaml"\n', 'utf-8');
+  await writeFile(join(templateRoot, 'agent-preflight-checklist.yaml'), 'version: 0.2\n', 'utf-8');
+  await writeFile(join(templateRoot, 'issue-design-brief.md'), '# Issue Design Brief\n', 'utf-8');
+  await writeFile(join(templateRoot, 'non-code-evaluation-rubric.yaml'), 'version: 0.1\nname: non-code-evaluation-rubric\n', 'utf-8');
+  await writeFile(join(templateRoot, 'submission-evidence.md'), '# Submission Evidence\n', 'utf-8');
+
+  await mkdir(join(home, '.agent-workspace'), { recursive: true });
+  await writeFile(join(home, '.agent-workspace', 'registry.yaml'), yaml.stringify({
+    version: '1.0.0',
+    last_updated: new Date().toISOString(),
+    active_project: 'sample-project',
+    projects: [
+      {
+        id: 'sample-project',
+        name: 'Sample Project',
+        path: 'projects/sample-project',
+        status: 'active',
+        created: '2026-03-23',
+        last_accessed: new Date().toISOString(),
+      },
+    ],
+  }), 'utf-8');
+
+  return { home, projectRoot };
+}
+
+describe('standard kit commands', () => {
+  afterEach(() => {
+    delete process.env.AGENTICOS_HOME;
+  });
+
+  it('adopt creates missing files and does not overwrite existing copied templates', async () => {
+    const { home, projectRoot } = await setupKitHome();
+    process.env.AGENTICOS_HOME = home;
+
+    await mkdir(join(projectRoot, '.context'), { recursive: true });
+    await writeFile(join(projectRoot, '.context', 'quick-start.md'), 'custom quick start\n', 'utf-8');
+
+    const result = JSON.parse(await runStandardKitAdopt({
+      project_path: projectRoot,
+      project_name: 'Sample Project',
+      project_description: 'Adoption test project',
+    })) as {
+      status: string;
+      created_files: string[];
+      skipped_existing_templates: string[];
+      upgraded_generated_files: string[];
+    };
+
+    expect(result.status).toBe('ADOPTED');
+    expect(result.created_files).toContain('.project.yaml');
+    expect(result.created_files).toContain('AGENTS.md');
+    expect(result.created_files).toContain('CLAUDE.md');
+    expect(result.created_files).toContain('tasks/templates/non-code-evaluation-rubric.yaml');
+    expect(result.skipped_existing_templates).toContain('.context/quick-start.md');
+    expect(result.upgraded_generated_files).toEqual([]);
+
+    const projectYaml = yaml.parse(await readFile(join(projectRoot, '.project.yaml'), 'utf-8')) as any;
+    expect(projectYaml.meta.name).toBe('Sample Project');
+    expect(projectYaml.meta.id).toBe('sample-project');
+
+    const quickStart = await readFile(join(projectRoot, '.context', 'quick-start.md'), 'utf-8');
+    expect(quickStart).toBe('custom quick start\n');
+
+    const agentsMd = await readFile(join(projectRoot, 'AGENTS.md'), 'utf-8');
+    const claudeMd = await readFile(join(projectRoot, 'CLAUDE.md'), 'utf-8');
+    expect(agentsMd).toContain('agenticos-template: v3');
+    expect(claudeMd).toContain('agenticos-template: v3');
+  });
+
+  it('upgrade check reports missing, stale, matching, and diverged files', async () => {
+    const { home, projectRoot } = await setupKitHome();
+    process.env.AGENTICOS_HOME = home;
+
+    await mkdir(join(projectRoot, '.context'), { recursive: true });
+    await mkdir(join(projectRoot, 'tasks', 'templates'), { recursive: true });
+    await writeFile(join(projectRoot, 'AGENTS.md'), '<!-- agenticos-template: v2 -->\nold agents\n', 'utf-8');
+    await writeFile(join(projectRoot, '.context', 'quick-start.md'), await readFile(join(home, 'projects', 'agenticos', '.meta', 'templates', 'quick-start.md'), 'utf-8'), 'utf-8');
+    await writeFile(join(projectRoot, 'tasks', 'templates', 'issue-design-brief.md'), 'local customization\n', 'utf-8');
+
+    const result = JSON.parse(await runStandardKitUpgradeCheck({
+      project_path: projectRoot,
+      project_name: 'Sample Project',
+    })) as {
+      status: string;
+      missing_required_files: string[];
+      generated_files: Array<{ path: string; status: string; current_version: number | null }>;
+      copied_templates: Array<{ path: string; status: string }>;
+    };
+
+    expect(result.status).toBe('CHECKED');
+    expect(result.missing_required_files).toContain('CLAUDE.md');
+    expect(result.missing_required_files).toContain('.project.yaml');
+
+    const agentsStatus = result.generated_files.find((item) => item.path === 'AGENTS.md');
+    const claudeStatus = result.generated_files.find((item) => item.path === 'CLAUDE.md');
+    expect(agentsStatus).toMatchObject({ status: 'stale', current_version: 2 });
+    expect(claudeStatus).toMatchObject({ status: 'missing', current_version: null });
+
+    const quickStartStatus = result.copied_templates.find((item) => item.path === '.context/quick-start.md');
+    const designBriefStatus = result.copied_templates.find((item) => item.path === 'tasks/templates/issue-design-brief.md');
+    const rubricStatus = result.copied_templates.find((item) => item.path === 'tasks/templates/non-code-evaluation-rubric.yaml');
+    expect(quickStartStatus).toMatchObject({ status: 'matches_canonical' });
+    expect(designBriefStatus).toMatchObject({ status: 'diverged_from_canonical' });
+    expect(rubricStatus).toMatchObject({ status: 'missing' });
+  });
+});

--- a/projects/agenticos/mcp-server/src/tools/index.ts
+++ b/projects/agenticos/mcp-server/src/tools/index.ts
@@ -5,3 +5,4 @@ export { recordSession } from './record.js';
 export { runPreflight } from './preflight.js';
 export { runBranchBootstrap } from './branch-bootstrap.js';
 export { runPrScopeCheck } from './pr-scope-check.js';
+export { runStandardKitAdopt, runStandardKitUpgradeCheck } from './standard-kit.js';

--- a/projects/agenticos/mcp-server/src/tools/standard-kit.ts
+++ b/projects/agenticos/mcp-server/src/tools/standard-kit.ts
@@ -1,0 +1,11 @@
+import { adoptStandardKit, checkStandardKitUpgrade } from '../utils/standard-kit.js';
+
+export async function runStandardKitAdopt(args: any): Promise<string> {
+  const result = await adoptStandardKit(args ?? {});
+  return JSON.stringify(result, null, 2);
+}
+
+export async function runStandardKitUpgradeCheck(args: any): Promise<string> {
+  const result = await checkStandardKitUpgrade(args ?? {});
+  return JSON.stringify(result, null, 2);
+}

--- a/projects/agenticos/mcp-server/src/utils/__tests__/distill.test.ts
+++ b/projects/agenticos/mcp-server/src/utils/__tests__/distill.test.ts
@@ -13,6 +13,7 @@ describe('distill templates', () => {
     expect(content).toContain('agenticos_pr_scope_check');
     expect(content).toContain('.context/quick-start.md');
     expect(content).toContain('tasks/templates/agent-preflight-checklist.yaml');
+    expect(content).toContain('tasks/templates/non-code-evaluation-rubric.yaml');
   });
 
   it('generates CLAUDE.md with guardrail flow and template navigation', () => {
@@ -24,5 +25,6 @@ describe('distill templates', () => {
     expect(content).toContain('agenticos_pr_scope_check');
     expect(content).toContain('.context/quick-start.md');
     expect(content).toContain('tasks/templates/submission-evidence.md');
+    expect(content).toContain('tasks/templates/non-code-evaluation-rubric.yaml');
   });
 });

--- a/projects/agenticos/mcp-server/src/utils/distill.ts
+++ b/projects/agenticos/mcp-server/src/utils/distill.ts
@@ -1,4 +1,5 @@
 import { readFile, writeFile } from 'fs/promises';
+import { readFileSync } from 'fs';
 
 /**
  * Current template version. Increment when templates change.
@@ -88,6 +89,7 @@ Then greet the user with: project name, last progress, current pending items, su
 | \`tasks/\` | Task tracking |
 | \`tasks/templates/agent-preflight-checklist.yaml\` | Preflight checklist template |
 | \`tasks/templates/issue-design-brief.md\` | Design-loop template |
+| \`tasks/templates/non-code-evaluation-rubric.yaml\` | Non-code evaluation rubric |
 | \`tasks/templates/submission-evidence.md\` | Submission evidence template |
 | \`artifacts/\` | Outputs and deliverables |
 `;
@@ -161,7 +163,7 @@ function buildClaudeMdContent(name: string, description: string, state?: StateYa
 
   const nav = userContent?.navigation
     ? `## Navigation\n\n${userContent.navigation}\n`
-    : `## Navigation\n\n| 目录/文件 | 用途 |\n|-----------|------|\n| \`.project.yaml\` | 项目元信息 |\n| \`.context/quick-start.md\` | 快速项目概览 |\n| \`.context/state.yaml\` | 当前会话状态及工作记忆 |\n| \`.context/conversations/\` | 会话记录（自动生成） |\n| \`knowledge/\` | 持久化知识文档 |\n| \`tasks/\` | 任务追踪 |\n| \`tasks/templates/agent-preflight-checklist.yaml\` | preflight 模板 |\n| \`tasks/templates/issue-design-brief.md\` | 设计循环模板 |\n| \`tasks/templates/submission-evidence.md\` | 提交证据模板 |\n| \`artifacts/\` | 产出物 |\n`;
+    : `## Navigation\n\n| 目录/文件 | 用途 |\n|-----------|------|\n| \`.project.yaml\` | 项目元信息 |\n| \`.context/quick-start.md\` | 快速项目概览 |\n| \`.context/state.yaml\` | 当前会话状态及工作记忆 |\n| \`.context/conversations/\` | 会话记录（自动生成） |\n| \`knowledge/\` | 持久化知识文档 |\n| \`tasks/\` | 任务追踪 |\n| \`tasks/templates/agent-preflight-checklist.yaml\` | preflight 模板 |\n| \`tasks/templates/issue-design-brief.md\` | 设计循环模板 |\n| \`tasks/templates/non-code-evaluation-rubric.yaml\` | 非代码评估模板 |\n| \`tasks/templates/submission-evidence.md\` | 提交证据模板 |\n| \`artifacts/\` | 产出物 |\n`;
 
   return `${VERSION_MARKER}
 # CLAUDE.md — ${name}
@@ -243,7 +245,7 @@ export function generateClaudeMd(name: string, description: string, state?: Stat
 
 /** Upgrade an existing CLAUDE.md to current template version, preserving user content. */
 export function upgradeClaudeMd(claudeMdPath: string, name: string, description: string, state?: StateYaml): string {
-  const content = readFile(claudeMdPath, 'utf-8').toString();
+  const content = readFileSync(claudeMdPath, 'utf-8');
   return buildClaudeMdContent(name, description, state, extractUserContent(content));
 }
 

--- a/projects/agenticos/mcp-server/src/utils/standard-kit.ts
+++ b/projects/agenticos/mcp-server/src/utils/standard-kit.ts
@@ -1,0 +1,367 @@
+import { mkdir, readFile, writeFile } from 'fs/promises';
+import { existsSync, readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import yaml from 'yaml';
+import { getAgenticOSHome, loadRegistry } from './registry.js';
+import { CURRENT_TEMPLATE_VERSION, extractTemplateVersion, generateAgentsMd, generateClaudeMd, upgradeClaudeMd } from './distill.js';
+
+interface StandardKitEntry {
+  path: string;
+  canonical_source?: string;
+}
+
+interface StandardKitLayer {
+  entries?: StandardKitEntry[];
+}
+
+interface StandardKitManifest {
+  kit_id: string;
+  kit_version: string;
+  layers: {
+    generated_files?: StandardKitLayer;
+    copied_templates?: StandardKitLayer;
+  };
+  adoption?: {
+    required_files?: string[];
+  };
+}
+
+export interface ResolvedProjectTarget {
+  projectPath: string;
+  projectName: string;
+  projectDescription: string;
+  projectId: string;
+}
+
+export interface AdoptResult {
+  command: 'agenticos_standard_kit_adopt';
+  status: 'ADOPTED';
+  project_path: string;
+  project_name: string;
+  project_id: string;
+  kit_id: string;
+  kit_version: string;
+  created_files: string[];
+  upgraded_generated_files: string[];
+  skipped_existing_templates: string[];
+  skipped_current_generated_files: string[];
+}
+
+export interface UpgradeCheckGeneratedStatus {
+  path: string;
+  status: 'missing' | 'current' | 'stale';
+  current_version: number | null;
+  expected_version: number;
+}
+
+export interface UpgradeCheckTemplateStatus {
+  path: string;
+  status: 'missing' | 'matches_canonical' | 'diverged_from_canonical';
+  canonical_source: string;
+}
+
+export interface UpgradeCheckResult {
+  command: 'agenticos_standard_kit_upgrade_check';
+  status: 'CHECKED';
+  project_path: string;
+  project_name: string;
+  project_id: string;
+  kit_id: string;
+  kit_version: string;
+  missing_required_files: string[];
+  generated_files: UpgradeCheckGeneratedStatus[];
+  copied_templates: UpgradeCheckTemplateStatus[];
+}
+
+export async function loadStandardKitManifest(): Promise<StandardKitManifest> {
+  const manifestPath = join(getAgenticOSHome(), 'projects', 'agenticos', '.meta', 'standard-kit', 'manifest.yaml');
+  const content = await readFile(manifestPath, 'utf-8');
+  return yaml.parse(content) as StandardKitManifest;
+}
+
+export function resolveCanonicalSourcePath(relativeSourcePath: string): string {
+  return join(getAgenticOSHome(), relativeSourcePath);
+}
+
+function slugifyProjectName(name: string): string {
+  return name.toLowerCase().trim().replace(/\s+/g, '-');
+}
+
+function today(): string {
+  return new Date().toISOString().split('T')[0];
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+async function resolveProjectPath(projectPath?: string): Promise<string> {
+  if (projectPath) return projectPath;
+
+  const registry = await loadRegistry();
+  if (!registry.active_project) {
+    throw new Error('No project_path provided and no active project found in registry.');
+  }
+
+  const active = registry.projects.find((project) => project.id === registry.active_project);
+  if (!active) {
+    throw new Error(`Active project "${registry.active_project}" not found in registry.`);
+  }
+
+  return active.path;
+}
+
+async function readProjectYaml(projectPath: string): Promise<any | null> {
+  const projectYamlPath = join(projectPath, '.project.yaml');
+  if (!existsSync(projectYamlPath)) return null;
+  return yaml.parse(await readFile(projectYamlPath, 'utf-8'));
+}
+
+async function resolveProjectIdentity(projectPath: string, projectName?: string, projectDescription?: string): Promise<ResolvedProjectTarget> {
+  const projectYaml = await readProjectYaml(projectPath);
+
+  const registry = await loadRegistry();
+  const registryMatch = registry.projects.find((project) => project.path === projectPath);
+
+  const resolvedName =
+    projectName ||
+    projectYaml?.meta?.name ||
+    registryMatch?.name;
+
+  if (!resolvedName) {
+    throw new Error('Unable to resolve project name. Provide project_name or create .project.yaml first.');
+  }
+
+  const resolvedDescription =
+    projectDescription ||
+    projectYaml?.meta?.description ||
+    '';
+
+  const resolvedId =
+    projectYaml?.meta?.id ||
+    registryMatch?.id ||
+    slugifyProjectName(resolvedName);
+
+  return {
+    projectPath,
+    projectName: resolvedName,
+    projectDescription: resolvedDescription,
+    projectId: resolvedId,
+  };
+}
+
+async function ensureParentDir(path: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+}
+
+async function ensureStandardDirectories(projectPath: string): Promise<void> {
+  await mkdir(join(projectPath, '.context', 'conversations'), { recursive: true });
+  await mkdir(join(projectPath, 'knowledge'), { recursive: true });
+  await mkdir(join(projectPath, 'tasks', 'templates'), { recursive: true });
+  await mkdir(join(projectPath, 'artifacts'), { recursive: true });
+}
+
+function renderProjectYamlTemplate(templateContent: string, project: ResolvedProjectTarget): string {
+  const parsed = yaml.parse(templateContent) as any;
+  parsed.meta = parsed.meta || {};
+  parsed.meta.name = project.projectName;
+  parsed.meta.id = project.projectId;
+  parsed.meta.version = parsed.meta.version || '1.0.0';
+  parsed.meta.created = today();
+  if (project.projectDescription) {
+    parsed.meta.description = project.projectDescription;
+  }
+  parsed.status = parsed.status || {};
+  parsed.status.last_updated = today();
+  parsed.status.phase = parsed.status.phase || 'planning';
+  return yaml.stringify(parsed);
+}
+
+function renderQuickStartTemplate(templateContent: string, project: ResolvedProjectTarget): string {
+  return templateContent
+    .replace(/\[Project Name\]/g, project.projectName)
+    .replace(/\[Main objective\]/g, project.projectDescription || 'Define the main objective')
+    .replace(/\[Current phase\]/g, 'planning')
+    .replace(/\[What was done last\]/g, 'Standard kit adopted')
+    .replace(/\[What to do next\]/g, 'Define project goals and first implementation issue')
+    .replace(/\[Important fact 1\]/g, 'This project now uses the AgenticOS standard kit')
+    .replace(/\[Important fact 2\]/g, 'Generated agent instructions can be upgraded through template version changes')
+    .replace(/\[Task 1\]/g, 'Define project goals')
+    .replace(/\[Task 2\]/g, 'Create the first issue and design brief')
+    .replace(/\[Decision\]/g, 'Adopt the AgenticOS standard kit');
+}
+
+function renderStateTemplate(templateContent: string): string {
+  const parsed = yaml.parse(templateContent) as any;
+  parsed.session = parsed.session || {};
+  parsed.session.id = `session-${today()}-001`;
+  parsed.session.started = nowIso();
+  parsed.session.agent = 'agenticos-standard-kit';
+  parsed.current_task = parsed.current_task || {};
+  parsed.current_task.id = null;
+  parsed.current_task.title = null;
+  parsed.current_task.status = 'pending';
+  parsed.current_task.next_step = 'Define project goals';
+  parsed.loaded_context = ['.project.yaml', '.context/quick-start.md'];
+  return yaml.stringify(parsed);
+}
+
+function renderCopiedTemplate(destinationPath: string, templateContent: string, project: ResolvedProjectTarget): string {
+  if (destinationPath === '.project.yaml') {
+    return renderProjectYamlTemplate(templateContent, project);
+  }
+  if (destinationPath === '.context/quick-start.md') {
+    return renderQuickStartTemplate(templateContent, project);
+  }
+  if (destinationPath === '.context/state.yaml') {
+    return renderStateTemplate(templateContent);
+  }
+  return templateContent;
+}
+
+function getGeneratedEntries(manifest: StandardKitManifest): StandardKitEntry[] {
+  return manifest.layers.generated_files?.entries || [];
+}
+
+function getCopiedTemplateEntries(manifest: StandardKitManifest): StandardKitEntry[] {
+  return manifest.layers.copied_templates?.entries || [];
+}
+
+export async function adoptStandardKit(args: { project_path?: string; project_name?: string; project_description?: string }): Promise<AdoptResult> {
+  const manifest = await loadStandardKitManifest();
+  const projectPath = await resolveProjectPath(args.project_path);
+  const project = await resolveProjectIdentity(projectPath, args.project_name, args.project_description);
+
+  await ensureStandardDirectories(project.projectPath);
+
+  const createdFiles: string[] = [];
+  const upgradedGeneratedFiles: string[] = [];
+  const skippedExistingTemplates: string[] = [];
+  const skippedCurrentGeneratedFiles: string[] = [];
+
+  for (const entry of getCopiedTemplateEntries(manifest)) {
+    if (!entry.canonical_source) continue;
+    const destination = join(project.projectPath, entry.path);
+    if (existsSync(destination)) {
+      skippedExistingTemplates.push(entry.path);
+      continue;
+    }
+
+    const templateContent = await readFile(resolveCanonicalSourcePath(entry.canonical_source), 'utf-8');
+    const rendered = renderCopiedTemplate(entry.path, templateContent, project);
+    await ensureParentDir(destination);
+    await writeFile(destination, rendered, 'utf-8');
+    createdFiles.push(entry.path);
+  }
+
+  for (const entry of getGeneratedEntries(manifest)) {
+    const destination = join(project.projectPath, entry.path);
+    if (!existsSync(destination)) {
+      const content = entry.path === 'AGENTS.md'
+        ? generateAgentsMd(project.projectName, project.projectDescription)
+        : generateClaudeMd(project.projectName, project.projectDescription);
+      await writeFile(destination, content, 'utf-8');
+      createdFiles.push(entry.path);
+      continue;
+    }
+
+    const existingContent = await readFile(destination, 'utf-8');
+    const version = extractTemplateVersion(existingContent);
+    if (version >= CURRENT_TEMPLATE_VERSION) {
+      skippedCurrentGeneratedFiles.push(entry.path);
+      continue;
+    }
+
+    const upgraded = entry.path === 'AGENTS.md'
+      ? generateAgentsMd(project.projectName, project.projectDescription)
+      : upgradeClaudeMd(destination, project.projectName, project.projectDescription);
+    await writeFile(destination, upgraded, 'utf-8');
+    upgradedGeneratedFiles.push(entry.path);
+  }
+
+  return {
+    command: 'agenticos_standard_kit_adopt',
+    status: 'ADOPTED',
+    project_path: project.projectPath,
+    project_name: project.projectName,
+    project_id: project.projectId,
+    kit_id: manifest.kit_id,
+    kit_version: manifest.kit_version,
+    created_files: createdFiles,
+    upgraded_generated_files: upgradedGeneratedFiles,
+    skipped_existing_templates: skippedExistingTemplates,
+    skipped_current_generated_files: skippedCurrentGeneratedFiles,
+  };
+}
+
+export async function checkStandardKitUpgrade(args: { project_path?: string; project_name?: string; project_description?: string }): Promise<UpgradeCheckResult> {
+  const manifest = await loadStandardKitManifest();
+  const projectPath = await resolveProjectPath(args.project_path);
+  const project = await resolveProjectIdentity(projectPath, args.project_name, args.project_description);
+
+  const missingRequiredFiles: string[] = [];
+  const generatedFiles: UpgradeCheckGeneratedStatus[] = [];
+  const copiedTemplates: UpgradeCheckTemplateStatus[] = [];
+
+  for (const requiredPath of manifest.adoption?.required_files || []) {
+    if (!existsSync(join(project.projectPath, requiredPath))) {
+      missingRequiredFiles.push(requiredPath);
+    }
+  }
+
+  for (const entry of getGeneratedEntries(manifest)) {
+    const destination = join(project.projectPath, entry.path);
+    if (!existsSync(destination)) {
+      generatedFiles.push({
+        path: entry.path,
+        status: 'missing',
+        current_version: null,
+        expected_version: CURRENT_TEMPLATE_VERSION,
+      });
+      continue;
+    }
+
+    const content = await readFile(destination, 'utf-8');
+    const version = extractTemplateVersion(content);
+    generatedFiles.push({
+      path: entry.path,
+      status: version >= CURRENT_TEMPLATE_VERSION ? 'current' : 'stale',
+      current_version: version,
+      expected_version: CURRENT_TEMPLATE_VERSION,
+    });
+  }
+
+  for (const entry of getCopiedTemplateEntries(manifest)) {
+    if (!entry.canonical_source) continue;
+    const destination = join(project.projectPath, entry.path);
+    if (!existsSync(destination)) {
+      copiedTemplates.push({
+        path: entry.path,
+        status: 'missing',
+        canonical_source: entry.canonical_source,
+      });
+      continue;
+    }
+
+    const destinationContent = readFileSync(destination, 'utf-8');
+    const canonicalContent = readFileSync(resolveCanonicalSourcePath(entry.canonical_source), 'utf-8');
+    copiedTemplates.push({
+      path: entry.path,
+      status: destinationContent === canonicalContent ? 'matches_canonical' : 'diverged_from_canonical',
+      canonical_source: entry.canonical_source,
+    });
+  }
+
+  return {
+    command: 'agenticos_standard_kit_upgrade_check',
+    status: 'CHECKED',
+    project_path: project.projectPath,
+    project_name: project.projectName,
+    project_id: project.projectId,
+    kit_id: manifest.kit_id,
+    kit_version: manifest.kit_version,
+    missing_required_files: missingRequiredFiles,
+    generated_files: generatedFiles,
+    copied_templates: copiedTemplates,
+  };
+}

--- a/projects/agenticos/standards/.context/quick-start.md
+++ b/projects/agenticos/standards/.context/quick-start.md
@@ -26,6 +26,9 @@ Its job is to define and evolve:
   - `projects/agenticos/.meta/templates/`
   - `projects/agenticos/.meta/standard-kit/`
 - `non-code-evaluation-rubric.yaml` has been restored into the main template surface as part of this consolidation wave
+- issue `#72` is now implementing first-class standard-kit commands for adopt and upgrade-check
+- `knowledge/standard-kit-command-design-v1-2026-03-23.md` records the command contract for the first slice
+- `knowledge/standard-kit-command-implementation-report-2026-03-23.md` records the landed implementation scope and verification
 
 ## Recommended Entry Documents
 
@@ -37,10 +40,12 @@ Start here:
 4. `knowledge/product-positioning-and-design-review-2026-03-22.md`
 5. `knowledge/agent-preflight-and-execution-protocol-2026-03-23.md`
 6. `knowledge/guardrail-flow-wiring-report-2026-03-23.md`
+7. `knowledge/standard-kit-command-design-v1-2026-03-23.md`
+8. `knowledge/standard-kit-command-implementation-report-2026-03-23.md`
 
 ## Next Steps
 
 1. Stop writing new canonical standards records into the retired standalone repo
-2. Decide whether standard-kit adoption and upgrade should become first-class commands
+2. Land issue `#72` so standard-kit adoption and upgrade-check become first-class commands
 3. Decide whether status surfaces should summarize latest guardrail evidence more explicitly
 4. Only open a new selective-merge issue if one specific archived artifact is later proven to fill a real canonical gap

--- a/projects/agenticos/standards/.context/state.yaml
+++ b/projects/agenticos/standards/.context/state.yaml
@@ -5,9 +5,9 @@ session:
   last_backup: 2026-03-23T10:35:00.000Z
 
 current_task:
-  title: finalize retirement of the standalone standards repo after the first consolidation wave
+  title: add first-class standard-kit adopt and upgrade-check commands
   status: in_progress
-  updated: 2026-03-23T12:45:00.000Z
+  updated: 2026-03-23T13:45:00.000Z
 
 working_memory:
   facts:
@@ -24,14 +24,19 @@ working_memory:
     - runtime-project-extraction-closure-report-2026-03-23.md is the last remaining high-signal standalone-only report worth canonical merge
     - the remaining standalone-only runtime extraction reports are superseded by canonical main-repo planning and execution documents
     - self-hosting-migration-resolution-draft-2026-03-23.md is superseded by self-hosting-migration-resolution-v1-2026-03-23.md
+    - issue #72 tracks first-class standard-kit commands for adopt and upgrade-check
+    - standard-kit v1 now has a design document at knowledge/standard-kit-command-design-v1-2026-03-23.md
+    - the implementation slice adds agenticos_standard_kit_adopt and agenticos_standard_kit_upgrade_check to the MCP tool surface
+    - standard-kit v1 now restores generated navigation consistency by listing tasks/templates/non-code-evaluation-rubric.yaml
   decisions:
     - keep one main AgenticOS product repository and one canonical standards area inside it
     - merge durable standards knowledge into the main repo, but archive raw standalone context/history instead of treating it as live state
     - keep the archive read-only and use it only for provenance or later selective recovery
     - preserve the live .context/.last_record marker because current tooling still uses it
     - no second broad merge wave is needed for the retired standalone standards repo
+    - standard-kit v1 should ship adopt plus upgrade-check before any destructive copied-template upgrade flow
   pending:
-    - decide whether standard-kit adoption and upgrade should become first-class commands
+    - merge issue #72 so adopt and upgrade-check become part of the canonical tool surface
     - decide whether live status surfaces should summarize the latest guardrail evidence more explicitly
     - stop treating the standalone repo as a live writable standards source
 
@@ -45,4 +50,6 @@ loaded_context:
   - knowledge/agent-preflight-and-execution-protocol-2026-03-23.md
   - knowledge/guardrail-flow-wiring-report-2026-03-23.md
   - knowledge/downstream-standard-kit-implementation-report-2026-03-23.md
+  - knowledge/standard-kit-command-design-v1-2026-03-23.md
+  - knowledge/standard-kit-command-implementation-report-2026-03-23.md
   - knowledge/runtime-project-extraction-closure-report-2026-03-23.md

--- a/projects/agenticos/standards/knowledge/standard-kit-command-design-v1-2026-03-23.md
+++ b/projects/agenticos/standards/knowledge/standard-kit-command-design-v1-2026-03-23.md
@@ -1,0 +1,102 @@
+# Standard-Kit Command Design v1 - 2026-03-23
+
+## Summary
+
+Issue `#72` adds first-class command entry points for the downstream standard kit.
+
+The smallest safe first slice is:
+
+1. `agenticos_standard_kit_adopt`
+2. `agenticos_standard_kit_upgrade_check`
+
+This slice intentionally does **not** implement destructive in-place copied-template upgrades.
+
+## Why This Slice
+
+The current product already has:
+
+- canonical kit metadata in `projects/agenticos/.meta/standard-kit/manifest.yaml`
+- canonical copied templates in `projects/agenticos/.meta/templates/`
+- canonical generated guidance in `distill.ts`
+
+What is still missing is an operational surface that lets another project:
+
+- adopt the standard kit
+- inspect its upgrade posture later
+
+## Command Roles
+
+### `agenticos_standard_kit_adopt`
+
+Purpose:
+
+- materialize the canonical standard kit into a downstream project root
+
+Behavior in v1:
+
+- load the standard-kit manifest
+- resolve the target project root
+- create missing parent directories
+- copy missing copied-template files from canonical sources
+- create generated files (`AGENTS.md`, `CLAUDE.md`) if missing
+- upgrade generated files if their template marker version is stale
+- do **not** overwrite existing copied-template files
+
+Return shape should report:
+
+- target path
+- kit version
+- files created
+- generated files upgraded
+- copied-template files skipped because they already exist
+
+### `agenticos_standard_kit_upgrade_check`
+
+Purpose:
+
+- compare an existing downstream project against the canonical kit surface without mutating it
+
+Behavior in v1:
+
+- load the standard-kit manifest
+- resolve the target project root
+- report missing required files
+- report generated-file template version status
+- report copied-template status:
+  - `missing`
+  - `matches_canonical`
+  - `diverged_from_canonical`
+
+Return shape should report:
+
+- target path
+- kit version
+- missing files
+- generated file statuses
+- copied-template statuses
+
+## Deliberate Non-Goals
+
+v1 should not:
+
+- overwrite project-owned copied templates in place
+- auto-merge local changes with canonical template updates
+- mutate repository-root infrastructure such as `.github/`
+- require a project to already be registered if an explicit path is given
+
+## Resolution Rules
+
+Target resolution should support:
+
+1. explicit `project_path`
+2. fallback to the active project in the registry
+
+This keeps the command usable both for registered AgenticOS projects and for directed adoption flows.
+
+## Verification
+
+The first bounded implementation should be considered sufficient if:
+
+1. tests prove adopt creates missing kit files without overwriting project-owned templates
+2. tests prove upgrade-check correctly classifies missing, matching, diverged, and stale generated files
+3. MCP tool registration exposes both commands with explicit descriptions and schemas

--- a/projects/agenticos/standards/knowledge/standard-kit-command-implementation-report-2026-03-23.md
+++ b/projects/agenticos/standards/knowledge/standard-kit-command-implementation-report-2026-03-23.md
@@ -1,0 +1,71 @@
+# Standard-Kit Command Implementation Report - 2026-03-23
+
+## Summary
+
+Issue `#72` adds the first operational command surface for the downstream standard kit.
+
+New MCP tools:
+
+- `agenticos_standard_kit_adopt`
+- `agenticos_standard_kit_upgrade_check`
+
+## What Landed
+
+### `agenticos_standard_kit_adopt`
+
+The adopt command now:
+
+- resolves a target project through explicit `project_path` or the active registry project
+- loads the canonical standard-kit manifest
+- creates missing directories needed by the kit surface
+- copies missing copied-template files from canonical sources
+- creates generated `AGENTS.md` and `CLAUDE.md` files when missing
+- upgrades stale generated files when the template marker version is older than the current distill version
+- avoids overwriting existing copied-template files
+
+### `agenticos_standard_kit_upgrade_check`
+
+The upgrade-check command now:
+
+- resolves a target project through explicit `project_path` or the active registry project
+- loads the canonical standard-kit manifest
+- reports missing required files
+- reports generated-file template version status
+- reports copied-template status as:
+  - `missing`
+  - `matches_canonical`
+  - `diverged_from_canonical`
+
+## Supporting Changes
+
+- added reusable standard-kit helpers under `projects/agenticos/mcp-server/src/utils/standard-kit.ts`
+- registered both commands in the MCP server entry surface
+- fixed `upgradeClaudeMd` so stale generated `CLAUDE.md` files can be upgraded correctly
+- aligned generated navigation text so it includes:
+  - `tasks/templates/non-code-evaluation-rubric.yaml`
+
+## Verification
+
+Verification completed in the isolated `#72` worktree:
+
+- `npm install`
+- `npm test -- --run src/tools/__tests__/standard-kit.test.ts`
+- `npm test`
+
+Result:
+
+- `62 passed | 3 skipped`
+
+## Limits of v1
+
+This slice intentionally does not:
+
+- overwrite project-owned copied templates in place
+- auto-merge local copied-template customizations with canonical template changes
+- mutate repository-root infrastructure such as `.github/`
+
+## Follow-Up
+
+The natural next step after v1 is:
+
+- add a guided upgrade command or upgrade plan that can stage selective copied-template refreshes without silently overwriting project-owned files


### PR DESCRIPTION
## Summary
- add `agenticos_standard_kit_adopt` and `agenticos_standard_kit_upgrade_check` to the MCP tool surface
- add reusable standard-kit helpers and tests for adopt/upgrade-check behavior
- align standards docs and generated navigation with the canonical standard-kit surface

## Verification
- `npm install`
- `npm run build`
- `npm test`
- `ruby -e 'require "yaml"; YAML.load_file("projects/agenticos/standards/.context/state.yaml"); puts "state ok"'`

Closes #72
