### PR TITLE
feat(mcp-server): surface latest guardrail evidence in status (#74)

### DIFF
--- a/projects/agenticos/mcp-server/src/tools/__tests__/project.test.ts
+++ b/projects/agenticos/mcp-server/src/tools/__tests__/project.test.ts
@@ -430,4 +430,120 @@ describe('getStatus', () => {
     expect(result).toContain('None');
     expect(result).toContain('Test Project');
   });
+
+  it('shows a friendly guardrail placeholder when no guardrail evidence exists', async () => {
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: 'test-project',
+      projects: [
+        {
+          id: 'test-project',
+          name: 'Test Project',
+          path: '/test/path',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    fsPromisesMock.readFile.mockResolvedValue(
+      JSON.stringify({
+        session: { last_backup: '2025-01-02T12:00:00.000Z' },
+        working_memory: { pending: [], decisions: [] },
+      })
+    );
+
+    const result = await getStatus();
+
+    expect(result).toContain('🛡️ Latest guardrail: None recorded');
+  });
+
+  it('shows the latest BLOCK guardrail summary and reason', async () => {
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: 'test-project',
+      projects: [
+        {
+          id: 'test-project',
+          name: 'Test Project',
+          path: '/test/path',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    fsPromisesMock.readFile.mockResolvedValue(
+      JSON.stringify({
+        session: { last_backup: '2025-01-02T12:00:00.000Z' },
+        working_memory: { pending: [], decisions: [] },
+        guardrail_evidence: {
+          updated_at: '2025-01-02T13:00:00.000Z',
+          last_command: 'agenticos_preflight',
+          preflight: {
+            command: 'agenticos_preflight',
+            recorded_at: '2025-01-02T13:00:00.000Z',
+            issue_id: '74',
+            result: {
+              status: 'BLOCK',
+              block_reasons: ['branch includes unrelated commits relative to origin/main'],
+            },
+          },
+        },
+      })
+    );
+
+    const result = await getStatus();
+
+    expect(result).toContain('agenticos_preflight -> BLOCK');
+    expect(result).toContain('Issue: #74');
+    expect(result).toContain('branch includes unrelated commits');
+  });
+
+  it('shows the latest REDIRECT guardrail summary and redirect action', async () => {
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: 'test-project',
+      projects: [
+        {
+          id: 'test-project',
+          name: 'Test Project',
+          path: '/test/path',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    fsPromisesMock.readFile.mockResolvedValue(
+      JSON.stringify({
+        session: { last_backup: '2025-01-02T12:00:00.000Z' },
+        working_memory: { pending: [], decisions: [] },
+        guardrail_evidence: {
+          updated_at: '2025-01-02T14:00:00.000Z',
+          last_command: 'agenticos_preflight',
+          preflight: {
+            command: 'agenticos_preflight',
+            recorded_at: '2025-01-02T14:00:00.000Z',
+            issue_id: '74',
+            result: {
+              status: 'REDIRECT',
+              redirect_actions: ['create an isolated issue branch/worktree before implementation'],
+            },
+          },
+        },
+      })
+    );
+
+    const result = await getStatus();
+
+    expect(result).toContain('agenticos_preflight -> REDIRECT');
+    expect(result).toContain('create an isolated issue branch/worktree');
+  });
 });

--- a/projects/agenticos/mcp-server/src/tools/project.ts
+++ b/projects/agenticos/mcp-server/src/tools/project.ts
@@ -6,6 +6,79 @@ import { loadRegistry, saveRegistry } from '../utils/registry.js';
 import { generateClaudeMd, generateAgentsMd, updateClaudeMdState, upgradeClaudeMd, CURRENT_TEMPLATE_VERSION, extractTemplateVersion } from '../utils/distill.js';
 import { writeFile } from 'fs/promises';
 
+type GuardrailCommand = 'agenticos_preflight' | 'agenticos_branch_bootstrap' | 'agenticos_pr_scope_check';
+
+interface GuardrailEvidenceEntry {
+  command?: GuardrailCommand;
+  recorded_at?: string;
+  issue_id?: string | null;
+  result?: {
+    status?: string;
+    summary?: string;
+    block_reasons?: string[];
+    redirect_actions?: string[];
+    notes?: string[];
+    branch_name?: string;
+    worktree_path?: string;
+  };
+}
+
+interface GuardrailEvidenceState {
+  updated_at?: string;
+  last_command?: GuardrailCommand;
+  preflight?: GuardrailEvidenceEntry;
+  branch_bootstrap?: GuardrailEvidenceEntry;
+  pr_scope_check?: GuardrailEvidenceEntry;
+}
+
+function formatTimestamp(value?: string): string | null {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleString('zh-CN', { timeZone: 'Asia/Shanghai' });
+}
+
+function getLatestGuardrailEntry(guardrailEvidence?: GuardrailEvidenceState): GuardrailEvidenceEntry | null {
+  if (!guardrailEvidence?.last_command) return null;
+
+  switch (guardrailEvidence.last_command) {
+    case 'agenticos_preflight':
+      return guardrailEvidence.preflight || null;
+    case 'agenticos_branch_bootstrap':
+      return guardrailEvidence.branch_bootstrap || null;
+    case 'agenticos_pr_scope_check':
+      return guardrailEvidence.pr_scope_check || null;
+  }
+}
+
+function summarizeGuardrailDetail(entry: GuardrailEvidenceEntry): string | null {
+  const result = entry.result;
+  if (!result) return null;
+
+  if (result.status === 'BLOCK' && result.block_reasons && result.block_reasons.length > 0) {
+    return result.block_reasons[0];
+  }
+
+  if (result.status === 'REDIRECT' && result.redirect_actions && result.redirect_actions.length > 0) {
+    return result.redirect_actions[0];
+  }
+
+  if (result.status === 'CREATED') {
+    if (result.branch_name) {
+      return `created ${result.branch_name}`;
+    }
+    if (result.notes && result.notes.length > 0) {
+      return result.notes[0];
+    }
+  }
+
+  if (result.summary) {
+    return result.summary;
+  }
+
+  return null;
+}
+
 export async function switchProject(args: any): Promise<string> {
   const { project } = args;
   const registry = await loadRegistry();
@@ -127,6 +200,24 @@ export async function getStatus(): Promise<string> {
   if (state.session?.last_backup) {
     const backupDate = new Date(state.session.last_backup).toLocaleString('zh-CN', { timeZone: 'Asia/Shanghai' });
     lines.push(`💾 Last saved: ${backupDate}`);
+  }
+
+  const latestGuardrail = getLatestGuardrailEntry(state.guardrail_evidence as GuardrailEvidenceState | undefined);
+  if (latestGuardrail?.command) {
+    const status = latestGuardrail.result?.status || 'UNKNOWN';
+    const recordedAt = formatTimestamp(latestGuardrail.recorded_at) || formatTimestamp((state.guardrail_evidence as GuardrailEvidenceState | undefined)?.updated_at) || 'Unknown time';
+    lines.push(`🛡️ Latest guardrail: ${latestGuardrail.command} -> ${status} (${recordedAt})`);
+
+    if (latestGuardrail.issue_id) {
+      lines.push(`   Issue: #${latestGuardrail.issue_id}`);
+    }
+
+    const detail = summarizeGuardrailDetail(latestGuardrail);
+    if (detail) {
+      lines.push(`   Detail: ${detail}`);
+    }
+  } else {
+    lines.push('🛡️ Latest guardrail: None recorded');
   }
 
   lines.push('');

--- a/projects/agenticos/standards/.context/quick-start.md
+++ b/projects/agenticos/standards/.context/quick-start.md
@@ -29,6 +29,8 @@ Its job is to define and evolve:
 - issue `#72` is now implementing first-class standard-kit commands for adopt and upgrade-check
 - `knowledge/standard-kit-command-design-v1-2026-03-23.md` records the command contract for the first slice
 - `knowledge/standard-kit-command-implementation-report-2026-03-23.md` records the landed implementation scope and verification
+- issue `#74` now upgrades project status output to summarize the latest persisted guardrail evidence
+- `knowledge/status-guardrail-evidence-implementation-report-2026-03-24.md` records the status-surface implementation and verification
 
 ## Recommended Entry Documents
 
@@ -42,10 +44,11 @@ Start here:
 6. `knowledge/guardrail-flow-wiring-report-2026-03-23.md`
 7. `knowledge/standard-kit-command-design-v1-2026-03-23.md`
 8. `knowledge/standard-kit-command-implementation-report-2026-03-23.md`
+9. `knowledge/status-guardrail-evidence-implementation-report-2026-03-24.md`
 
 ## Next Steps
 
 1. Stop writing new canonical standards records into the retired standalone repo
-2. Land issue `#72` so standard-kit adoption and upgrade-check become first-class commands
-3. Decide whether status surfaces should summarize latest guardrail evidence more explicitly
+2. Land issue `#74` so `agenticos_status` exposes the latest persisted guardrail evidence by default
+3. Decide whether other entry surfaces beyond `agenticos_status` should summarize latest guardrail evidence too
 4. Only open a new selective-merge issue if one specific archived artifact is later proven to fill a real canonical gap

--- a/projects/agenticos/standards/.context/state.yaml
+++ b/projects/agenticos/standards/.context/state.yaml
@@ -5,9 +5,9 @@ session:
   last_backup: 2026-03-23T10:35:00.000Z
 
 current_task:
-  title: add first-class standard-kit adopt and upgrade-check commands
+  title: surface the latest persisted guardrail evidence in normal project status output
   status: in_progress
-  updated: 2026-03-23T13:45:00.000Z
+  updated: 2026-03-24T01:55:00.000Z
 
 working_memory:
   facts:
@@ -28,6 +28,9 @@ working_memory:
     - standard-kit v1 now has a design document at knowledge/standard-kit-command-design-v1-2026-03-23.md
     - the implementation slice adds agenticos_standard_kit_adopt and agenticos_standard_kit_upgrade_check to the MCP tool surface
     - standard-kit v1 now restores generated navigation consistency by listing tasks/templates/non-code-evaluation-rubric.yaml
+    - issue #74 tracks status-surface exposure for persisted guardrail evidence
+    - agenticos_status now summarizes the latest guardrail command, result, timestamp, and the most relevant detail when guardrail evidence exists
+    - status output now explicitly shows a no-evidence placeholder when guardrail_evidence is absent
   decisions:
     - keep one main AgenticOS product repository and one canonical standards area inside it
     - merge durable standards knowledge into the main repo, but archive raw standalone context/history instead of treating it as live state
@@ -35,9 +38,10 @@ working_memory:
     - preserve the live .context/.last_record marker because current tooling still uses it
     - no second broad merge wave is needed for the retired standalone standards repo
     - standard-kit v1 should ship adopt plus upgrade-check before any destructive copied-template upgrade flow
+    - status surfaces should prefer compact human-readable guardrail summaries over raw persisted JSON blobs
   pending:
-    - merge issue #72 so adopt and upgrade-check become part of the canonical tool surface
-    - decide whether live status surfaces should summarize the latest guardrail evidence more explicitly
+    - merge issue #74 so the latest guardrail evidence becomes visible in the canonical status surface
+    - decide whether `agenticos_switch` or other entry surfaces should also summarize latest guardrail evidence
     - stop treating the standalone repo as a live writable standards source
 
 loaded_context:
@@ -52,4 +56,5 @@ loaded_context:
   - knowledge/downstream-standard-kit-implementation-report-2026-03-23.md
   - knowledge/standard-kit-command-design-v1-2026-03-23.md
   - knowledge/standard-kit-command-implementation-report-2026-03-23.md
+  - knowledge/status-guardrail-evidence-implementation-report-2026-03-24.md
   - knowledge/runtime-project-extraction-closure-report-2026-03-23.md

--- a/projects/agenticos/standards/knowledge/status-guardrail-evidence-implementation-report-2026-03-24.md
+++ b/projects/agenticos/standards/knowledge/status-guardrail-evidence-implementation-report-2026-03-24.md
@@ -1,0 +1,62 @@
+# Status Guardrail Evidence Implementation Report - 2026-03-24
+
+## Summary
+
+Issue `#74` upgrades the normal project status surface so the latest persisted guardrail evidence is visible without opening raw YAML state.
+
+The first slice lands in:
+
+- `agenticos_status`
+- `getStatus()`
+
+## What Changed
+
+When a project has `guardrail_evidence` in `.context/state.yaml`, status output now shows:
+
+- the latest guardrail command
+- the latest result status
+- the recorded timestamp
+- the related issue number when present
+- the most relevant detail for blocking or redirect states
+
+Examples of surfaced states:
+
+- `PASS`
+- `BLOCK`
+- `REDIRECT`
+
+When no guardrail evidence exists, status now explicitly says:
+
+- `Latest guardrail: None recorded`
+
+## Formatting Rule
+
+The v1 status surface keeps the summary intentionally compact.
+
+It does not dump full JSON payloads.
+Instead it extracts the most useful top-level signal:
+
+- `block_reasons[0]` for `BLOCK`
+- `redirect_actions[0]` for `REDIRECT`
+- `summary` for ordinary pass-style results
+- branch creation note for `CREATED` style bootstrap results
+
+## Verification
+
+Verification completed in the isolated `#74` worktree:
+
+- `npm install`
+- `npm test -- --run src/tools/__tests__/project.test.ts`
+- `npm test`
+
+Result:
+
+- `65 passed | 3 skipped`
+
+## Follow-Up
+
+The next refinement, if needed, is not more raw detail.
+
+The next likely improvement is:
+
+- decide whether `agenticos_switch` or other entry surfaces should also summarize the latest guardrail evidence in the same compact style


### PR DESCRIPTION
## Summary
- surface the latest persisted guardrail evidence in `agenticos_status`
- show command, result, timestamp, issue id, and the most relevant blocking or redirect detail
- record the status-surface enhancement in canonical standards docs

## Verification
- `npm install`
- `npm test -- --run src/tools/__tests__/project.test.ts`
- `npm test`
- `ruby -e "require \"yaml\"; YAML.load_file(\"projects/agenticos/standards/.context/state.yaml\"); puts \"state ok\""`

Closes #74