### PR TITLE
feat: add bounded health surface for canonical checkout freshness (#97)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ The agent will call `agenticos_init` and set up the project structure automatica
 | `agenticos_preflight` | Evaluate implementation/PR guardrails | `task_type`, `repo_path`, `issue_id`, `declared_target_files` |
 | `agenticos_branch_bootstrap` | Create issue branch + isolated worktree from `origin/main` | `issue_id`, `slug`, `repo_path`, `worktree_root` |
 | `agenticos_pr_scope_check` | Validate commit/file scope before PR | `issue_id`, `repo_path`, `declared_target_files` |
+| `agenticos_health` | Check canonical checkout, entry-surface, and guardrail freshness | `repo_path`, `project_path`, `check_standard_kit` |
 | `agenticos_refresh_entry_surfaces` | Refresh quick-start and state from structured merged-work inputs | `project_path`, `summary`, `status`, `current_focus` |
 | `agenticos_record` | Record session progress | `summary`, `decisions`, `outcomes`, `pending`, `current_task` |
 | `agenticos_save` | Save state + git backup | `message` (commit message) |

--- a/projects/agenticos/mcp-server/README.md
+++ b/projects/agenticos/mcp-server/README.md
@@ -207,6 +207,18 @@ Validate that the current branch diff stays within the intended issue scope.
 
 **Returns**: JSON with `PASS` or `BLOCK`
 
+### agenticos_health
+Evaluate whether a canonical checkout and project context are fresh enough to trust before starting work.
+
+**Parameters**:
+- `repo_path` (required)
+- `project_path` (optional)
+- `remote_base_branch` (optional, default `origin/main`)
+- `checkout_role` (optional, currently `canonical`)
+- `check_standard_kit` (optional)
+
+**Returns**: JSON with overall `PASS`, `WARN`, or `BLOCK`
+
 ### agenticos_refresh_entry_surfaces
 Deterministically refresh `.context/quick-start.md` and `.context/state.yaml` from structured merged-work inputs.
 

--- a/projects/agenticos/mcp-server/src/index.ts
+++ b/projects/agenticos/mcp-server/src/index.ts
@@ -34,7 +34,7 @@ import {
   ListResourcesRequestSchema,
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { initProject, switchProject, listProjects, getStatus, saveState, recordSession, runPreflight, runBranchBootstrap, runPrScopeCheck, runEntrySurfaceRefresh, runStandardKitAdopt, runStandardKitUpgradeCheck } from './tools/index.js';
+import { initProject, switchProject, listProjects, getStatus, saveState, recordSession, runPreflight, runBranchBootstrap, runPrScopeCheck, runHealth, runEntrySurfaceRefresh, runStandardKitAdopt, runStandardKitUpgradeCheck } from './tools/index.js';
 import { getProjectContext } from './resources/index.js';
 
 const server = new Server(
@@ -192,6 +192,21 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
       },
     },
     {
+      name: 'agenticos_health',
+      description: 'Evaluate whether a canonical checkout and project context are fresh enough to trust before starting work.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          repo_path: { type: 'string', description: 'Absolute repository checkout path to evaluate.' },
+          project_path: { type: 'string', description: 'Optional absolute project path whose state freshness should be checked.' },
+          remote_base_branch: { type: 'string', description: 'Remote base branch expected for canonical checkout freshness (default: origin/main).' },
+          checkout_role: { type: 'string', enum: ['canonical'], description: 'Checkout role. Currently canonical-only.' },
+          check_standard_kit: { type: 'boolean', description: 'Whether to include standard-kit drift in the health report.' },
+        },
+        required: ['repo_path'],
+      },
+    },
+    {
       name: 'agenticos_refresh_entry_surfaces',
       description: 'Deterministically refresh .context/quick-start.md and .context/state.yaml from structured merged-work inputs.',
       inputSchema: {
@@ -265,6 +280,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       return { content: [{ type: 'text', text: await runBranchBootstrap(args ?? {}) }] };
     case 'agenticos_pr_scope_check':
       return { content: [{ type: 'text', text: await runPrScopeCheck(args ?? {}) }] };
+    case 'agenticos_health':
+      return { content: [{ type: 'text', text: await runHealth(args ?? {}) }] };
     case 'agenticos_refresh_entry_surfaces':
       return { content: [{ type: 'text', text: await runEntrySurfaceRefresh(args ?? {}) }] };
     case 'agenticos_standard_kit_adopt':

--- a/projects/agenticos/mcp-server/src/tools/health.ts
+++ b/projects/agenticos/mcp-server/src/tools/health.ts
@@ -1,0 +1,6 @@
+import { runHealthCheck } from '../utils/health.js';
+
+export async function runHealth(args: any): Promise<string> {
+  const result = await runHealthCheck(args ?? {});
+  return JSON.stringify(result, null, 2);
+}

--- a/projects/agenticos/mcp-server/src/tools/index.ts
+++ b/projects/agenticos/mcp-server/src/tools/index.ts
@@ -5,5 +5,6 @@ export { recordSession } from './record.js';
 export { runPreflight } from './preflight.js';
 export { runBranchBootstrap } from './branch-bootstrap.js';
 export { runPrScopeCheck } from './pr-scope-check.js';
+export { runHealth } from './health.js';
 export { runEntrySurfaceRefresh } from './entry-surface-refresh.js';
 export { runStandardKitAdopt, runStandardKitUpgradeCheck } from './standard-kit.js';

--- a/projects/agenticos/mcp-server/src/utils/__tests__/health.test.ts
+++ b/projects/agenticos/mcp-server/src/utils/__tests__/health.test.ts
@@ -1,0 +1,210 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, mkdir, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const childProcessMock = vi.hoisted(() => ({
+  exec: vi.fn(),
+}));
+
+const standardKitMock = vi.hoisted(() => ({
+  checkStandardKitUpgrade: vi.fn(),
+}));
+
+vi.mock('child_process', () => ({
+  exec: childProcessMock.exec,
+}));
+
+vi.mock('../standard-kit.js', () => ({
+  checkStandardKitUpgrade: standardKitMock.checkStandardKitUpgrade,
+}));
+
+import { runHealthCheck } from '../health.js';
+import { runHealth } from '../../tools/health.js';
+
+async function setupProjectRoot(stateYaml: string): Promise<string> {
+  const projectRoot = await mkdtemp(join(tmpdir(), 'agenticos-health-'));
+  await mkdir(join(projectRoot, '.context'), { recursive: true });
+  await writeFile(join(projectRoot, '.context', 'state.yaml'), stateYaml, 'utf-8');
+  return projectRoot;
+}
+
+describe('health command', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reports PASS when the canonical checkout is clean and freshness signals are present', async () => {
+    const projectRoot = await setupProjectRoot(`session:\n  last_entry_surface_refresh: "2026-03-25T00:00:00.000Z"\nguardrail_evidence:\n  last_command: "agenticos_preflight"\nentry_surface_refresh:\n  refreshed_at: "2026-03-25T00:00:00.000Z"\n`);
+    childProcessMock.exec.mockImplementation((_: string, cb: Function) => cb(null, '## main...origin/main\n', ''));
+    standardKitMock.checkStandardKitUpgrade.mockResolvedValue({
+      missing_required_files: [],
+      generated_files: [{ path: 'AGENTS.md', status: 'current' }],
+      copied_templates: [{ path: '.context/quick-start.md', status: 'matches_canonical' }],
+    });
+
+    const result = await runHealthCheck({
+      repo_path: '/repo',
+      project_path: projectRoot,
+      check_standard_kit: true,
+    });
+
+    expect(result.status).toBe('PASS');
+    expect(result.gates).toEqual([
+      { gate: 'repo_sync', status: 'PASS', summary: 'Canonical checkout is clean and aligned with origin/main.' },
+      { gate: 'entry_surface_refresh', status: 'PASS', summary: 'Entry surfaces have explicit refresh metadata.' },
+      { gate: 'guardrail_evidence', status: 'PASS', summary: 'Latest guardrail evidence is present (agenticos_preflight).' },
+      { gate: 'standard_kit', status: 'PASS', summary: 'Standard-kit files match the canonical kit.' },
+    ]);
+
+    const wrapped = JSON.parse(await runHealth({
+      repo_path: '/repo',
+      project_path: projectRoot,
+    })) as { command: string; status: string };
+    expect(wrapped.command).toBe('agenticos_health');
+    expect(wrapped.status).toBe('PASS');
+  });
+
+  it('reports BLOCK and WARN gates for a behind or dirty canonical checkout with stale state surfaces', async () => {
+    const projectRoot = await setupProjectRoot(`session:\n  id: "session-1"\n`);
+    childProcessMock.exec.mockImplementation((_: string, cb: Function) => cb(null, '## main...origin/main [behind 2]\n M README.md\n', ''));
+
+    const result = await runHealthCheck({
+      repo_path: '/repo',
+      project_path: projectRoot,
+    });
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.gates).toEqual([
+      {
+        gate: 'repo_sync',
+        status: 'BLOCK',
+        summary: 'Canonical checkout is not aligned with origin/main: ## main...origin/main [behind 2]',
+      },
+      {
+        gate: 'entry_surface_refresh',
+        status: 'WARN',
+        summary: 'Entry surfaces do not yet have explicit refresh metadata.',
+      },
+      {
+        gate: 'guardrail_evidence',
+        status: 'WARN',
+        summary: 'No persisted guardrail evidence is present yet.',
+      },
+    ]);
+  });
+
+  it('reports WARN when project state cannot be read and when standard-kit drift exists', async () => {
+    childProcessMock.exec.mockImplementation((_: string, cb: Function) => cb(null, '## main...origin/main\n', ''));
+    standardKitMock.checkStandardKitUpgrade.mockResolvedValue({
+      missing_required_files: ['CLAUDE.md'],
+      generated_files: [{ path: 'AGENTS.md', status: 'stale' }],
+      copied_templates: [{ path: '.context/quick-start.md', status: 'diverged_from_canonical' }],
+    });
+
+    const result = await runHealthCheck({
+      repo_path: '/repo',
+      project_path: '/missing/project',
+      check_standard_kit: true,
+    });
+
+    expect(result.status).toBe('WARN');
+    expect(result.gates).toEqual([
+      { gate: 'repo_sync', status: 'PASS', summary: 'Canonical checkout is clean and aligned with origin/main.' },
+      {
+        gate: 'entry_surface_refresh',
+        status: 'WARN',
+        summary: 'Project state could not be read, so entry-surface freshness was not proven.',
+      },
+      {
+        gate: 'guardrail_evidence',
+        status: 'WARN',
+        summary: 'Project state could not be read, so guardrail visibility was not proven.',
+      },
+      {
+        gate: 'standard_kit',
+        status: 'WARN',
+        summary: 'Standard-kit drift was detected and should be reviewed before starting work.',
+      },
+    ]);
+  });
+
+  it('blocks a canonical checkout that is on main but still dirty', async () => {
+    const projectRoot = await setupProjectRoot(`entry_surface_refresh:\n  refreshed_at: "2026-03-25T00:00:00.000Z"\n`);
+    childProcessMock.exec.mockImplementation((_: string, cb: Function) => cb(null, '## main...origin/main\n M README.md\n', ''));
+
+    const result = await runHealthCheck({
+      repo_path: '/repo',
+      project_path: projectRoot,
+    });
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.gates[0]).toEqual({
+      gate: 'repo_sync',
+      status: 'BLOCK',
+      summary: 'Canonical checkout is dirty and cannot be treated as a trusted starting point.',
+    });
+  });
+
+  it('fails closed on missing repo_path, git command failure fallbacks, missing branch status, and missing project_path for standard-kit checks', async () => {
+    await expect(() => runHealth(undefined)).rejects.toThrow('repo_path is required.');
+
+    childProcessMock.exec.mockImplementation((_: string, cb: Function) => cb(new Error('git failed'), '', 'git failed'));
+    await expect(() => runHealthCheck({ repo_path: '/repo' })).rejects.toThrow('git failed');
+
+    childProcessMock.exec.mockImplementation((_: string, cb: Function) => cb(new Error('message only git failure'), '', ''));
+    await expect(() => runHealthCheck({ repo_path: '/repo' })).rejects.toThrow('message only git failure');
+
+    const nullStateProjectRoot = await setupProjectRoot('null');
+    childProcessMock.exec.mockImplementation((_: string, cb: Function) => cb(null, '\n', ''));
+    const missingBranchResult = await runHealthCheck({
+      repo_path: '/repo',
+      project_path: nullStateProjectRoot,
+    });
+
+    expect(missingBranchResult.status).toBe('BLOCK');
+    expect(missingBranchResult.gates).toEqual([
+      {
+        gate: 'repo_sync',
+        status: 'BLOCK',
+        summary: 'Canonical checkout is not aligned with origin/main: missing branch status',
+      },
+      {
+        gate: 'entry_surface_refresh',
+        status: 'WARN',
+        summary: 'Entry surfaces do not yet have explicit refresh metadata.',
+      },
+      {
+        gate: 'guardrail_evidence',
+        status: 'WARN',
+        summary: 'No persisted guardrail evidence is present yet.',
+      },
+    ]);
+
+    childProcessMock.exec.mockImplementation((_: string, cb: Function) => cb(null, '## main...origin/main\n', ''));
+    const result = await runHealthCheck({
+      repo_path: '/repo',
+      check_standard_kit: true,
+    });
+
+    expect(result.status).toBe('WARN');
+    expect(result.gates).toEqual([
+      { gate: 'repo_sync', status: 'PASS', summary: 'Canonical checkout is clean and aligned with origin/main.' },
+      {
+        gate: 'entry_surface_refresh',
+        status: 'WARN',
+        summary: 'Project state could not be read, so entry-surface freshness was not proven.',
+      },
+      {
+        gate: 'guardrail_evidence',
+        status: 'WARN',
+        summary: 'Project state could not be read, so guardrail visibility was not proven.',
+      },
+      {
+        gate: 'standard_kit',
+        status: 'WARN',
+        summary: 'Standard-kit drift check was requested without a project_path.',
+      },
+    ]);
+  });
+});

