### PR TITLE
feat(meta): define Homebrew post-install contract (#30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,19 @@ brew tap madlouse/agenticos
 brew install agenticos
 ```
 
+Homebrew installs:
+
+- the `agenticos-mcp` binary
+- a seed workspace directory under Homebrew `var`
+
+Homebrew does **not**:
+
+- edit Claude Code, Codex, Cursor, or Gemini CLI configuration for you
+- restart your AI tool
+- prove activation by itself
+
+After `brew install`, bootstrap one supported agent below, restart it, and verify `agenticos_list` explicitly.
+
 ### Option B — Manual install (from GitHub Releases)
 
 ```bash

--- a/projects/agenticos/homebrew-tap/Formula/agenticos.rb
+++ b/projects/agenticos/homebrew-tap/Formula/agenticos.rb
@@ -1,5 +1,5 @@
 class Agenticos < Formula
-  desc "AI-native project management MCP server for Claude Code, Cursor, and Codex"
+  desc "AI-native project management MCP server for Claude Code, Codex, Cursor, and Gemini CLI"
   homepage "https://github.com/madlouse/AgenticOS"
   url "https://github.com/madlouse/AgenticOS/releases/download/v0.2.1/agenticos-mcp.tgz"
   sha256 "f87d5e1a14442ac327f474a133cfafca32e6dd418cc48ab26e4f71fee72d501e"
@@ -17,26 +17,39 @@ class Agenticos < Formula
   end
 
   def post_install
-    # Print setup instructions
     ohai "AgenticOS installed!"
-    ohai "Workspace: #{var}/agenticos"
+    ohai "Installed:"
+    ohai "  - agenticos-mcp"
+    ohai "  - workspace seed at #{var}/agenticos/.agent-workspace"
     ohai ""
-    ohai "Add to your shell profile (~/.zshrc or ~/.bashrc):"
+    ohai "Homebrew does not edit Claude Code, Codex, Cursor, or Gemini CLI configs for you."
+    ohai "Choose a supported agent bootstrap path, restart the tool, then verify with agenticos_list."
+    ohai ""
+    ohai "Recommended workspace override:"
     ohai "  export AGENTICOS_HOME=#{var}/agenticos"
-    ohai ""
-    ohai "Then add to your AI tool's MCP config:"
-    ohai '  { "command": "agenticos-mcp", "args": [] }'
   end
 
   def caveats
     <<~EOS
-      AgenticOS MCP server has been installed.
+      AgenticOS has been installed.
 
-      1. Set your workspace location (add to ~/.zshrc or ~/.bashrc):
+      Homebrew installs the binary and a seed workspace. It does not edit AI tool configs,
+      restart the tool, or prove activation automatically.
+
+      1. Set your workspace location (add to ~/.zshrc or ~/.bashrc) if you want to use the
+         Homebrew-managed workspace seed:
            export AGENTICOS_HOME="#{var}/agenticos"
-         Or use the default: ~/AgenticOS
+         Otherwise leave AGENTICOS_HOME unset and use the product default: ~/AgenticOS
 
-      2. Add to your Claude Code MCP config (~/.claude/settings/mcp.json):
+      2. Bootstrap one officially supported agent:
+
+         Claude Code
+           claude mcp add --transport stdio --scope user agenticos -- agenticos-mcp
+
+         Codex
+           codex mcp add agenticos -- agenticos-mcp
+
+         Cursor (~/.cursor/mcp.json)
            {
              "mcpServers": {
                "agenticos": {
@@ -46,7 +59,17 @@ class Agenticos < Formula
              }
            }
 
-      3. Restart your AI tool to activate.
+         Gemini CLI
+           gemini mcp add -s user agenticos agenticos-mcp
+
+      3. Restart the AI tool.
+
+      4. Verify activation by confirming the server is listed in the tool's MCP diagnostics
+         and by explicitly calling agenticos_list.
+
+      5. Product policy: Homebrew is reminder-only today.
+         It does not mutate user agent configs by default.
+         A future opt-in bootstrap helper may be added later, but silent config mutation is out of scope.
     EOS
   end
 

--- a/projects/agenticos/homebrew-tap/README.md
+++ b/projects/agenticos/homebrew-tap/README.md
@@ -11,13 +11,36 @@ brew install agenticos
 
 ## Usage
 
-After installation, set your workspace and configure your AI tool:
+Homebrew installs:
+
+- the `agenticos-mcp` binary
+- a seed workspace at Homebrew `var`
+
+Homebrew does **not**:
+
+- edit Claude Code, Codex, Cursor, or Gemini CLI configuration automatically
+- restart your AI tool
+- verify activation for you
+
+After installation, set your workspace if needed, bootstrap one officially supported agent, restart it, and verify `agenticos_list`:
 
 ```bash
 # Optional: customize workspace location
-export AGENTICOS_HOME="$HOME/AgenticOS"   # default
+export AGENTICOS_HOME="$(brew --prefix)/var/agenticos"
 
-# Add to MCP config (~/.claude/settings/mcp.json)
+# Claude Code
+claude mcp add --transport stdio --scope user agenticos -- agenticos-mcp
+
+# Codex
+codex mcp add agenticos -- agenticos-mcp
+
+# Gemini CLI
+gemini mcp add -s user agenticos agenticos-mcp
+```
+
+For Cursor, add this to `~/.cursor/mcp.json`:
+
+```json
 {
   "mcpServers": {
     "agenticos": {
@@ -27,6 +50,10 @@ export AGENTICOS_HOME="$HOME/AgenticOS"   # default
   }
 }
 ```
+
+Then restart the AI tool and confirm `agenticos_list` works.
+
+Homebrew policy is reminder-only today. It does not silently mutate user agent configs.
 
 ## Upgrade
 

--- a/projects/agenticos/mcp-server/README.md
+++ b/projects/agenticos/mcp-server/README.md
@@ -20,6 +20,17 @@ A project management system designed for AI collaboration. When you work on comp
 
 Install AgenticOS, bootstrap one supported agent, restart that agent, then explicitly verify `agenticos_list` works before relying on project-intent routing.
 
+### Homebrew Post-Install Contract
+
+If the user installed AgenticOS with Homebrew:
+
+- Homebrew installs the binary and a seed workspace
+- Homebrew does **not** edit Claude Code, Codex, Cursor, or Gemini CLI configuration
+- Homebrew does **not** restart the AI tool
+- Homebrew does **not** prove activation by itself
+
+So post-install success only means the package landed. It does not mean the agent is already bootstrapped.
+
 ### When to Use
 
 AgenticOS is ideal for:

--- a/projects/agenticos/mcp-server/src/utils/__tests__/bootstrap-matrix.test.ts
+++ b/projects/agenticos/mcp-server/src/utils/__tests__/bootstrap-matrix.test.ts
@@ -5,6 +5,7 @@ import { join } from 'path';
 import yaml from 'yaml';
 import {
   getBootstrapAgent,
+  getOfficialBootstrapAgents,
   loadAgentBootstrapMatrix,
 } from '../bootstrap-matrix.js';
 
@@ -122,5 +123,14 @@ describe('bootstrap matrix', () => {
     const matrix = await loadAgentBootstrapMatrix();
 
     expect(getBootstrapAgent(matrix, 'codex').label).toBe('Codex');
+  });
+
+  it('returns only official supported agents for Homebrew-facing messaging', async () => {
+    const home = await setupBootstrapHome();
+    process.env.AGENTICOS_HOME = home;
+
+    const matrix = await loadAgentBootstrapMatrix();
+
+    expect(getOfficialBootstrapAgents(matrix).map((agent) => agent.id)).toEqual(['claude-code']);
   });
 });

