### PR TITLE
feat: add rubric-backed non-code evaluation command (#96)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ The agent will call `agenticos_init` and set up the project structure automatica
 | `agenticos_pr_scope_check` | Validate commit/file scope before PR | `issue_id`, `repo_path`, `declared_target_files` |
 | `agenticos_health` | Check canonical checkout, entry-surface, and guardrail freshness | `repo_path`, `project_path`, `check_standard_kit` |
 | `agenticos_refresh_entry_surfaces` | Refresh quick-start and state from structured merged-work inputs | `project_path`, `summary`, `status`, `current_focus` |
+| `agenticos_non_code_evaluate` | Validate a completed non-code rubric and persist latest structured evidence into project state | `project_path`, `rubric_path` |
 | `agenticos_record` | Record session progress | `summary`, `decisions`, `outcomes`, `pending`, `current_task` |
 | `agenticos_save` | Save state + git backup | `message` (commit message) |
 

--- a/projects/agenticos/mcp-server/README.md
+++ b/projects/agenticos/mcp-server/README.md
@@ -236,6 +236,15 @@ Deterministically refresh `.context/quick-start.md` and `.context/state.yaml` fr
 
 **Returns**: JSON with `REFRESHED`
 
+### agenticos_non_code_evaluate
+Validate a completed non-code evaluation rubric against the canonical contract and persist the latest structured evidence into project state.
+
+**Parameters**:
+- `project_path` (required)
+- `rubric_path` (required)
+
+**Returns**: JSON with `RECORDED`
+
 ---
 
 ## 📦 Resources Reference

--- a/projects/agenticos/mcp-server/src/index.ts
+++ b/projects/agenticos/mcp-server/src/index.ts
@@ -34,7 +34,7 @@ import {
   ListResourcesRequestSchema,
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { initProject, switchProject, listProjects, getStatus, saveState, recordSession, runPreflight, runBranchBootstrap, runPrScopeCheck, runHealth, runEntrySurfaceRefresh, runStandardKitAdopt, runStandardKitUpgradeCheck } from './tools/index.js';
+import { initProject, switchProject, listProjects, getStatus, saveState, recordSession, runPreflight, runBranchBootstrap, runPrScopeCheck, runHealth, runEntrySurfaceRefresh, runStandardKitAdopt, runStandardKitUpgradeCheck, runNonCodeEvaluate } from './tools/index.js';
 import { getProjectContext } from './resources/index.js';
 
 const server = new Server(
@@ -254,6 +254,18 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         },
       },
     },
+    {
+      name: 'agenticos_non_code_evaluate',
+      description: 'Validate a completed non-code evaluation rubric against the canonical contract and persist the latest structured evidence into project state.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          project_path: { type: 'string', description: 'Absolute project path whose latest non-code evaluation evidence should be updated.' },
+          rubric_path: { type: 'string', description: 'Absolute or project-relative path to the completed rubric YAML file.' },
+        },
+        required: ['project_path', 'rubric_path'],
+      },
+    },
   ],
 }));
 
@@ -288,6 +300,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       return { content: [{ type: 'text', text: await runStandardKitAdopt(args ?? {}) }] };
     case 'agenticos_standard_kit_upgrade_check':
       return { content: [{ type: 'text', text: await runStandardKitUpgradeCheck(args ?? {}) }] };
+    case 'agenticos_non_code_evaluate':
+      return { content: [{ type: 'text', text: await runNonCodeEvaluate(args ?? {}) }] };
     default:
       throw new Error(`Unknown tool: ${name}`);
   }

--- a/projects/agenticos/mcp-server/src/tools/index.ts
+++ b/projects/agenticos/mcp-server/src/tools/index.ts
@@ -8,3 +8,4 @@ export { runPrScopeCheck } from './pr-scope-check.js';
 export { runHealth } from './health.js';
 export { runEntrySurfaceRefresh } from './entry-surface-refresh.js';
 export { runStandardKitAdopt, runStandardKitUpgradeCheck } from './standard-kit.js';
+export { runNonCodeEvaluate } from './non-code-evaluate.js';

--- a/projects/agenticos/mcp-server/src/tools/non-code-evaluate.ts
+++ b/projects/agenticos/mcp-server/src/tools/non-code-evaluate.ts
@@ -1,0 +1,6 @@
+import { evaluateNonCode } from '../utils/non-code-evaluation.js';
+
+export async function runNonCodeEvaluate(args: any): Promise<string> {
+  const result = await evaluateNonCode(args ?? {});
+  return JSON.stringify(result, null, 2);
+}

