### PR TITLE
feat(meta): define sub-agent inheritance protocol (#28)

### DIFF
--- a/projects/agenticos/.meta/standard-kit/README.md
+++ b/projects/agenticos/.meta/standard-kit/README.md
@@ -73,6 +73,20 @@ The canonical rationale lives in:
 
 - `projects/agenticos/standards/knowledge/memory-layer-contract-spec-2026-03-25.md`
 
+## Sub-Agent Protocol
+
+The kit now also carries the canonical sub-agent inheritance protocol.
+
+Downstream projects inherit:
+
+- `tasks/templates/sub-agent-handoff.md`
+- sub-agent inheritance fields inside `tasks/templates/issue-design-brief.md`
+- sub-agent verification fields inside `tasks/templates/submission-evidence.md`
+
+The canonical rationale lives in:
+
+- `projects/agenticos/standards/knowledge/sub-agent-inheritance-protocol-2026-03-25.md`
+
 ## Package Contents
 
 See:

--- a/projects/agenticos/.meta/standard-kit/adoption-checklist.md
+++ b/projects/agenticos/.meta/standard-kit/adoption-checklist.md
@@ -11,6 +11,7 @@ Use this checklist when adopting the AgenticOS workflow standard in a downstream
 - [ ] create `tasks/templates/agent-preflight-checklist.yaml`
 - [ ] create `tasks/templates/issue-design-brief.md`
 - [ ] create `tasks/templates/non-code-evaluation-rubric.yaml`
+- [ ] create `tasks/templates/sub-agent-handoff.md`
 - [ ] create `tasks/templates/submission-evidence.md`
 
 ## Generated Agent Instructions
@@ -26,6 +27,7 @@ Use this checklist when adopting the AgenticOS workflow standard in a downstream
 - [ ] redirected implementation work uses `agenticos_branch_bootstrap`
 - [ ] PR submission or merge runs `agenticos_pr_scope_check`
 - [ ] implementation work uses issue-first branch naming and isolated worktrees
+- [ ] delegated sub-agent work uses an explicit inheritance packet and verification echo
 
 ## Repository Boundary
 

--- a/projects/agenticos/.meta/standard-kit/manifest.yaml
+++ b/projects/agenticos/.meta/standard-kit/manifest.yaml
@@ -45,6 +45,10 @@ layers:
         canonical_source: projects/agenticos/.meta/templates/non-code-evaluation-rubric.yaml
         inheritance: copied_template
         customizable: yes
+      - path: tasks/templates/sub-agent-handoff.md
+        canonical_source: projects/agenticos/.meta/templates/sub-agent-handoff.md
+        inheritance: copied_template
+        customizable: yes
       - path: tasks/templates/submission-evidence.md
         canonical_source: projects/agenticos/.meta/templates/submission-evidence.md
         inheritance: copied_template
@@ -79,6 +83,7 @@ adoption:
     - tasks/templates/agent-preflight-checklist.yaml
     - tasks/templates/issue-design-brief.md
     - tasks/templates/non-code-evaluation-rubric.yaml
+    - tasks/templates/sub-agent-handoff.md
     - tasks/templates/submission-evidence.md
   required_behavior:
     - memory_layer_contracts
@@ -86,3 +91,4 @@ adoption:
     - issue_first_branching
     - isolated_worktree_execution
     - pr_scope_validation
+    - sub_agent_context_inheritance

--- a/projects/agenticos/.meta/templates/issue-design-brief.md
+++ b/projects/agenticos/.meta/templates/issue-design-brief.md
@@ -17,6 +17,16 @@
 - Related issues/risks:
 - Files or docs reviewed:
 
+## Sub-Agent Inheritance Packet
+- Sub-agent needed:
+- Delegated scope:
+- Project identity to pass:
+- Current task / issue context to pass:
+- Constraints / non-goals to pass:
+- Knowledge or task files to pass:
+- Expected output shape:
+- Verification the sub-agent must echo back:
+
 ## Design Pass 1
 - Proposed approach:
 - Why this approach:

--- a/projects/agenticos/.meta/templates/sub-agent-handoff.md
+++ b/projects/agenticos/.meta/templates/sub-agent-handoff.md
@@ -1,0 +1,28 @@
+# Sub-Agent Handoff
+
+## Project Identity
+- Project:
+- Project ID:
+- Project Path:
+
+## Task Scope
+- Issue:
+- Delegated sub-task:
+- Expected output:
+
+## Required Context
+- Current task:
+- Constraints / non-goals:
+- Relevant knowledge files:
+- Relevant task files:
+
+## Verification Before Work
+- Restate the project:
+- Restate the task:
+- Restate key constraints:
+- State what evidence will be returned:
+
+## Return Contract
+- Code or document output:
+- Verification evidence:
+- Residual risks:

--- a/projects/agenticos/.meta/templates/submission-evidence.md
+++ b/projects/agenticos/.meta/templates/submission-evidence.md
@@ -15,6 +15,12 @@
 - Critique completed:
 - Acceptance defined before edit:
 
+## Sub-Agent Verification
+- Sub-agents used:
+- Inheritance packet defined:
+- Sub-agent understanding verified before work:
+- Parent agent distilled important results back into canonical files:
+
 ## Verification
 - Deliverable type:
 - Commands run:

--- a/projects/agenticos/mcp-server/src/tools/__tests__/standard-kit.test.ts
+++ b/projects/agenticos/mcp-server/src/tools/__tests__/standard-kit.test.ts
@@ -4,6 +4,20 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import yaml from 'yaml';
 import { runStandardKitAdopt, runStandardKitUpgradeCheck } from '../standard-kit.js';
+import { generateAgentsMd } from '../../utils/distill.js';
+
+async function writeRegistry(home: string, registry: unknown): Promise<void> {
+  await mkdir(join(home, '.agent-workspace'), { recursive: true });
+  await writeFile(join(home, '.agent-workspace', 'registry.yaml'), yaml.stringify(registry), 'utf-8');
+}
+
+async function writeManifest(home: string, manifest: unknown): Promise<void> {
+  await writeFile(
+    join(home, 'projects', 'agenticos', '.meta', 'standard-kit', 'manifest.yaml'),
+    yaml.stringify(manifest),
+    'utf-8',
+  );
+}
 
 async function setupKitHome(): Promise<{ home: string; projectRoot: string }> {
   const home = await mkdtemp(join(tmpdir(), 'agenticos-standard-kit-'));
@@ -34,6 +48,7 @@ async function setupKitHome(): Promise<{ home: string; projectRoot: string }> {
           { path: 'tasks/templates/agent-preflight-checklist.yaml', canonical_source: 'projects/agenticos/.meta/templates/agent-preflight-checklist.yaml' },
           { path: 'tasks/templates/issue-design-brief.md', canonical_source: 'projects/agenticos/.meta/templates/issue-design-brief.md' },
           { path: 'tasks/templates/non-code-evaluation-rubric.yaml', canonical_source: 'projects/agenticos/.meta/templates/non-code-evaluation-rubric.yaml' },
+          { path: 'tasks/templates/sub-agent-handoff.md', canonical_source: 'projects/agenticos/.meta/templates/sub-agent-handoff.md' },
           { path: 'tasks/templates/submission-evidence.md', canonical_source: 'projects/agenticos/.meta/templates/submission-evidence.md' },
         ],
       },
@@ -48,6 +63,7 @@ async function setupKitHome(): Promise<{ home: string; projectRoot: string }> {
         'tasks/templates/agent-preflight-checklist.yaml',
         'tasks/templates/issue-design-brief.md',
         'tasks/templates/non-code-evaluation-rubric.yaml',
+        'tasks/templates/sub-agent-handoff.md',
         'tasks/templates/submission-evidence.md',
       ],
     },
