### PR TITLE
feat: automate deterministic standards entry-surface refresh (#99)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ The agent will call `agenticos_init` and set up the project structure automatica
 | `agenticos_preflight` | Evaluate implementation/PR guardrails | `task_type`, `repo_path`, `issue_id`, `declared_target_files` |
 | `agenticos_branch_bootstrap` | Create issue branch + isolated worktree from `origin/main` | `issue_id`, `slug`, `repo_path`, `worktree_root` |
 | `agenticos_pr_scope_check` | Validate commit/file scope before PR | `issue_id`, `repo_path`, `declared_target_files` |
+| `agenticos_refresh_entry_surfaces` | Refresh quick-start and state from structured merged-work inputs | `project_path`, `summary`, `status`, `current_focus` |
 | `agenticos_record` | Record session progress | `summary`, `decisions`, `outcomes`, `pending`, `current_task` |
 | `agenticos_save` | Save state + git backup | `message` (commit message) |
 

--- a/projects/agenticos/mcp-server/README.md
+++ b/projects/agenticos/mcp-server/README.md
@@ -207,6 +207,23 @@ Validate that the current branch diff stays within the intended issue scope.
 
 **Returns**: JSON with `PASS` or `BLOCK`
 
+### agenticos_refresh_entry_surfaces
+Deterministically refresh `.context/quick-start.md` and `.context/state.yaml` from structured merged-work inputs.
+
+**Parameters**:
+- `project_path` (required)
+- `summary` (required)
+- `status` (required)
+- `current_focus` (required)
+- `issue_id` (optional)
+- `facts` (optional)
+- `decisions` (optional)
+- `pending` (optional)
+- `report_paths` (optional)
+- `recommended_entry_documents` (optional)
+
+**Returns**: JSON with `REFRESHED`
+
 ---
 
 ## 📦 Resources Reference

--- a/projects/agenticos/mcp-server/src/index.ts
+++ b/projects/agenticos/mcp-server/src/index.ts
@@ -34,7 +34,7 @@ import {
   ListResourcesRequestSchema,
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { initProject, switchProject, listProjects, getStatus, saveState, recordSession, runPreflight, runBranchBootstrap, runPrScopeCheck, runStandardKitAdopt, runStandardKitUpgradeCheck } from './tools/index.js';
+import { initProject, switchProject, listProjects, getStatus, saveState, recordSession, runPreflight, runBranchBootstrap, runPrScopeCheck, runEntrySurfaceRefresh, runStandardKitAdopt, runStandardKitUpgradeCheck } from './tools/index.js';
 import { getProjectContext } from './resources/index.js';
 
 const server = new Server(
@@ -192,6 +192,30 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
       },
     },
     {
+      name: 'agenticos_refresh_entry_surfaces',
+      description: 'Deterministically refresh .context/quick-start.md and .context/state.yaml from structured merged-work inputs.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          project_path: { type: 'string', description: 'Absolute target project path whose entry surfaces should be refreshed.' },
+          project_name: { type: 'string', description: 'Optional project name override when .project.yaml metadata is missing or stale.' },
+          project_description: { type: 'string', description: 'Optional project description override used for quick-start project overview.' },
+          issue_id: { type: 'string', description: 'Optional merged issue identifier that produced this refresh.' },
+          summary: { type: 'string', description: 'Required concise summary of what just landed.' },
+          status: { type: 'string', description: 'Required high-level project status label to surface in quick-start.' },
+          current_focus: { type: 'string', description: 'Required current focus line for the refreshed entry surfaces.' },
+          current_task_title: { type: 'string', description: 'Optional current task title override written into state.' },
+          current_task_status: { type: 'string', description: 'Optional current task status override written into state.' },
+          facts: { type: 'array', items: { type: 'string' }, description: 'Optional concise facts to persist into working memory and quick-start.' },
+          decisions: { type: 'array', items: { type: 'string' }, description: 'Optional concise decisions to persist into working memory.' },
+          pending: { type: 'array', items: { type: 'string' }, description: 'Optional next-work queue; the first item becomes Resume Here and next_step.' },
+          report_paths: { type: 'array', items: { type: 'string' }, description: 'Optional landed report paths to include in loaded context and quick-start.' },
+          recommended_entry_documents: { type: 'array', items: { type: 'string' }, description: 'Optional recommended entry documents for fast resume.' },
+        },
+        required: ['project_path', 'summary', 'status', 'current_focus'],
+      },
+    },
+    {
       name: 'agenticos_standard_kit_adopt',
       description: 'Adopt the canonical AgenticOS downstream standard kit into a project by creating missing copied templates and generated guidance.',
       inputSchema: {
@@ -241,6 +265,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       return { content: [{ type: 'text', text: await runBranchBootstrap(args ?? {}) }] };
     case 'agenticos_pr_scope_check':
       return { content: [{ type: 'text', text: await runPrScopeCheck(args ?? {}) }] };
+    case 'agenticos_refresh_entry_surfaces':
+      return { content: [{ type: 'text', text: await runEntrySurfaceRefresh(args ?? {}) }] };
     case 'agenticos_standard_kit_adopt':
       return { content: [{ type: 'text', text: await runStandardKitAdopt(args ?? {}) }] };
     case 'agenticos_standard_kit_upgrade_check':

--- a/projects/agenticos/mcp-server/src/tools/entry-surface-refresh.ts
+++ b/projects/agenticos/mcp-server/src/tools/entry-surface-refresh.ts
@@ -1,0 +1,6 @@
+import { refreshEntrySurfaces } from '../utils/entry-surface-refresh.js';
+
+export async function runEntrySurfaceRefresh(args: any): Promise<string> {
+  const result = await refreshEntrySurfaces(args ?? {});
+  return JSON.stringify(result, null, 2);
+}

--- a/projects/agenticos/mcp-server/src/tools/index.ts
+++ b/projects/agenticos/mcp-server/src/tools/index.ts
@@ -5,4 +5,5 @@ export { recordSession } from './record.js';
 export { runPreflight } from './preflight.js';
 export { runBranchBootstrap } from './branch-bootstrap.js';
 export { runPrScopeCheck } from './pr-scope-check.js';
+export { runEntrySurfaceRefresh } from './entry-surface-refresh.js';
 export { runStandardKitAdopt, runStandardKitUpgradeCheck } from './standard-kit.js';

--- a/projects/agenticos/mcp-server/src/utils/__tests__/entry-surface-refresh.test.ts
+++ b/projects/agenticos/mcp-server/src/utils/__tests__/entry-surface-refresh.test.ts
@@ -1,0 +1,240 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtemp, mkdir, readFile, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import yaml from 'yaml';
+import { refreshEntrySurfaces } from '../entry-surface-refresh.js';
+import { runEntrySurfaceRefresh } from '../../tools/entry-surface-refresh.js';
+
+async function setupProjectRoot(): Promise<string> {
+  const projectRoot = await mkdtemp(join(tmpdir(), 'agenticos-entry-refresh-'));
+  await mkdir(join(projectRoot, '.context'), { recursive: true });
+  return projectRoot;
+}
+
+describe('entry surface refresh', () => {
+  afterEach(() => {
+    delete process.env.AGENTICOS_HOME;
+  });
+
+  it('refreshes quick-start and state deterministically from structured merged-work inputs', async () => {
+    const projectRoot = await setupProjectRoot();
+    await writeFile(
+      join(projectRoot, '.project.yaml'),
+      yaml.stringify({
+        meta: {
+          name: 'Standards',
+          description: 'Canonical standards area inside AgenticOS.',
+        },
+      }),
+      'utf-8',
+    );
+    await writeFile(
+      join(projectRoot, '.context', 'state.yaml'),
+      yaml.stringify({
+        session: { id: 'session-1', started: '2026-03-24T00:00:00.000Z', agent: 'codex' },
+        guardrail_evidence: { last_command: 'agenticos_preflight' },
+      }),
+      'utf-8',
+    );
+
+    const result = await refreshEntrySurfaces({
+      project_path: projectRoot,
+      issue_id: '99',
+      summary: 'Defined deterministic entry-surface refresh automation.',
+      status: 'active',
+      current_focus: 'Implement the next health command issue',
+      current_task_status: 'pending',
+      facts: ['Entry surfaces now refresh from structured merge results'],
+      decisions: ['Avoid freeform AI summarization for live entry surfaces'],
+      pending: ['Implement #97'],
+      report_paths: [
+        'knowledge/canonical-sync-contract-2026-03-25.md',
+        'knowledge/entry-surface-refresh-design-2026-03-25.md',
+        'knowledge/entry-surface-refresh-design-2026-03-25.md',
+      ],
+      recommended_entry_documents: [
+        'knowledge/canonical-sync-contract-2026-03-25.md',
+        'knowledge/canonical-sync-implementation-report-2026-03-25.md',
+      ],
+    });
+
+    expect(result.status).toBe('REFRESHED');
+    expect(result.project_name).toBe('Standards');
+    expect(result.issue_id).toBe('99');
+    expect(result.report_paths).toEqual([
+      'knowledge/canonical-sync-contract-2026-03-25.md',
+      'knowledge/entry-surface-refresh-design-2026-03-25.md',
+      'knowledge/entry-surface-refresh-design-2026-03-25.md',
+    ]);
+
+    const quickStart = await readFile(join(projectRoot, '.context', 'quick-start.md'), 'utf-8');
+    expect(quickStart).toContain('# Standards - Quick Start');
+    expect(quickStart).toContain('Canonical standards area inside AgenticOS.');
+    expect(quickStart).toContain('Issue #99 merged');
+    expect(quickStart).toContain('Implement #97');
+    expect(quickStart).toContain('knowledge/entry-surface-refresh-design-2026-03-25.md');
+    expect(quickStart).toContain('## Recommended Entry Documents');
+
+    const state = yaml.parse(await readFile(join(projectRoot, '.context', 'state.yaml'), 'utf-8')) as any;
+    expect(state.session.id).toBe('session-1');
+    expect(state.session.started).toBe('2026-03-24T00:00:00.000Z');
+    expect(state.session.agent).toBe('codex');
+    expect(state.current_task.title).toBe('Implement the next health command issue');
+    expect(state.current_task.status).toBe('pending');
+    expect(state.current_task.next_step).toBe('Implement #97');
+    expect(state.working_memory.facts).toEqual(['Entry surfaces now refresh from structured merge results']);
+    expect(state.working_memory.decisions).toEqual(['Avoid freeform AI summarization for live entry surfaces']);
+    expect(state.working_memory.pending).toEqual(['Implement #97']);
+    expect(state.loaded_context).toEqual([
+      '.project.yaml',
+      '.context/quick-start.md',
+      'knowledge/canonical-sync-contract-2026-03-25.md',
+      'knowledge/entry-surface-refresh-design-2026-03-25.md',
+      'knowledge/canonical-sync-implementation-report-2026-03-25.md',
+    ]);
+    expect(state.entry_surface_refresh.issue_id).toBe('99');
+    expect(state.guardrail_evidence.last_command).toBe('agenticos_preflight');
+  });
+
+  it('falls back to basename and summary when project metadata is missing and list fields are absent', async () => {
+    const projectRoot = await setupProjectRoot();
+    await writeFile(join(projectRoot, '.context', 'state.yaml'), 'null', 'utf-8');
+
+    const result = await refreshEntrySurfaces({
+      project_path: projectRoot,
+      summary: 'Refresh fallback summary',
+      status: 'implemented',
+      current_focus: 'Review remaining entry surfaces',
+    });
+
+    expect(result.project_name).toBe(projectRoot.split('/').pop());
+    expect(result.issue_id).toBeNull();
+    expect(result.recommended_entry_documents).toEqual([]);
+
+    const quickStart = await readFile(join(projectRoot, '.context', 'quick-start.md'), 'utf-8');
+    expect(quickStart).toContain('Refresh fallback summary');
+    expect(quickStart).toContain('- No key facts recorded');
+
+    const state = yaml.parse(await readFile(join(projectRoot, '.context', 'state.yaml'), 'utf-8')) as any;
+    expect(state.session.id).toContain('entry-refresh-');
+    expect(state.session.agent).toBe('agenticos-entry-refresh');
+    expect(state.current_task.title).toBe('Review remaining entry surfaces');
+    expect(state.current_task.status).toBe('pending');
+    expect(state.current_task.next_step).toBe('Review remaining entry surfaces');
+    expect(state.working_memory.facts).toEqual([]);
+    expect(state.loaded_context).toEqual(['.project.yaml', '.context/quick-start.md']);
+  });
+
+  it('prefers explicit project identity overrides and filters non-string list values', async () => {
+    const projectRoot = await setupProjectRoot();
+    await writeFile(
+      join(projectRoot, '.project.yaml'),
+      yaml.stringify({
+        meta: {
+          name: 'Yaml Name',
+          description: 'Yaml Description',
+        },
+      }),
+      'utf-8',
+    );
+
+    await refreshEntrySurfaces({
+      project_path: projectRoot,
+      project_name: 'Override Name',
+      project_description: 'Override Description',
+      summary: 'Override refresh',
+      status: 'active',
+      current_focus: 'Ship the override path',
+      current_task_title: 'Custom task title',
+      current_task_status: 'implemented',
+      facts: ['kept fact', 42 as any, '  trimmed fact  ' as any],
+      decisions: ['decision one'],
+      pending: ['pending one'],
+      report_paths: ['knowledge/report-one.md', '' as any, 7 as any],
+      recommended_entry_documents: ['knowledge/doc-one.md'],
+    });
+
+    const quickStart = await readFile(join(projectRoot, '.context', 'quick-start.md'), 'utf-8');
+    expect(quickStart).toContain('# Override Name - Quick Start');
+    expect(quickStart).toContain('Override Description');
+
+    const state = yaml.parse(await readFile(join(projectRoot, '.context', 'state.yaml'), 'utf-8')) as any;
+    expect(state.current_task.title).toBe('Custom task title');
+    expect(state.current_task.status).toBe('implemented');
+    expect(state.working_memory.facts).toEqual(['kept fact', 'trimmed fact']);
+    expect(state.loaded_context).toEqual([
+      '.project.yaml',
+      '.context/quick-start.md',
+      'knowledge/report-one.md',
+      'knowledge/doc-one.md',
+    ]);
+  });
+
+  it('falls back to basename inside the readable project-yaml path when metadata fields are empty', async () => {
+    const projectRoot = await setupProjectRoot();
+    await writeFile(join(projectRoot, '.project.yaml'), yaml.stringify({ meta: {} }), 'utf-8');
+
+    await refreshEntrySurfaces({
+      project_path: projectRoot,
+      summary: 'Readable yaml fallback summary',
+      status: 'active',
+      current_focus: 'Use basename fallback',
+    });
+
+    const quickStart = await readFile(join(projectRoot, '.context', 'quick-start.md'), 'utf-8');
+    expect(quickStart).toContain(`# ${projectRoot.split('/').pop()} - Quick Start`);
+    expect(quickStart).toContain('Readable yaml fallback summary');
+  });
+
+  it('returns structured JSON through the tool wrapper and validates required fields', async () => {
+    const projectRoot = await setupProjectRoot();
+
+    const result = JSON.parse(await runEntrySurfaceRefresh({
+      project_path: projectRoot,
+      project_name: 'Wrapper Project',
+      summary: 'Wrapper refresh',
+      status: 'active',
+      current_focus: 'Do the next thing',
+      pending: ['Do the next thing'],
+    })) as {
+      status: string;
+      project_name: string;
+      quick_start_path: string;
+    };
+
+    expect(result.status).toBe('REFRESHED');
+    expect(result.project_name).toBe('Wrapper Project');
+    expect(result.quick_start_path).toContain('.context/quick-start.md');
+
+    await expect(() => runEntrySurfaceRefresh(undefined)).rejects.toThrow('project_path is required.');
+
+    await expect(() => refreshEntrySurfaces({
+      project_path: '',
+      summary: 'bad',
+      status: 'active',
+      current_focus: 'focus',
+    } as any)).rejects.toThrow('project_path is required.');
+
+    await expect(() => refreshEntrySurfaces({
+      project_path: projectRoot,
+      summary: '',
+      status: 'active',
+      current_focus: 'focus',
+    })).rejects.toThrow('summary is required.');
+
+    await expect(() => refreshEntrySurfaces({
+      project_path: projectRoot,
+      summary: 'ok',
+      status: '',
+      current_focus: 'focus',
+    })).rejects.toThrow('status is required.');
+
+    await expect(() => refreshEntrySurfaces({
+      project_path: projectRoot,
+      summary: 'ok',
+      status: 'active',
+      current_focus: '',
+    })).rejects.toThrow('current_focus is required.');
+  });
+});

--- a/projects/agenticos/mcp-server/src/utils/entry-surface-refresh.ts
+++ b/projects/agenticos/mcp-server/src/utils/entry-surface-refresh.ts
@@ -1,0 +1,247 @@
+import { mkdir, readFile, writeFile } from 'fs/promises';
+import { basename, dirname, join } from 'path';
+import yaml from 'yaml';
+
+export interface EntrySurfaceRefreshArgs {
+  project_path: string;
+  project_name?: string;
+  project_description?: string;
+  issue_id?: string;
+  summary: string;
+  status: string;
+  current_focus: string;
+  current_task_title?: string;
+  current_task_status?: string;
+  facts?: string[];
+  decisions?: string[];
+  pending?: string[];
+  report_paths?: string[];
+  recommended_entry_documents?: string[];
+}
+
+export interface EntrySurfaceRefreshResult {
+  command: 'agenticos_refresh_entry_surfaces';
+  status: 'REFRESHED';
+  project_path: string;
+  project_name: string;
+  refreshed_at: string;
+  issue_id: string | null;
+  quick_start_path: string;
+  state_path: string;
+  report_paths: string[];
+  recommended_entry_documents: string[];
+}
+
+interface ResolvedProjectIdentity {
+  projectName: string;
+  projectDescription: string;
+}
+
+function normalizeList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((item) => (typeof item === 'string' ? item.trim() : ''))
+    .filter((item) => item.length > 0);
+}
+
+function uniqueOrdered(values: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const value of values) {
+    if (!seen.has(value)) {
+      seen.add(value);
+      result.push(value);
+    }
+  }
+
+  return result;
+}
+
+async function readProjectIdentity(projectPath: string, args: EntrySurfaceRefreshArgs): Promise<ResolvedProjectIdentity> {
+  try {
+    const parsed = yaml.parse(await readFile(join(projectPath, '.project.yaml'), 'utf-8')) as any;
+    return {
+      projectName: args.project_name || parsed?.meta?.name || basename(projectPath),
+      projectDescription: args.project_description || parsed?.meta?.description || '',
+    };
+  } catch {
+    return {
+      projectName: args.project_name || basename(projectPath),
+      projectDescription: args.project_description || '',
+    };
+  }
+}
+
+async function readState(statePath: string): Promise<any> {
+  try {
+    return yaml.parse(await readFile(statePath, 'utf-8')) || {};
+  } catch {
+    return {};
+  }
+}
+
+function buildQuickStart(args: EntrySurfaceRefreshArgs, identity: ResolvedProjectIdentity, refreshedAt: string): string {
+  const pending = normalizeList(args.pending);
+  const facts = normalizeList(args.facts);
+  const reportPaths = normalizeList(args.report_paths);
+  const recommendedDocs = normalizeList(args.recommended_entry_documents);
+  const overview = identity.projectDescription || args.summary;
+  const lastAction = args.issue_id
+    ? `Issue #${args.issue_id} merged — ${args.summary}`
+    : args.summary;
+  const resumeHere = pending[0] || args.current_focus;
+
+  const lines: string[] = [
+    `# ${identity.projectName} - Quick Start`,
+    '',
+    '## Project Overview',
+    '',
+    overview,
+    '',
+    '## Current Status',
+    '',
+    `- **Status**: ${args.status}`,
+    `- **Last Action**: ${lastAction}`,
+    `- **Current Focus**: ${args.current_focus}`,
+    `- **Resume Here**: ${resumeHere}`,
+    `- **Refreshed At**: ${refreshedAt}`,
+    '',
+    '## Key Facts',
+  ];
+
+  if (facts.length > 0) {
+    for (const fact of facts.slice(0, 5)) {
+      lines.push(`- ${fact}`);
+    }
+  } else {
+    lines.push('- No key facts recorded');
+  }
+
+  if (reportPaths.length > 0) {
+    lines.push('', '## Latest Landed Reports', '');
+    for (const reportPath of reportPaths) {
+      lines.push(`- ${reportPath}`);
+    }
+  }
+
+  if (recommendedDocs.length > 0) {
+    lines.push('', '## Recommended Entry Documents', '');
+    recommendedDocs.forEach((doc, index) => {
+      lines.push(`${index + 1}. ${doc}`);
+    });
+  }
+
+  lines.push(
+    '',
+    '## Canonical Layers',
+    '- Operational state: `.context/state.yaml`',
+    '- Session history: `.context/conversations/`',
+    '- Durable knowledge: `knowledge/`',
+    '- Execution plans: `tasks/`',
+    '- Deliverables: `artifacts/`',
+  );
+
+  return `${lines.join('\n')}\n`;
+}
+
+function buildState(
+  args: EntrySurfaceRefreshArgs,
+  existingState: any,
+  refreshedAt: string,
+): any {
+  const facts = normalizeList(args.facts);
+  const decisions = normalizeList(args.decisions);
+  const pending = normalizeList(args.pending);
+  const reportPaths = normalizeList(args.report_paths);
+  const recommendedDocs = normalizeList(args.recommended_entry_documents);
+
+  const state = existingState;
+  state.session = state.session || {};
+  if (!state.session.id) {
+    state.session.id = `entry-refresh-${refreshedAt.substring(0, 10)}`;
+  }
+  if (!state.session.started) {
+    state.session.started = refreshedAt;
+  }
+  if (!state.session.agent) {
+    state.session.agent = 'agenticos-entry-refresh';
+  }
+  state.session.last_backup = refreshedAt;
+  state.session.last_entry_surface_refresh = refreshedAt;
+
+  state.current_task = {
+    ...(state.current_task || {}),
+    title: args.current_task_title || args.current_focus,
+    status: args.current_task_status || 'pending',
+    next_step: pending[0] || args.current_focus,
+    updated: refreshedAt,
+  };
+
+  state.working_memory = state.working_memory || {};
+  state.working_memory.facts = facts;
+  state.working_memory.decisions = decisions;
+  state.working_memory.pending = pending;
+
+  state.loaded_context = uniqueOrdered([
+    '.project.yaml',
+    '.context/quick-start.md',
+    ...reportPaths,
+    ...recommendedDocs,
+  ]);
+
+  state.entry_surface_refresh = {
+    refreshed_at: refreshedAt,
+    issue_id: args.issue_id || null,
+    summary: args.summary,
+    status: args.status,
+    current_focus: args.current_focus,
+    report_paths: reportPaths,
+    recommended_entry_documents: recommendedDocs,
+  };
+
+  return state;
+}
+
+export async function refreshEntrySurfaces(args: EntrySurfaceRefreshArgs): Promise<EntrySurfaceRefreshResult> {
+  if (!args?.project_path) {
+    throw new Error('project_path is required.');
+  }
+  if (!args?.summary?.trim()) {
+    throw new Error('summary is required.');
+  }
+  if (!args?.status?.trim()) {
+    throw new Error('status is required.');
+  }
+  if (!args?.current_focus?.trim()) {
+    throw new Error('current_focus is required.');
+  }
+
+  const refreshedAt = new Date().toISOString();
+  const projectPath = args.project_path;
+  const quickStartPath = join(projectPath, '.context', 'quick-start.md');
+  const statePath = join(projectPath, '.context', 'state.yaml');
+
+  await mkdir(dirname(quickStartPath), { recursive: true });
+
+  const identity = await readProjectIdentity(projectPath, args);
+  const existingState = await readState(statePath);
+  const nextState = buildState(args, existingState, refreshedAt);
+  const nextQuickStart = buildQuickStart(args, identity, refreshedAt);
+
+  await writeFile(quickStartPath, nextQuickStart, 'utf-8');
+  await writeFile(statePath, yaml.stringify(nextState), 'utf-8');
+
+  return {
+    command: 'agenticos_refresh_entry_surfaces',
+    status: 'REFRESHED',
+    project_path: projectPath,
+    project_name: identity.projectName,
+    refreshed_at: refreshedAt,
+    issue_id: args.issue_id || null,
+    quick_start_path: quickStartPath,
+    state_path: statePath,
+    report_paths: normalizeList(args.report_paths),
+    recommended_entry_documents: normalizeList(args.recommended_entry_documents),
+  };
+}