--- a/projects/agenticos/mcp-server/src/utils/health.ts
+++ b/projects/agenticos/mcp-server/src/utils/health.ts
@@ -1,0 +1,200 @@
+import { exec } from 'child_process';
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+import yaml from 'yaml';
+import { checkStandardKitUpgrade } from './standard-kit.js';
+
+export interface HealthArgs {
+  repo_path: string;
+  project_path?: string;
+  remote_base_branch?: string;
+  checkout_role?: 'canonical';
+  check_standard_kit?: boolean;
+}
+
+export interface HealthGate {
+  gate: 'repo_sync' | 'entry_surface_refresh' | 'guardrail_evidence' | 'standard_kit';
+  status: 'PASS' | 'WARN' | 'BLOCK';
+  summary: string;
+}
+
+export interface HealthResult {
+  command: 'agenticos_health';
+  status: 'PASS' | 'WARN' | 'BLOCK';
+  repo_path: string;
+  project_path: string | null;
+  remote_base_branch: string;
+  checkout_role: 'canonical';
+  checked_at: string;
+  gates: HealthGate[];
+}
+
+function execCommand(command: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    exec(command, (error, stdout, stderr) => {
+      if (error) {
+        reject(new Error(stderr || stdout || error.message));
+        return;
+      }
+      resolve(stdout);
+    });
+  });
+}
+
+function combineHealthStatus(gates: HealthGate[]): 'PASS' | 'WARN' | 'BLOCK' {
+  if (gates.some((gate) => gate.status === 'BLOCK')) return 'BLOCK';
+  if (gates.some((gate) => gate.status === 'WARN')) return 'WARN';
+  return 'PASS';
+}
+
+function parseRepoSyncGate(statusOutput: string, remoteBaseBranch: string): HealthGate {
+  const lines = statusOutput.trimEnd().split('\n');
+  const branchLine = lines[0] || '';
+  const fileChanges = lines.slice(1).filter((line) => line.trim().length > 0);
+  const expectedBranchLine = `## main...${remoteBaseBranch}`;
+
+  if (branchLine !== expectedBranchLine) {
+    return {
+      gate: 'repo_sync',
+      status: 'BLOCK',
+      summary: `Canonical checkout is not aligned with ${remoteBaseBranch}: ${branchLine || 'missing branch status'}`,
+    };
+  }
+
+  if (fileChanges.length > 0) {
+    return {
+      gate: 'repo_sync',
+      status: 'BLOCK',
+      summary: 'Canonical checkout is dirty and cannot be treated as a trusted starting point.',
+    };
+  }
+
+  return {
+    gate: 'repo_sync',
+    status: 'PASS',
+    summary: `Canonical checkout is clean and aligned with ${remoteBaseBranch}.`,
+  };
+}
+
+async function readState(projectPath?: string): Promise<any | null> {
+  if (!projectPath) return null;
+
+  try {
+    return yaml.parse(await readFile(join(projectPath, '.context', 'state.yaml'), 'utf-8')) || {};
+  } catch {
+    return null;
+  }
+}
+
+function buildEntrySurfaceGate(state: any | null): HealthGate {
+  if (!state) {
+    return {
+      gate: 'entry_surface_refresh',
+      status: 'WARN',
+      summary: 'Project state could not be read, so entry-surface freshness was not proven.',
+    };
+  }
+
+  if (state.entry_surface_refresh?.refreshed_at || state.session?.last_entry_surface_refresh) {
+    return {
+      gate: 'entry_surface_refresh',
+      status: 'PASS',
+      summary: 'Entry surfaces have explicit refresh metadata.',
+    };
+  }
+
+  return {
+    gate: 'entry_surface_refresh',
+    status: 'WARN',
+    summary: 'Entry surfaces do not yet have explicit refresh metadata.',
+  };
+}
+
+function buildGuardrailGate(state: any | null): HealthGate {
+  if (!state) {
+    return {
+      gate: 'guardrail_evidence',
+      status: 'WARN',
+      summary: 'Project state could not be read, so guardrail visibility was not proven.',
+    };
+  }
+
+  if (state.guardrail_evidence?.last_command) {
+    return {
+      gate: 'guardrail_evidence',
+      status: 'PASS',
+      summary: `Latest guardrail evidence is present (${state.guardrail_evidence.last_command}).`,
+    };
+  }
+
+  return {
+    gate: 'guardrail_evidence',
+    status: 'WARN',
+    summary: 'No persisted guardrail evidence is present yet.',
+  };
+}
+
+async function buildStandardKitGate(args: HealthArgs): Promise<HealthGate | null> {
+  if (!args.check_standard_kit) return null;
+  if (!args.project_path) {
+    return {
+      gate: 'standard_kit',
+      status: 'WARN',
+      summary: 'Standard-kit drift check was requested without a project_path.',
+    };
+  }
+
+  const result = await checkStandardKitUpgrade({ project_path: args.project_path });
+  const hasMissingRequired = result.missing_required_files.length > 0;
+  const hasStaleGenerated = result.generated_files.some((file) => file.status !== 'current');
+  const hasTemplateDrift = result.copied_templates.some((file) => file.status !== 'matches_canonical');
+
+  if (!hasMissingRequired && !hasStaleGenerated && !hasTemplateDrift) {
+    return {
+      gate: 'standard_kit',
+      status: 'PASS',
+      summary: 'Standard-kit files match the canonical kit.',
+    };
+  }
+
+  return {
+    gate: 'standard_kit',
+    status: 'WARN',
+    summary: 'Standard-kit drift was detected and should be reviewed before starting work.',
+  };
+}
+
+export async function runHealthCheck(args: HealthArgs): Promise<HealthResult> {
+  if (!args?.repo_path) {
+    throw new Error('repo_path is required.');
+  }
+
+  const remoteBaseBranch = args.remote_base_branch || 'origin/main';
+  const checkoutRole = args.checkout_role || 'canonical';
+  const checkedAt = new Date().toISOString();
+
+  const repoStatus = await execCommand(`git -C "${args.repo_path}" status --short --branch`);
+  const state = await readState(args.project_path);
+
+  const gates: HealthGate[] = [
+    parseRepoSyncGate(repoStatus, remoteBaseBranch),
+    buildEntrySurfaceGate(state),
+    buildGuardrailGate(state),
+  ];
+
+  const standardKitGate = await buildStandardKitGate(args);
+  if (standardKitGate) {
+    gates.push(standardKitGate);
+  }
+
+  return {
+    command: 'agenticos_health',
+    status: combineHealthStatus(gates),
+    repo_path: args.repo_path,
+    project_path: args.project_path || null,
+    remote_base_branch: remoteBaseBranch,
+    checkout_role: checkoutRole,
+    checked_at: checkedAt,
+    gates,
+  };
+}