@@ -60,10 +76,10 @@ async function setupKitHome(): Promise<{ home: string; projectRoot: string }> {
   await writeFile(join(templateRoot, 'agent-preflight-checklist.yaml'), 'version: 0.2\n', 'utf-8');
   await writeFile(join(templateRoot, 'issue-design-brief.md'), '# Issue Design Brief\n', 'utf-8');
   await writeFile(join(templateRoot, 'non-code-evaluation-rubric.yaml'), 'version: 0.1\nname: non-code-evaluation-rubric\n', 'utf-8');
+  await writeFile(join(templateRoot, 'sub-agent-handoff.md'), '# Sub-Agent Handoff\n', 'utf-8');
   await writeFile(join(templateRoot, 'submission-evidence.md'), '# Submission Evidence\n', 'utf-8');
 
-  await mkdir(join(home, '.agent-workspace'), { recursive: true });
-  await writeFile(join(home, '.agent-workspace', 'registry.yaml'), yaml.stringify({
+  await writeRegistry(home, {
     version: '1.0.0',
     last_updated: new Date().toISOString(),
     active_project: 'sample-project',
@@ -77,7 +93,7 @@ async function setupKitHome(): Promise<{ home: string; projectRoot: string }> {
         last_accessed: new Date().toISOString(),
       },
     ],
-  }), 'utf-8');
+  });
 
   return { home, projectRoot };
 }
