### PR TITLE
feat(meta): define per-agent bootstrap standard (#29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AgenticOS
 
-AI-native project management system for Claude Code, Cursor, Codex, and any MCP-compatible AI tool. Persists context and state across sessions so your AI agent always knows where it left off.
+AI-native project management system for Claude Code, Codex, Cursor, Gemini CLI, and other MCP-capable tools. Persists context and state across sessions so your AI agent always knows where it left off.
 
 ## Install
 
@@ -22,15 +22,27 @@ npm install -g ./agenticos-mcp.tgz
 
 ---
 
-## MCP Configuration
+## Supported Agent Bootstrap
 
-Add to your AI tool's MCP config file:
+AgenticOS is `MCP-native`.
 
-**Claude Code** — `~/.claude/settings/mcp.json`
-**Cursor** — `~/.cursor/mcp.json`
-**Windsurf** — `~/.codeium/windsurf/mcp_config.json`
+Bootstrap has two separate layers:
 
-If installed via Homebrew, use the binary directly (faster, no npx overhead):
+1. **Transport bootstrap**: register the `agenticos` MCP server successfully.
+2. **Project-intent routing**: make sure the agent is actually reading project instructions and using the tools when the task calls for it.
+
+If transport works but project-create/switch behavior is weak, that is a routing problem, not an MCP registration problem.
+
+### Officially Supported Agent Paths
+
+| Agent | Canonical bootstrap | Canonical config location | Verify |
+|------|---------------------|---------------------------|--------|
+| Claude Code | `claude mcp add --transport stdio --scope user agenticos -- agenticos-mcp` | Claude-managed user MCP config | `claude mcp list`, `/mcp`, then call `agenticos_list` |
+| Codex | `codex mcp add agenticos -- agenticos-mcp` | `~/.codex/config.toml` | `codex mcp list`, then call `agenticos_list` |
+| Cursor | Add `agenticos` to `~/.cursor/mcp.json` | `~/.cursor/mcp.json` | Restart Cursor, then open MCP settings or run `cursor-agent mcp list` |
+| Gemini CLI | `gemini mcp add -s user agenticos agenticos-mcp` | `~/.gemini/settings.json` | `gemini mcp list`, restart Gemini CLI, then call `agenticos_list` |
+
+### Cursor Global `mcp.json`
 
 ```json
 {
@@ -43,20 +55,19 @@ If installed via Homebrew, use the binary directly (faster, no npx overhead):
 }
 ```
 
-If installed via npm/manual download:
+### Experimental / Manual
 
-```json
-{
-  "mcpServers": {
-    "agenticos": {
-      "command": "npx",
-      "args": ["-y", "agenticos-mcp"]
-    }
-  }
-}
-```
+Other MCP-capable tools are currently **experimental**. They are only considered bootstrapped if:
 
-Restart your AI tool after saving the config.
+- they can register a local stdio MCP server
+- `agenticos` appears in that tool's MCP diagnostics
+- `agenticos_list` can be called successfully
+
+Restart the AI tool after registration or config changes.
+
+The machine-readable source of truth for this support matrix lives in:
+
+- `projects/agenticos/.meta/bootstrap/agent-bootstrap-matrix.yaml`
 
 ---
 
@@ -185,7 +196,7 @@ brew tap madlouse/agenticos && brew install agenticos
 echo 'export AGENTICOS_HOME="$HOME/AgenticOS"' >> ~/.zshrc
 source ~/.zshrc
 
-# 3. Configure mcp.json and restart your AI tool
+# 3. Bootstrap one of the supported agents above and restart it
 ```
 
 ### Migrate existing projects from another machine

--- a/projects/agenticos/.meta/bootstrap/agent-bootstrap-matrix.yaml
+++ b/projects/agenticos/.meta/bootstrap/agent-bootstrap-matrix.yaml
@@ -1,0 +1,93 @@
+version: 1
+primary_integration_mode: mcp-native
+supported_agents:
+  - id: claude-code
+    label: Claude Code
+    support_tier: official
+    transport: stdio
+    canonical_bootstrap_method: cli-command
+    canonical_config_location: claude-managed user MCP config via `claude mcp add --scope user`
+    bootstrap_command: claude mcp add --transport stdio --scope user agenticos -- agenticos-mcp
+    verification:
+      - run `claude mcp list`
+      - run `/mcp` inside Claude Code
+      - confirm `agenticos` is present and call `agenticos_list`
+    transport_debug:
+      - if `agenticos` is missing from `claude mcp list`, MCP registration failed
+      - if the server is listed but unavailable, confirm `agenticos-mcp --version` works and restart Claude Code
+    routing_debug:
+      - if tools are available but project-intent prompts do not trigger routing, load the project `CLAUDE.md` and `AGENTS.md`
+      - call the relevant `agenticos_*` tool explicitly before treating the problem as transport failure
+  - id: codex
+    label: Codex
+    support_tier: official
+    transport: stdio
+    canonical_bootstrap_method: cli-command
+    canonical_config_location: ~/.codex/config.toml managed via `codex mcp add`
+    bootstrap_command: codex mcp add agenticos -- agenticos-mcp
+    verification:
+      - run `codex mcp list`
+      - confirm `agenticos` appears in the configured server list
+      - call `agenticos_list` explicitly from a Codex session
+    transport_debug:
+      - if `agenticos` is missing from `codex mcp list`, registration did not land in the active config
+      - if `agenticos` exists but fails to start, confirm `agenticos-mcp --version` works and restart Codex
+    routing_debug:
+      - Codex transport success does not guarantee natural-language project-intent routing
+      - if routing is weak, use explicit `agenticos_*` tool calls and ensure project instructions are loaded
+  - id: cursor
+    label: Cursor
+    support_tier: official
+    transport: stdio
+    canonical_bootstrap_method: global-mcp-json
+    canonical_config_location: ~/.cursor/mcp.json
+    bootstrap_snippet: |
+      {
+        "mcpServers": {
+          "agenticos": {
+            "command": "agenticos-mcp",
+            "args": []
+          }
+        }
+      }
+    verification:
+      - restart Cursor after saving `~/.cursor/mcp.json`
+      - open Cursor MCP settings or run `cursor-agent mcp list` if Cursor CLI is installed
+      - confirm `agenticos` appears and can call `agenticos_list`
+    transport_debug:
+      - if `agenticos` is absent after restart, validate JSON syntax and confirm `agenticos-mcp --version`
+      - if using `cursor-agent`, compare `cursor-agent mcp list` with the editor view to rule out config-scope confusion
+    routing_debug:
+      - project-specific `.cursor/mcp.json` exists, but AgenticOS bootstrap should stay user-global by default
+      - if tools appear but intent routing is weak, use explicit `agenticos_*` tool calls and rely on project instructions
+  - id: gemini-cli
+    label: Gemini CLI
+    support_tier: official
+    transport: stdio
+    canonical_bootstrap_method: cli-command
+    canonical_config_location: ~/.gemini/settings.json managed via `gemini mcp add -s user`
+    bootstrap_command: gemini mcp add -s user agenticos agenticos-mcp
+    verification:
+      - run `gemini mcp list`
+      - restart Gemini CLI after registration
+      - confirm `agenticos` appears and can call `agenticos_list`
+    transport_debug:
+      - if `agenticos` is missing from `gemini mcp list`, the user-scope registration did not land
+      - if `agenticos` is listed but unusable, confirm `agenticos-mcp --version` works and restart Gemini CLI
+    routing_debug:
+      - transport registration only proves MCP availability, not project-intent recognition
+      - if intent routing does not trigger, use explicit `agenticos_*` calls and ensure the project instructions are loaded
+experimental_agents:
+  - id: generic-mcp-tool
+    label: Other MCP-Compatible Tools
+    support_tier: experimental
+    transport: varies
+    canonical_bootstrap_method: manual
+    canonical_config_location: tool-specific
+    verification:
+      - confirm the tool can register a local stdio MCP server
+      - confirm `agenticos` appears and can call `agenticos_list`
+    transport_debug:
+      - debug transport using that tool's own MCP diagnostics first
+    routing_debug:
+      - treat project-intent routing as unsupported unless the tool has explicit AgenticOS instructions

--- a/projects/agenticos/mcp-server/README.md
+++ b/projects/agenticos/mcp-server/README.md
@@ -18,19 +18,7 @@ A project management system designed for AI collaboration. When you work on comp
 
 ### Quick Start
 
-Tell your AI assistant:
-
-```
-"安装 AgenticOS"
-```
-
-The AI will configure everything automatically. Then start using:
-
-```
-"创建新项目来管理 XXX"
-"切换到 XXX 项目"
-"列出所有项目"
-```
+Install AgenticOS, bootstrap one supported agent, restart that agent, then explicitly verify `agenticos_list` works before relying on project-intent routing.
 
 ### When to Use
 
@@ -58,83 +46,67 @@ my-project/
 
 ---
 
-## 🤖 For AI Agents: Installation Protocol
+## 🤖 Supported Agent Bootstrap Standard
 
-### When user says: "安装 AgenticOS" / "配置 AgenticOS" / "setup AgenticOS"
+Bootstrap is complete only when:
 
-Execute these steps autonomously:
+1. the MCP server is registered for the target agent
+2. the agent has been restarted if required
+3. `agenticos_list` succeeds
 
-#### Step 1: Add MCP Configuration
+Transport bootstrap and project-intent routing are different concerns.
 
-Detect AI tool and update config:
-- **Claude Code/Kiro**: `~/.claude/settings/mcp.json` or `~/.kiro/settings/mcp.json`
-- **Cursor**: `~/.cursor/settings/mcp.json`
-- **Codex**: Check Codex MCP config path
+- **transport bootstrap** proves the tool is registered and callable
+- **routing** proves the agent is reading project instructions and choosing the tool when appropriate
 
-Read existing config, merge this:
-```json
-{
-  "mcpServers": {
-    "agenticos": {
-      "command": "npx",
-      "args": ["-y", "agenticos-mcp"],
-      "disabled": false,
-      "autoApprove": []
-    }
-  }
-}
-```
+### Claude Code
 
-#### Step 2: Add Trigger Logic
+- canonical bootstrap: `claude mcp add --transport stdio --scope user agenticos -- agenticos-mcp`
+- verify:
+  - `claude mcp list`
+  - `/mcp`
+  - explicit `agenticos_list`
+- debug split:
+  - if `agenticos` is missing from `claude mcp list`, fix MCP registration first
+  - if `agenticos` exists but intent routing is weak, load `CLAUDE.md` / `AGENTS.md` and call the tool explicitly
 
-Append to user-level config (`~/.claude/CLAUDE.md`, etc.):
+### Codex
 
-```markdown
-## 🚀 AgenticOS Integration
+- canonical bootstrap: `codex mcp add agenticos -- agenticos-mcp`
+- canonical config location: `~/.codex/config.toml`
+- verify:
+  - `codex mcp list`
+  - explicit `agenticos_list`
+- debug split:
+  - if `agenticos` is missing from `codex mcp list`, registration did not land in the active config
+  - if it is present but prompts still do not route correctly, treat that as routing behavior rather than transport failure
 
-### When to Suggest Creating a Project
+### Cursor
 
-Check for complexity signals:
-- Task requires 3+ steps
-- Multiple files involved
-- Cross-session tracking needed
-- Keywords: "项目"、"长期"、"持续"、"管理"
+- canonical bootstrap: add `agenticos` to `~/.cursor/mcp.json`
+- verify:
+  - restart Cursor
+  - check Cursor MCP settings or `cursor-agent mcp list` if the Cursor CLI is installed
+  - explicit `agenticos_list`
+- debug split:
+  - if `agenticos` never appears after restart, validate the JSON and executable path
+  - if tools appear but project-intent routing is weak, use explicit tools and project instructions
 
-Ask user:
-"这个任务较复杂且具有持续性，是否需要创建 AgenticOS 项目来管理？
+### Gemini CLI
 
-AgenticOS 提供：
-- 完整记录所有决策和对话
-- 跨会话恢复工作状态
-- 自动备份到 Git
-- 跨工具使用"
+- canonical bootstrap: `gemini mcp add -s user agenticos agenticos-mcp`
+- canonical config location: `~/.gemini/settings.json`
+- verify:
+  - `gemini mcp list`
+  - restart Gemini CLI
+  - explicit `agenticos_list`
+- debug split:
+  - if `agenticos` is missing from `gemini mcp list`, bootstrap did not land
+  - if it is present but behavior is weak, treat that as routing/instruction quality rather than MCP transport failure
 
-### Explicit Commands
-- "切换到 XX 项目" → agenticos_switch
-- "创建新项目" → agenticos_init
-- "列出项目" → agenticos_list
-- "保存项目" → agenticos_save
-```
+### Other MCP-Compatible Tools
 
-#### Step 3: Initialize System
-
-```bash
-mkdir -p ~/AgenticOS/.agent-workspace
-```
-
-Create `~/AgenticOS/.agent-workspace/registry.yaml`:
-```yaml
-version: "1.0.0"
-last_updated: "2026-03-16T08:52:20Z"
-active_project: null
-projects: []
-```
-
-#### Step 4: Verify & Report
-
-1. Call `agenticos_list` tool
-2. Confirm it returns project list or "No projects found"
-3. Tell user: "✅ AgenticOS 已配置完成"
+These are currently experimental. Do not describe them as first-class supported agents unless they have a documented bootstrap, verification, and debugging contract.
 
 ---
 

--- a/projects/agenticos/mcp-server/src/utils/__tests__/bootstrap-matrix.test.ts
+++ b/projects/agenticos/mcp-server/src/utils/__tests__/bootstrap-matrix.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtemp, mkdir, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import yaml from 'yaml';
+import {
+  getBootstrapAgent,
+  loadAgentBootstrapMatrix,
+} from '../bootstrap-matrix.js';
+
+async function setupBootstrapHome(): Promise<string> {
+  const home = await mkdtemp(join(tmpdir(), 'agenticos-bootstrap-matrix-'));
+  const bootstrapDir = join(home, 'projects', 'agenticos', '.meta', 'bootstrap');
+  await mkdir(bootstrapDir, { recursive: true });
+  await writeFile(
+    join(bootstrapDir, 'agent-bootstrap-matrix.yaml'),
+    yaml.stringify({
+      version: 1,
+      primary_integration_mode: 'mcp-native',
+      supported_agents: [
+        {
+          id: 'claude-code',
+          label: 'Claude Code',
+          support_tier: 'official',
+          transport: 'stdio',
+          canonical_bootstrap_method: 'cli-command',
+          canonical_config_location: 'managed',
+          bootstrap_command: 'claude mcp add --transport stdio --scope user agenticos -- agenticos-mcp',
+          verification: ['claude mcp list'],
+          transport_debug: ['transport'],
+          routing_debug: ['routing'],
+        },
+      ],
+      experimental_agents: [
+        {
+          id: 'generic-mcp-tool',
+          label: 'Generic',
+          support_tier: 'experimental',
+          transport: 'varies',
+          canonical_bootstrap_method: 'manual',
+          canonical_config_location: 'tool-specific',
+          verification: ['manual verify'],
+          transport_debug: ['transport'],
+          routing_debug: ['routing'],
+        },
+      ],
+    }),
+    'utf-8',
+  );
+  return home;
+}
+
+async function setupBootstrapHomeWithoutExperimental(): Promise<string> {
+  const home = await mkdtemp(join(tmpdir(), 'agenticos-bootstrap-matrix-no-exp-'));
+  const bootstrapDir = join(home, 'projects', 'agenticos', '.meta', 'bootstrap');
+  await mkdir(bootstrapDir, { recursive: true });
+  await writeFile(
+    join(bootstrapDir, 'agent-bootstrap-matrix.yaml'),
+    yaml.stringify({
+      version: 1,
+      primary_integration_mode: 'mcp-native',
+      supported_agents: [
+        {
+          id: 'codex',
+          label: 'Codex',
+          support_tier: 'official',
+          transport: 'stdio',
+          canonical_bootstrap_method: 'cli-command',
+          canonical_config_location: 'managed',
+          verification: ['codex mcp list'],
+          transport_debug: ['transport'],
+          routing_debug: ['routing'],
+        },
+      ],
+    }),
+    'utf-8',
+  );
+  return home;
+}
+
+describe('bootstrap matrix', () => {
+  afterEach(() => {
+    delete process.env.AGENTICOS_HOME;
+  });
+
+  it('loads the canonical bootstrap matrix from AGENTICOS_HOME', async () => {
+    const home = await setupBootstrapHome();
+    process.env.AGENTICOS_HOME = home;
+
+    const matrix = await loadAgentBootstrapMatrix();
+
+    expect(matrix.version).toBe(1);
+    expect(matrix.primary_integration_mode).toBe('mcp-native');
+    expect(matrix.supported_agents.map((agent) => agent.id)).toEqual(['claude-code']);
+  });
+
+  it('returns both official and experimental agents by id', async () => {
+    const home = await setupBootstrapHome();
+    process.env.AGENTICOS_HOME = home;
+
+    const matrix = await loadAgentBootstrapMatrix();
+
+    expect(getBootstrapAgent(matrix, 'claude-code').support_tier).toBe('official');
+    expect(getBootstrapAgent(matrix, 'generic-mcp-tool').support_tier).toBe('experimental');
+  });
+
+  it('fails closed for unknown agent ids', async () => {
+    const home = await setupBootstrapHome();
+    process.env.AGENTICOS_HOME = home;
+
+    const matrix = await loadAgentBootstrapMatrix();
+
+    expect(() => getBootstrapAgent(matrix, 'missing-agent')).toThrow(
+      'Unknown bootstrap agent "missing-agent".',
+    );
+  });
+
+  it('still resolves official agents when experimental agents are omitted', async () => {
+    const home = await setupBootstrapHomeWithoutExperimental();
+    process.env.AGENTICOS_HOME = home;
+
+    const matrix = await loadAgentBootstrapMatrix();
+
+    expect(getBootstrapAgent(matrix, 'codex').label).toBe('Codex');
+  });
+});

--- a/projects/agenticos/mcp-server/src/utils/bootstrap-matrix.ts
+++ b/projects/agenticos/mcp-server/src/utils/bootstrap-matrix.ts
@@ -1,0 +1,52 @@
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+import yaml from 'yaml';
+import { getAgenticOSHome } from './registry.js';
+
+export interface AgentBootstrapEntry {
+  id: string;
+  label: string;
+  support_tier: 'official' | 'experimental';
+  transport: string;
+  canonical_bootstrap_method: string;
+  canonical_config_location: string;
+  bootstrap_command?: string;
+  bootstrap_snippet?: string;
+  verification: string[];
+  transport_debug: string[];
+  routing_debug: string[];
+}
+
+export interface AgentBootstrapMatrix {
+  version: number;
+  primary_integration_mode: string;
+  supported_agents: AgentBootstrapEntry[];
+  experimental_agents?: AgentBootstrapEntry[];
+}
+
+export async function loadAgentBootstrapMatrix(): Promise<AgentBootstrapMatrix> {
+  const matrixPath = join(
+    getAgenticOSHome(),
+    'projects',
+    'agenticos',
+    '.meta',
+    'bootstrap',
+    'agent-bootstrap-matrix.yaml',
+  );
+  const content = await readFile(matrixPath, 'utf-8');
+  return yaml.parse(content) as AgentBootstrapMatrix;
+}
+
+export function getBootstrapAgent(
+  matrix: AgentBootstrapMatrix,
+  agentId: string,
+): AgentBootstrapEntry {
+  const match = [...matrix.supported_agents, ...(matrix.experimental_agents || [])]
+    .find((agent) => agent.id === agentId);
+
+  if (!match) {
+    throw new Error(`Unknown bootstrap agent "${agentId}".`);
+  }
+
+  return match;
+}

--- a/projects/agenticos/standards/.context/quick-start.md
+++ b/projects/agenticos/standards/.context/quick-start.md
@@ -49,6 +49,10 @@ Its job is to define and evolve:
 - issue `#28` now defines the canonical sub-agent inheritance packet and verification echo requirements for delegated non-trivial work
 - `knowledge/sub-agent-inheritance-protocol-2026-03-25.md` records the protocol itself
 - `knowledge/sub-agent-inheritance-implementation-report-2026-03-25.md` records the template, standards-doc, and standard-kit adoption changes
+- issue `#29` now defines the canonical per-agent bootstrap standard for Claude Code, Codex, Cursor, and Gemini CLI
+- `projects/agenticos/.meta/bootstrap/agent-bootstrap-matrix.yaml` is now the machine-readable source of truth for supported-agent bootstrap
+- `knowledge/per-agent-bootstrap-standard-2026-03-25.md` records the transport-vs-routing contract and official support surface
+- `knowledge/per-agent-bootstrap-standard-implementation-report-2026-03-25.md` records the landed matrix, parser, and docs alignment work
 
 ## Recommended Entry Documents
 
@@ -73,11 +77,13 @@ Start here:
 17. `knowledge/memory-layer-contract-implementation-report-2026-03-25.md`
 18. `knowledge/sub-agent-inheritance-protocol-2026-03-25.md`
 19. `knowledge/sub-agent-inheritance-implementation-report-2026-03-25.md`
+20. `knowledge/per-agent-bootstrap-standard-2026-03-25.md`
+21. `knowledge/per-agent-bootstrap-standard-implementation-report-2026-03-25.md`
 
 ## Next Steps
 
 1. Use the reconciled open backlog, not the pre-self-hosting issue list, as the canonical remaining work queue
 2. Treat `/Users/jeking/dev/AgenticOS` as the trusted local canonical checkout again; use isolated worktrees for changes
-3. Continue with the remaining core backlog: `#29`, `#30`, `#31`
+3. Continue with the remaining core backlog: `#30`, `#31`
 4. Decide whether any additional entry surfaces need the same compact guardrail summary beyond `agenticos_status` and `agenticos_switch`
 5. Only open a new selective-merge issue if one specific archived artifact is later proven to fill a real canonical gap

--- a/projects/agenticos/standards/.context/state.yaml
+++ b/projects/agenticos/standards/.context/state.yaml
@@ -5,9 +5,9 @@ session:
   last_backup: 2026-03-23T10:35:00.000Z
 
 current_task:
-  title: define and land the canonical sub-agent inheritance and verification protocol
+  title: define the per-agent bootstrap standard and canonical support matrix
   status: implemented
-  updated: 2026-03-25T02:10:00.000Z
+  updated: 2026-03-25T03:10:00.000Z
 
 working_memory:
   facts:
@@ -61,6 +61,9 @@ working_memory:
     - issue #28 now freezes a canonical sub-agent inheritance packet and required verification echo for delegated non-trivial work
     - the downstream standard kit now includes tasks/templates/sub-agent-handoff.md and surfaces delegated-work expectations in the adoption checklist
     - issue-design-brief.md and submission-evidence.md now contain explicit sub-agent inheritance and verification sections
+    - issue #29 now freezes one canonical bootstrap matrix for Claude Code, Codex, Cursor, and Gemini CLI
+    - bootstrap docs now distinguish MCP transport registration from project-intent routing behavior
+    - the machine-readable bootstrap source of truth now lives at projects/agenticos/.meta/bootstrap/agent-bootstrap-matrix.yaml
   decisions:
     - keep one main AgenticOS product repository and one canonical standards area inside it
     - merge durable standards knowledge into the main repo, but archive raw standalone context/history instead of treating it as live state
@@ -77,9 +80,9 @@ working_memory:
     - project-boundary enforcement should centralize identity proof in one shared resolver rather than duplicate weaker checks in record/save/context
     - memory-layer enforcement should start by freezing canonical contracts in standards and templates before attempting broader runtime linting
     - sub-agent inheritance should land first as a standard-kit-backed protocol and template contract before any deeper runtime automation
+    - per-agent bootstrap should land as one canonical matrix plus aligned docs, while Homebrew caveats and fallback-mode strategy remain separate follow-up issues
   pending:
     - decide whether any entry surfaces beyond `agenticos_status` and `agenticos_switch` need the same compact guardrail summary
-    - implement issue #29 to define per-agent bootstrap standards
     - implement issue #30 to define Homebrew post-install bootstrap for supported agents
     - implement issue #31 to define the MCP-native vs CLI+Skills integration matrix
 
@@ -107,3 +110,5 @@ loaded_context:
   - knowledge/memory-layer-contract-implementation-report-2026-03-25.md
   - knowledge/sub-agent-inheritance-protocol-2026-03-25.md
   - knowledge/sub-agent-inheritance-implementation-report-2026-03-25.md
+  - knowledge/per-agent-bootstrap-standard-2026-03-25.md
+  - knowledge/per-agent-bootstrap-standard-implementation-report-2026-03-25.md

--- a/projects/agenticos/standards/knowledge/per-agent-bootstrap-standard-2026-03-25.md
+++ b/projects/agenticos/standards/knowledge/per-agent-bootstrap-standard-2026-03-25.md
@@ -1,0 +1,67 @@
+# Per-Agent Bootstrap Standard - 2026-03-25
+
+## Design Reflection
+
+Issue `#29` is not about whether AgenticOS should support many agents.
+
+That product direction is already set.
+
+The actual gap is that bootstrap behavior was being described in several places with different supported-agent sets, different config assumptions, and no clean separation between:
+
+1. **MCP transport availability**
+2. **project-intent routing behavior**
+
+Without that split, failures get misdiagnosed:
+
+- a missing MCP registration looks like a routing problem
+- weak natural-language triggering looks like an install problem
+- outdated config examples create fake incompatibility between agents
+
+The adopted design is:
+
+- freeze one canonical machine-readable agent bootstrap matrix
+- align the root README and MCP server README to that matrix
+- define verification and debug steps per agent
+- keep Homebrew caveats for issue `#30`
+- keep fallback-mode product choices for issue `#31`
+
+## Canonical Supported Agents
+
+Officially covered in this issue:
+
+1. Claude Code
+2. Codex
+3. Cursor
+4. Gemini CLI
+
+All other MCP-capable tools remain experimental unless they have the same level of bootstrap, verification, and debugging documentation.
+
+## Required Per-Agent Contract
+
+For each officially supported agent, the standard must define:
+
+1. canonical bootstrap method
+2. canonical config location or CLI-managed config surface
+3. mandatory restart expectation if applicable
+4. mandatory verification steps
+5. transport-debug steps
+6. routing-debug steps
+
+## Transport vs Routing
+
+This issue freezes one important product rule:
+
+- **transport bootstrap** means `agenticos` is registered and callable
+- **routing** means the agent actually chooses or suggests the right `agenticos_*` tools at the right time
+
+Transport success does not prove routing quality.
+
+That distinction must appear in every canonical bootstrap document.
+
+## Canonical Source of Truth
+
+The machine-readable source of truth is:
+
+- `projects/agenticos/.meta/bootstrap/agent-bootstrap-matrix.yaml`
+
+Human-facing summaries should align to it rather than inventing separate support lists.

--- a/projects/agenticos/standards/knowledge/per-agent-bootstrap-standard-implementation-report-2026-03-25.md
+++ b/projects/agenticos/standards/knowledge/per-agent-bootstrap-standard-implementation-report-2026-03-25.md
@@ -1,0 +1,50 @@
+# Per-Agent Bootstrap Standard Implementation Report - 2026-03-25
+
+## Scope
+
+Issue `#29` lands the per-agent bootstrap standard in three places:
+
+1. a machine-readable bootstrap matrix
+2. canonical human-facing bootstrap docs
+3. a small parser test to keep the matrix loadable and queryable
+
+## Landed Changes
+
+### Canonical Matrix
+
+- added `.meta/bootstrap/agent-bootstrap-matrix.yaml`
+
+### Parser and Verification Harness
+
+- added `mcp-server/src/utils/bootstrap-matrix.ts`
+- added `mcp-server/src/utils/__tests__/bootstrap-matrix.test.ts`
+
+### Canonical Docs
+
+- updated root `README.md`
+- updated `projects/agenticos/mcp-server/README.md`
+- added `knowledge/per-agent-bootstrap-standard-2026-03-25.md`
+
+## Why This Design
+
+The issue could have been solved with prose only.
+
+That was rejected because the support matrix would drift again.
+
+Using one machine-readable matrix gives later issues a stable base:
+
+- `#30` can map Homebrew caveats to the same supported agents
+- `#31` can compare MCP-native versus fallback modes against the same support surface
+
+## Verification
+
+- `npm install`
+- `npm run build`
+- `npm test -- --run src/utils/__tests__/bootstrap-matrix.test.ts`
+- targeted coverage for `src/utils/bootstrap-matrix.ts`
+- `npm test`
+- YAML parsing for `.meta/bootstrap/agent-bootstrap-matrix.yaml`
+
+## Outcome
+
+Agent bootstrap is now described as a canonical support contract instead of a scattered set of installation hints.


### PR DESCRIPTION
## Summary
- freeze a canonical per-agent bootstrap matrix for Claude Code, Codex, Cursor, and Gemini CLI
- align the root README and MCP server README to the same supported-agent contract
- add a parser test so the bootstrap matrix stays loadable and queryable

## Design Reflection
- kept this issue focused on the supported-agent bootstrap contract, not Homebrew caveats or fallback-mode product strategy
- split MCP transport bootstrap from project-intent routing so failures can be debugged without guessing
- chose a machine-readable matrix as the canonical source to reduce future doc drift across install surfaces

## Verification
- npm install
- npm run build
- npm test -- --run src/utils/__tests__/bootstrap-matrix.test.ts
- npx vitest run --coverage.enabled true --coverage.provider=v8 --coverage.reporter=text --coverage.include=src/utils/bootstrap-matrix.ts src/utils/__tests__/bootstrap-matrix.test.ts
- npm test
- ruby -e 'require "yaml"; YAML.load_file(ARGV[0]); puts "bootstrap matrix ok"' projects/agenticos/.meta/bootstrap/agent-bootstrap-matrix.yaml
- ruby -e 'require "yaml"; YAML.load_file(ARGV[0]); puts "state ok"' projects/agenticos/standards/.context/state.yaml
- python3 doc consistency check for Claude Code / Codex / Cursor / Gemini CLI across README surfaces

## Coverage
- src/utils/bootstrap-matrix.ts: 100 statements / 100 branches / 100 functions / 100 lines