### PR TITLE
docs: define canonical local sync contract and surface freshness (#98)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ Repository boundary rule:
 6. **Release**: Tag `v*` → triggers Release workflow → update Homebrew sha256
 7. **Runtime separation**: Treat `.runtime/` and `.claude/worktrees/` as runtime-only, never as product source
 8. **Git transport fallback**: If HTTPS push breaks because of local proxy or credential plumbing, use the documented command-scoped no-proxy + `GIT_ASKPASS` fallback in `CONTRIBUTING.md`; if needed, add command-scoped `-c http.version=HTTP/1.1`; do not embed tokens in remote URLs
+9. **Canonical sync**: Before treating `/Users/jeking/dev/AgenticOS` as a trusted starting point, resync it to `origin/main` with the canonical sync contract in `projects/agenticos/standards/knowledge/canonical-sync-contract-2026-03-25.md`; do not infer live project state from a behind or dirty canonical checkout
 
 ## Guardrail Flow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,25 @@ Full Git Flow (with `develop` + `release/*`) is designed for large teams with in
 5. **Open PR** — reference issue with `Closes #42`
 6. **Merge** — once CI passes, merge with merge commit (not squash)
 
+### Canonical Local Sync
+
+Before you treat `/Users/jeking/dev/AgenticOS` as a trusted local starting point, resync it:
+
+```bash
+git -C /Users/jeking/dev/AgenticOS fetch origin --prune
+git -C /Users/jeking/dev/AgenticOS checkout main
+git -C /Users/jeking/dev/AgenticOS pull --ff-only origin main
+git -C /Users/jeking/dev/AgenticOS status --short --branch
+```
+
+Trusted output is a clean:
+
+```text
+## main...origin/main
+```
+
+If the checkout is dirty, ahead, or behind, do not use it as your trusted local reasoning base. Resync first, then open or use an isolated worktree for real implementation work.
+
 ## Commit Types
 
 | Type | When to use |

--- a/projects/agenticos/standards/.context/quick-start.md
+++ b/projects/agenticos/standards/.context/quick-start.md
@@ -62,6 +62,15 @@ Its job is to define and evolve:
 - `knowledge/integration-mode-matrix-implementation-report-2026-03-25.md` records the parser, docs, and roadmap alignment work
 - issue `#92` now closes the last strict-verification gap left after `#25` by raising the touched project-boundary runtime files to full branch coverage
 - `knowledge/project-boundary-coverage-closure-report-2026-03-25.md` records the added fallback-path regression cases and the final `100 / 100 / 100 / 100` targeted coverage result
+- issue `#98` now freezes the canonical sync contract for `/Users/jeking/dev/AgenticOS` and the freshness contract for live standards entry surfaces
+- `knowledge/canonical-sync-contract-2026-03-25.md` records when the local canonical checkout may be trusted and when `quick-start.md` and `state.yaml` must be refreshed
+- `knowledge/canonical-sync-implementation-report-2026-03-25.md` records the executable verification procedure and the intended post-merge proof run
+- the next higher-order backlog is now:
+  - `#99` standards entry-surface refresh automation
+  - `#97` `agenticos_health`
+  - `#96` rubric-backed non-code evaluation
+  - `#95` delegated-work runtime enforcement
+  - `#94` entry-surface guardrail-summary design review
 
 ## Recommended Entry Documents
 
@@ -93,11 +102,13 @@ Start here:
 24. `knowledge/integration-mode-matrix-2026-03-25.md`
 25. `knowledge/integration-mode-matrix-implementation-report-2026-03-25.md`
 26. `knowledge/project-boundary-coverage-closure-report-2026-03-25.md`
+27. `knowledge/canonical-sync-contract-2026-03-25.md`
+28. `knowledge/canonical-sync-implementation-report-2026-03-25.md`
 
 ## Next Steps
 
-1. Use the reconciled open backlog, not the pre-self-hosting issue list, as the canonical remaining work queue
-2. Treat `/Users/jeking/dev/AgenticOS` as the trusted local canonical checkout again; use isolated worktrees for changes
-3. Reassess the remaining backlog now that `#25`, `#26`, `#28`, `#29`, `#30`, and `#31` are all frozen and fully verified
-4. Decide whether any additional entry surfaces need the same compact guardrail summary beyond `agenticos_status` and `agenticos_switch`
-5. Only open a new selective-merge issue if one specific archived artifact is later proven to fill a real canonical gap
+1. Apply the `#98` canonical sync contract to `/Users/jeking/dev/AgenticOS` after merge and verify that the local main checkout is clean and current
+2. Execute `#99` so standards entry surfaces stop depending on manual refresh discipline after merged work
+3. Execute `#97` to give Agents one health surface for checkout freshness, standards freshness, and guardrail visibility
+4. Execute `#96` to turn rubric-backed non-code evaluation into a first-class verification command
+5. Execute `#95`, then revisit `#94` only after the higher-priority runtime enforcement work is done

--- a/projects/agenticos/standards/.context/state.yaml
+++ b/projects/agenticos/standards/.context/state.yaml
@@ -5,9 +5,9 @@ session:
   last_backup: 2026-03-23T10:35:00.000Z
 
 current_task:
-  title: close the final strict-verification gap after the remaining-six backlog completion
+  title: define the canonical sync contract for the local AgenticOS checkout and live standards surfaces
   status: implemented
-  updated: 2026-03-25T01:54:00.000Z
+  updated: 2026-03-25T02:05:00.000Z
 
 working_memory:
   facts:
@@ -73,6 +73,9 @@ working_memory:
     - issue #92 now closes the last strict-verification gap left after #25 by raising the touched boundary files to full branch coverage
     - the project-boundary runtime surface now has explicit targeted 100 percent statements, branches, functions, and lines coverage across project-target, context, record, and save
     - issue #92 verification passed with targeted tests, targeted coverage, npm run build, and the full mcp-server test suite
+    - issue #98 now freezes the trust contract for when /Users/jeking/dev/AgenticOS may be treated as the canonical local checkout
+    - issue #98 also freezes the freshness contract for when standards quick-start and state surfaces must be refreshed after merged work
+    - the next higher-order backlog is now #99, #97, #96, #95, and #94 in that priority order
   decisions:
     - keep one main AgenticOS product repository and one canonical standards area inside it
     - merge durable standards knowledge into the main repo, but archive raw standalone context/history instead of treating it as live state
@@ -93,8 +96,13 @@ working_memory:
     - Homebrew post-install should remain reminder-only until an explicit opt-in bootstrap helper exists
     - fallback integration modes must be documented as narrower than MCP-native, not as equal parallel runtime modes
     - strict coverage follow-up issues should add the smallest fallback-path regression tests needed to prove the existing design rather than reopening already-correct runtime behavior
+    - canonical local sync should be treated as a repeatable contract with executable verification, not as an occasional operator cleanup task
   pending:
-    - decide whether any entry surfaces beyond `agenticos_status` and `agenticos_switch` need the same compact guardrail summary
+    - execute issue #99 to automate standards entry-surface refresh after merged work
+    - execute issue #97 to add one health surface for checkout freshness, standards freshness, and guardrail visibility
+    - execute issue #96 to turn rubric-backed non-code evaluation into a first-class command
+    - execute issue #95 to enforce delegated-work handoff packets and verification echoes at runtime
+    - revisit issue #94 after the higher-priority health and enforcement work is complete
 
 loaded_context:
   - .project.yaml

--- a/projects/agenticos/standards/knowledge/canonical-sync-contract-2026-03-25.md
+++ b/projects/agenticos/standards/knowledge/canonical-sync-contract-2026-03-25.md
@@ -1,0 +1,104 @@
+# Canonical Sync Contract — 2026-03-25
+
+## Purpose
+
+This contract defines when `/Users/jeking/dev/AgenticOS` may be trusted as the canonical local AgenticOS checkout and when the live standards entry surfaces may be treated as fresh resume context.
+
+The goal is to prevent a familiar failure mode:
+
+- `origin/main` has already moved forward
+- the local canonical checkout has not been fast-forwarded
+- `projects/agenticos/standards/.context/quick-start.md` and `.context/state.yaml` are therefore stale
+- a later Agent starts from old local context and reasons from the wrong repository state
+
+## Source-of-Truth Order
+
+When these differ, trust order is:
+
+1. `origin/main`
+2. an isolated issue worktree branched from the current `origin/main`
+3. the local canonical checkout `/Users/jeking/dev/AgenticOS`
+4. archived snapshots and retired project history
+
+The local canonical checkout is only trustworthy when it has been explicitly resynced to `origin/main`.
+
+## Canonical Sync Procedure
+
+Run from the local canonical checkout:
+
+```bash
+git -C /Users/jeking/dev/AgenticOS fetch origin --prune
+git -C /Users/jeking/dev/AgenticOS checkout main
+git -C /Users/jeking/dev/AgenticOS pull --ff-only origin main
+git -C /Users/jeking/dev/AgenticOS status --short --branch
+```
+
+Expected result:
+
+- branch is `main`
+- checkout is not ahead of `origin/main`
+- checkout is not behind `origin/main`
+- working tree is clean
+
+Trusted status looks like:
+
+```text
+## main...origin/main
+```
+
+If the checkout is dirty, ahead, or cannot fast-forward cleanly, it is not a trusted canonical starting point for Agent work.
+
+## Live Standards Freshness Contract
+
+The standards entry surfaces:
+
+- `projects/agenticos/standards/.context/quick-start.md`
+- `projects/agenticos/standards/.context/state.yaml`
+
+must be refreshed whenever merged work changes any of these:
+
+- canonical standards decisions
+- backlog shape
+- canonical execution rules
+- visible entry-surface behavior
+- the set of issues that a newly entering Agent should treat as the current next-step queue
+
+This means freshness is based on semantic resume impact, not just file churn.
+
+## Required Refresh Policy
+
+After a merged issue lands, use this rule:
+
+1. if the issue changes canonical standards knowledge or Agent entry behavior, update the standards entry surfaces in the same issue flow or an immediate follow-up issue
+2. `quick-start.md` must summarize the new state at a human-readable resume level
+3. `state.yaml` must reflect the current task, current known facts, current decisions, and the new pending queue
+4. neither file should become an append-only dump of every historical detail
+
+## Freshness Verification
+
+After sync, verify:
+
+```bash
+ruby -e 'require "yaml"; YAML.load_file("/Users/jeking/dev/AgenticOS/projects/agenticos/standards/.context/state.yaml"); puts "state-ok"'
+rg -n "#98|canonical sync|higher-order backlog|#99|#97|#96|#95|#94" /Users/jeking/dev/AgenticOS/projects/agenticos/standards/.context/quick-start.md /Users/jeking/dev/AgenticOS/projects/agenticos/standards/.context/state.yaml
+```
+
+Verification intent:
+
+- `state.yaml` must remain valid YAML
+- the live entry surfaces must mention the currently relevant post-remaining-six state, not the superseded pre-closure backlog
+
+## Non-Goals
+
+This contract does not:
+
+- replace isolated worktrees for implementation work
+- make the local canonical checkout a place for feature development
+- require archived historical files to be continuously refreshed
+- attempt to auto-summarize every merged document into the live entry surfaces
+
+## Outcome
+
+The local canonical checkout is a trusted base checkout only after explicit fast-forward sync.
+
+The live standards entry surfaces are fresh only when they reflect the current post-merge resume reality for the next Agent, not just the last time someone edited those files.

--- a/projects/agenticos/standards/knowledge/canonical-sync-implementation-report-2026-03-25.md
+++ b/projects/agenticos/standards/knowledge/canonical-sync-implementation-report-2026-03-25.md
@@ -1,0 +1,80 @@
+# Canonical Sync Implementation Report — 2026-03-25
+
+## Scope
+
+Issue `#98` closes the gap between:
+
+- the intended role of `/Users/jeking/dev/AgenticOS` as the trusted local canonical checkout
+- the actual risk that the local checkout and live standards entry surfaces can fall behind merged mainline work
+
+This work does two things:
+
+1. defines the canonical sync and freshness contract
+2. applies and verifies that contract against the real local checkout
+
+## Design Reflection
+
+The right fix was not another one-off cleanup report.
+
+The problem after `#78` was procedural drift:
+
+- the local checkout had once been restored
+- later merged work accumulated again
+- the checkout and standards entry surfaces drifted behind remote truth
+
+So the correct solution is a reusable contract plus one real proof run, not another ad hoc cleanup narrative.
+
+## Landed Changes
+
+This issue lands:
+
+- a canonical sync contract for `/Users/jeking/dev/AgenticOS`
+- a live standards freshness contract for `quick-start.md` and `state.yaml`
+- standards entry-surface updates that reflect the post-remaining-six backlog state
+- root-level contribution guidance that tells future agents to resync the canonical checkout before trusting it
+
+## Verification Plan
+
+Contract verification requires both repository and standards-surface proof:
+
+```bash
+git -C /Users/jeking/dev/AgenticOS fetch origin --prune
+git -C /Users/jeking/dev/AgenticOS checkout main
+git -C /Users/jeking/dev/AgenticOS pull --ff-only origin main
+git -C /Users/jeking/dev/AgenticOS status --short --branch
+ruby -e 'require "yaml"; YAML.load_file("/Users/jeking/dev/AgenticOS/projects/agenticos/standards/.context/state.yaml"); puts "state-ok"'
+rg -n "#98|canonical sync|higher-order backlog|#99|#97|#96|#95|#94" /Users/jeking/dev/AgenticOS/projects/agenticos/standards/.context/quick-start.md /Users/jeking/dev/AgenticOS/projects/agenticos/standards/.context/state.yaml
+```
+
+## Expected Outcome
+
+After merge and local sync:
+
+- `/Users/jeking/dev/AgenticOS` is again a clean `main...origin/main` checkout
+- the standards entry surfaces reflect the post-remaining-six state and the new higher-order backlog
+- a future Agent can trust the local canonical tree as a correct starting point again
+
+## Proof Run During Issue Execution
+
+Before this issue, the local canonical checkout reported:
+
+```text
+## main...origin/main [behind 24]
+```
+
+During issue execution, the sync contract was applied:
+
+```bash
+git -C /Users/jeking/dev/AgenticOS fetch origin --prune
+git -C /Users/jeking/dev/AgenticOS checkout main
+git -C /Users/jeking/dev/AgenticOS pull --ff-only origin main
+git -C /Users/jeking/dev/AgenticOS status --short --branch
+```
+
+Observed result before this PR is merged:
+
+```text
+## main...origin/main
+```
+
+That proves the sync contract works operationally on the real local checkout. After this PR merges, the same fast-forward procedure must be run once more so the local canonical tree picks up the `#98` contract itself.


### PR DESCRIPTION
## Summary
- define the canonical sync contract for /Users/jeking/dev/AgenticOS
- define the freshness contract for standards quick-start and state surfaces
- update AGENTS, CONTRIBUTING, and standards entry surfaces to reflect the post-remaining-six backlog

## Verification
- ruby -e 'require "yaml"; YAML.load_file("/Users/jeking/worktrees/agenticos-sync-98/projects/agenticos/standards/.context/state.yaml"); puts "state-ok"'\n- rg -n "canonical sync|#99|#97|#96|#95|#94" /Users/jeking/worktrees/agenticos-sync-98/projects/agenticos/standards/.context/quick-start.md /Users/jeking/worktrees/agenticos-sync-98/projects/agenticos/standards/.context/state.yaml /Users/jeking/worktrees/agenticos-sync-98/AGENTS.md /Users/jeking/worktrees/agenticos-sync-98/CONTRIBUTING.md /Users/jeking/worktrees/agenticos-sync-98/projects/agenticos/standards/knowledge/canonical-sync-contract-2026-03-25.md\n- git -C /Users/jeking/dev/AgenticOS fetch origin --prune\n- git -C /Users/jeking/dev/AgenticOS checkout main\n- git -C /Users/jeking/dev/AgenticOS pull --ff-only origin main\n- git -C /Users/jeking/dev/AgenticOS status --short --branch