@@ -110,6 +126,7 @@ describe('standard kit commands', () => {
     expect(result.created_files).toContain('AGENTS.md');
     expect(result.created_files).toContain('CLAUDE.md');
     expect(result.created_files).toContain('tasks/templates/non-code-evaluation-rubric.yaml');
+    expect(result.created_files).toContain('tasks/templates/sub-agent-handoff.md');
     expect(result.skipped_existing_templates).toContain('.context/quick-start.md');
     expect(result.upgraded_generated_files).toEqual([]);
 
@@ -164,8 +181,316 @@ describe('standard kit commands', () => {
     const quickStartStatus = result.copied_templates.find((item) => item.path === '.context/quick-start.md');
     const designBriefStatus = result.copied_templates.find((item) => item.path === 'tasks/templates/issue-design-brief.md');
     const rubricStatus = result.copied_templates.find((item) => item.path === 'tasks/templates/non-code-evaluation-rubric.yaml');
+    const subAgentHandoffStatus = result.copied_templates.find((item) => item.path === 'tasks/templates/sub-agent-handoff.md');
     expect(quickStartStatus).toMatchObject({ status: 'matches_canonical' });
     expect(designBriefStatus).toMatchObject({ status: 'diverged_from_canonical' });
     expect(rubricStatus).toMatchObject({ status: 'missing' });
+    expect(subAgentHandoffStatus).toMatchObject({ status: 'missing' });
+  });
+
+  it('adopt can resolve the active project from registry and upgrades stale generated files while skipping current ones', async () => {
+    const { home, projectRoot } = await setupKitHome();
+    process.env.AGENTICOS_HOME = home;
+
+    await writeFile(join(projectRoot, 'AGENTS.md'), generateAgentsMd('Sample Project', ''), 'utf-8');
+    await writeFile(
+      join(projectRoot, 'CLAUDE.md'),
+      '<!-- agenticos-template: v2 -->\n# CLAUDE.md — Sample Project\n\n## Project DNA\n\ncustom dna\n\n## Navigation\n\ncustom nav\n',
+      'utf-8',
+    );
+
+    const result = JSON.parse(await runStandardKitAdopt(undefined)) as {
+      status: string;
+      created_files: string[];
+      upgraded_generated_files: string[];
+      skipped_current_generated_files: string[];
+      project_id: string;
+      project_name: string;
+    };
+
+    expect(result.status).toBe('ADOPTED');
+    expect(result.project_name).toBe('Sample Project');
+    expect(result.project_id).toBe('sample-project');
+    expect(result.upgraded_generated_files).toContain('CLAUDE.md');
+    expect(result.skipped_current_generated_files).toContain('AGENTS.md');
+    expect(result.created_files).toContain('.project.yaml');
+
+    const claudeMd = await readFile(join(projectRoot, 'CLAUDE.md'), 'utf-8');
+    expect(claudeMd).toContain('agenticos-template: v3');
+    expect(claudeMd).toContain('custom dna');
+    expect(claudeMd).toContain('## Current State');
+  });
+
+  it('upgrade check reports current generated files when template versions already match', async () => {
+    const { home, projectRoot } = await setupKitHome();
+    process.env.AGENTICOS_HOME = home;
+
+    await writeFile(join(projectRoot, 'AGENTS.md'), generateAgentsMd('Sample Project', ''), 'utf-8');
+    await writeFile(join(projectRoot, 'CLAUDE.md'), '<!-- agenticos-template: v3 -->\ncurrent claude\n', 'utf-8');
+
+    const result = JSON.parse(await runStandardKitUpgradeCheck({ project_path: projectRoot })) as {
+      generated_files: Array<{ path: string; status: string; current_version: number | null }>;
+    };
+
+    expect(result.generated_files.find((item) => item.path === 'AGENTS.md')).toMatchObject({
+      status: 'current',
+      current_version: 3,
+    });
+    expect(result.generated_files.find((item) => item.path === 'CLAUDE.md')).toMatchObject({
+      status: 'current',
+      current_version: 3,
+    });
+  });
+
+  it('upgrade check can resolve project identity from an existing .project.yaml through the active registry project', async () => {
+    const { home, projectRoot } = await setupKitHome();
+    process.env.AGENTICOS_HOME = home;
+
+    await writeFile(
+      join(projectRoot, '.project.yaml'),
+      'meta:\n  name: "Yaml Project"\n  id: "yaml-project"\n  description: "yaml description"\n',
+      'utf-8',
+    );
+
+    const result = JSON.parse(await runStandardKitUpgradeCheck(undefined)) as {
+      project_name: string;
+      project_id: string;
+    };
+
+    expect(result.project_name).toBe('Yaml Project');
+    expect(result.project_id).toBe('yaml-project');
+  });
+
+  it('adopt upgrades stale AGENTS.md files to the current generated template', async () => {
+    const { home, projectRoot } = await setupKitHome();
+    process.env.AGENTICOS_HOME = home;
+
+    await writeFile(join(projectRoot, 'AGENTS.md'), '<!-- agenticos-template: v2 -->\nold agents\n', 'utf-8');
+
+    const result = JSON.parse(await runStandardKitAdopt({
+      project_path: projectRoot,
+      project_name: 'Sample Project',
+    })) as {
+      upgraded_generated_files: string[];
+    };
+
+    expect(result.upgraded_generated_files).toContain('AGENTS.md');
+    const agentsMd = await readFile(join(projectRoot, 'AGENTS.md'), 'utf-8');
+    expect(agentsMd).toContain('agenticos-template: v3');
+    expect(agentsMd).toContain('Guardrail Protocol');
+  });
+
+  it('adopt slugifies a provided project name when no canonical project id exists yet', async () => {
+    const { home } = await setupKitHome();
+    process.env.AGENTICOS_HOME = home;
+
+    const orphanProjectRoot = join(home, 'projects', 'custom-project');
+    await mkdir(orphanProjectRoot, { recursive: true });
+
+    const result = JSON.parse(await runStandardKitAdopt({
+      project_path: orphanProjectRoot,
+      project_name: 'Custom Project',
+    })) as {
+      project_id: string;
+      project_name: string;
+    };
+
+    expect(result.project_name).toBe('Custom Project');
+    expect(result.project_id).toBe('custom-project');
+  });
+
+  it('adopt tolerates a minimal manifest and skips copied-template entries without canonical sources', async () => {
+    const { home, projectRoot } = await setupKitHome();
+    process.env.AGENTICOS_HOME = home;
+
+    await writeManifest(home, {
+      kit_id: 'downstream-standard-kit',
+      kit_version: '0.1.0',
+      layers: {
+        copied_templates: {
+          entries: [{ path: 'tasks/templates/ignored.md' }],
+        },
+      },
+    });
+
+    const result = JSON.parse(await runStandardKitAdopt({
+      project_path: projectRoot,
+      project_name: 'Sample Project',
+    })) as {
+      created_files: string[];
+      upgraded_generated_files: string[];
+    };
+
+    expect(result.created_files).toEqual([]);
+    expect(result.upgraded_generated_files).toEqual([]);
+  });
+
+  it('upgrade check tolerates a minimal manifest and skips copied-template entries without canonical sources', async () => {
+    const { home, projectRoot } = await setupKitHome();
+    process.env.AGENTICOS_HOME = home;
+
+    await writeManifest(home, {
+      kit_id: 'downstream-standard-kit',
+      kit_version: '0.1.0',
+      layers: {
+        copied_templates: {
+          entries: [{ path: 'tasks/templates/ignored.md' }],
+        },
+      },
+    });
+
+    const result = JSON.parse(await runStandardKitUpgradeCheck({
+      project_path: projectRoot,
+      project_name: 'Sample Project',
+    })) as {
+      missing_required_files: string[];
+      generated_files: unknown[];
+      copied_templates: unknown[];
+    };
+
+    expect(result.missing_required_files).toEqual([]);
+    expect(result.generated_files).toEqual([]);
+    expect(result.copied_templates).toEqual([]);
+  });
+
+  it('adopt fills missing state sections and preserves an explicit project phase from the template', async () => {
+    const { home, projectRoot } = await setupKitHome();
+    process.env.AGENTICOS_HOME = home;
+
+    await writeManifest(home, {
+      kit_id: 'downstream-standard-kit',
+      kit_version: '0.1.0',
+      layers: {
+        copied_templates: {
+          entries: [
+            { path: '.project.yaml', canonical_source: 'projects/agenticos/.meta/templates/.project.yaml' },
+            { path: '.context/state.yaml', canonical_source: 'projects/agenticos/.meta/templates/state.yaml' },
+          ],
+        },
+      },
+    });
+    await writeFile(
+      join(home, 'projects', 'agenticos', '.meta', 'templates', '.project.yaml'),
+      'meta:\n  name: "Template Name"\nstatus:\n  phase: "discovery"\n',
+      'utf-8',
+    );
+    await writeFile(
+      join(home, 'projects', 'agenticos', '.meta', 'templates', 'state.yaml'),
+      'loaded_context: []\n',
+      'utf-8',
+    );
+
+    await runStandardKitAdopt({
+      project_path: projectRoot,
+      project_name: 'Sample Project',
+    });
+
+    const projectYaml = yaml.parse(await readFile(join(projectRoot, '.project.yaml'), 'utf-8')) as any;
+    const stateYaml = yaml.parse(await readFile(join(projectRoot, '.context', 'state.yaml'), 'utf-8')) as any;
+
+    expect(projectYaml.status.phase).toBe('discovery');
+    expect(projectYaml.status.last_updated).toBeTypeOf('string');
+    expect(stateYaml.session.id).toMatch(/^session-\d{4}-\d{2}-\d{2}-001$/);
+    expect(stateYaml.current_task.status).toBe('pending');
+    expect(stateYaml.current_task.next_step).toBe('Define project goals');
+  });
+
+  it('adopt fills missing project metadata and default planning status when the project template is skeletal', async () => {
+    const { home, projectRoot } = await setupKitHome();
+    process.env.AGENTICOS_HOME = home;
+
+    await writeManifest(home, {
+      kit_id: 'downstream-standard-kit',
+      kit_version: '0.1.0',
+      layers: {
+        copied_templates: {
+          entries: [
+            { path: '.project.yaml', canonical_source: 'projects/agenticos/.meta/templates/.project.yaml' },
+          ],
+        },
+      },
+    });
+    await writeFile(
+      join(home, 'projects', 'agenticos', '.meta', 'templates', '.project.yaml'),
+      '{}\n',
+      'utf-8',
+    );
+
+    await runStandardKitAdopt({
+      project_path: projectRoot,
+      project_name: 'Sample Project',
+    });
+
+    const projectYaml = yaml.parse(await readFile(join(projectRoot, '.project.yaml'), 'utf-8')) as any;
+    expect(projectYaml.meta.name).toBe('Sample Project');
+    expect(projectYaml.meta.id).toBe('sample-project');
+    expect(projectYaml.meta.version).toBe('1.0.0');
+    expect(projectYaml.status.phase).toBe('planning');
+  });
+
+  it('upgrade check tolerates manifests with no copied-template layer at all', async () => {
+    const { home, projectRoot } = await setupKitHome();
+    process.env.AGENTICOS_HOME = home;
+
+    await writeManifest(home, {
+      kit_id: 'downstream-standard-kit',
+      kit_version: '0.1.0',
+      layers: {},
+    });
+
+    const result = JSON.parse(await runStandardKitUpgradeCheck({
+      project_path: projectRoot,
+      project_name: 'Sample Project',
+    })) as {
+      generated_files: unknown[];
+      copied_templates: unknown[];
+    };
+
+    expect(result.generated_files).toEqual([]);
+    expect(result.copied_templates).toEqual([]);
+  });
+
+  it('adopt blocks when no active project exists and no project_path is provided', async () => {
+    const { home } = await setupKitHome();
+    process.env.AGENTICOS_HOME = home;
+
+    await writeRegistry(home, {
+      version: '1.0.0',
+      last_updated: new Date().toISOString(),
+      active_project: null,
+      projects: [],
+    });
+
+    await expect(runStandardKitAdopt(undefined)).rejects.toThrow(
+      'No project_path provided and no active project found in registry.',
+    );
+  });
+
+  it('adopt blocks when the registry active project cannot be resolved', async () => {
+    const { home } = await setupKitHome();
+    process.env.AGENTICOS_HOME = home;
+
+    await writeRegistry(home, {
+      version: '1.0.0',
+      last_updated: new Date().toISOString(),
+      active_project: 'missing-project',
+      projects: [],
+    });
+
+    await expect(runStandardKitAdopt({})).rejects.toThrow(
+      'Active project "missing-project" not found in registry.',
+    );
+  });
+
+  it('adopt blocks when project identity cannot resolve a name', async () => {
+    const { home } = await setupKitHome();
+    process.env.AGENTICOS_HOME = home;
+
+    const orphanProjectRoot = join(home, 'projects', 'orphan-project');
+    await mkdir(orphanProjectRoot, { recursive: true });
+
+    await expect(runStandardKitAdopt({ project_path: orphanProjectRoot })).rejects.toThrow(
+      'Unable to resolve project name. Provide project_name or create .project.yaml first.',
+    );
   });
 });