--- a/projects/agenticos/standards/.context/quick-start.md
+++ b/projects/agenticos/standards/.context/quick-start.md
@@ -65,8 +65,10 @@ Its job is to define and evolve:
 - issue `#98` now freezes the canonical sync contract for `/Users/jeking/dev/AgenticOS` and the freshness contract for live standards entry surfaces
 - `knowledge/canonical-sync-contract-2026-03-25.md` records when the local canonical checkout may be trusted and when `quick-start.md` and `state.yaml` must be refreshed
 - `knowledge/canonical-sync-implementation-report-2026-03-25.md` records the executable verification procedure and the intended post-merge proof run
+- issue `#99` now adds a deterministic refresh surface for `quick-start.md` and `state.yaml` instead of relying on manual post-merge edits
+- `knowledge/entry-surface-refresh-design-2026-03-25.md` records why bounded structured refresh is preferred over freeform summarization
+- `knowledge/entry-surface-refresh-implementation-report-2026-03-25.md` records the landed command, runtime files, and verification
 - the next higher-order backlog is now:
-  - `#99` standards entry-surface refresh automation
   - `#97` `agenticos_health`
   - `#96` rubric-backed non-code evaluation
   - `#95` delegated-work runtime enforcement
@@ -104,11 +106,12 @@ Start here:
 26. `knowledge/project-boundary-coverage-closure-report-2026-03-25.md`
 27. `knowledge/canonical-sync-contract-2026-03-25.md`
 28. `knowledge/canonical-sync-implementation-report-2026-03-25.md`