--- a/projects/agenticos/standards/.context/quick-start.md
+++ b/projects/agenticos/standards/.context/quick-start.md
@@ -68,8 +68,10 @@ Its job is to define and evolve:
 - issue `#99` now adds a deterministic refresh surface for `quick-start.md` and `state.yaml` instead of relying on manual post-merge edits
 - `knowledge/entry-surface-refresh-design-2026-03-25.md` records why bounded structured refresh is preferred over freeform summarization
 - `knowledge/entry-surface-refresh-implementation-report-2026-03-25.md` records the landed command, runtime files, and verification
+- issue `#97` now adds one bounded `agenticos_health` surface for canonical checkout freshness, entry-surface refresh freshness, guardrail visibility, and optional standard-kit drift
+- `knowledge/health-command-design-2026-03-25.md` records why this should be a compact pre-work health gate instead of a dashboard
+- `knowledge/health-command-implementation-report-2026-03-25.md` records the landed gates, runtime files, and verification
 - the next higher-order backlog is now:
-  - `#97` `agenticos_health`
   - `#96` rubric-backed non-code evaluation
   - `#95` delegated-work runtime enforcement
   - `#94` entry-surface guardrail-summary design review
@@ -108,10 +110,11 @@ Start here:
 28. `knowledge/canonical-sync-implementation-report-2026-03-25.md`
 29. `knowledge/entry-surface-refresh-design-2026-03-25.md`
 30. `knowledge/entry-surface-refresh-implementation-report-2026-03-25.md`