--- a/projects/agenticos/standards/.context/quick-start.md
+++ b/projects/agenticos/standards/.context/quick-start.md
@@ -46,6 +46,9 @@ Its job is to define and evolve:
 - issue `#26` now freezes the canonical memory-layer contract and pushes it into the downstream standard kit and templates
 - `knowledge/memory-layer-contract-spec-2026-03-25.md` records the contract itself
 - `knowledge/memory-layer-contract-implementation-report-2026-03-25.md` records the template, kit, and documentation alignment work
+- issue `#28` now defines the canonical sub-agent inheritance packet and verification echo requirements for delegated non-trivial work
+- `knowledge/sub-agent-inheritance-protocol-2026-03-25.md` records the protocol itself
+- `knowledge/sub-agent-inheritance-implementation-report-2026-03-25.md` records the template, standards-doc, and standard-kit adoption changes
 
 ## Recommended Entry Documents
 
@@ -68,11 +71,13 @@ Start here:
 15. `knowledge/project-boundary-isolation-implementation-report-2026-03-25.md`
 16. `knowledge/memory-layer-contract-spec-2026-03-25.md`
 17. `knowledge/memory-layer-contract-implementation-report-2026-03-25.md`
+18. `knowledge/sub-agent-inheritance-protocol-2026-03-25.md`
+19. `knowledge/sub-agent-inheritance-implementation-report-2026-03-25.md`
 
 ## Next Steps
 
 1. Use the reconciled open backlog, not the pre-self-hosting issue list, as the canonical remaining work queue
 2. Treat `/Users/jeking/dev/AgenticOS` as the trusted local canonical checkout again; use isolated worktrees for changes