--- a/projects/agenticos/mcp-server/src/utils/__tests__/homebrew-bootstrap-docs.test.ts
+++ b/projects/agenticos/mcp-server/src/utils/__tests__/homebrew-bootstrap-docs.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { readFile } from 'fs/promises';
+import { resolve } from 'path';
+import {
+  getOfficialBootstrapAgents,
+  loadAgentBootstrapMatrix,
+} from '../bootstrap-matrix.js';
+
+function repoRoot(): string {
+  return resolve(process.cwd(), '..', '..', '..');
+}
+
+function normalizeDoc(text: string): string {
+  return text.toLowerCase().replace(/[`*]/g, '');
+}
+
+describe('homebrew bootstrap docs', () => {
+  afterEach(() => {
+    delete process.env.AGENTICOS_HOME;
+  });
+
+  it('keeps the Homebrew-facing docs aligned with the official supported agents and manual bootstrap contract', async () => {
+    const root = repoRoot();
+    process.env.AGENTICOS_HOME = root;
+
+    const matrix = await loadAgentBootstrapMatrix();
+    const agents = getOfficialBootstrapAgents(matrix).map((agent) => agent.label);
+
+    const rootReadme = await readFile(resolve(root, 'README.md'), 'utf-8');
+    const tapReadme = await readFile(resolve(root, 'projects', 'agenticos', 'homebrew-tap', 'README.md'), 'utf-8');
+    const formula = await readFile(resolve(root, 'projects', 'agenticos', 'homebrew-tap', 'Formula', 'agenticos.rb'), 'utf-8');
+    const mcpReadme = await readFile(resolve(root, 'projects', 'agenticos', 'mcp-server', 'README.md'), 'utf-8');
+
+    for (const agent of agents) {
+      expect(rootReadme).toContain(agent);
+      expect(tapReadme).toContain(agent);
+      expect(formula).toContain(agent);
+      expect(mcpReadme).toContain(agent);
+    }
+
+    for (const doc of [rootReadme, tapReadme, formula, mcpReadme]) {
+      const normalized = normalizeDoc(doc);
+      expect(normalized).toContain('does not');
+      expect(doc).toContain('agenticos_list');
+      expect(normalized).toContain('restart');
+    }
+  });
+});

--- a/projects/agenticos/mcp-server/src/utils/bootstrap-matrix.ts
+++ b/projects/agenticos/mcp-server/src/utils/bootstrap-matrix.ts
@@ -50,3 +50,9 @@ export function getBootstrapAgent(
 
   return match;
 }
+
+export function getOfficialBootstrapAgents(
+  matrix: AgentBootstrapMatrix,
+): AgentBootstrapEntry[] {
+  return matrix.supported_agents.filter((agent) => agent.support_tier === 'official');
+}

--- a/projects/agenticos/standards/.context/quick-start.md
+++ b/projects/agenticos/standards/.context/quick-start.md
@@ -53,6 +53,9 @@ Its job is to define and evolve:
 - `projects/agenticos/.meta/bootstrap/agent-bootstrap-matrix.yaml` is now the machine-readable source of truth for supported-agent bootstrap
 - `knowledge/per-agent-bootstrap-standard-2026-03-25.md` records the transport-vs-routing contract and official support surface
 - `knowledge/per-agent-bootstrap-standard-implementation-report-2026-03-25.md` records the landed matrix, parser, and docs alignment work
+- issue `#30` now defines the Homebrew post-install contract as reminder-only, not automatic agent activation
+- `knowledge/homebrew-post-install-contract-2026-03-25.md` records the product decision for install vs activation
+- `knowledge/homebrew-post-install-implementation-report-2026-03-25.md` records the formula, tap README, root README, and MCP README alignment work
 
 ## Recommended Entry Documents
 
@@ -79,11 +82,13 @@ Start here:
 19. `knowledge/sub-agent-inheritance-implementation-report-2026-03-25.md`
 20. `knowledge/per-agent-bootstrap-standard-2026-03-25.md`
 21. `knowledge/per-agent-bootstrap-standard-implementation-report-2026-03-25.md`
+22. `knowledge/homebrew-post-install-contract-2026-03-25.md`
+23. `knowledge/homebrew-post-install-implementation-report-2026-03-25.md`
 
 ## Next Steps
 
 1. Use the reconciled open backlog, not the pre-self-hosting issue list, as the canonical remaining work queue
 2. Treat `/Users/jeking/dev/AgenticOS` as the trusted local canonical checkout again; use isolated worktrees for changes
-3. Continue with the remaining core backlog: `#30`, `#31`
+3. Continue with the remaining core backlog: `#31`
 4. Decide whether any additional entry surfaces need the same compact guardrail summary beyond `agenticos_status` and `agenticos_switch`
 5. Only open a new selective-merge issue if one specific archived artifact is later proven to fill a real canonical gap

--- a/projects/agenticos/standards/.context/state.yaml
+++ b/projects/agenticos/standards/.context/state.yaml
@@ -5,9 +5,9 @@ session:
   last_backup: 2026-03-23T10:35:00.000Z
 
 current_task:
-  title: define the per-agent bootstrap standard and canonical support matrix
+  title: define the Homebrew post-install bootstrap contract for supported agents
   status: implemented
-  updated: 2026-03-25T03:10:00.000Z
+  updated: 2026-03-25T03:40:00.000Z
 
 working_memory:
   facts:
@@ -64,6 +64,9 @@ working_memory:
     - issue #29 now freezes one canonical bootstrap matrix for Claude Code, Codex, Cursor, and Gemini CLI
     - bootstrap docs now distinguish MCP transport registration from project-intent routing behavior
     - the machine-readable bootstrap source of truth now lives at projects/agenticos/.meta/bootstrap/agent-bootstrap-matrix.yaml
+    - issue #30 now freezes Homebrew as a reminder-only post-install surface rather than automatic agent activation
+    - Homebrew-facing docs now say installation does not edit agent configs, restart tools, or prove activation
+    - a docs consistency test now checks root README, tap README, formula, and MCP README against the official supported agent set
   decisions:
     - keep one main AgenticOS product repository and one canonical standards area inside it
     - merge durable standards knowledge into the main repo, but archive raw standalone context/history instead of treating it as live state
@@ -81,9 +84,9 @@ working_memory:
     - memory-layer enforcement should start by freezing canonical contracts in standards and templates before attempting broader runtime linting
     - sub-agent inheritance should land first as a standard-kit-backed protocol and template contract before any deeper runtime automation
     - per-agent bootstrap should land as one canonical matrix plus aligned docs, while Homebrew caveats and fallback-mode strategy remain separate follow-up issues
+    - Homebrew post-install should remain reminder-only until an explicit opt-in bootstrap helper exists
   pending:
     - decide whether any entry surfaces beyond `agenticos_status` and `agenticos_switch` need the same compact guardrail summary
-    - implement issue #30 to define Homebrew post-install bootstrap for supported agents
     - implement issue #31 to define the MCP-native vs CLI+Skills integration matrix
 
 loaded_context:
@@ -112,3 +115,5 @@ loaded_context:
   - knowledge/sub-agent-inheritance-implementation-report-2026-03-25.md
   - knowledge/per-agent-bootstrap-standard-2026-03-25.md
   - knowledge/per-agent-bootstrap-standard-implementation-report-2026-03-25.md
+  - knowledge/homebrew-post-install-contract-2026-03-25.md
+  - knowledge/homebrew-post-install-implementation-report-2026-03-25.md

--- a/projects/agenticos/standards/knowledge/homebrew-post-install-contract-2026-03-25.md
+++ b/projects/agenticos/standards/knowledge/homebrew-post-install-contract-2026-03-25.md
@@ -1,0 +1,28 @@
+# Homebrew Post-Install Contract - 2026-03-25
+
+## Design Reflection
+
+Issue `#30` is not about adding more installation channels.
+
+It is about preventing one misleading product state:
+
+- **package installed**
+- but **agent not actually bootstrapped**
+
+The design problem was inconsistency across the four Homebrew-facing surfaces:
+
+1. root README
+2. tap README
+3. formula `post_install`
+4. formula `caveats`
+
+The adopted decision is:
+
+- Homebrew is **reminder-only** today
+- it installs the package and a seed workspace
+- it does **not** silently mutate user AI tool configs
+- it does **not** claim activation until the user bootstraps a supported agent, restarts it, and verifies `agenticos_list`
+
+This issue intentionally reuses the official supported-agent set frozen in issue `#29`.
+
+It does not redesign fallback integration modes.

--- a/projects/agenticos/standards/knowledge/homebrew-post-install-implementation-report-2026-03-25.md
+++ b/projects/agenticos/standards/knowledge/homebrew-post-install-implementation-report-2026-03-25.md
@@ -1,0 +1,35 @@
+# Homebrew Post-Install Implementation Report - 2026-03-25
+
+## Scope
+
+Issue `#30` aligns the Homebrew-facing install surfaces to one product contract:
+
+- installation is real
+- activation is still manual
+- verification is mandatory
+
+## Landed Changes
+
+- updated root `README.md`
+- updated `projects/agenticos/homebrew-tap/README.md`
+- updated `projects/agenticos/homebrew-tap/Formula/agenticos.rb`
+- updated `projects/agenticos/mcp-server/README.md`
+- added a Homebrew docs consistency test
+
+## Product Decision
+
+Homebrew is reminder-only today.
+
+It does not silently mutate user Claude Code, Codex, Cursor, or Gemini CLI configuration.
+
+Future opt-in bootstrap helpers may exist later, but default install-time config mutation is out of scope.
+
+## Verification
+
+- `npm install`
+- `npm run build`
+- `npm test -- --run src/utils/__tests__/bootstrap-matrix.test.ts src/utils/__tests__/homebrew-bootstrap-docs.test.ts`
+- targeted coverage for `src/utils/bootstrap-matrix.ts`
+- `npm test`
+- YAML parsing for standards state
+- docs consistency test across root README, tap README, formula, and MCP server README


### PR DESCRIPTION
## Summary
- align the root README, tap README, formula caveats, and MCP README to one Homebrew post-install contract
- keep Homebrew reminder-only: install succeeds, but agent bootstrap remains manual and explicitly verified
- add a docs consistency test against the official supported-agent set

## Design Reflection
- kept this issue focused on post-install product behavior instead of redoing the supported-agent matrix or fallback strategy
- made Homebrew explicit about what it installs versus what it does not do
- reused the official supported-agent set from #29 to avoid introducing a second bootstrap source of truth

## Verification
- npm install
- npm run build
- npm test -- --run src/utils/__tests__/bootstrap-matrix.test.ts src/utils/__tests__/homebrew-bootstrap-docs.test.ts
- npx vitest run --coverage.enabled true --coverage.provider=v8 --coverage.reporter=text --coverage.include=src/utils/bootstrap-matrix.ts src/utils/__tests__/bootstrap-matrix.test.ts src/utils/__tests__/homebrew-bootstrap-docs.test.ts
- npm test
- ruby -e 'require "yaml"; YAML.load_file(ARGV[0]); puts "state ok"' projects/agenticos/standards/.context/state.yaml
- python3 docs contract check across root README, tap README, formula, and MCP README

## Coverage
- src/utils/bootstrap-matrix.ts: 100 statements / 100 branches / 100 functions / 100 lines