+31. `knowledge/health-command-design-2026-03-25.md`
+32. `knowledge/health-command-implementation-report-2026-03-25.md`
 
 ## Next Steps
 
-1. Execute `#97` to give Agents one health surface for checkout freshness, standards freshness, and guardrail visibility
-2. Execute `#96` to turn rubric-backed non-code evaluation into a first-class verification command
-3. Execute `#95` to enforce delegated-work handoff packets and verification echoes at runtime
-4. Revisit `#94` only after the higher-priority health and enforcement work is done
+1. Execute `#96` to turn rubric-backed non-code evaluation into a first-class verification command
+2. Execute `#95` to enforce delegated-work handoff packets and verification echoes at runtime
+3. Revisit `#94` only after the higher-priority health and enforcement work is done

--- a/projects/agenticos/standards/.context/state.yaml
+++ b/projects/agenticos/standards/.context/state.yaml
@@ -5,9 +5,9 @@ session:
   last_backup: 2026-03-23T10:35:00.000Z
 
 current_task:
-  title: automate deterministic refresh of standards quick-start and state after merged work
+  title: add one bounded health surface for checkout freshness and resume-signal freshness
   status: implemented
-  updated: 2026-03-25T02:06:00.000Z
+  updated: 2026-03-25T02:12:00.000Z
 
 working_memory:
   facts:
