### PR TITLE
fix: preserve literal dots in pr scope matching

### DIFF
--- a/projects/agenticos/mcp-server/src/tools/__tests__/pr-scope-check.test.ts
+++ b/projects/agenticos/mcp-server/src/tools/__tests__/pr-scope-check.test.ts
@@ -67,6 +67,28 @@ describe('runPrScopeCheck', () => {
     expect(persistGuardrailEvidenceMock).toHaveBeenCalledTimes(1);
   });
 
+  it('returns PASS when declared exact file paths contain dots', async () => {
+    mockGitResponses({
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'log --format=%s origin/main..HEAD': 'fix(mcp-server): preserve literal dots in pr scope matching (#114)\n',
+      'diff --name-only origin/main...HEAD': 'README.md\nprojects/agenticos/mcp-server/src/tools/__tests__/edit-guard.test.ts\n',
+    });
+
+    const result = JSON.parse(await runPrScopeCheck({
+      issue_id: '114',
+      repo_path: '/repo',
+      declared_target_files: [
+        'README.md',
+        'projects/agenticos/mcp-server/src/tools/__tests__/edit-guard.test.ts',
+      ],
+      expected_issue_scope: 'pr_scope_exact_file_match',
+    })) as { status: string; unexpected_files: string[] };
+
+    expect(result.status).toBe('PASS');
+    expect(result.unexpected_files).toEqual([]);
+  });
+
   it('returns BLOCK when commit subjects do not match the current issue', async () => {
     mockGitResponses({
       'rev-parse origin/main': 'base999\n',

--- a/projects/agenticos/mcp-server/src/tools/pr-scope-check.ts
+++ b/projects/agenticos/mcp-server/src/tools/pr-scope-check.ts
@@ -45,19 +45,32 @@ function escapeRegex(value: string): string {
 
 function patternToRegex(pattern: string): RegExp {
   const normalized = pattern.replace(/\\/g, '/');
-  const tokens = normalized.match(/\*\*|\*|\.{3}|[^*.]+/g) ?? [];
-  const source = tokens
-    .map((token) => {
-      if (token === '**' || token === '...') {
-        return '.*';
-      }
-      if (token === '*') {
-        return '[^/]*';
-      }
-      return escapeRegex(token);
-    })
-    .join('');
-  return new RegExp(`^${source}$`);
+  let source = '^';
+
+  for (let index = 0; index < normalized.length; ) {
+    if (normalized.startsWith('**', index)) {
+      source += '.*';
+      index += 2;
+      continue;
+    }
+
+    if (normalized.startsWith('...', index)) {
+      source += '.*';
+      index += 3;
+      continue;
+    }
+
+    if (normalized[index] === '*') {
+      source += '[^/]*';
+      index += 1;
+      continue;
+    }
+
+    source += escapeRegex(normalized[index]);
+    index += 1;
+  }
+
+  return new RegExp(`${source}$`);
 }
 
 function fileMatchesDeclaredScope(file: string, patterns: string[]): boolean {


### PR DESCRIPTION
## Summary
- preserve literal `.` characters when converting `declared_target_files` patterns for `agenticos_pr_scope_check`
- add a regression test for exact declared file paths like `README.md` and `*.test.ts`
- verify the fix against the real `#113` changed-file set that was being blocked incorrectly

## Testing
- `npm test -- --run src/tools/__tests__/pr-scope-check.test.ts`
- `npm run build`
- black-box replay of `#113` declared target files against the patched `runPrScopeCheck` returned `PASS`

Closes #114