+29. `knowledge/entry-surface-refresh-design-2026-03-25.md`
+30. `knowledge/entry-surface-refresh-implementation-report-2026-03-25.md`
 
 ## Next Steps
 
-1. Apply the `#98` canonical sync contract to `/Users/jeking/dev/AgenticOS` after merge and verify that the local main checkout is clean and current
-2. Execute `#99` so standards entry surfaces stop depending on manual refresh discipline after merged work
-3. Execute `#97` to give Agents one health surface for checkout freshness, standards freshness, and guardrail visibility
-4. Execute `#96` to turn rubric-backed non-code evaluation into a first-class verification command
-5. Execute `#95`, then revisit `#94` only after the higher-priority runtime enforcement work is done
+1. Execute `#97` to give Agents one health surface for checkout freshness, standards freshness, and guardrail visibility
+2. Execute `#96` to turn rubric-backed non-code evaluation into a first-class verification command
+3. Execute `#95` to enforce delegated-work handoff packets and verification echoes at runtime
+4. Revisit `#94` only after the higher-priority health and enforcement work is done

--- a/projects/agenticos/standards/.context/state.yaml
+++ b/projects/agenticos/standards/.context/state.yaml
@@ -5,9 +5,9 @@ session:
   last_backup: 2026-03-23T10:35:00.000Z
 
 current_task:
