### PR TITLE
test: raise project-boundary coverage to 100 percent (#92)

### DIFF
--- a/projects/agenticos/mcp-server/src/tools/__tests__/record.test.ts
+++ b/projects/agenticos/mcp-server/src/tools/__tests__/record.test.ts
@@ -387,6 +387,31 @@ describe('recordSession', () => {
     }
   });
 
+  it('falls back to empty arrays when JSON-stringified list arguments are invalid', async () => {
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry());
+    mockProjectFiles({
+      state: {
+        session: {},
+        working_memory: { decisions: ['existing'], facts: ['fact'], pending: ['pending'] },
+      },
+    });
+
+    await recordSession({
+      summary: 'test',
+      decisions: 'not-json',
+      outcomes: 'also-not-json',
+      pending: 'broken-json',
+    });
+
+    const writeCalls = fsPromisesMock.writeFile.mock.calls;
+    const stateCall = writeCalls.find((c) => c[0].endsWith('state.yaml'));
+    const writtenState = JSON.parse(stateCall![1] as string);
+
+    expect(writtenState.working_memory.decisions).toEqual(['existing']);
+    expect(writtenState.working_memory.facts).toEqual(['fact']);
+    expect(writtenState.working_memory.pending).toEqual(['pending']);
+  });
+
   it('returns success message with paths', async () => {
     registryMock.loadRegistry.mockResolvedValue(buildRegistry());
     mockProjectFiles({ state: { session: {}, working_memory: { decisions: [], facts: [], pending: [] } } });
@@ -418,6 +443,94 @@ describe('recordSession', () => {
     const result = await recordSession({ summary: 'test session' });
 
     expect(result).toContain('✅ Session recorded');
+  });
+
+  it('creates a new conversation file and default state when conversation and state files do not exist yet', async () => {
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry());
+    fsPromisesMock.readFile.mockImplementation(async (path: string) => {
+      if (path.endsWith('/.project.yaml')) {
+        return JSON.stringify({ meta: { id: 'test-project', name: 'Test Project' } });
+      }
+      if (path.endsWith('/state.yaml')) {
+        throw new Error('missing state');
+      }
+      if (path.includes('/conversations/') && path.endsWith('.md')) {
+        throw new Error('missing conversation');
+      }
+      if (path.endsWith('/quick-start.md')) {
+        return '# Quick Start\n\n1. Define project goals';
+      }
+      return '';
+    });
+
+    const result = await recordSession({
+      summary: 'bootstrapped',
+      current_task: { title: 'Bootstrap project' },
+    });
+
+    const writeCalls = fsPromisesMock.writeFile.mock.calls;
+    const convCall = writeCalls.find((c) => c[0].includes('conversations') && c[0].endsWith('.md'));
+    const stateCall = writeCalls.find((c) => c[0].endsWith('state.yaml'));
+    expect(convCall).toBeDefined();
+    expect(String(convCall![1])).toContain('# Sessions');
+    expect(stateCall).toBeDefined();
+    const writtenState = JSON.parse(stateCall![1] as string);
+    expect(writtenState.working_memory).toEqual({ facts: [], decisions: [], pending: [] });
+    expect(writtenState.session.last_backup).toBeDefined();
+    expect(writtenState.current_task.title).toBe('Bootstrap project');
+    expect(result).toContain('✅ Session recorded');
+  });
+
+  it('falls back to an empty state object when state parsing returns nothing', async () => {
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry());
+    fsPromisesMock.readFile.mockImplementation(async (path: string) => {
+      if (path.endsWith('/.project.yaml')) {
+        return JSON.stringify({ meta: { id: 'test-project', name: 'Test Project' } });
+      }
+      if (path.endsWith('/state.yaml')) {
+        return 'not-json';
+      }
+      if (path.endsWith('/quick-start.md')) {
+        return '# Quick Start\n\n1. Define project goals';
+      }
+      return '';
+    });
+    yamlMock.parse.mockImplementation((content: string) => {
+      if (content === 'not-json') return undefined;
+      try { return JSON.parse(content); } catch { return undefined; }
+    });
+
+    await recordSession({ summary: 'test session' });
+
+    const writeCalls = fsPromisesMock.writeFile.mock.calls;
+    const stateCall = writeCalls.find((c) => c[0].endsWith('state.yaml'));
+    const writtenState = JSON.parse(stateCall![1] as string);
+    expect(writtenState.working_memory).toEqual({ facts: [], decisions: [], pending: [] });
+    expect(writtenState.session.last_backup).toBeDefined();
+  });
+
+  it('falls back to an empty state object when state parsing returns null', async () => {
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry());
+    fsPromisesMock.readFile.mockImplementation(async (path: string) => {
+      if (path.endsWith('/.project.yaml')) {
+        return JSON.stringify({ meta: { id: 'test-project', name: 'Test Project' } });
+      }
+      if (path.endsWith('/state.yaml')) {
+        return 'null';
+      }
+      if (path.endsWith('/quick-start.md')) {
+        return '# Quick Start\n\n1. Define project goals';
+      }
+      return '';
+    });
+
+    await recordSession({ summary: 'test session' });
+
+    const writeCalls = fsPromisesMock.writeFile.mock.calls;
+    const stateCall = writeCalls.find((c) => c[0].endsWith('state.yaml'));
+    const writtenState = JSON.parse(stateCall![1] as string);
+    expect(writtenState.working_memory).toEqual({ facts: [], decisions: [], pending: [] });
+    expect(writtenState.session.last_backup).toBeDefined();
   });
 
   it('only updates last_recorded on the resolved project', async () => {

--- a/projects/agenticos/mcp-server/src/tools/__tests__/save.test.ts
+++ b/projects/agenticos/mcp-server/src/tools/__tests__/save.test.ts
@@ -286,6 +286,87 @@ describe('saveState', () => {
     expect(result).toContain('commit failed');
   });
 
+  it('surfaces git commit failure details from stdout when stderr is empty', async () => {
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry());
+    mockProjectFiles({ state: { session: {} } });
+    childProcessMock.exec.mockImplementation(
+      (cmd: string, cb: (err: Error | null, stdout?: string, stderr?: string) => void) => {
+        if (cmd.includes('rev-parse --show-toplevel')) {
+          cb(null, '/test/path\n', '');
+          return;
+        }
+        if (cmd.includes(' add ')) {
+          cb(null, '', '');
+          return;
+        }
+        if (cmd.includes(' commit ')) {
+          cb(new Error('commit failed'), 'stdout failure details', '');
+          return;
+        }
+        cb(null, '', '');
+      }
+    );
+
+    const result = await saveState({ message: 'test' });
+
+    expect(result).toContain('git commit failed');
+    expect(result).toContain('commit failed');
+  });
+
+  it('surfaces git commit failure details from the error message when stdout and stderr are empty', async () => {
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry());
+    mockProjectFiles({ state: { session: {} } });
+    childProcessMock.exec.mockImplementation(
+      (cmd: string, cb: (err: Error | null, stdout?: string, stderr?: string) => void) => {
+        if (cmd.includes('rev-parse --show-toplevel')) {
+          cb(null, '/test/path\n', '');
+          return;
+        }
+        if (cmd.includes(' add ')) {
+          cb(null, '', '');
+          return;
+        }
+        if (cmd.includes(' commit ')) {
+          cb(new Error('message only failure'), '', '');
+          return;
+        }
+        cb(null, '', '');
+      }
+    );
+
+    const result = await saveState({ message: 'test' });
+
+    expect(result).toContain('git commit failed');
+    expect(result).toContain('message only failure');
+  });
+
+  it('still returns a commit failure when stderr, stdout, and message are all empty', async () => {
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry());
+    mockProjectFiles({ state: { session: {} } });
+    childProcessMock.exec.mockImplementation(
+      (cmd: string, cb: (err: Error | null, stdout?: string, stderr?: string) => void) => {
+        if (cmd.includes('rev-parse --show-toplevel')) {
+          cb(null, '/test/path\n', '');
+          return;
+        }
+        if (cmd.includes(' add ')) {
+          cb(null, '', '');
+          return;
+        }
+        if (cmd.includes(' commit ')) {
+          cb({} as Error, '', '');
+          return;
+        }
+        cb(null, '', '');
+      }
+    );
+
+    const result = await saveState({ message: 'test' });
+
+    expect(result).toContain('git commit failed');
+    expect(result).toContain('Error: undefined');
+  });
+
   it('reports when there is nothing new to commit', async () => {
     registryMock.loadRegistry.mockResolvedValue(buildRegistry());
     mockProjectFiles({ state: { session: {} } });

--- a/projects/agenticos/standards/.context/quick-start.md
+++ b/projects/agenticos/standards/.context/quick-start.md
@@ -60,6 +60,8 @@ Its job is to define and evolve:
 - `projects/agenticos/.meta/bootstrap/integration-mode-matrix.yaml` is now the machine-readable source of truth for primary vs fallback integration modes
 - `knowledge/integration-mode-matrix-2026-03-25.md` records the product decision for primary and fallback modes
 - `knowledge/integration-mode-matrix-implementation-report-2026-03-25.md` records the parser, docs, and roadmap alignment work
+- issue `#92` now closes the last strict-verification gap left after `#25` by raising the touched project-boundary runtime files to full branch coverage
+- `knowledge/project-boundary-coverage-closure-report-2026-03-25.md` records the added fallback-path regression cases and the final `100 / 100 / 100 / 100` targeted coverage result
 
 ## Recommended Entry Documents
 
@@ -90,11 +92,12 @@ Start here:
 23. `knowledge/homebrew-post-install-implementation-report-2026-03-25.md`
 24. `knowledge/integration-mode-matrix-2026-03-25.md`
 25. `knowledge/integration-mode-matrix-implementation-report-2026-03-25.md`
+26. `knowledge/project-boundary-coverage-closure-report-2026-03-25.md`
 
 ## Next Steps
 
 1. Use the reconciled open backlog, not the pre-self-hosting issue list, as the canonical remaining work queue
 2. Treat `/Users/jeking/dev/AgenticOS` as the trusted local canonical checkout again; use isolated worktrees for changes
-3. Reassess the remaining backlog now that `#28` through `#31` are all frozen into canonical standards
+3. Reassess the remaining backlog now that `#25`, `#26`, `#28`, `#29`, `#30`, and `#31` are all frozen and fully verified
 4. Decide whether any additional entry surfaces need the same compact guardrail summary beyond `agenticos_status` and `agenticos_switch`
 5. Only open a new selective-merge issue if one specific archived artifact is later proven to fill a real canonical gap

--- a/projects/agenticos/standards/.context/state.yaml
+++ b/projects/agenticos/standards/.context/state.yaml
@@ -5,9 +5,9 @@ session:
   last_backup: 2026-03-23T10:35:00.000Z
 
 current_task:
-  title: define the integration mode matrix and primary vs fallback product decision
+  title: close the final strict-verification gap after the remaining-six backlog completion
   status: implemented
-  updated: 2026-03-25T04:20:00.000Z
+  updated: 2026-03-25T01:54:00.000Z
 
 working_memory:
   facts:
@@ -70,6 +70,9 @@ working_memory:
     - issue #31 now freezes a canonical integration mode matrix with MCP-native as the primary mode
     - the product now distinguishes MCP plus Skills Assist as a supported fallback, CLI Wrapper as a limited fallback, and Skills-only Guidance as experimental
     - README, MCP README, and ROADMAP now reflect the same primary/fallback decision
+    - issue #92 now closes the last strict-verification gap left after #25 by raising the touched boundary files to full branch coverage
+    - the project-boundary runtime surface now has explicit targeted 100 percent statements, branches, functions, and lines coverage across project-target, context, record, and save
+    - issue #92 verification passed with targeted tests, targeted coverage, npm run build, and the full mcp-server test suite
   decisions:
     - keep one main AgenticOS product repository and one canonical standards area inside it
     - merge durable standards knowledge into the main repo, but archive raw standalone context/history instead of treating it as live state
@@ -89,6 +92,7 @@ working_memory:
     - per-agent bootstrap should land as one canonical matrix plus aligned docs, while Homebrew caveats and fallback-mode strategy remain separate follow-up issues
     - Homebrew post-install should remain reminder-only until an explicit opt-in bootstrap helper exists
     - fallback integration modes must be documented as narrower than MCP-native, not as equal parallel runtime modes
+    - strict coverage follow-up issues should add the smallest fallback-path regression tests needed to prove the existing design rather than reopening already-correct runtime behavior
   pending:
     - decide whether any entry surfaces beyond `agenticos_status` and `agenticos_switch` need the same compact guardrail summary
 

--- a/projects/agenticos/standards/knowledge/project-boundary-coverage-closure-report-2026-03-25.md
+++ b/projects/agenticos/standards/knowledge/project-boundary-coverage-closure-report-2026-03-25.md
@@ -1,0 +1,79 @@
+# Project Boundary Coverage Closure Report — 2026-03-25
+
+## Scope
+
+This report closes the last verification gap left after the original `#25` landing.
+
+Issue `#25` already landed the fail-closed project-boundary resolver and boundary enforcement for:
+
+- `agenticos_record`
+- `agenticos_save`
+- `agenticos://context/current`
+
+The remaining gap was not behavioral. It was verification strictness: the touched runtime files were at full statement/line/function coverage, but not yet at full branch coverage.
+
+Issue `#92` was opened as a narrow follow-up to raise the targeted branch coverage for the `#25` runtime surface to `100 / 100 / 100 / 100`.
+
+## Design Reflection
+
+The correct fix here was not to change product behavior again.
+
+The issue was purely a verification-quality gap, so the right solution was:
+
+1. keep the runtime implementation unchanged
+2. identify the exact uncovered branch short-circuits
+3. add the smallest regression tests that prove those fallback paths
+4. rerun targeted coverage and then full validation
+
+This preserves the original `#25` design while making the verification contract match the stricter requirement for full executable confidence.
+
+## Added Regression Cases
+
+### `record.ts`
+
+Added state-parse fallback coverage for the case where `yaml.parse(stateContent)` returns `null`, so the `|| {}` fallback path is explicitly proven.
+
+### `save.ts`
+
+Added commit-failure fallback coverage for the case where `stderr`, `stdout`, and `message` are all empty, so the final `|| ''` fallback path is explicitly proven.
+
+## Coverage Result
+
+Targeted coverage was rerun for these boundary files:
+
+- `src/utils/project-target.ts`
+- `src/resources/context.ts`
+- `src/tools/record.ts`
+- `src/tools/save.ts`
+
+Final result:
+
+- `project-target.ts`: `100 / 100 / 100 / 100`
+- `context.ts`: `100 / 100 / 100 / 100`
+- `record.ts`: `100 / 100 / 100 / 100`
+- `save.ts`: `100 / 100 / 100 / 100`
+
+## Verification
+
+Executed in isolated worktree `test/92-project-boundary-branches`:
+
+```bash
+npm install
+./node_modules/.bin/vitest run --run src/utils/__tests__/project-target.test.ts src/resources/__tests__/context.test.ts src/tools/__tests__/record.test.ts src/tools/__tests__/save.test.ts
+./node_modules/.bin/vitest run --coverage.enabled true --coverage.provider=v8 --coverage.reporter=text --coverage.include=src/utils/project-target.ts --coverage.include=src/resources/context.ts --coverage.include=src/tools/record.ts --coverage.include=src/tools/save.ts src/utils/__tests__/project-target.test.ts src/resources/__tests__/context.test.ts src/tools/__tests__/record.test.ts src/tools/__tests__/save.test.ts
+npm run build
+npm test
+```
+
+Observed result:
+
+- targeted tests passed: `53 passed`
+- targeted coverage reached `100 / 100 / 100 / 100` for all four files
+- full build passed
+- full test suite passed: `131 passed`
+
+## Outcome
+
+The original `#25` boundary-proof design remains correct.
+
+The verification contract is now also complete: the full touched project-boundary runtime surface has explicit branch-level proof for both happy-path and fallback-path behavior.


### PR DESCRIPTION
## Summary
- add fallback-path regression tests for project-boundary coverage gaps
- prove null-state fallback in record and empty-message fallback in save
- record the strict coverage closure in standards state and knowledge

## Verification
- npm install
- ./node_modules/.bin/vitest run --run src/utils/__tests__/project-target.test.ts src/resources/__tests__/context.test.ts src/tools/__tests__/record.test.ts src/tools/__tests__/save.test.ts
- ./node_modules/.bin/vitest run --coverage.enabled true --coverage.provider=v8 --coverage.reporter=text --coverage.include=src/utils/project-target.ts --coverage.include=src/resources/context.ts --coverage.include=src/tools/record.ts --coverage.include=src/tools/save.ts src/utils/__tests__/project-target.test.ts src/resources/__tests__/context.test.ts src/tools/__tests__/record.test.ts src/tools/__tests__/save.test.ts
- npm run build
- npm test