--- a/projects/agenticos/mcp-server/src/utils/__tests__/non-code-evaluation.test.ts
+++ b/projects/agenticos/mcp-server/src/utils/__tests__/non-code-evaluation.test.ts
@@ -1,0 +1,550 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtemp, mkdir, readFile, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import yaml from 'yaml';
+import { evaluateNonCode } from '../non-code-evaluation.js';
+import { runNonCodeEvaluate } from '../../tools/non-code-evaluate.js';
+
+async function setupProjectRoot(): Promise<string> {
+  const projectRoot = await mkdtemp(join(tmpdir(), 'agenticos-non-code-eval-'));
+  await mkdir(join(projectRoot, '.context'), { recursive: true });
+  await mkdir(join(projectRoot, 'knowledge'), { recursive: true });
+  await mkdir(join(projectRoot, 'artifacts'), { recursive: true });
+  return projectRoot;
+}
+
+async function writeRubric(projectRoot: string, content: Record<string, unknown>, relativePath = 'artifacts/non-code-evaluation.yaml'): Promise<string> {
+  const rubricPath = join(projectRoot, relativePath);
+  await mkdir(join(projectRoot, 'artifacts'), { recursive: true });
+  await writeFile(rubricPath, yaml.stringify(content), 'utf-8');
+  return rubricPath;
+}
+
+describe('non-code evaluation command', () => {
+  afterEach(() => {
+    delete process.env.AGENTICOS_HOME;
+  });
+
+  it('validates a completed rubric, persists latest evidence, and returns a structured tool result', async () => {
+    const projectRoot = await setupProjectRoot();
+    await writeFile(join(projectRoot, 'knowledge', 'design.md'), '# Design\n', 'utf-8');
+    await writeFile(
+      join(projectRoot, '.context', 'state.yaml'),
+      yaml.stringify({
+        session: { id: 'session-1', started: '2026-03-25T00:00:00.000Z', agent: 'codex' },
+      }),
+      'utf-8',
+    );
+
+    await writeRubric(projectRoot, {
+      name: 'non-code-evaluation-rubric',
+      artifact: {
+        path: 'knowledge/design.md',
+        type: 'design_doc',
+      },
+      goal: {
+        intended_outcome: 'Freeze the design contract before implementation.',
+        linked_issue: '96',
+      },
+      criteria: [
+        { name: 'goal_alignment', result: 'PASS', notes: 'Aligned with the issue scope.' },
+        { name: 'executability', result: 'PASS', notes: 'Checks and pseudocode are explicit.' },
+        { name: 'consistency', result: 'PASS', notes: 'No conflicts with existing standards.' },
+        { name: 'completeness', result: 'PASS', notes: 'Entry, flow, and failure states are covered.' },
+        { name: 'downstream_usability', result: 'PASS', notes: 'Another agent can pick this up.' },
+      ],
+      evaluation: {
+        overall_result: 'PASS',
+        residual_risks: ['Docs still depend on operator discipline.', '' as any, 7 as any],
+      },
+    });
+
+    const result = await evaluateNonCode({
+      project_path: projectRoot,
+      rubric_path: 'artifacts/non-code-evaluation.yaml',
+    });
+
+    expect(result.status).toBe('RECORDED');
+    expect(result.project_path).toBe(projectRoot);
+    expect(result.rubric_path).toBe('artifacts/non-code-evaluation.yaml');
+    expect(result.artifact_path).toBe('knowledge/design.md');
+    expect(result.artifact_type).toBe('design_doc');
+    expect(result.linked_issue).toBe('96');
+    expect(result.overall_result).toBe('PASS');
+    expect(result.criteria).toEqual([
+      { name: 'goal_alignment', result: 'PASS' },
+      { name: 'executability', result: 'PASS' },
+      { name: 'consistency', result: 'PASS' },
+      { name: 'completeness', result: 'PASS' },
+      { name: 'downstream_usability', result: 'PASS' },
+    ]);
+
+    const state = yaml.parse(await readFile(join(projectRoot, '.context', 'state.yaml'), 'utf-8')) as any;
+    expect(state.session.id).toBe('session-1');
+    expect(state.session.started).toBe('2026-03-25T00:00:00.000Z');
+    expect(state.session.agent).toBe('codex');
+    expect(state.session.last_non_code_evaluation).toBe(result.recorded_at);
+    expect(state.non_code_evaluation.updated_at).toBe(result.recorded_at);
+    expect(state.non_code_evaluation.latest.command).toBe('agenticos_non_code_evaluate');
+    expect(state.non_code_evaluation.latest.rubric_path).toBe('artifacts/non-code-evaluation.yaml');
+    expect(state.non_code_evaluation.latest.artifact).toEqual({
+      path: 'knowledge/design.md',
+      type: 'design_doc',
+    });
+    expect(state.non_code_evaluation.latest.goal).toEqual({
+      intended_outcome: 'Freeze the design contract before implementation.',
+      linked_issue: '96',
+    });
+    expect(state.non_code_evaluation.latest.evaluation).toEqual({
+      method: 'llm_rubric_review',
+      passes_required: 1,
+      overall_result: 'PASS',
+    });
+    expect(state.non_code_evaluation.latest.criteria).toHaveLength(5);
+    expect(state.non_code_evaluation.latest.residual_risks).toEqual(['Docs still depend on operator discipline.']);
+
+    const wrapped = JSON.parse(await runNonCodeEvaluate({
+      project_path: projectRoot,
+      rubric_path: join(projectRoot, 'artifacts', 'non-code-evaluation.yaml'),
+    })) as { command: string; overall_result: string };
+    expect(wrapped.command).toBe('agenticos_non_code_evaluate');
+    expect(wrapped.overall_result).toBe('PASS');
+  });
+
+  it('accepts absolute artifact paths, explicit evaluation metadata, and rewrites the latest evidence slot', async () => {
+    const projectRoot = await setupProjectRoot();
+    const artifactPath = join(projectRoot, 'knowledge', 'workflow.md');
+    await writeFile(artifactPath, '# Workflow\n', 'utf-8');
+
+    await writeRubric(projectRoot, {
+      name: 'non-code-evaluation-rubric',
+      artifact: {
+        path: artifactPath,
+        type: 'workflow_spec',
+      },
+      goal: {
+        intended_outcome: 'Record the workflow spec result.',
+        linked_issue: '96',
+      },
+      criteria: [
+        { name: 'goal_alignment', result: 'FAIL', notes: 'Scope still misses rollout details.' },
+        { name: 'executability', result: 'PASS', notes: 'Execution flow is explicit.' },
+        { name: 'consistency', result: 'PASS', notes: 'Matches current positioning.' },
+        { name: 'completeness', result: 'PASS', notes: 'Major sections exist.' },
+        { name: 'downstream_usability', result: 'PASS', notes: 'Readable without chat history.' },
+      ],
+      evaluation: {
+        method: 'manual_review',
+        passes_required: 2,
+        overall_result: 'FAIL',
+        residual_risks: ['Needs rollout-specific examples.'],
+      },
+    }, 'artifacts/workflow-evaluation.yaml');
+
+    const result = await evaluateNonCode({
+      project_path: projectRoot,
+      rubric_path: join(projectRoot, 'artifacts', 'workflow-evaluation.yaml'),
+    });
+
+    expect(result.overall_result).toBe('FAIL');
+    expect(result.artifact_type).toBe('workflow_spec');
+    expect(result.residual_risks).toEqual(['Needs rollout-specific examples.']);
+
+    const state = yaml.parse(await readFile(join(projectRoot, '.context', 'state.yaml'), 'utf-8')) as any;
+    expect(state.non_code_evaluation.latest.evaluation).toEqual({
+      method: 'manual_review',
+      passes_required: 2,
+      overall_result: 'FAIL',
+    });
+    expect(state.non_code_evaluation.latest.criteria[0]).toMatchObject({
+      name: 'goal_alignment',
+      question: expect.any(String),
+      pass_threshold: expect.any(String),
+      result: 'FAIL',
+      notes: 'Scope still misses rollout details.',
+    });
+  });
+
+  it('treats a null state file as empty mutable state and still records the evaluation', async () => {
+    const projectRoot = await setupProjectRoot();
+    await writeFile(join(projectRoot, 'knowledge', 'protocol.md'), '# Protocol\n', 'utf-8');
+    await writeFile(join(projectRoot, '.context', 'state.yaml'), 'null', 'utf-8');
+    await writeRubric(projectRoot, {
+      name: 'non-code-evaluation-rubric',
+      artifact: {
+        path: 'knowledge/protocol.md',
+        type: 'protocol_doc',
+      },
+      goal: {
+        intended_outcome: 'Handle null state inputs cleanly.',
+        linked_issue: '96',
+      },
+      criteria: [
+        { name: 'goal_alignment', result: 'PASS' },
+        { name: 'executability', result: 'PASS' },
+        { name: 'consistency', result: 'PASS' },
+        { name: 'completeness', result: 'PASS' },
+        { name: 'downstream_usability', result: 'PASS' },
+      ],
+      evaluation: {
+        overall_result: 'PASS',
+      },
+    }, 'artifacts/null-state-evaluation.yaml');
+
+    const result = await evaluateNonCode({
+      project_path: projectRoot,
+      rubric_path: 'artifacts/null-state-evaluation.yaml',
+    });
+
+    const state = yaml.parse(await readFile(join(projectRoot, '.context', 'state.yaml'), 'utf-8')) as any;
+    expect(result.overall_result).toBe('PASS');
+    expect(state.non_code_evaluation.latest.artifact.type).toBe('protocol_doc');
+    expect(state.session.last_non_code_evaluation).toBe(result.recorded_at);
+  });
+
+  it('fails closed on missing inputs, malformed rubrics, and missing files', async () => {
+    const projectRoot = await setupProjectRoot();
+    await writeFile(join(projectRoot, 'knowledge', 'spec.md'), '# Spec\n', 'utf-8');
+
+    await expect(() => runNonCodeEvaluate(undefined)).rejects.toThrow('project_path is required.');
+    await expect(() => evaluateNonCode({ project_path: '', rubric_path: 'artifacts/rubric.yaml' } as any)).rejects.toThrow('project_path is required.');
+    await expect(() => evaluateNonCode({ project_path: projectRoot, rubric_path: '' } as any)).rejects.toThrow('rubric_path is required.');
+    await expect(() => evaluateNonCode({ project_path: projectRoot, rubric_path: 7 as any })).rejects.toThrow('rubric_path is required.');
+    await expect(() => evaluateNonCode({ project_path: projectRoot, rubric_path: 'artifacts/missing.yaml' })).rejects.toThrow(`rubric_path does not exist: ${join(projectRoot, 'artifacts', 'missing.yaml')}`);
+
+    await writeRubric(projectRoot, {
+      name: 'wrong-name',
+      artifact: { path: 'knowledge/spec.md', type: 'knowledge_doc' },
+      goal: { intended_outcome: 'Bad rubric', linked_issue: '96' },
+      criteria: [],
+      evaluation: { overall_result: 'PASS' },
+    }, 'artifacts/bad-name.yaml');
+    await expect(() => evaluateNonCode({
+      project_path: projectRoot,
+      rubric_path: 'artifacts/bad-name.yaml',
+    })).rejects.toThrow('rubric name must be non-code-evaluation-rubric.');
+
+    await writeRubric(projectRoot, {
+      name: 'non-code-evaluation-rubric',
+      artifact: { path: '', type: 'knowledge_doc' },
+      goal: { intended_outcome: 'Bad artifact path', linked_issue: '96' },
+      criteria: [
+        { name: 'goal_alignment', result: 'PASS' },
+        { name: 'executability', result: 'PASS' },
+        { name: 'consistency', result: 'PASS' },
+        { name: 'completeness', result: 'PASS' },
+        { name: 'downstream_usability', result: 'PASS' },
+      ],
+      evaluation: { overall_result: 'PASS' },
+    }, 'artifacts/missing-artifact-path.yaml');
+    await expect(() => evaluateNonCode({
+      project_path: projectRoot,
+      rubric_path: 'artifacts/missing-artifact-path.yaml',
+    })).rejects.toThrow('artifact.path is required.');
+
+    await writeRubric(projectRoot, {
+      name: 'non-code-evaluation-rubric',
+      artifact: { path: 'knowledge/spec.md', type: 'unknown_doc' },
+      goal: { intended_outcome: 'Bad artifact type', linked_issue: '96' },
+      criteria: [
+        { name: 'goal_alignment', result: 'PASS' },
+        { name: 'executability', result: 'PASS' },
+        { name: 'consistency', result: 'PASS' },
+        { name: 'completeness', result: 'PASS' },
+        { name: 'downstream_usability', result: 'PASS' },
+      ],
+      evaluation: { overall_result: 'PASS' },
+    }, 'artifacts/bad-artifact-type.yaml');
+    await expect(() => evaluateNonCode({
+      project_path: projectRoot,
+      rubric_path: 'artifacts/bad-artifact-type.yaml',
+    })).rejects.toThrow('artifact.type must be one of: protocol_doc, design_doc, knowledge_doc, issue_draft, workflow_spec.');
+
+    await writeRubric(projectRoot, {
+      name: 'non-code-evaluation-rubric',
+      artifact: { path: 'knowledge/missing.md', type: 'knowledge_doc' },
+      goal: { intended_outcome: 'Missing artifact file', linked_issue: '96' },
+      criteria: [
+        { name: 'goal_alignment', result: 'PASS' },
+        { name: 'executability', result: 'PASS' },
+        { name: 'consistency', result: 'PASS' },
+        { name: 'completeness', result: 'PASS' },
+        { name: 'downstream_usability', result: 'PASS' },
+      ],
+      evaluation: { overall_result: 'PASS' },
+    }, 'artifacts/missing-artifact-file.yaml');
+    await expect(() => evaluateNonCode({
+      project_path: projectRoot,
+      rubric_path: 'artifacts/missing-artifact-file.yaml',
+    })).rejects.toThrow(`artifact.path does not exist: ${join(projectRoot, 'knowledge', 'missing.md')}`);
+
+    await writeRubric(projectRoot, {
+      name: 'non-code-evaluation-rubric',
+      artifact: { path: 'knowledge/spec.md', type: 'knowledge_doc' },
+      goal: { intended_outcome: 'Missing criterion', linked_issue: '96' },
+      criteria: [
+        { name: 'goal_alignment', result: 'PASS' },
+        { name: 'executability', result: 'PASS' },
+        { name: 'consistency', result: 'PASS' },
+        { name: 'completeness', result: 'PASS' },
+      ],
+      evaluation: { overall_result: 'PASS' },
+    }, 'artifacts/missing-criterion.yaml');
+    await expect(() => evaluateNonCode({
+      project_path: projectRoot,
+      rubric_path: 'artifacts/missing-criterion.yaml',
+    })).rejects.toThrow('criteria must contain every canonical criterion exactly once.');
+
+    await writeRubric(projectRoot, {
+      name: 'non-code-evaluation-rubric',
+      artifact: { path: 'knowledge/spec.md', type: 'knowledge_doc' },
+      goal: { intended_outcome: 'No criteria', linked_issue: '96' },
+      criteria: [],
+      evaluation: { overall_result: 'PASS' },
+    }, 'artifacts/no-criteria.yaml');
+    await expect(() => evaluateNonCode({
+      project_path: projectRoot,
+      rubric_path: 'artifacts/no-criteria.yaml',
+    })).rejects.toThrow('criteria are required.');
+
+    await writeRubric(projectRoot, {
+      name: 'non-code-evaluation-rubric',
+      artifact: { path: 'knowledge/spec.md', type: 'knowledge_doc' },
+      goal: { intended_outcome: 'Duplicate criterion', linked_issue: '96' },
+      criteria: [
+        { name: 'goal_alignment', result: 'PASS' },
+        { name: 'goal_alignment', result: 'PASS' },
+        { name: 'consistency', result: 'PASS' },
+        { name: 'completeness', result: 'PASS' },
+        { name: 'downstream_usability', result: 'PASS' },
+      ],
+      evaluation: { overall_result: 'PASS' },
+    }, 'artifacts/duplicate-criterion.yaml');
+    await expect(() => evaluateNonCode({
+      project_path: projectRoot,
+      rubric_path: 'artifacts/duplicate-criterion.yaml',
+    })).rejects.toThrow('criteria contains duplicate canonical criterion "goal_alignment".');
+
+    await writeRubric(projectRoot, {
+      name: 'non-code-evaluation-rubric',
+      artifact: { path: 'knowledge/spec.md', type: 'knowledge_doc' },
+      goal: { intended_outcome: 'Unknown criterion', linked_issue: '96' },
+      criteria: [
+        { name: 'goal_alignment', result: 'PASS' },
+        { name: 'executability', result: 'PASS' },
+        { name: 'consistency', result: 'PASS' },
+        { name: 'completeness', result: 'PASS' },
+        { name: 'mystery', result: 'PASS' },
+      ],
+      evaluation: { overall_result: 'PASS' },
+    }, 'artifacts/unknown-criterion.yaml');
+    await expect(() => evaluateNonCode({
+      project_path: projectRoot,
+      rubric_path: 'artifacts/unknown-criterion.yaml',
+    })).rejects.toThrow('criteria contains unknown canonical criterion "mystery".');
+
+    await writeRubric(projectRoot, {
+      name: 'non-code-evaluation-rubric',
+      artifact: { path: 'knowledge/spec.md', type: 'knowledge_doc' },
+      goal: { intended_outcome: 'Bad criterion result', linked_issue: '96' },
+      criteria: [
+        { name: 'goal_alignment', result: 7 as any },
+        { name: 'executability', result: 'PASS' },
+        { name: 'consistency', result: 'PASS' },
+        { name: 'completeness', result: 'PASS' },
+        { name: 'downstream_usability', result: 'PASS' },
+      ],
+      evaluation: { overall_result: 'FAIL' },
+    }, 'artifacts/bad-criterion-result.yaml');
+    await expect(() => evaluateNonCode({
+      project_path: projectRoot,
+      rubric_path: 'artifacts/bad-criterion-result.yaml',
+    })).rejects.toThrow('criteria[0].result must be PASS or FAIL.');
+
+    await writeFile(join(projectRoot, 'artifacts', 'null-rubric.yaml'), 'null', 'utf-8');
+    await expect(() => evaluateNonCode({
+      project_path: projectRoot,
+      rubric_path: 'artifacts/null-rubric.yaml',
+    })).rejects.toThrow('rubric name must be non-code-evaluation-rubric.');
+
+    await writeRubric(projectRoot, {
+      name: 'non-code-evaluation-rubric',
+      artifact: { path: 'knowledge/spec.md', type: 'knowledge_doc' },
+      goal: { intended_outcome: 'Bad overall result', linked_issue: '96' },
+      criteria: [
+        { name: 'goal_alignment', result: 'FAIL' },
+        { name: 'executability', result: 'PASS' },
+        { name: 'consistency', result: 'PASS' },
+        { name: 'completeness', result: 'PASS' },
+        { name: 'downstream_usability', result: 'PASS' },
+      ],
+      evaluation: { overall_result: 'PASS' },
+    }, 'artifacts/bad-overall-result.yaml');
+    await expect(() => evaluateNonCode({
+      project_path: projectRoot,
+      rubric_path: 'artifacts/bad-overall-result.yaml',
+    })).rejects.toThrow('evaluation.overall_result must match criteria results (FAIL).');
+
+    await writeRubric(projectRoot, {
+      name: 'non-code-evaluation-rubric',
+      artifact: { path: 'knowledge/spec.md', type: 'knowledge_doc' },
+      goal: { intended_outcome: '', linked_issue: '' },
+      criteria: [
+        { name: 'goal_alignment', result: 'PASS' },
+        { name: 'executability', result: 'PASS' },
+        { name: 'consistency', result: 'PASS' },
+        { name: 'completeness', result: 'PASS' },
+        { name: 'downstream_usability', result: 'PASS' },
+      ],
+      evaluation: { overall_result: 'PASS' },
+    }, 'artifacts/missing-goal.yaml');
+    await expect(() => evaluateNonCode({
+      project_path: projectRoot,
+      rubric_path: 'artifacts/missing-goal.yaml',
+    })).rejects.toThrow('goal.intended_outcome is required.');
+
+    await writeRubric(projectRoot, {
+      name: 'non-code-evaluation-rubric',
+      artifact: { path: 'knowledge/spec.md', type: 'knowledge_doc' },
+      goal: { intended_outcome: 'Missing linked issue', linked_issue: '' },
+      criteria: [
+        { name: 'goal_alignment', result: 'PASS' },
+        { name: 'executability', result: 'PASS' },
+        { name: 'consistency', result: 'PASS' },
+        { name: 'completeness', result: 'PASS' },
+        { name: 'downstream_usability', result: 'PASS' },
+      ],
+      evaluation: { overall_result: 'PASS' },
+    }, 'artifacts/missing-linked-issue.yaml');
+    await expect(() => evaluateNonCode({
+      project_path: projectRoot,
+      rubric_path: 'artifacts/missing-linked-issue.yaml',
+    })).rejects.toThrow('goal.linked_issue is required.');
+  });
+
+  it('fails closed when the canonical rubric contract is broken', async () => {
+    const projectRoot = await setupProjectRoot();
+    await writeFile(join(projectRoot, 'knowledge', 'spec.md'), '# Spec\n', 'utf-8');
+    await writeRubric(projectRoot, {
+      name: 'non-code-evaluation-rubric',
+      artifact: { path: 'knowledge/spec.md', type: 'knowledge_doc' },
+      goal: { intended_outcome: 'Use the canonical rubric', linked_issue: '96' },
+      criteria: [
+        { name: 'goal_alignment', result: 'PASS' },
+        { name: 'executability', result: 'PASS' },
+        { name: 'consistency', result: 'PASS' },
+        { name: 'completeness', result: 'PASS' },
+        { name: 'downstream_usability', result: 'PASS' },
+      ],
+      evaluation: { overall_result: 'PASS' },
+    }, 'artifacts/valid.yaml');
+
+    const canonicalRubricPath = join(process.cwd(), '..', '.meta', 'templates', 'non-code-evaluation-rubric.yaml');
+    const originalCanonicalRubric = await readFile(canonicalRubricPath, 'utf-8');
+
+    try {
+      await writeFile(canonicalRubricPath, 'name: [broken', 'utf-8');
+
+      await expect(() => evaluateNonCode({
+        project_path: projectRoot,
+        rubric_path: 'artifacts/valid.yaml',
+      })).rejects.toThrow(`Canonical rubric could not be read at ${canonicalRubricPath}.`);
+
+      await writeFile(canonicalRubricPath, yaml.stringify({
+        name: 'wrong-canonical-name',
+        artifact: {
+          allowed_types: ['knowledge_doc'],
+        },
+        criteria: [
+          {
+            name: 'goal_alignment',
+            question: 'x',
+            pass_threshold: 'y',
+          },
+        ],
+      }), 'utf-8');
+
+      await expect(() => evaluateNonCode({
+        project_path: projectRoot,
+        rubric_path: 'artifacts/valid.yaml',
+      })).rejects.toThrow(`Canonical rubric at ${canonicalRubricPath} has an unexpected name.`);
+
+      await writeFile(canonicalRubricPath, yaml.stringify({
+        name: 'non-code-evaluation-rubric',
+        artifact: {
+          allowed_types: ['knowledge_doc'],
+        },
+        criteria: [],
+      }), 'utf-8');
+
+      await expect(() => evaluateNonCode({
+        project_path: projectRoot,
+        rubric_path: 'artifacts/valid.yaml',
+      })).rejects.toThrow('Canonical rubric criteria are missing.');
+
+      await writeFile(canonicalRubricPath, yaml.stringify({
+        name: 'non-code-evaluation-rubric',
+        artifact: {},
+        criteria: [
+          {
+            name: 'goal_alignment',
+            question: 'x',
+            pass_threshold: 'y',
+          },
+        ],
+      }), 'utf-8');
+
+      await expect(() => evaluateNonCode({
+        project_path: projectRoot,
+        rubric_path: 'artifacts/valid.yaml',
+      })).rejects.toThrow('Canonical rubric allowed artifact types are missing.');
+
+      await writeFile(canonicalRubricPath, yaml.stringify({
+        name: 'non-code-evaluation-rubric',
+        artifact: {
+          allowed_types: ['knowledge_doc'],
+        },
+        criteria: [
+          {
+            name: 'goal_alignment',
+            question: 'x',
+            pass_threshold: 'y',
+          },
+        ],
+        evaluation: {
+          passes_required: 1,
+        },
+      }), 'utf-8');
+
+      await expect(() => evaluateNonCode({
+        project_path: projectRoot,
+        rubric_path: 'artifacts/valid.yaml',
+      })).rejects.toThrow('Canonical rubric evaluation.method is missing.');
+
+      await writeFile(canonicalRubricPath, yaml.stringify({
+        name: 'non-code-evaluation-rubric',
+        artifact: {
+          allowed_types: ['knowledge_doc'],
+        },
+        criteria: [
+          {
+            name: 'goal_alignment',
+            question: 'x',
+            pass_threshold: 'y',
+          },
+        ],
+        evaluation: {
+          method: 'llm_rubric_review',
+        },
+      }), 'utf-8');
+
+      await expect(() => evaluateNonCode({
+        project_path: projectRoot,
+        rubric_path: 'artifacts/valid.yaml',
+      })).rejects.toThrow('Canonical rubric evaluation.passes_required is missing.');
+    } finally {
+      await writeFile(canonicalRubricPath, originalCanonicalRubric, 'utf-8');
+    }
+  });
+});