@@ -77,7 +77,8 @@ working_memory:
     - issue #98 also freezes the freshness contract for when standards quick-start and state surfaces must be refreshed after merged work
     - issue #99 now adds a deterministic bounded refresh command for quick-start and state surfaces using structured merged-work inputs
     - the refresh command writes bounded entry-surface metadata into state instead of attempting freeform summarization
-    - the next higher-order backlog is now #97, #96, #95, and #94 in that priority order
+    - issue #97 now adds one bounded health command for canonical checkout freshness, entry-surface freshness, guardrail visibility, and optional standard-kit drift
+    - the next higher-order backlog is now #96, #95, and #94 in that priority order
   decisions:
     - keep one main AgenticOS product repository and one canonical standards area inside it
     - merge durable standards knowledge into the main repo, but archive raw standalone context/history instead of treating it as live state
@@ -100,8 +101,8 @@ working_memory:
     - strict coverage follow-up issues should add the smallest fallback-path regression tests needed to prove the existing design rather than reopening already-correct runtime behavior
     - canonical local sync should be treated as a repeatable contract with executable verification, not as an occasional operator cleanup task
     - entry-surface refresh should be deterministic and bounded, not an unconstrained summarizer over arbitrary merged documents
+    - health should be a compact pre-work gate with high-signal PASS/WARN/BLOCK semantics, not a broad dashboard
   pending:
-    - execute issue #97 to add one health surface for checkout freshness, standards freshness, and guardrail visibility
     - execute issue #96 to turn rubric-backed non-code evaluation into a first-class command
     - execute issue #95 to enforce delegated-work handoff packets and verification echoes at runtime
     - revisit issue #94 after the higher-priority health and enforcement work is complete

--- a/projects/agenticos/standards/knowledge/health-command-design-2026-03-25.md
+++ b/projects/agenticos/standards/knowledge/health-command-design-2026-03-25.md
@@ -1,0 +1,101 @@
+# Health Command Design — 2026-03-25
+
+## Problem
+
+AgenticOS now has several important pre-work signals:
+
+- whether the canonical checkout is current and clean
+- whether the live entry surfaces have explicit refresh metadata
+- whether persisted guardrail evidence exists
+- whether standard-kit drift is already visible
+
+Today these checks exist, but they are scattered across:
+
+- `git status`
+- `state.yaml`
+- guardrail evidence inspection
+- standard-kit upgrade checks
+
+That means an agent can still start work from a degraded environment unless it remembers to run several separate checks.
+
+## Design Reflection
+
+This should not become a generic dashboard.
+
+The right product shape is one bounded health surface that answers one practical question:
+
+> Can this environment be trusted as a starting point before work begins?
+
+That means the health command should aggregate only a small number of high-signal gates and report them with the same clear semantics already used elsewhere:
+
+- `PASS`
+- `WARN`
+- `BLOCK`
+
+## Chosen Scope
+
+Add one command:
+
+- `agenticos_health`
+
+It evaluates:
+
+1. `repo_sync`
+2. `entry_surface_refresh`
+3. `guardrail_evidence`
+4. `standard_kit` (optional)
+
+### Repo Sync
+
+For this issue, checkout role is intentionally limited to:
+
+- `canonical`
+
+Meaning the command is explicitly for trusted local base checkouts, not issue worktrees.
+
+Canonical checkout is `PASS` only when:
+
+- branch status is exactly `main...origin/main`
+- working tree is clean
+
+Anything else is a `BLOCK`.
+
+### Entry-Surface Refresh
+
+This gate checks whether project state contains explicit refresh metadata:
+
+- `entry_surface_refresh.refreshed_at`
+or
+- `session.last_entry_surface_refresh`
+
+Missing metadata is a `WARN`, not a `BLOCK`, because the environment may still be usable but is not fully proven fresh.
+
+### Guardrail Evidence
+
+This gate checks whether `guardrail_evidence.last_command` exists.
+
+Missing evidence is a `WARN`.
+
+### Standard-Kit Drift
+
+This gate is optional and reuses the existing standard-kit upgrade-check logic.
+
+Detected drift is a `WARN`, not a `BLOCK`, because drift should usually be reviewed before work but does not always invalidate the environment.
+
+## Non-Goals
+
+This issue does not:
+
+- replace `agenticos_preflight`
+- judge issue scope or branch ancestry for implementation work
+- act as a release-readiness dashboard
+- infer project health from arbitrary heuristics outside these explicit gates
+
+## Acceptance Shape
+
+The issue is complete when:
+
+- there is one executable `agenticos_health` surface
+- the output is deterministic and compact
+- it uses `PASS / WARN / BLOCK`
+- it proves the canonical checkout and project freshness signals without becoming a noisy dashboard