-3. Continue with the remaining core backlog: `#28`, `#29`, `#30`, `#31`
+3. Continue with the remaining core backlog: `#29`, `#30`, `#31`
 4. Decide whether any additional entry surfaces need the same compact guardrail summary beyond `agenticos_status` and `agenticos_switch`
 5. Only open a new selective-merge issue if one specific archived artifact is later proven to fill a real canonical gap

--- a/projects/agenticos/standards/.context/state.yaml
+++ b/projects/agenticos/standards/.context/state.yaml
@@ -5,9 +5,9 @@ session:
   last_backup: 2026-03-23T10:35:00.000Z
 
 current_task:
-  title: freeze the canonical memory-layer contract in standards and templates
+  title: define and land the canonical sub-agent inheritance and verification protocol
   status: implemented
-  updated: 2026-03-25T00:59:00.000Z
+  updated: 2026-03-25T02:10:00.000Z
 
 working_memory:
   facts:
@@ -58,6 +58,9 @@ working_memory:
     - the downstream standard kit and default templates now carry the memory-layer contract by default
     - the mcp-server project structure docs now describe quick-start as orientation, state as mutable operational state, and conversations as append-only history
     - issue #26 verification passed with npm install, npm run build, targeted standard-kit tests, the full test suite, and YAML parsing for contract-bearing templates