--- a/projects/agenticos/mcp-server/src/utils/non-code-evaluation.ts
+++ b/projects/agenticos/mcp-server/src/utils/non-code-evaluation.ts
@@ -1,0 +1,357 @@
+import { access, mkdir, readFile, writeFile } from 'fs/promises';
+import { dirname, isAbsolute, join, relative, resolve } from 'path';
+import { fileURLToPath } from 'url';
+import yaml from 'yaml';
+
+export interface NonCodeEvaluationArgs {
+  project_path: string;
+  rubric_path: string;
+}
+
+type NonCodeArtifactType =
+  | 'protocol_doc'
+  | 'design_doc'
+  | 'knowledge_doc'
+  | 'issue_draft'
+  | 'workflow_spec';
+
+type NonCodeCriterionResult = 'PASS' | 'FAIL';
+
+interface CanonicalCriterion {
+  name: string;
+  question: string;
+  pass_threshold: string;
+}
+
+interface CanonicalRubric {
+  name: string;
+  artifact?: {
+    allowed_types?: NonCodeArtifactType[];
+  };
+  criteria?: CanonicalCriterion[];
+  evaluation?: {
+    method?: string;
+    passes_required?: number;
+  };
+}
+
+interface RubricCriterionInput {
+  name?: string;
+  result?: string;
+  notes?: string;
+}
+
+interface RubricInput {
+  name?: string;
+  artifact?: {
+    path?: string;
+    type?: string;
+  };
+  goal?: {
+    intended_outcome?: string;
+    linked_issue?: string;
+  };
+  criteria?: RubricCriterionInput[];
+  evaluation?: {
+    overall_result?: string;
+    residual_risks?: unknown;
+    method?: string;
+    passes_required?: number;
+  };
+}
+
+export interface NonCodeEvaluationResult {
+  command: 'agenticos_non_code_evaluate';
+  status: 'RECORDED';
+  project_path: string;
+  state_path: string;
+  rubric_path: string;
+  artifact_path: string;
+  artifact_type: NonCodeArtifactType;
+  linked_issue: string;
+  overall_result: NonCodeCriterionResult;
+  recorded_at: string;
+  criteria: Array<{
+    name: string;
+    result: NonCodeCriterionResult;
+  }>;
+  residual_risks: string[];
+}
+
+interface PersistedCriterion {
+  name: string;
+  question: string;
+  pass_threshold: string;
+  result: NonCodeCriterionResult;
+  notes: string;
+}
+
+interface NormalizedEvaluation {
+  rubricPath: string;
+  artifactPath: string;
+  artifactType: NonCodeArtifactType;
+  intendedOutcome: string;
+  linkedIssue: string;
+  overallResult: NonCodeCriterionResult;
+  residualRisks: string[];
+  criteria: PersistedCriterion[];
+  method: string;
+  passesRequired: number;
+}
+
+interface StateYaml {
+  session?: Record<string, unknown>;
+  non_code_evaluation?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+const CANONICAL_RUBRIC_NAME = 'non-code-evaluation-rubric';
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const CANONICAL_RUBRIC_PATH = resolve(__dirname, '..', '..', '..', '.meta', 'templates', 'non-code-evaluation-rubric.yaml');
+
+function normalizeAbsolutePath(projectPath: string, candidatePath: string): string {
+  return isAbsolute(candidatePath) ? resolve(candidatePath) : resolve(projectPath, candidatePath);
+}
+
+function toProjectRelativePath(projectPath: string, targetPath: string): string {
+  return relative(projectPath, targetPath);
+}
+
+function normalizeString(value: unknown, fieldName: string): string {
+  const normalized = typeof value === 'string' ? value.trim() : '';
+  if (!normalized) {
+    throw new Error(`${fieldName} is required.`);
+  }
+  return normalized;
+}
+
+function normalizeStringList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((item) => (typeof item === 'string' ? item.trim() : ''))
+    .filter((item) => item.length > 0);
+}
+
+function normalizeCriterionResult(value: unknown, fieldName: string): NonCodeCriterionResult {
+  const normalized = typeof value === 'string' ? value.trim().toUpperCase() : '';
+  if (normalized === 'PASS' || normalized === 'FAIL') {
+    return normalized;
+  }
+  throw new Error(`${fieldName} must be PASS or FAIL.`);
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readYamlFile<T>(path: string, notFoundMessage: string): Promise<T> {
+  try {
+    return (yaml.parse(await readFile(path, 'utf-8')) || {}) as T;
+  } catch {
+    throw new Error(notFoundMessage);
+  }
+}
+
+async function loadCanonicalRubric(): Promise<CanonicalRubric> {
+  const rubric = await readYamlFile<CanonicalRubric>(
+    CANONICAL_RUBRIC_PATH,
+    `Canonical rubric could not be read at ${CANONICAL_RUBRIC_PATH}.`,
+  );
+
+  if (rubric.name !== CANONICAL_RUBRIC_NAME) {
+    throw new Error(`Canonical rubric at ${CANONICAL_RUBRIC_PATH} has an unexpected name.`);
+  }
+
+  if (!Array.isArray(rubric.criteria) || rubric.criteria.length === 0) {
+    throw new Error('Canonical rubric criteria are missing.');
+  }
+
+  const allowedTypes = rubric.artifact?.allowed_types;
+  if (!Array.isArray(allowedTypes) || allowedTypes.length === 0) {
+    throw new Error('Canonical rubric allowed artifact types are missing.');
+  }
+
+  if (typeof rubric.evaluation?.method !== 'string' || rubric.evaluation.method.trim().length === 0) {
+    throw new Error('Canonical rubric evaluation.method is missing.');
+  }
+
+  if (typeof rubric.evaluation?.passes_required !== 'number') {
+    throw new Error('Canonical rubric evaluation.passes_required is missing.');
+  }
+
+  return rubric;
+}
+
+function normalizeCriteria(
+  inputCriteria: RubricCriterionInput[] | undefined,
+  canonicalCriteria: CanonicalCriterion[],
+): PersistedCriterion[] {
+  if (!Array.isArray(inputCriteria) || inputCriteria.length === 0) {
+    throw new Error('criteria are required.');
+  }
+
+  const canonicalByName = new Map(canonicalCriteria.map((criterion) => [criterion.name, criterion]));
+  const seen = new Set<string>();
+
+  const normalized = inputCriteria.map((criterion, index) => {
+    const name = normalizeString(criterion?.name, `criteria[${index}].name`);
+    const canonical = canonicalByName.get(name);
+    if (!canonical) {
+      throw new Error(`criteria contains unknown canonical criterion "${name}".`);
+    }
+    if (seen.has(name)) {
+      throw new Error(`criteria contains duplicate canonical criterion "${name}".`);
+    }
+    seen.add(name);
+
+    return {
+      name,
+      question: canonical.question,
+      pass_threshold: canonical.pass_threshold,
+      result: normalizeCriterionResult(criterion?.result, `criteria[${index}].result`),
+      notes: typeof criterion?.notes === 'string' ? criterion.notes.trim() : '',
+    };
+  });
+
+  if (normalized.length !== canonicalCriteria.length) {
+    throw new Error('criteria must contain every canonical criterion exactly once.');
+  }
+
+  return normalized;
+}
+
+async function readState(statePath: string): Promise<StateYaml> {
+  try {
+    return (yaml.parse(await readFile(statePath, 'utf-8')) || {}) as StateYaml;
+  } catch {
+    return {};
+  }
+}
+
+function normalizeEvaluation(
+  args: NonCodeEvaluationArgs,
+  canonicalRubric: CanonicalRubric,
+  rubric: RubricInput,
+): NormalizedEvaluation {
+  if (rubric.name !== CANONICAL_RUBRIC_NAME) {
+    throw new Error(`rubric name must be ${CANONICAL_RUBRIC_NAME}.`);
+  }
+
+  const artifactPathInput = normalizeString(rubric.artifact?.path, 'artifact.path');
+  const artifactType = normalizeString(rubric.artifact?.type, 'artifact.type') as NonCodeArtifactType;
+  if (!canonicalRubric.artifact?.allowed_types?.includes(artifactType)) {
+    throw new Error(`artifact.type must be one of: ${canonicalRubric.artifact?.allowed_types?.join(', ')}.`);
+  }
+
+  const artifactPath = normalizeAbsolutePath(args.project_path, artifactPathInput);
+  const criteria = normalizeCriteria(rubric.criteria, canonicalRubric.criteria!);
+  const overallResult = normalizeCriterionResult(rubric.evaluation?.overall_result, 'evaluation.overall_result');
+  const derivedOverallResult: NonCodeCriterionResult = criteria.every((criterion) => criterion.result === 'PASS') ? 'PASS' : 'FAIL';
+
+  if (overallResult !== derivedOverallResult) {
+    throw new Error(`evaluation.overall_result must match criteria results (${derivedOverallResult}).`);
+  }
+
+  return {
+    rubricPath: normalizeAbsolutePath(args.project_path, args.rubric_path),
+    artifactPath,
+    artifactType,
+    intendedOutcome: normalizeString(rubric.goal?.intended_outcome, 'goal.intended_outcome'),
+    linkedIssue: normalizeString(rubric.goal?.linked_issue, 'goal.linked_issue'),
+    overallResult,
+    residualRisks: normalizeStringList(rubric.evaluation?.residual_risks),
+    criteria,
+    method: typeof rubric.evaluation?.method === 'string' && rubric.evaluation.method.trim().length > 0
+      ? rubric.evaluation.method.trim()
+      : canonicalRubric.evaluation!.method!,
+    passesRequired: typeof rubric.evaluation?.passes_required === 'number'
+      ? rubric.evaluation.passes_required
+      : canonicalRubric.evaluation!.passes_required!,
+  };
+}
+
+function buildPersistedState(
+  state: StateYaml,
+  evaluation: NormalizedEvaluation,
+  projectPath: string,
+  recordedAt: string,
+): StateYaml {
+  state.session = state.session || {};
+  state.session.last_non_code_evaluation = recordedAt;
+
+  state.non_code_evaluation = {
+    updated_at: recordedAt,
+    latest: {
+      command: 'agenticos_non_code_evaluate',
+      recorded_at: recordedAt,
+      rubric_path: toProjectRelativePath(projectPath, evaluation.rubricPath),
+      artifact: {
+        path: toProjectRelativePath(projectPath, evaluation.artifactPath),
+        type: evaluation.artifactType,
+      },
+      goal: {
+        intended_outcome: evaluation.intendedOutcome,
+        linked_issue: evaluation.linkedIssue,
+      },
+      evaluation: {
+        method: evaluation.method,
+        passes_required: evaluation.passesRequired,
+        overall_result: evaluation.overallResult,
+      },
+      criteria: evaluation.criteria,
+      residual_risks: evaluation.residualRisks,
+    },
+  };
+
+  return state;
+}
+
+export async function evaluateNonCode(args: NonCodeEvaluationArgs): Promise<NonCodeEvaluationResult> {
+  const projectPath = normalizeString(args?.project_path, 'project_path');
+  const rubricPathInput = normalizeString(args?.rubric_path, 'rubric_path');
+
+  const canonicalRubric = await loadCanonicalRubric();
+  const rubricPath = normalizeAbsolutePath(projectPath, rubricPathInput);
+
+  if (!(await pathExists(rubricPath))) {
+    throw new Error(`rubric_path does not exist: ${rubricPath}`);
+  }
+
+  const rubric = await readYamlFile<RubricInput>(rubricPath, `rubric_path could not be read: ${rubricPath}`);
+  const normalized = normalizeEvaluation({ project_path: projectPath, rubric_path: rubricPathInput }, canonicalRubric, rubric);
+
+  if (!(await pathExists(normalized.artifactPath))) {
+    throw new Error(`artifact.path does not exist: ${normalized.artifactPath}`);
+  }
+
+  const statePath = join(projectPath, '.context', 'state.yaml');
+  await mkdir(dirname(statePath), { recursive: true });
+
+  const recordedAt = new Date().toISOString();
+  const nextState = buildPersistedState(await readState(statePath), normalized, projectPath, recordedAt);
+  await writeFile(statePath, yaml.stringify(nextState), 'utf-8');
+
+  return {
+    command: 'agenticos_non_code_evaluate',
+    status: 'RECORDED',
+    project_path: projectPath,
+    state_path: statePath,
+    rubric_path: toProjectRelativePath(projectPath, normalized.rubricPath),
+    artifact_path: toProjectRelativePath(projectPath, normalized.artifactPath),
+    artifact_type: normalized.artifactType,
+    linked_issue: normalized.linkedIssue,
+    overall_result: normalized.overallResult,
+    recorded_at: recordedAt,
+    criteria: normalized.criteria.map((criterion) => ({
+      name: criterion.name,
+      result: criterion.result,
+    })),
+    residual_risks: normalized.residualRisks,
+  };
+}

--- a/projects/agenticos/standards/.context/quick-start.md
+++ b/projects/agenticos/standards/.context/quick-start.md
@@ -71,8 +71,10 @@ Its job is to define and evolve:
 - issue `#97` now adds one bounded `agenticos_health` surface for canonical checkout freshness, entry-surface refresh freshness, guardrail visibility, and optional standard-kit drift
 - `knowledge/health-command-design-2026-03-25.md` records why this should be a compact pre-work health gate instead of a dashboard
 - `knowledge/health-command-implementation-report-2026-03-25.md` records the landed gates, runtime files, and verification
+- issue `#96` now adds one bounded first-class non-code evaluation command that validates completed rubric files and persists the latest structured evidence into project state
+- `knowledge/non-code-evaluation-command-design-2026-03-25.md` records why this issue should validate and persist rubric results rather than inventing a second scoring system
+- `knowledge/non-code-evaluation-command-implementation-report-2026-03-25.md` records the landed command, persistence contract, and full targeted coverage result
 - the next higher-order backlog is now:
-  - `#96` rubric-backed non-code evaluation
   - `#95` delegated-work runtime enforcement
   - `#94` entry-surface guardrail-summary design review
 
@@ -112,9 +114,10 @@ Start here:
 30. `knowledge/entry-surface-refresh-implementation-report-2026-03-25.md`
 31. `knowledge/health-command-design-2026-03-25.md`
 32. `knowledge/health-command-implementation-report-2026-03-25.md`
+33. `knowledge/non-code-evaluation-command-design-2026-03-25.md`
+34. `knowledge/non-code-evaluation-command-implementation-report-2026-03-25.md`
 
 ## Next Steps
 
-1. Execute `#96` to turn rubric-backed non-code evaluation into a first-class verification command
-2. Execute `#95` to enforce delegated-work handoff packets and verification echoes at runtime
-3. Revisit `#94` only after the higher-priority health and enforcement work is done
+1. Execute `#95` to enforce delegated-work handoff packets and verification echoes at runtime
+2. Revisit `#94` only after the higher-priority enforcement work is done

--- a/projects/agenticos/standards/.context/state.yaml
+++ b/projects/agenticos/standards/.context/state.yaml
@@ -5,9 +5,9 @@ session:
   last_backup: 2026-03-23T10:35:00.000Z
 
 current_task:
-  title: add one bounded health surface for checkout freshness and resume-signal freshness
-  status: implemented
-  updated: 2026-03-25T02:12:00.000Z
+  title: enforce delegated-work handoff packets and verification echoes at runtime
+  status: pending
+  updated: 2026-03-25T10:28:00.000Z
 
 working_memory:
   facts:
@@ -78,7 +78,9 @@ working_memory:
     - issue #99 now adds a deterministic bounded refresh command for quick-start and state surfaces using structured merged-work inputs
     - the refresh command writes bounded entry-surface metadata into state instead of attempting freeform summarization
     - issue #97 now adds one bounded health command for canonical checkout freshness, entry-surface freshness, guardrail visibility, and optional standard-kit drift
-    - the next higher-order backlog is now #96, #95, and #94 in that priority order
+    - issue #96 now adds one bounded first-class non-code evaluation command that validates completed rubric files against the canonical template and persists the latest structured evidence into state
+    - targeted coverage for the #96 runtime surface reached full 100 percent statements, branches, functions, and lines across non-code-evaluation.ts and non-code-evaluate.ts
+    - the next higher-order backlog is now #95 and #94 in that priority order
   decisions:
     - keep one main AgenticOS product repository and one canonical standards area inside it
     - merge durable standards knowledge into the main repo, but archive raw standalone context/history instead of treating it as live state
@@ -102,8 +104,8 @@ working_memory:
     - canonical local sync should be treated as a repeatable contract with executable verification, not as an occasional operator cleanup task
     - entry-surface refresh should be deterministic and bounded, not an unconstrained summarizer over arbitrary merged documents
     - health should be a compact pre-work gate with high-signal PASS/WARN/BLOCK semantics, not a broad dashboard
+    - non-code evaluation should be a deterministic validator and persistence surface around the canonical rubric, not an embedded opaque scoring system
   pending:
-    - execute issue #96 to turn rubric-backed non-code evaluation into a first-class command
     - execute issue #95 to enforce delegated-work handoff packets and verification echoes at runtime
     - revisit issue #94 after the higher-priority health and enforcement work is complete
 
@@ -137,3 +139,5 @@ loaded_context:
   - knowledge/homebrew-post-install-implementation-report-2026-03-25.md
   - knowledge/integration-mode-matrix-2026-03-25.md
   - knowledge/integration-mode-matrix-implementation-report-2026-03-25.md
+  - knowledge/non-code-evaluation-command-design-2026-03-25.md
+  - knowledge/non-code-evaluation-command-implementation-report-2026-03-25.md

--- a/projects/agenticos/standards/knowledge/non-code-evaluation-command-design-2026-03-25.md
+++ b/projects/agenticos/standards/knowledge/non-code-evaluation-command-design-2026-03-25.md
@@ -1,0 +1,97 @@
+# Non-Code Evaluation Command Design
+
+## Issue
+
+- `#96` `feat: add rubric-backed non-code evaluation as a first-class command`
+
+## Design Reflection
+
+This issue should not introduce a second scoring system or hide judgment behind an opaque model call.
+The canonical non-code rubric already exists. The missing capability is a first-class command that:
+
+1. reads a completed rubric file
+2. validates it against the canonical rubric contract
+3. normalizes the result into deterministic structured evidence
+4. persists that evidence in project state so later workflow surfaces can reference it
+
+The right scope is therefore **rubric validation and evidence persistence**, not generic AI evaluation.
+
+## Chosen Shape
+
+Add one MCP command:
+
+- `agenticos_non_code_evaluate`
+
+The command will:
+
+1. require a `project_path`
+2. require a `rubric_path`
+3. load the canonical template from `projects/agenticos/.meta/templates/non-code-evaluation-rubric.yaml`
+4. validate that the provided rubric:
+   - uses the canonical rubric name
+   - supplies a non-empty artifact path and artifact type
+   - uses an allowed artifact type
+   - supplies a goal and linked issue
+   - includes exactly the canonical criteria names
+   - does not leave criteria in `pending`
+   - sets `evaluation.overall_result` consistently with the criterion results
+5. persist the normalized evidence to `.context/state.yaml`
+
+## State Contract
+
+Persist under:
+
+```yaml
+non_code_evaluation:
+  updated_at: <iso timestamp>
+  latest:
+    command: agenticos_non_code_evaluate
+    recorded_at: <iso timestamp>
+    rubric_path: <project-relative path>
+    artifact:
+      path: <project-relative path>
+      type: <artifact type>
+    goal:
+      intended_outcome: <string>
+      linked_issue: <string>
+    evaluation:
+      method: llm_rubric_review
+      passes_required: 1
+      overall_result: PASS|FAIL
+    criteria:
+      - name: goal_alignment
+        question: ...
+        pass_threshold: ...
+        result: PASS|FAIL
+        notes: ...
+    residual_risks:
+      - ...
+```
+
+Also update:
+
+```yaml
+session:
+  last_non_code_evaluation: <iso timestamp>
+```
+
+## Status Surface
+
+`agenticos_status` and `agenticos_switch` should show a compact latest non-code evaluation summary.
+This keeps the result visible without adding a second reporting channel.
+
+## Non-Goals
+
+- no LLM judge call inside the command
+- no auto-generation of rubric content
+- no historical append-only evaluation log in `state.yaml`
+- no direct mutation of submission evidence files
+
+## Verification
+
+Implementation must prove:
+
+1. deterministic validation and persistence with fixture rubric files
+2. failure on malformed or incomplete rubric files
+3. latest evaluation summary visible in `status` and `switch`
+4. touched runtime files reach `100 / 100 / 100 / 100`

--- a/projects/agenticos/standards/knowledge/non-code-evaluation-command-implementation-report-2026-03-25.md
+++ b/projects/agenticos/standards/knowledge/non-code-evaluation-command-implementation-report-2026-03-25.md
@@ -1,0 +1,111 @@
+# Non-Code Evaluation Command Implementation Report
+
+## Issue
+
+- `#96` `feat: add rubric-backed non-code evaluation as a first-class command`
+
+## What Landed
+
+AgenticOS now has one first-class non-code evaluation command:
+
+- `agenticos_non_code_evaluate`
+
+The command:
+
+1. reads a completed rubric YAML file
+2. validates it against the canonical rubric contract in `projects/agenticos/.meta/templates/non-code-evaluation-rubric.yaml`
+3. normalizes the result into deterministic structured evidence
+4. persists the latest evaluation into `.context/state.yaml`
+
+## Runtime Surface
+
+Added:
+
+- `projects/agenticos/mcp-server/src/utils/non-code-evaluation.ts`
+- `projects/agenticos/mcp-server/src/tools/non-code-evaluate.ts`
+- `projects/agenticos/mcp-server/src/utils/__tests__/non-code-evaluation.test.ts`
+
+Updated:
+
+- `projects/agenticos/mcp-server/src/index.ts`
+- `projects/agenticos/mcp-server/src/tools/index.ts`
+- `README.md`
+- `projects/agenticos/mcp-server/README.md`
+
+## Command Contract
+
+Inputs:
+
+- `project_path`
+- `rubric_path`
+
+Behavior:
+
+- fails closed on malformed or incomplete rubric files
+- reuses canonical artifact-type and criterion definitions
+- rejects incomplete or invalid criterion results
+- rejects mismatched `evaluation.overall_result`
+- persists only the latest bounded non-code evaluation evidence
+
+Persisted state shape:
+
+```yaml
+session:
+  last_non_code_evaluation: <iso timestamp>
+
+non_code_evaluation:
+  updated_at: <iso timestamp>
+  latest:
+    command: agenticos_non_code_evaluate
+    recorded_at: <iso timestamp>
+    rubric_path: <project-relative path>
+    artifact:
+      path: <project-relative path>
+      type: <artifact type>
+    goal:
+      intended_outcome: <string>
+      linked_issue: <string>
+    evaluation:
+      method: <string>
+      passes_required: <number>
+      overall_result: PASS|FAIL
+    criteria:
+      - name: <canonical criterion>
+        question: <canonical question>
+        pass_threshold: <canonical threshold>
+        result: PASS|FAIL
+        notes: <string>
+    residual_risks:
+      - <string>
+```
+
+## Design Reflection Outcome
+
+This issue intentionally did **not** add an embedded LLM judge.
+The command is a deterministic validator and persistence surface around the canonical rubric.
+That keeps evaluation explicit, reviewable, and reusable by later workflow surfaces without creating a second hidden scoring system.
+
+## Verification
+
+Targeted coverage:
+
+- `src/utils/non-code-evaluation.ts` -> `100 / 100 / 100 / 100`
+- `src/tools/non-code-evaluate.ts` -> `100 / 100 / 100 / 100`
+
+Commands:
+
+- `npm run build`
+- `npm test`
+- `npx vitest run --coverage.enabled true --coverage.provider=v8 --coverage.reporter=text --coverage.include=src/utils/non-code-evaluation.ts --coverage.include=src/tools/non-code-evaluate.ts src/utils/__tests__/non-code-evaluation.test.ts`
+
+Result:
+
+- targeted coverage passed at full `100 / 100 / 100 / 100`
+- full suite passed: `146 passed`
+
+## Follow-On
+
+This issue makes non-code verification evidence first-class and machine-readable.
+The next adjacent enforcement step remains:
+
+- `#95` delegated-work handoff packets and verification echoes at runtime


### PR DESCRIPTION
## Summary
- add `agenticos_non_code_evaluate` as a first-class MCP command
- validate completed rubric files against the canonical non-code rubric and persist latest evidence into project state
- document the design reflection and implementation report in standards

## Design Reflection
This issue does not add a second AI scoring system. It narrows the problem to one deterministic runtime surface that validates a completed rubric, normalizes it against the canonical template, and persists the latest evidence so later workflow surfaces can consume it.

## Verification
- `npm run build`
- `npm test`
- `npx vitest run --coverage.enabled true --coverage.provider=v8 --coverage.reporter=text --coverage.include=src/utils/non-code-evaluation.ts --coverage.include=src/tools/non-code-evaluate.ts src/utils/__tests__/non-code-evaluation.test.ts`
- targeted coverage result: `100 / 100 / 100 / 100`