--- a/projects/agenticos/standards/knowledge/health-command-implementation-report-2026-03-25.md
+++ b/projects/agenticos/standards/knowledge/health-command-implementation-report-2026-03-25.md
@@ -1,0 +1,49 @@
+# Health Command Implementation Report — 2026-03-25
+
+## Scope
+
+Issue `#97` adds a bounded pre-work health surface:
+
+- `agenticos_health`
+
+Backed by:
+
+- `src/utils/health.ts`
+- `src/tools/health.ts`
+
+## What Landed
+
+The command now reports one compact structured health result across these gates:
+
+1. `repo_sync`
+2. `entry_surface_refresh`
+3. `guardrail_evidence`
+4. `standard_kit` (optional)
+
+The command is intentionally scoped to canonical checkout trust rather than issue-worktree implementation checks.
+
+## Verification
+
+Targeted runtime verification:
+
+```bash
+npm test -- --run src/utils/__tests__/health.test.ts
+npx vitest run --coverage.enabled true --coverage.provider=v8 --coverage.reporter=text --coverage.include=src/utils/health.ts --coverage.include=src/tools/health.ts src/utils/__tests__/health.test.ts
+```
+
+Result:
+
+- `src/utils/health.ts`: `100 / 100 / 100 / 100`
+- `src/tools/health.ts`: `100 / 100 / 100 / 100`
+
+Repository-level verification:
+
+```bash
+npm run build
+npm test
+ruby -e 'require "yaml"; YAML.load_file("projects/agenticos/standards/.context/state.yaml"); puts "state-ok"'
+```
+
+## Outcome
+
+AgenticOS now has one explicit health surface that tells an agent whether the current canonical checkout and project freshness signals are safe enough to trust before starting work.


### PR DESCRIPTION
## Summary
- add agenticos_health for canonical checkout freshness, entry-surface freshness, guardrail visibility, and optional standard-kit drift
- keep the health surface bounded and PASS/WARN/BLOCK based instead of a broad dashboard
- update standards/docs to make the post-#99 queue explicit

## Verification
- npm test -- --run src/utils/__tests__/health.test.ts
- npx vitest run --coverage.enabled true --coverage.provider=v8 --coverage.reporter=text --coverage.include=src/utils/health.ts --coverage.include=src/tools/health.ts src/utils/__tests__/health.test.ts
- npm run build
- npm test
- ruby -e 'require "yaml"; YAML.load_file("/Users/jeking/worktrees/agenticos-health-97/projects/agenticos/standards/.context/state.yaml"); puts "state-ok"'