-  title: define the canonical sync contract for the local AgenticOS checkout and live standards surfaces
+  title: automate deterministic refresh of standards quick-start and state after merged work
   status: implemented
-  updated: 2026-03-25T02:05:00.000Z
+  updated: 2026-03-25T02:06:00.000Z
 
 working_memory:
   facts:
@@ -75,7 +75,9 @@ working_memory:
     - issue #92 verification passed with targeted tests, targeted coverage, npm run build, and the full mcp-server test suite
     - issue #98 now freezes the trust contract for when /Users/jeking/dev/AgenticOS may be treated as the canonical local checkout
     - issue #98 also freezes the freshness contract for when standards quick-start and state surfaces must be refreshed after merged work
-    - the next higher-order backlog is now #99, #97, #96, #95, and #94 in that priority order
+    - issue #99 now adds a deterministic bounded refresh command for quick-start and state surfaces using structured merged-work inputs
+    - the refresh command writes bounded entry-surface metadata into state instead of attempting freeform summarization
+    - the next higher-order backlog is now #97, #96, #95, and #94 in that priority order
   decisions:
     - keep one main AgenticOS product repository and one canonical standards area inside it
     - merge durable standards knowledge into the main repo, but archive raw standalone context/history instead of treating it as live state
@@ -97,8 +99,8 @@ working_memory:
     - fallback integration modes must be documented as narrower than MCP-native, not as equal parallel runtime modes
     - strict coverage follow-up issues should add the smallest fallback-path regression tests needed to prove the existing design rather than reopening already-correct runtime behavior
     - canonical local sync should be treated as a repeatable contract with executable verification, not as an occasional operator cleanup task