+    - issue #28 now freezes a canonical sub-agent inheritance packet and required verification echo for delegated non-trivial work
+    - the downstream standard kit now includes tasks/templates/sub-agent-handoff.md and surfaces delegated-work expectations in the adoption checklist
+    - issue-design-brief.md and submission-evidence.md now contain explicit sub-agent inheritance and verification sections
   decisions:
     - keep one main AgenticOS product repository and one canonical standards area inside it
     - merge durable standards knowledge into the main repo, but archive raw standalone context/history instead of treating it as live state
@@ -73,9 +76,9 @@ working_memory:
     - agenticos_switch should treat its return string as a first-class mid-conversation handoff surface instead of only listing context file paths
     - project-boundary enforcement should centralize identity proof in one shared resolver rather than duplicate weaker checks in record/save/context
     - memory-layer enforcement should start by freezing canonical contracts in standards and templates before attempting broader runtime linting
+    - sub-agent inheritance should land first as a standard-kit-backed protocol and template contract before any deeper runtime automation
   pending:
     - decide whether any entry surfaces beyond `agenticos_status` and `agenticos_switch` need the same compact guardrail summary
-    - implement issue #28 to define sub-agent context inheritance and verification rules
     - implement issue #29 to define per-agent bootstrap standards
     - implement issue #30 to define Homebrew post-install bootstrap for supported agents
     - implement issue #31 to define the MCP-native vs CLI+Skills integration matrix
