### PR TITLE
feat(meta): define integration mode matrix (#31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,21 @@ The machine-readable source of truth for this support matrix lives in:
 
 - `projects/agenticos/.meta/bootstrap/agent-bootstrap-matrix.yaml`
 
+## Integration Modes
+
+AgenticOS supports multiple integration modes, but they are not equal:
+
+| Mode | Status | Purpose |
+|------|--------|---------|
+| `MCP-native` | primary | Canonical AgenticOS execution path |
+| `MCP + Skills Assist` | supported fallback | Keep MCP as the execution path but use skills/prompt overlays to improve routing and bootstrap ergonomics |
+| `CLI Wrapper` | limited fallback | Operator diagnostics and temporary bootstrap recovery only |
+| `Skills-only Guidance` | experimental | Research or tool-specific guidance without the canonical MCP surface |
+
+The machine-readable source of truth for this mode decision lives in:
+
+- `projects/agenticos/.meta/bootstrap/integration-mode-matrix.yaml`
+
 ---
 
 ## Quick Start

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,6 +14,7 @@
 - [x] GitHub Releases + Homebrew distribution
 - [x] CI pipeline (TypeScript lint, build, test)
 - [x] Open-source workflow: Issue → Branch → PR
+- [x] Integration mode decision: `MCP-native` primary, `MCP + Skills Assist` supported fallback, `CLI Wrapper` limited fallback, `Skills-only Guidance` experimental
 
 ## v0.3.0 — Next
 

--- a/projects/agenticos/.meta/bootstrap/integration-mode-matrix.yaml
+++ b/projects/agenticos/.meta/bootstrap/integration-mode-matrix.yaml
@@ -1,0 +1,56 @@
+version: 1
+primary_mode: mcp-native
+modes:
+  - id: mcp-native
+    label: MCP-native
+    status: canonical
+    when_to_use: default mode for officially supported agents
+    capabilities:
+      - full AgenticOS MCP tool surface
+      - context resource loading
+      - guardrail flow
+      - standard-kit adoption and upgrade checks
+    limitations:
+      - requires working MCP transport and per-agent bootstrap
+      - requires routing or explicit tool use inside the agent
+    non_goals:
+      - none
+  - id: mcp-plus-skills
+    label: MCP + Skills Assist
+    status: supported-fallback
+    when_to_use: when MCP transport works but routing, prompting, or bootstrap ergonomics need help
+    capabilities:
+      - keeps MCP as the canonical execution path
+      - allows skills or prompt overlays to improve routing and operator guidance
+    limitations:
+      - still depends on MCP for canonical tool execution
+      - adds agent-specific maintenance overhead
+    non_goals:
+      - not a second canonical data plane
+      - not a replacement for MCP-native execution
+  - id: cli-wrapper
+    label: CLI Wrapper
+    status: limited-fallback
+    when_to_use: operator recovery, diagnostics, or temporary bootstrap gaps
+    capabilities:
+      - can help inspect workspace or assist bootstrap
+      - useful when MCP is temporarily unavailable
+    limitations:
+      - no parity guarantee with the MCP tool surface
+      - weaker context/resource ergonomics than MCP
+    non_goals:
+      - not the default downstream integration mode
+      - not a canonical substitute for MCP-native execution
+  - id: skills-only
+    label: Skills-only Guidance
+    status: experimental
+    when_to_use: research or tool-specific experimentation only
+    capabilities:
+      - prompt conventions and routing guidance
+      - installation or debugging instructions
+    limitations:
+      - cannot provide the canonical AgenticOS tool or resource surface
+      - cannot guarantee durable context restore by itself
+    non_goals:
+      - not an officially supported runtime mode
+      - not sufficient for full AgenticOS compatibility

--- a/projects/agenticos/mcp-server/README.md
+++ b/projects/agenticos/mcp-server/README.md
@@ -119,6 +119,15 @@ Transport bootstrap and project-intent routing are different concerns.
 
 These are currently experimental. Do not describe them as first-class supported agents unless they have a documented bootstrap, verification, and debugging contract.
 
+## Integration Modes
+
+AgenticOS does not treat every fallback as equal:
+
+- `MCP-native` is the canonical primary mode
+- `MCP + Skills Assist` is the supported fallback when transport works but routing or operator ergonomics need help
+- `CLI Wrapper` is limited to diagnostics and temporary bootstrap recovery
+- `Skills-only Guidance` is experimental and does not provide the canonical AgenticOS runtime surface
+
 ---
 
 ## 🛠️ Tools Reference

--- a/projects/agenticos/mcp-server/src/utils/__tests__/integration-matrix.test.ts
+++ b/projects/agenticos/mcp-server/src/utils/__tests__/integration-matrix.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtemp, mkdir, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import yaml from 'yaml';
+import {
+  getIntegrationMode,
+  getPrimaryIntegrationMode,
+  loadIntegrationModeMatrix,
+} from '../integration-matrix.js';
+
+async function setupIntegrationHome(): Promise<string> {
+  const home = await mkdtemp(join(tmpdir(), 'agenticos-integration-matrix-'));
+  const bootstrapDir = join(home, 'projects', 'agenticos', '.meta', 'bootstrap');
+  await mkdir(bootstrapDir, { recursive: true });
+  await writeFile(
+    join(bootstrapDir, 'integration-mode-matrix.yaml'),
+    yaml.stringify({
+      version: 1,
+      primary_mode: 'mcp-native',
+      modes: [
+        {
+          id: 'mcp-native',
+          label: 'MCP-native',
+          status: 'canonical',
+          when_to_use: 'default',
+          capabilities: ['full'],
+          limitations: ['bootstrap'],
+          non_goals: ['none'],
+        },
+        {
+          id: 'skills-only',
+          label: 'Skills-only Guidance',
+          status: 'experimental',
+          when_to_use: 'research',
+          capabilities: ['guidance'],
+          limitations: ['no tools'],
+          non_goals: ['not official'],
+        },
+      ],
+    }),
+    'utf-8',
+  );
+  return home;
+}
+
+describe('integration matrix', () => {
+  afterEach(() => {
+    delete process.env.AGENTICOS_HOME;
+  });
+
+  it('loads the integration mode matrix', async () => {
+    const home = await setupIntegrationHome();
+    process.env.AGENTICOS_HOME = home;
+
+    const matrix = await loadIntegrationModeMatrix();
+
+    expect(matrix.version).toBe(1);
+    expect(matrix.primary_mode).toBe('mcp-native');
+    expect(matrix.modes.map((mode) => mode.id)).toEqual(['mcp-native', 'skills-only']);
+  });
+
+  it('returns both primary and non-primary modes', async () => {
+    const home = await setupIntegrationHome();
+    process.env.AGENTICOS_HOME = home;
+
+    const matrix = await loadIntegrationModeMatrix();
+
+    expect(getPrimaryIntegrationMode(matrix).status).toBe('canonical');
+    expect(getIntegrationMode(matrix, 'skills-only').status).toBe('experimental');
+  });
+
+  it('fails closed for unknown mode ids', async () => {
+    const home = await setupIntegrationHome();
+    process.env.AGENTICOS_HOME = home;
+
+    const matrix = await loadIntegrationModeMatrix();
+
+    expect(() => getIntegrationMode(matrix, 'cli-wrapper')).toThrow(
+      'Unknown integration mode "cli-wrapper".',
+    );
+  });
+});

--- a/projects/agenticos/mcp-server/src/utils/__tests__/integration-mode-docs.test.ts
+++ b/projects/agenticos/mcp-server/src/utils/__tests__/integration-mode-docs.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { readFile } from 'fs/promises';
+import { resolve } from 'path';
+import {
+  getPrimaryIntegrationMode,
+  loadIntegrationModeMatrix,
+} from '../integration-matrix.js';
+
+function repoRoot(): string {
+  return resolve(process.cwd(), '..', '..', '..');
+}
+
+describe('integration mode docs', () => {
+  afterEach(() => {
+    delete process.env.AGENTICOS_HOME;
+  });
+
+  it('keeps README, MCP README, and ROADMAP aligned with the primary/fallback decision', async () => {
+    const root = repoRoot();
+    process.env.AGENTICOS_HOME = root;
+
+    const matrix = await loadIntegrationModeMatrix();
+    const primary = getPrimaryIntegrationMode(matrix);
+
+    const rootReadme = await readFile(resolve(root, 'README.md'), 'utf-8');
+    const mcpReadme = await readFile(resolve(root, 'projects', 'agenticos', 'mcp-server', 'README.md'), 'utf-8');
+    const roadmap = await readFile(resolve(root, 'ROADMAP.md'), 'utf-8');
+
+    for (const doc of [rootReadme, mcpReadme, roadmap]) {
+      expect(doc).toContain(primary.label);
+      expect(doc).toContain('CLI Wrapper');
+      expect(doc).toContain('Skills-only Guidance');
+    }
+  });
+});

--- a/projects/agenticos/mcp-server/src/utils/integration-matrix.ts
+++ b/projects/agenticos/mcp-server/src/utils/integration-matrix.ts
@@ -1,0 +1,50 @@
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+import yaml from 'yaml';
+import { getAgenticOSHome } from './registry.js';
+
+export interface IntegrationModeEntry {
+  id: string;
+  label: string;
+  status: 'canonical' | 'supported-fallback' | 'limited-fallback' | 'experimental';
+  when_to_use: string;
+  capabilities: string[];
+  limitations: string[];
+  non_goals: string[];
+}
+
+export interface IntegrationModeMatrix {
+  version: number;
+  primary_mode: string;
+  modes: IntegrationModeEntry[];
+}
+
+export async function loadIntegrationModeMatrix(): Promise<IntegrationModeMatrix> {
+  const matrixPath = join(
+    getAgenticOSHome(),
+    'projects',
+    'agenticos',
+    '.meta',
+    'bootstrap',
+    'integration-mode-matrix.yaml',
+  );
+  const content = await readFile(matrixPath, 'utf-8');
+  return yaml.parse(content) as IntegrationModeMatrix;
+}
+
+export function getIntegrationMode(
+  matrix: IntegrationModeMatrix,
+  modeId: string,
+): IntegrationModeEntry {
+  const match = matrix.modes.find((mode) => mode.id === modeId);
+  if (!match) {
+    throw new Error(`Unknown integration mode "${modeId}".`);
+  }
+  return match;
+}
+
+export function getPrimaryIntegrationMode(
+  matrix: IntegrationModeMatrix,
+): IntegrationModeEntry {
+  return getIntegrationMode(matrix, matrix.primary_mode);
+}

--- a/projects/agenticos/standards/.context/quick-start.md
+++ b/projects/agenticos/standards/.context/quick-start.md
@@ -56,6 +56,10 @@ Its job is to define and evolve:
 - issue `#30` now defines the Homebrew post-install contract as reminder-only, not automatic agent activation
 - `knowledge/homebrew-post-install-contract-2026-03-25.md` records the product decision for install vs activation
 - `knowledge/homebrew-post-install-implementation-report-2026-03-25.md` records the formula, tap README, root README, and MCP README alignment work
+- issue `#31` now defines the canonical integration mode matrix for MCP-native, MCP + Skills Assist, CLI Wrapper, and Skills-only Guidance
+- `projects/agenticos/.meta/bootstrap/integration-mode-matrix.yaml` is now the machine-readable source of truth for primary vs fallback integration modes
+- `knowledge/integration-mode-matrix-2026-03-25.md` records the product decision for primary and fallback modes
+- `knowledge/integration-mode-matrix-implementation-report-2026-03-25.md` records the parser, docs, and roadmap alignment work
 
 ## Recommended Entry Documents
 
@@ -84,11 +88,13 @@ Start here:
 21. `knowledge/per-agent-bootstrap-standard-implementation-report-2026-03-25.md`
 22. `knowledge/homebrew-post-install-contract-2026-03-25.md`
 23. `knowledge/homebrew-post-install-implementation-report-2026-03-25.md`
+24. `knowledge/integration-mode-matrix-2026-03-25.md`
+25. `knowledge/integration-mode-matrix-implementation-report-2026-03-25.md`
 
 ## Next Steps
 
 1. Use the reconciled open backlog, not the pre-self-hosting issue list, as the canonical remaining work queue
 2. Treat `/Users/jeking/dev/AgenticOS` as the trusted local canonical checkout again; use isolated worktrees for changes
-3. Continue with the remaining core backlog: `#31`
+3. Reassess the remaining backlog now that `#28` through `#31` are all frozen into canonical standards
 4. Decide whether any additional entry surfaces need the same compact guardrail summary beyond `agenticos_status` and `agenticos_switch`
 5. Only open a new selective-merge issue if one specific archived artifact is later proven to fill a real canonical gap

--- a/projects/agenticos/standards/.context/state.yaml
+++ b/projects/agenticos/standards/.context/state.yaml
@@ -5,9 +5,9 @@ session:
   last_backup: 2026-03-23T10:35:00.000Z
 
 current_task:
-  title: define the Homebrew post-install bootstrap contract for supported agents
+  title: define the integration mode matrix and primary vs fallback product decision
   status: implemented
-  updated: 2026-03-25T03:40:00.000Z
+  updated: 2026-03-25T04:20:00.000Z
 
 working_memory:
   facts:
@@ -67,6 +67,9 @@ working_memory:
     - issue #30 now freezes Homebrew as a reminder-only post-install surface rather than automatic agent activation
     - Homebrew-facing docs now say installation does not edit agent configs, restart tools, or prove activation
     - a docs consistency test now checks root README, tap README, formula, and MCP README against the official supported agent set
+    - issue #31 now freezes a canonical integration mode matrix with MCP-native as the primary mode
+    - the product now distinguishes MCP plus Skills Assist as a supported fallback, CLI Wrapper as a limited fallback, and Skills-only Guidance as experimental
+    - README, MCP README, and ROADMAP now reflect the same primary/fallback decision
   decisions:
     - keep one main AgenticOS product repository and one canonical standards area inside it
     - merge durable standards knowledge into the main repo, but archive raw standalone context/history instead of treating it as live state
@@ -85,9 +88,9 @@ working_memory:
     - sub-agent inheritance should land first as a standard-kit-backed protocol and template contract before any deeper runtime automation
     - per-agent bootstrap should land as one canonical matrix plus aligned docs, while Homebrew caveats and fallback-mode strategy remain separate follow-up issues
     - Homebrew post-install should remain reminder-only until an explicit opt-in bootstrap helper exists
+    - fallback integration modes must be documented as narrower than MCP-native, not as equal parallel runtime modes
   pending:
     - decide whether any entry surfaces beyond `agenticos_status` and `agenticos_switch` need the same compact guardrail summary
-    - implement issue #31 to define the MCP-native vs CLI+Skills integration matrix
 
 loaded_context:
   - .project.yaml
@@ -117,3 +120,5 @@ loaded_context:
   - knowledge/per-agent-bootstrap-standard-implementation-report-2026-03-25.md
   - knowledge/homebrew-post-install-contract-2026-03-25.md
   - knowledge/homebrew-post-install-implementation-report-2026-03-25.md
+  - knowledge/integration-mode-matrix-2026-03-25.md
+  - knowledge/integration-mode-matrix-implementation-report-2026-03-25.md

--- a/projects/agenticos/standards/knowledge/integration-mode-matrix-2026-03-25.md
+++ b/projects/agenticos/standards/knowledge/integration-mode-matrix-2026-03-25.md
@@ -1,0 +1,36 @@
+# Integration Mode Matrix - 2026-03-25
+
+## Design Reflection
+
+Issue `#31` is not asking whether MCP is useful.
+
+That decision is already settled.
+
+The real design problem is how AgenticOS should talk about fallback without accidentally creating multiple canonical product modes.
+
+If the product says "MCP is primary" but also treats CLI wrappers or skills-only flows as equal runtime paths, the operating model becomes self-contradictory.
+
+The adopted decision is:
+
+- **MCP-native** is the only canonical primary mode
+- **MCP + Skills Assist** is a supported fallback for routing and operator ergonomics, not a second data plane
+- **CLI Wrapper** is a limited operator fallback for diagnostics and temporary bootstrap gaps
+- **Skills-only Guidance** remains experimental and is not an officially supported runtime mode
+
+## Canonical Source of Truth
+
+The machine-readable source of truth is:
+
+- `projects/agenticos/.meta/bootstrap/integration-mode-matrix.yaml`
+
+## Product Rule
+
+Fallback exists to reduce operational fragility.
+
+Fallback does not redefine the canonical execution model.
+
+That means:
+
+- durable project state still assumes the MCP-native contract
+- fallback modes must declare narrower scope and explicit non-goals
+- docs and roadmap should describe fallback as limited rather than symmetrical

--- a/projects/agenticos/standards/knowledge/integration-mode-matrix-implementation-report-2026-03-25.md
+++ b/projects/agenticos/standards/knowledge/integration-mode-matrix-implementation-report-2026-03-25.md
@@ -1,0 +1,27 @@
+# Integration Mode Matrix Implementation Report - 2026-03-25
+
+## Scope
+
+Issue `#31` lands the product decision about primary and fallback integration modes.
+
+The landed slice includes:
+
+1. a machine-readable integration mode matrix
+2. a parser and tests
+3. README / MCP README / ROADMAP alignment
+
+## Product Decision
+
+- `MCP-native` is the canonical primary mode
+- `MCP + Skills Assist` is the supported fallback
+- `CLI Wrapper` is a limited operator fallback
+- `Skills-only Guidance` is experimental
+
+## Verification
+
+- `npm install`
+- `npm run build`
+- `npm test -- --run src/utils/__tests__/integration-matrix.test.ts src/utils/__tests__/integration-mode-docs.test.ts`
+- targeted coverage for `src/utils/integration-matrix.ts`
+- `npm test`
+- README / MCP README / ROADMAP consistency through the docs test


### PR DESCRIPTION
## Summary
- freeze a machine-readable integration mode matrix for MCP-native and the fallback modes
- align README, MCP README, and ROADMAP with one primary vs fallback product decision
- add parser and docs consistency tests so the mode decision stays executable

## Design Reflection
- treated this as a product-decision issue, not just a transport implementation note
- kept MCP-native as the only canonical primary mode to avoid creating multiple equal runtime models
- scoped fallback modes narrowly so they reduce operational fragility without redefining the core contract

## Verification
- npm install
- npm run build
- npm test -- --run src/utils/__tests__/integration-matrix.test.ts src/utils/__tests__/integration-mode-docs.test.ts
- npx vitest run --coverage.enabled true --coverage.provider=v8 --coverage.reporter=text --coverage.include=src/utils/integration-matrix.ts src/utils/__tests__/integration-matrix.test.ts src/utils/__tests__/integration-mode-docs.test.ts
- npm test
- ruby -e 'require "yaml"; YAML.load_file(ARGV[0]); puts "integration matrix ok"' projects/agenticos/.meta/bootstrap/integration-mode-matrix.yaml
- ruby -e 'require "yaml"; YAML.load_file(ARGV[0]); puts "state ok"' projects/agenticos/standards/.context/state.yaml
- python3 docs consistency check for README, MCP README, and ROADMAP

## Coverage
- src/utils/integration-matrix.ts: 100 statements / 100 branches / 100 functions / 100 lines