+    - entry-surface refresh should be deterministic and bounded, not an unconstrained summarizer over arbitrary merged documents
   pending:
-    - execute issue #99 to automate standards entry-surface refresh after merged work
     - execute issue #97 to add one health surface for checkout freshness, standards freshness, and guardrail visibility
     - execute issue #96 to turn rubric-backed non-code evaluation into a first-class command
     - execute issue #95 to enforce delegated-work handoff packets and verification echoes at runtime

--- a/projects/agenticos/standards/knowledge/entry-surface-refresh-design-2026-03-25.md
+++ b/projects/agenticos/standards/knowledge/entry-surface-refresh-design-2026-03-25.md
@@ -1,0 +1,86 @@
+# Entry Surface Refresh Design — 2026-03-25
+
+## Problem
+
+`projects/agenticos/standards/.context/quick-start.md` and `.context/state.yaml` are the first live resume surfaces for future agents.
+
+The current gap is not that these files are missing. The gap is that they still depend on manual rewriting after merged issue work.
+
+That creates two failure modes:
+
+- merged standards knowledge exists, but the entry surfaces still describe stale work
+- agents recover from the entry surfaces, not from the newest merged issue reports
+
+## Design Reflection
+
+The wrong solution would be a freeform summarizer that scans arbitrary merged documents and rewrites the entry surfaces heuristically.
+
+That would be noisy, hard to verify, and likely to violate the memory-layer contract for:
+
+- `quick-start.md` as concise orientation
+- `state.yaml` as mutable operational state
+
+The right solution is a bounded refresh command:
+
+- input is structured merged-work data
+- output is deterministic quick-start and state content
+- refresh remains concise and resume-oriented
+- verification can be direct and fixture-based
+
+## Chosen Design
+
+Add one command:
+
+- `agenticos_refresh_entry_surfaces`
+
+It accepts:
+
+- target `project_path`
+- concise merged-work `summary`
+- high-level `status`
+- `current_focus`
+- optional `issue_id`
+- optional `facts`, `decisions`, `pending`
+- optional landed `report_paths`
+- optional `recommended_entry_documents`
+
+It then:
+
+1. resolves project identity from `.project.yaml`, with explicit overrides allowed
+2. rewrites `.context/quick-start.md` using a deterministic resume format
+3. rewrites `.context/state.yaml` using deterministic operational-state updates
+4. persists a bounded `entry_surface_refresh` section in state for later auditability
+
+## Why This Scope Is Correct
+
+This solves the actual automation gap without:
+
+- inventing AI summarization rules for arbitrary docs
+- turning `quick-start.md` into an append-only log
+- turning `state.yaml` into a second knowledge base
+- coupling refresh to GitHub API availability
+
+It also composes cleanly with later work:
+
+- `#97` can report entry-surface freshness
+- later post-merge automation can call this command
+- later review tooling can inspect `entry_surface_refresh`
+
+## Non-Goals
+
+This issue does not:
+
+- auto-detect every merged issue without structured input
+- refresh arbitrary archived files
+- redesign the memory-layer contract
+- replace standards knowledge reports as the canonical detailed record
+
+## Acceptance Shape
+
+The feature is complete when:
+
+- refresh is deterministic
+- quick-start remains concise
+- state remains operational
+- landed report paths and next-step backlog can be injected without manual file editing
+- runtime tests prove the refresh logic at 100 percent statements, branches, functions, and lines coverage