@@ -102,3 +105,5 @@ loaded_context:
   - knowledge/project-boundary-isolation-implementation-report-2026-03-25.md
   - knowledge/memory-layer-contract-spec-2026-03-25.md
   - knowledge/memory-layer-contract-implementation-report-2026-03-25.md
+  - knowledge/sub-agent-inheritance-protocol-2026-03-25.md
+  - knowledge/sub-agent-inheritance-implementation-report-2026-03-25.md

--- a/projects/agenticos/standards/AGENTS.md
+++ b/projects/agenticos/standards/AGENTS.md
@@ -24,6 +24,7 @@ Treat archived standalone material as read-only historical evidence, not as the 
 3. Keep `.context/quick-start.md` and `.context/state.yaml` current enough that another agent can resume without chat history.
 4. Do not create a second active standards repo or write new canonical records into `projects/agentic-os-development`.
 5. Prefer canonical template surfaces under `projects/agenticos/.meta/templates/` and `projects/agenticos/.meta/standard-kit/` over ad hoc local template copies.
+6. If you delegate to a sub-agent for non-trivial work, pass a defined inheritance packet and require the sub-agent to restate project, task, constraints, and expected evidence before it starts.
 
 ## Directory Structure
 

--- a/projects/agenticos/standards/CLAUDE.md
+++ b/projects/agenticos/standards/CLAUDE.md
@@ -29,6 +29,7 @@ Do not treat archived standalone records as the live source of truth.
    - `projects/agenticos/.meta/templates/`
    - `projects/agenticos/.meta/standard-kit/`
 5. Treat the archive as read-only provenance.
+6. For non-trivial delegated work, define a sub-agent inheritance packet and require a verification echo before the sub-agent edits or concludes.
 
 ## Navigation
 

--- a/projects/agenticos/standards/knowledge/sub-agent-inheritance-implementation-report-2026-03-25.md
+++ b/projects/agenticos/standards/knowledge/sub-agent-inheritance-implementation-report-2026-03-25.md
@@ -1,0 +1,88 @@
+# Sub-Agent Inheritance Implementation Report - 2026-03-25
+
+## Scope
+
+Issue `#28` closes the gap where delegated sub-agents could start work with only ad hoc parent summaries.
+
+The landed slice deliberately stays at the standards and standard-kit layer.
+
+It does **not** introduce new MCP runtime behavior yet.
+
+Instead it makes sub-agent inheritance auditable by:
+
+- freezing a canonical inheritance protocol
+- adding a reusable handoff template
+- adding inheritance fields to design and submission templates
+- pushing the requirement into downstream adoption guidance
+- updating standards-area agent instructions to require a verification echo
+
+## Design Reflection
+
+The main design tradeoff was whether to modify runtime generators and enforcement first.
+
+That was rejected for this issue because:
+
+- the problem statement is primarily about protocol ambiguity, not missing low-level transport
+- changing generator/runtime behavior would widen scope into a larger template-distribution change
+- standards-first landing is enough to make delegated work explicit, reviewable, and downstream-adoptable
+
+The adopted design therefore treats issue `#28` as a contract-freezing issue:
+
+1. define the inheritance packet
+2. define required verification behavior
+3. put both into canonical templates
+4. make downstream kit adoption carry those templates by default
+
+## Landed Changes
+
+### Canonical Protocol
+
+- added `knowledge/sub-agent-inheritance-protocol-2026-03-25.md`
+
+### Canonical Templates
+
+- added `.meta/templates/sub-agent-handoff.md`
+- updated `.meta/templates/issue-design-brief.md`
+- updated `.meta/templates/submission-evidence.md`
+
+### Downstream Standard Kit
+
+- updated `.meta/standard-kit/manifest.yaml`
+- updated `.meta/standard-kit/README.md`
+- updated `.meta/standard-kit/adoption-checklist.md`
+
+### Standards Agent-Facing Rules
+
+- updated `standards/AGENTS.md`
+- updated `standards/CLAUDE.md`
+
+### Verification Harness
+
+- updated `mcp-server/src/tools/__tests__/standard-kit.test.ts`
+
+## Acceptance Mapping
+
+- standard sub-agent inheritance protocol documented: yes
+- required inputs and verification behavior specified: yes
+- reflected in agent-facing docs: yes
+- downstream test scenario or simulation defined: yes
+
+## Verification
+
+Validation for this issue must prove two things:
+
+1. the canonical protocol and templates exist in the main standards surface
+2. standard-kit adoption/upgrade behavior recognizes the new delegated-work template
+
+The verification record is therefore:
+
+- `npm install`
+- `npm run build`
+- `npm test -- --run src/tools/__tests__/standard-kit.test.ts`
+- `npm test`
+- targeted coverage for changed executable test-bearing files
+- YAML parsing for `manifest.yaml`
+
+## Outcome
+
+Delegated sub-agent work is now part of the canonical AgenticOS standard kit instead of an undocumented prompt habit.

