### PR TITLE
docs(standards): record canonical working copy cleanup (#78)

### DIFF
--- a/projects/agenticos/standards/.context/quick-start.md
+++ b/projects/agenticos/standards/.context/quick-start.md
@@ -35,6 +35,8 @@ Its job is to define and evolve:
 - `knowledge/switch-guardrail-evidence-implementation-report-2026-03-24.md` records the switch-surface implementation and verification
 - issue `#79` now reconciles the historical open backlog against landed self-hosting, standards, and guardrail changes
 - `knowledge/backlog-reconciliation-matrix-2026-03-24.md` records which old issues were closed, which remain open, and which required scope rewrite
+- issue `#78` now restores `/Users/jeking/dev/AgenticOS` as a clean canonical working copy aligned with `origin/main`
+- `knowledge/canonical-working-copy-cleanup-report-2026-03-24.md` records what was preserved, what was removed from the source checkout, and how the local main checkout was verified
 
 ## Recommended Entry Documents
 
@@ -51,10 +53,11 @@ Start here:
 9. `knowledge/status-guardrail-evidence-implementation-report-2026-03-24.md`
 10. `knowledge/switch-guardrail-evidence-implementation-report-2026-03-24.md`
 11. `knowledge/backlog-reconciliation-matrix-2026-03-24.md`
+12. `knowledge/canonical-working-copy-cleanup-report-2026-03-24.md`
 
 ## Next Steps
 
 1. Use the reconciled open backlog, not the pre-self-hosting issue list, as the canonical remaining work queue
-2. Execute issue `#78` to restore `/Users/jeking/dev/AgenticOS` as a clean canonical working copy
+2. Treat `/Users/jeking/dev/AgenticOS` as the trusted local canonical checkout again; use isolated worktrees for changes
 3. Decide whether any additional entry surfaces need the same compact guardrail summary beyond `agenticos_status` and `agenticos_switch`
 4. Only open a new selective-merge issue if one specific archived artifact is later proven to fill a real canonical gap

--- a/projects/agenticos/standards/.context/state.yaml
+++ b/projects/agenticos/standards/.context/state.yaml
@@ -5,9 +5,9 @@ session:
   last_backup: 2026-03-23T10:35:00.000Z
 
 current_task:
-  title: reconcile historical open backlog against landed mainline changes
+  title: restore /Users/jeking/dev/AgenticOS as a clean canonical working copy
   status: completed
-  updated: 2026-03-24T03:35:00.000Z
+  updated: 2026-03-24T15:18:00.000Z
 
 working_memory:
   facts:
@@ -38,6 +38,10 @@ working_memory:
     - issues #22, #27, #32, #33, #34, #39, #41, and #42 were closed during reconciliation because their core intent is now satisfied or duplicated
     - issues #25, #29, and #30 remain open but had their scope rewritten to reflect the current self-hosted repository layout
     - the remaining substantive open backlog is now concentrated in #23, #24, #25, #26, #28, #29, #30, #31, plus the new working-copy cleanup issue #78
+    - issue #78 restored /Users/jeking/dev/AgenticOS to a clean local main checkout aligned with origin/main
+    - the old local dirty state was preserved under /Users/jeking/worktrees/agenticos-working-copy-78-backup/2026-03-24/
+    - the previous local-only main commits for #23 and #24 were preserved on branch preserve/local-main-2026-03-24 before cleanup
+    - retired standalone standards residue and runtime-project leftovers were removed from the source checkout after backup
   decisions:
     - keep one main AgenticOS product repository and one canonical standards area inside it
     - merge durable standards knowledge into the main repo, but archive raw standalone context/history instead of treating it as live state
@@ -48,9 +52,11 @@ working_memory:
     - status surfaces should prefer compact human-readable guardrail summaries over raw persisted JSON blobs
     - switch should reuse the same compact guardrail-summary formatter as status instead of maintaining a second formatting path
     - backlog cleanup should prefer closing or rewriting historical issues over leaving architecture-era ambiguity in the open queue
+    - the local canonical checkout should be kept clean and used only as the trusted base, with implementation work moving to isolated issue worktrees
   pending:
-    - execute issue #78 to restore /Users/jeking/dev/AgenticOS as a clean canonical working copy
     - decide whether any entry surfaces beyond `agenticos_status` and `agenticos_switch` need the same compact guardrail summary
+    - execute issue #23 on an isolated issue branch instead of carrying local-only commits on main
+    - execute issue #24 on an isolated issue branch instead of carrying local-only commits on main
 
 loaded_context:
   - .project.yaml
@@ -67,4 +73,5 @@ loaded_context:
   - knowledge/status-guardrail-evidence-implementation-report-2026-03-24.md
   - knowledge/switch-guardrail-evidence-implementation-report-2026-03-24.md
   - knowledge/backlog-reconciliation-matrix-2026-03-24.md
+  - knowledge/canonical-working-copy-cleanup-report-2026-03-24.md
   - knowledge/runtime-project-extraction-closure-report-2026-03-23.md

--- a/projects/agenticos/standards/knowledge/canonical-working-copy-cleanup-report-2026-03-24.md
+++ b/projects/agenticos/standards/knowledge/canonical-working-copy-cleanup-report-2026-03-24.md
@@ -1,0 +1,100 @@
+# Canonical Working Copy Cleanup Report - 2026-03-24
+
+## Summary
+
+Issue `#78` restores the local directory `/Users/jeking/dev/AgenticOS` into a clean canonical working copy aligned with `origin/main`.
+
+The main goal was to stop treating that directory as a mixed historical workspace and restore it as the trusted local base checkout for future agent work.
+
+## Problem Before Cleanup
+
+The local checkout had drifted in four different ways at once:
+
+- local `main` was both ahead of and behind `origin/main`
+- tracked root files had local modifications against an outdated structure
+- staged deletions still reflected the retired standalone standards repo removal
+- untracked runtime-project and nested-repo residue still lived under the source checkout
+
+That meant a future agent entering `/Users/jeking/dev/AgenticOS` could infer the wrong repository layout and the wrong remaining work.
+
+## Preservation Before Cleanup
+
+Before any destructive cleanup, the local state was preserved under:
+
+- `/Users/jeking/worktrees/agenticos-working-copy-78-backup/2026-03-24/`
+
+Preserved artifacts include:
+
+- `working.patch`
+- `staged.patch`
+- `status.txt`
+- `head.txt`
+- `untracked.txt`
+- `untracked-tree/`
+- `local-main-ahead-commits.patch`
+
+The previous local-only `main` state was also preserved on:
+
+- `preserve/local-main-2026-03-24`
+
+## Local-Only Commits Preserved
+
+Two local commits on `main` were identified as real but unpublished work:
+
+- `9700790` `fix(record): defensively parse JSON-stringified array args (fixes #24)`
+- `fc40133` `feat(switch): inline project context in switch output (fixes #23)`
+
+These were preserved before resetting `main`, because they correspond to still-open issues and should be re-executed through normal issue/worktree flow rather than kept as hidden local drift on the canonical checkout.
+
+## Cleanup Actions
+
+The cleanup then performed these steps:
+
+1. reset `/Users/jeking/dev/AgenticOS` `main` to `origin/main`
+2. remove untracked runtime-project and retired-structure residue from the source checkout
+3. verify that the source checkout now reflects the canonical self-hosted layout
+
+Removed source-checkout residue included:
+
+- runtime project leftovers under `projects/2026okr/`
+- runtime project leftovers under `projects/360teams/`
+- runtime project leftovers under `projects/agentic-devops/`
+- runtime project leftovers under `projects/ghostty-optimization/`
+- retired standalone repo residue under `projects/agentic-os-development/`
+- orphaned local project leftovers under `projects/okr-management/` and `projects/t5t/`
+- local-only helper files such as `projects/t5t.js`
+
+## Verification
+
+Verification completed after cleanup:
+
+- `git -C /Users/jeking/dev/AgenticOS fetch origin --prune`
+- `git -C /Users/jeking/dev/AgenticOS status --short --branch`
+- confirmed `/Users/jeking/dev/AgenticOS/projects/agenticos/standards` exists
+- confirmed `/Users/jeking/dev/AgenticOS/projects/agenticos/mcp-server` exists
+- confirmed `/Users/jeking/dev/AgenticOS/projects/agentic-os-development` no longer exists as an active source-checkout structure
+
+Result:
+
+- local checkout now reports clean `main...origin/main`
+
+## Outcome
+
+`/Users/jeking/dev/AgenticOS` can now be treated as the trusted local canonical checkout again.
+
+Future implementation work should not accumulate there.
+
+Instead:
+
+- keep this checkout clean
+- branch from it
+- work in isolated issue worktrees
+
+## Follow-Up
+
+The preserved local-only work for open issues should now be replayed correctly:
+
+- `#23`
+- `#24`
+
+Those changes should be reintroduced on isolated issue branches, not kept as hidden local commits on the canonical main checkout.


### PR DESCRIPTION
## Summary
- record the canonical working copy cleanup in standards knowledge
- update standards entry state to reflect that /Users/jeking/dev/AgenticOS is clean again
- document where the preserved local dirty state and old local-only commits were stored

## Verification
- ruby -e 'require "yaml"; YAML.load_file("/Users/jeking/worktrees/agenticos-working-copy-78/projects/agenticos/standards/.context/state.yaml"); puts "state.yaml ok"'
- git -C /Users/jeking/dev/AgenticOS status --short --branch

Closes #78