--- a/projects/agenticos/standards/knowledge/entry-surface-refresh-implementation-report-2026-03-25.md
+++ b/projects/agenticos/standards/knowledge/entry-surface-refresh-implementation-report-2026-03-25.md
@@ -1,0 +1,65 @@
+# Entry Surface Refresh Implementation Report — 2026-03-25
+
+## Scope
+
+Issue `#99` implements deterministic refresh automation for live standards entry surfaces.
+
+The landed runtime surface is:
+
+- `agenticos_refresh_entry_surfaces`
+
+Backed by:
+
+- `src/utils/entry-surface-refresh.ts`
+- `src/tools/entry-surface-refresh.ts`
+
+## What Landed
+
+The command now:
+
+1. accepts bounded structured merged-work inputs
+2. resolves project identity from `.project.yaml` with safe overrides
+3. rewrites `.context/quick-start.md` into a concise resume format
+4. rewrites `.context/state.yaml` into bounded operational state
+5. persists `entry_surface_refresh` metadata for later inspection
+
+It does not attempt freeform summarization of arbitrary knowledge documents.
+
+## Standards and Docs Alignment
+
+This issue also updates:
+
+- root `README.md`
+- `projects/agenticos/mcp-server/README.md`
+- standards `.context/quick-start.md`
+- standards `.context/state.yaml`
+
+So the new higher-order queue is visible from the live standards entry surfaces.
+
+## Verification
+
+Targeted runtime verification:
+
+```bash
+npm test -- --run src/utils/__tests__/entry-surface-refresh.test.ts
+npx vitest run --coverage.enabled true --coverage.provider=v8 --coverage.reporter=text --coverage.include=src/utils/entry-surface-refresh.ts --coverage.include=src/tools/entry-surface-refresh.ts src/utils/__tests__/entry-surface-refresh.test.ts
+```
+
+Result:
+
+- `src/utils/entry-surface-refresh.ts`: `100 / 100 / 100 / 100`
+- `src/tools/entry-surface-refresh.ts`: `100 / 100 / 100 / 100`
+
+Repository-level verification:
+
+```bash
+npm run build
+npm test
+ruby -e 'require "yaml"; YAML.load_file("projects/agenticos/standards/.context/state.yaml"); puts "state-ok"'
+```
+
+## Outcome
+
+The entry-surface refresh step is now machine-executable and bounded.
+
+Future merged-work flows no longer need hand-edited standards quick-start and state updates to stay canonical, provided they call this refresh surface with structured inputs.


### PR DESCRIPTION
## Summary
- add a bounded refresh command for quick-start and state surfaces
- persist deterministic entry-surface refresh metadata instead of freeform summarization
- update standards/docs to make the new higher-order backlog the live resume queue

## Verification
- npm test -- --run src/utils/__tests__/entry-surface-refresh.test.ts
- npx vitest run --coverage.enabled true --coverage.provider=v8 --coverage.reporter=text --coverage.include=src/utils/entry-surface-refresh.ts --coverage.include=src/tools/entry-surface-refresh.ts src/utils/__tests__/entry-surface-refresh.test.ts
- npm run build
- npm test
- ruby -e 'require "yaml"; YAML.load_file("/Users/jeking/worktrees/agenticos-refresh-99/projects/agenticos/standards/.context/state.yaml"); puts "state-ok"'