--- a/projects/agenticos/standards/knowledge/sub-agent-inheritance-protocol-2026-03-25.md
+++ b/projects/agenticos/standards/knowledge/sub-agent-inheritance-protocol-2026-03-25.md
@@ -1,0 +1,88 @@
+# Sub-Agent Inheritance Protocol - 2026-03-25
+
+## Design Reflection
+
+Issue `#28` is not about whether sub-agents are useful.
+
+It is about making sub-agent startup predictable.
+
+Without a contract, the parent agent either:
+
+- sends too little context and the sub-agent starts context-blind
+- sends an ad hoc summary with no verification step
+- or asks the sub-agent to rediscover the same project state from scratch
+
+That produces drift, duplicated work, and unverifiable delegation.
+
+The adopted design is:
+
+- define one required inheritance packet
+- define one required verification loop
+- encode both into the standard kit templates and standards agent docs
+
+## Required Inheritance Packet
+
+Before spawning a sub-agent for substantive work, the parent agent must pass at least:
+
+1. project identity
+2. current task / issue scope
+3. key constraints and non-goals
+4. relevant knowledge files
+5. relevant task brief or execution plan
+6. expected output shape
+7. verification expectations
+
+The parent should not delegate using only a free-form one-line summary when the task is non-trivial.
+
+## Required Verification Behavior
+
+Before editing or producing final output, the sub-agent must confirm:
+
+1. what project it believes it is in
+2. what problem it is solving
+3. what constraints it must not violate
+4. what evidence it will return
+
+If that understanding is incomplete, the sub-agent should stop and request clarification from the parent agent instead of guessing.
+
+## Persistence Rules
+
+The parent agent remains responsible for canonical persistence.
+
+The sub-agent may produce:
+
+- implementation output
+- review findings
+- design alternatives
+- verification evidence
+
+But important results must be distilled back by the parent into the project's canonical files:
+
+- `knowledge/`
+- `tasks/`
+- `.context/state.yaml`
+- submission evidence
+
+## Template Implications
+
+The downstream standard kit should now include:
+
+- a sub-agent handoff template
+- explicit sub-agent packet fields in the issue design brief
+- explicit sub-agent verification fields in submission evidence
+
+## Simulation Scenario
+
+Minimal verification scenario:
+
+1. parent agent opens an issue design brief
+2. parent fills the sub-agent inheritance packet
+3. sub-agent restates project, task, constraints, and expected output
+4. sub-agent returns work plus evidence
+5. parent records the distilled result into canonical project state
+
+## Outcome
+
+After this issue, sub-agent collaboration is no longer a pure prompt habit.
+
+It becomes a standard-kit-backed protocol that downstream projects can adopt and audit.


### PR DESCRIPTION
## Summary
- freeze a canonical sub-agent inheritance protocol in standards
- add a reusable sub-agent handoff template and delegated-work fields in kit templates
- extend standard-kit tests so delegated-work adoption and upgrade paths stay covered

## Design Reflection
- kept this issue at the protocol/template layer instead of widening into runtime generator changes
- chose one inheritance packet plus one verification echo as the minimal enforceable contract for non-trivial delegated work
- pushed the contract into the standard kit so downstream projects inherit it by default

## Verification
- npm install
- npm run build
- npm test -- --run src/tools/__tests__/standard-kit.test.ts
- npx vitest run --coverage.enabled true --coverage.provider=v8 --coverage.reporter=text --coverage.include=src/tools/standard-kit.ts --coverage.include=src/utils/standard-kit.ts src/tools/__tests__/standard-kit.test.ts
- npm test
- ruby -e 'require "yaml"; YAML.load_file(ARGV[0]); puts "manifest ok"' projects/agenticos/.meta/standard-kit/manifest.yaml
- ruby -e 'require "yaml"; YAML.load_file(ARGV[0]); puts "state ok"' projects/agenticos/standards/.context/state.yaml

## Coverage
- src/tools/standard-kit.ts: 100 statements / 100 branches / 100 functions / 100 lines
- src/utils/standard-kit.ts: 100 statements / 100 branches / 100 functions / 100 lines