### PR TITLE
feat(project): show latest guardrail summary in switch output (#76)

### DIFF
--- a/projects/agenticos/mcp-server/src/tools/__tests__/project.test.ts
+++ b/projects/agenticos/mcp-server/src/tools/__tests__/project.test.ts
@@ -64,6 +64,9 @@ describe('switchProject', () => {
     vi.clearAllMocks();
     // By default, mock existsSync to return false (no CLAUDE.md/AGENTS.md)
     fsMock.existsSync.mockReturnValue(false);
+    yamlMock.parse.mockImplementation((content: string) => {
+      try { return JSON.parse(content); } catch { return undefined; }
+    });
   });
 
   afterEach(() => {
@@ -209,6 +212,79 @@ describe('switchProject', () => {
     const writeCalls = fsPromisesMock.writeFile.mock.calls;
     const claudeMdCall = writeCalls.find((c) => c[0].endsWith('CLAUDE.md'));
     expect(claudeMdCall).toBeDefined();
+  });
+
+  it('shows a friendly guardrail placeholder in switch output when no evidence exists', async () => {
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: null,
+      projects: [
+        {
+          id: 'my-project',
+          name: 'My Project',
+          path: '/test/path',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    fsPromisesMock.readFile.mockResolvedValue(
+      JSON.stringify({
+        meta: { description: '' },
+        session: { last_backup: '2025-01-02T12:00:00.000Z' },
+        working_memory: { pending: [], decisions: [] },
+      })
+    );
+
+    const result = await switchProject({ project: 'my-project' });
+
+    expect(result).toContain('🛡️ Latest guardrail: None recorded');
+  });
+
+  it('shows the latest guardrail summary in switch output when evidence exists', async () => {
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: null,
+      projects: [
+        {
+          id: 'my-project',
+          name: 'My Project',
+          path: '/test/path',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    fsPromisesMock.readFile.mockResolvedValue(
+      JSON.stringify({
+        meta: { description: '' },
+        guardrail_evidence: {
+          updated_at: '2025-01-02T14:00:00.000Z',
+          last_command: 'agenticos_preflight',
+          preflight: {
+            command: 'agenticos_preflight',
+            recorded_at: '2025-01-02T14:00:00.000Z',
+            issue_id: '76',
+            result: {
+              status: 'REDIRECT',
+              redirect_actions: ['create an isolated issue branch/worktree before implementation'],
+            },
+          },
+        },
+      })
+    );
+
+    const result = await switchProject({ project: 'my-project' });
+
+    expect(result).toContain('agenticos_preflight -> REDIRECT');
+    expect(result).toContain('Issue: #76');
+    expect(result).toContain('create an isolated issue branch/worktree');
   });
 });
 

--- a/projects/agenticos/mcp-server/src/tools/project.ts
+++ b/projects/agenticos/mcp-server/src/tools/project.ts
@@ -79,6 +79,32 @@ function summarizeGuardrailDetail(entry: GuardrailEvidenceEntry): string | null 
   return null;
 }
 
+function buildGuardrailSummaryLines(guardrailEvidence?: GuardrailEvidenceState): string[] {
+  const latestGuardrail = getLatestGuardrailEntry(guardrailEvidence);
+  if (!latestGuardrail?.command) {
+    return ['🛡️ Latest guardrail: None recorded'];
+  }
+
+  const status = latestGuardrail.result?.status || 'UNKNOWN';
+  const recordedAt =
+    formatTimestamp(latestGuardrail.recorded_at) ||
+    formatTimestamp(guardrailEvidence?.updated_at) ||
+    'Unknown time';
+
+  const lines = [`🛡️ Latest guardrail: ${latestGuardrail.command} -> ${status} (${recordedAt})`];
+
+  if (latestGuardrail.issue_id) {
+    lines.push(`   Issue: #${latestGuardrail.issue_id}`);
+  }
+
+  const detail = summarizeGuardrailDetail(latestGuardrail);
+  if (detail) {
+    lines.push(`   Detail: ${detail}`);
+  }
+
+  return lines;
+}
+
 export async function switchProject(args: any): Promise<string> {
   const { project } = args;
   const registry = await loadRegistry();
@@ -137,8 +163,9 @@ export async function switchProject(args: any): Promise<string> {
   }
 
   const bootstrap = bootstrapNotes.length > 0 ? '\n\n' + bootstrapNotes.join('\n') : '';
+  const guardrailSummary = buildGuardrailSummaryLines(state?.guardrail_evidence as GuardrailEvidenceState | undefined);
 
-  return `✅ Switched to project "${found.name}"\n\nPath: ${found.path}\nStatus: ${found.status}\n\nContext loaded from:\n- ${found.path}/.project.yaml\n- ${found.path}/.context/quick-start.md\n- ${found.path}/.context/state.yaml${bootstrap}`;
+  return `✅ Switched to project "${found.name}"\n\nPath: ${found.path}\nStatus: ${found.status}\n\nContext loaded from:\n- ${found.path}/.project.yaml\n- ${found.path}/.context/quick-start.md\n- ${found.path}/.context/state.yaml\n\n${guardrailSummary.join('\n')}${bootstrap}`;
 }
 
 export async function listProjects(): Promise<string> {
@@ -202,23 +229,7 @@ export async function getStatus(): Promise<string> {
     lines.push(`💾 Last saved: ${backupDate}`);
   }
 
-  const latestGuardrail = getLatestGuardrailEntry(state.guardrail_evidence as GuardrailEvidenceState | undefined);
-  if (latestGuardrail?.command) {
-    const status = latestGuardrail.result?.status || 'UNKNOWN';
-    const recordedAt = formatTimestamp(latestGuardrail.recorded_at) || formatTimestamp((state.guardrail_evidence as GuardrailEvidenceState | undefined)?.updated_at) || 'Unknown time';
-    lines.push(`🛡️ Latest guardrail: ${latestGuardrail.command} -> ${status} (${recordedAt})`);
-
-    if (latestGuardrail.issue_id) {
-      lines.push(`   Issue: #${latestGuardrail.issue_id}`);
-    }
-
-    const detail = summarizeGuardrailDetail(latestGuardrail);
-    if (detail) {
-      lines.push(`   Detail: ${detail}`);
-    }
-  } else {
-    lines.push('🛡️ Latest guardrail: None recorded');
-  }
+  lines.push(...buildGuardrailSummaryLines(state.guardrail_evidence as GuardrailEvidenceState | undefined));
 
   lines.push('');
   if (state.current_task) {

--- a/projects/agenticos/standards/.context/quick-start.md
+++ b/projects/agenticos/standards/.context/quick-start.md
@@ -31,6 +31,8 @@ Its job is to define and evolve:
 - `knowledge/standard-kit-command-implementation-report-2026-03-23.md` records the landed implementation scope and verification
 - issue `#74` now upgrades project status output to summarize the latest persisted guardrail evidence
 - `knowledge/status-guardrail-evidence-implementation-report-2026-03-24.md` records the status-surface implementation and verification
+- issue `#76` now extends the same compact latest-guardrail summary into `agenticos_switch`
+- `knowledge/switch-guardrail-evidence-implementation-report-2026-03-24.md` records the switch-surface implementation and verification
 
 ## Recommended Entry Documents
 
@@ -45,10 +47,11 @@ Start here:
 7. `knowledge/standard-kit-command-design-v1-2026-03-23.md`
 8. `knowledge/standard-kit-command-implementation-report-2026-03-23.md`
 9. `knowledge/status-guardrail-evidence-implementation-report-2026-03-24.md`
+10. `knowledge/switch-guardrail-evidence-implementation-report-2026-03-24.md`
 
 ## Next Steps
 
 1. Stop writing new canonical standards records into the retired standalone repo
-2. Land issue `#74` so `agenticos_status` exposes the latest persisted guardrail evidence by default
-3. Decide whether other entry surfaces beyond `agenticos_status` should summarize latest guardrail evidence too
+2. Treat `agenticos_status` and `agenticos_switch` as the baseline entry surfaces for compact guardrail visibility
+3. Decide whether any additional entry surfaces need the same summary, or whether the current pair is enough
 4. Only open a new selective-merge issue if one specific archived artifact is later proven to fill a real canonical gap

--- a/projects/agenticos/standards/.context/state.yaml
+++ b/projects/agenticos/standards/.context/state.yaml
@@ -5,9 +5,9 @@ session:
   last_backup: 2026-03-23T10:35:00.000Z
 
 current_task:
-  title: surface the latest persisted guardrail evidence in normal project status output
-  status: in_progress
-  updated: 2026-03-24T01:55:00.000Z
+  title: extend compact guardrail evidence summaries into switch output
+  status: completed
+  updated: 2026-03-24T02:15:00.000Z
 
 working_memory:
   facts:
@@ -31,6 +31,9 @@ working_memory:
     - issue #74 tracks status-surface exposure for persisted guardrail evidence
     - agenticos_status now summarizes the latest guardrail command, result, timestamp, and the most relevant detail when guardrail evidence exists
     - status output now explicitly shows a no-evidence placeholder when guardrail_evidence is absent
+    - issue #76 extends the same compact persisted guardrail summary into agenticos_switch
+    - switch output now shows the latest guardrail command, result, timestamp, issue id, and a compact detail when evidence exists
+    - switch output now explicitly shows a no-evidence placeholder when guardrail_evidence is absent
   decisions:
     - keep one main AgenticOS product repository and one canonical standards area inside it
     - merge durable standards knowledge into the main repo, but archive raw standalone context/history instead of treating it as live state
@@ -39,9 +42,9 @@ working_memory:
     - no second broad merge wave is needed for the retired standalone standards repo
     - standard-kit v1 should ship adopt plus upgrade-check before any destructive copied-template upgrade flow
     - status surfaces should prefer compact human-readable guardrail summaries over raw persisted JSON blobs
+    - switch should reuse the same compact guardrail-summary formatter as status instead of maintaining a second formatting path
   pending:
-    - merge issue #74 so the latest guardrail evidence becomes visible in the canonical status surface
-    - decide whether `agenticos_switch` or other entry surfaces should also summarize latest guardrail evidence
+    - decide whether any entry surfaces beyond `agenticos_status` and `agenticos_switch` need the same compact guardrail summary
     - stop treating the standalone repo as a live writable standards source
 
 loaded_context:
@@ -57,4 +60,5 @@ loaded_context:
   - knowledge/standard-kit-command-design-v1-2026-03-23.md
   - knowledge/standard-kit-command-implementation-report-2026-03-23.md
   - knowledge/status-guardrail-evidence-implementation-report-2026-03-24.md
+  - knowledge/switch-guardrail-evidence-implementation-report-2026-03-24.md
   - knowledge/runtime-project-extraction-closure-report-2026-03-23.md

--- a/projects/agenticos/standards/knowledge/switch-guardrail-evidence-implementation-report-2026-03-24.md
+++ b/projects/agenticos/standards/knowledge/switch-guardrail-evidence-implementation-report-2026-03-24.md
@@ -1,0 +1,58 @@
+# Switch Guardrail Evidence Implementation Report - 2026-03-24
+
+## Summary
+
+Issue `#76` extends the compact persisted guardrail summary from `agenticos_status` into `agenticos_switch`.
+
+The goal is to make the default entry surfaces consistent, so switching into a project immediately shows the latest guardrail state without opening raw YAML.
+
+## What Changed
+
+The implementation lands in:
+
+- `agenticos_switch`
+- `switchProject()`
+
+The switch response now shows:
+
+- the latest guardrail command
+- the latest result status
+- the recorded timestamp
+- the related issue number when present
+- the most relevant detail for blocking, redirect, or branch-bootstrap states
+
+When no guardrail evidence exists, switch output now explicitly says:
+
+- `Latest guardrail: None recorded`
+
+## Design Rule
+
+This slice does not introduce a second formatter.
+
+Instead, `switchProject()` now reuses the same compact guardrail-summary builder already used by `getStatus()`.
+
+That keeps:
+
+- formatting logic in one place
+- detail-priority rules consistent across entry surfaces
+- future guardrail summary changes from drifting between status and switch
+
+## Verification
+
+Verification completed in the isolated `#76` worktree:
+
+- `npm install`
+- `npm test -- --run src/tools/__tests__/project.test.ts`
+- `npm test`
+
+Result:
+
+- `67 passed | 3 skipped`
+
+## Follow-Up
+
+The next refinement, if needed, is not a third formatter.
+
+The next likely improvement is:
+
+- decide whether any additional entry surfaces beyond `agenticos_status` and `agenticos_switch` need the same compact guardrail summary


### PR DESCRIPTION
## Summary
- reuse the compact guardrail summary formatter for switch output
- surface latest guardrail evidence in `agenticos_switch`
- record the #76 landing in canonical standards context

## Verification
- npm install
- npm test -- --run src/tools/__tests__/project.test.ts
- npm test

Closes #76