### PR TITLE
feat: fail closed before out-of-flow implementation edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ Homebrew does **not**:
 
 After `brew install`, bootstrap one supported agent below, restart it, and verify `agenticos_list` explicitly.
 
+For implementation-affecting work, AgenticOS also ships a hook-friendly guard wrapper at `tools/check-edit-boundary.sh`.
+Use it from local automation or any client-side pre-edit hook layer to fail closed unless:
+
+- the active project matches the intended managed project
+- the intended issue is explicit
+- the latest persisted `agenticos_preflight` for that issue and repo is `PASS`
+
 ### Option B — Manual install (from GitHub Releases)
 
 ```bash
@@ -125,7 +132,8 @@ The agent will call `agenticos_init` and set up the project structure automatica
 | `agenticos_switch` | Switch active project | `project` (ID or name) |
 | `agenticos_list` | List all projects | — |
 | `agenticos_status` | Show active project status | — |
-| `agenticos_preflight` | Evaluate implementation/PR guardrails | `task_type`, `repo_path`, `issue_id`, `declared_target_files` |
+| `agenticos_preflight` | Evaluate implementation/PR guardrails | `task_type`, `repo_path`, `project_path`, `issue_id`, `declared_target_files` |
+| `agenticos_edit_guard` | Fail closed before implementation edits unless project alignment and matching PASS preflight evidence exist | `issue_id`, `repo_path`, `project_path`, `declared_target_files` |
 | `agenticos_branch_bootstrap` | Create issue branch + isolated worktree from `origin/main` | `issue_id`, `slug`, `repo_path`, `worktree_root` |
 | `agenticos_pr_scope_check` | Validate commit/file scope before PR | `issue_id`, `repo_path`, `declared_target_files` |
 | `agenticos_health` | Check canonical checkout, entry-surface, and guardrail freshness | `repo_path`, `project_path`, `check_standard_kit` |

--- a/projects/agenticos/mcp-server/README.md
+++ b/projects/agenticos/mcp-server/README.md
@@ -20,6 +20,8 @@ A project management system designed for AI collaboration. When you work on comp
 
 Install AgenticOS, bootstrap one supported agent, restart that agent, then explicitly verify `agenticos_list` works before relying on project-intent routing.
 
+When the client supports a pre-edit hook or local command wrapper, point that layer at `tools/check-edit-boundary.sh` so implementation edits fail closed unless project alignment and matching PASS preflight evidence already exist.
+
 ### Homebrew Post-Install Contract
 
 If the user installed AgenticOS with Homebrew:
@@ -179,10 +181,23 @@ Run machine-checkable guardrail preflight before implementation or PR creation.
 **Parameters**:
 - `task_type` (required)
 - `repo_path` (required)
+- `project_path` (optional, but recommended when `repo_path` is a larger checkout or worktree rather than the managed project root)
 - `issue_id` (required for implementation work)
 - `declared_target_files` (required for implementation work)
 
 **Returns**: JSON with `PASS`, `BLOCK`, or `REDIRECT`
+
+### agenticos_edit_guard
+Fail closed before implementation-affecting edits unless the active project and latest persisted preflight evidence already match the intended edit.
+
+**Parameters**:
+- `repo_path` (required)
+- `task_type` (required)
+- `declared_target_files` (required)
+- `issue_id` (required for implementation work)
+- `project_path` (optional, but recommended when `repo_path` is a self-hosting checkout or larger worktree)
+
+**Returns**: JSON with `PASS` or `BLOCK`
 
 ### agenticos_branch_bootstrap
 Create an issue branch and isolated worktree from the intended remote base.

--- a/projects/agenticos/mcp-server/src/index.ts
+++ b/projects/agenticos/mcp-server/src/index.ts
@@ -34,7 +34,7 @@ import {
   ListResourcesRequestSchema,
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { initProject, switchProject, listProjects, getStatus, saveState, recordSession, runPreflight, runBranchBootstrap, runPrScopeCheck, runHealth, runEntrySurfaceRefresh, runStandardKitAdopt, runStandardKitUpgradeCheck, runNonCodeEvaluate } from './tools/index.js';
+import { initProject, switchProject, listProjects, getStatus, saveState, recordSession, runPreflight, runBranchBootstrap, runPrScopeCheck, runHealth, runEditGuard, runEntrySurfaceRefresh, runStandardKitAdopt, runStandardKitUpgradeCheck, runNonCodeEvaluate } from './tools/index.js';
 import { getProjectContext } from './resources/index.js';
 
 const server = new Server(
@@ -134,6 +134,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
             description: 'Classified task type',
           },
           repo_path: { type: 'string', description: 'Absolute repository or worktree path to evaluate' },
+          project_path: { type: 'string', description: 'Optional managed project root when repo_path is a larger checkout or worktree.' },
           remote_base_branch: { type: 'string', description: 'Remote base branch to compare against (default: origin/main)' },
           declared_target_files: {
             type: 'array',
@@ -154,6 +155,29 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
           },
         },
         required: ['task_type', 'repo_path'],
+      },
+    },
+    {
+      name: 'agenticos_edit_guard',
+      description: 'Fail closed before implementation-affecting edits unless active-project alignment and matching PASS preflight evidence already exist.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          issue_id: { type: 'string', description: 'GitHub issue number or identifier for the current edit.' },
+          task_type: {
+            type: 'string',
+            enum: ['discussion_only', 'analysis_or_doc', 'implementation', 'bootstrap'],
+            description: 'Classified task type. Enforcement applies to implementation.',
+          },
+          repo_path: { type: 'string', description: 'Absolute repository or worktree path where the edit would occur.' },
+          project_path: { type: 'string', description: 'Optional explicit managed project root when repo_path is not itself inside the managed project.' },
+          declared_target_files: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Exact target files the edit intends to mutate. Must remain inside the latest PASS preflight scope.',
+          },
+        },
+        required: ['repo_path', 'task_type', 'declared_target_files'],
       },
     },
     {
@@ -288,6 +312,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       return { content: [{ type: 'text', text: await getStatus() }] };
     case 'agenticos_preflight':
       return { content: [{ type: 'text', text: await runPreflight(args ?? {}) }] };
+    case 'agenticos_edit_guard':
+      return { content: [{ type: 'text', text: await runEditGuard(args ?? {}) }] };
     case 'agenticos_branch_bootstrap':
       return { content: [{ type: 'text', text: await runBranchBootstrap(args ?? {}) }] };
     case 'agenticos_pr_scope_check':

--- a/projects/agenticos/mcp-server/src/tools/__tests__/edit-guard.test.ts
+++ b/projects/agenticos/mcp-server/src/tools/__tests__/edit-guard.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const yamlMock = vi.hoisted(() => ({
+  parse: vi.fn(),
+}));
+
+vi.mock('fs/promises', () => ({
+  readFile: vi.fn(),
+}));
+
+vi.mock('yaml', () => ({
+  default: yamlMock,
+}));
+
+vi.mock('../../utils/registry.js', () => ({
+  loadRegistry: vi.fn(),
+}));
+
+import { readFile } from 'fs/promises';
+import { loadRegistry } from '../../utils/registry.js';
+import { runEditGuard } from '../edit-guard.js';
+
+const readFileMock = readFile as unknown as ReturnType<typeof vi.fn>;
+const loadRegistryMock = loadRegistry as unknown as ReturnType<typeof vi.fn>;
+
+describe('runEditGuard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loadRegistryMock.mockResolvedValue({
+      active_project: 'agenticos-standards',
+      projects: [
+        {
+          id: 'agenticos-standards',
+          name: 'agenticos-standards',
+          path: '/workspace/projects/agenticos/standards',
+          status: 'active',
+          created: '2026-03-20',
+          last_accessed: '2026-03-20T00:00:00.000Z',
+        },
+      ],
+    });
+    readFileMock.mockImplementation(async (path: string) => {
+      if (path.endsWith('/.project.yaml')) {
+        return JSON.stringify({
+          meta: {
+            id: 'agenticos-standards',
+            name: 'agenticos-standards',
+          },
+        });
+      }
+
+      if (path.endsWith('/.context/state.yaml')) {
+        return JSON.stringify({
+          guardrail_evidence: {
+            preflight: {
+              issue_id: '113',
+              repo_path: '/workspace/source',
+              declared_target_files: [
+                'projects/agenticos/mcp-server/src/index.ts',
+                'projects/agenticos/tools/check-edit-boundary.sh',
+              ],
+              result: {
+                status: 'PASS',
+              },
+            },
+          },
+        });
+      }
+
+      throw new Error(`Unexpected path: ${path}`);
+    });
+    yamlMock.parse.mockImplementation((content: string) => JSON.parse(content));
+  });
+
+  it('passes when active project and latest preflight both match the intended edit', async () => {
+    const result = JSON.parse(await runEditGuard({
+      issue_id: '113',
+      task_type: 'implementation',
+      repo_path: '/workspace/source',
+      project_path: '/workspace/projects/agenticos/standards',
+      declared_target_files: [
+        'projects/agenticos/mcp-server/src/index.ts',
+      ],
+    })) as { status: string; preflight_ok: boolean; scope_ok: boolean };
+
+    expect(result.status).toBe('PASS');
+    expect(result.preflight_ok).toBe(true);
+    expect(result.scope_ok).toBe(true);
+  });
+
+  it('blocks when active project does not match the intended target project', async () => {
+    loadRegistryMock.mockResolvedValue({
+      active_project: 'cc-switch',
+      projects: [],
+    });
+
+    const result = JSON.parse(await runEditGuard({
+      issue_id: '113',
+      task_type: 'implementation',
+      repo_path: '/workspace/source',
+      project_path: '/workspace/projects/agenticos/standards',
+      declared_target_files: [
+        'projects/agenticos/mcp-server/src/index.ts',
+      ],
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons.join(' ')).toContain('does not match target project');
+  });
+
+  it('blocks when no preflight evidence is recorded', async () => {
+    readFileMock.mockImplementation(async (path: string) => {
+      if (path.endsWith('/.project.yaml')) {
+        return JSON.stringify({
+          meta: {
+            id: 'agenticos-standards',
+            name: 'agenticos-standards',
+          },
+        });
+      }
+
+      if (path.endsWith('/.context/state.yaml')) {
+        return JSON.stringify({});
+      }
+
+      throw new Error(`Unexpected path: ${path}`);
+    });
+
+    const result = JSON.parse(await runEditGuard({
+      issue_id: '113',
+      task_type: 'implementation',
+      repo_path: '/workspace/source',
+      project_path: '/workspace/projects/agenticos/standards',
+      declared_target_files: [
+        'projects/agenticos/mcp-server/src/index.ts',
+      ],
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons.join(' ')).toContain('no preflight evidence');
+  });
+
+  it('blocks when attempted targets exceed the preflight-declared scope', async () => {
+    const result = JSON.parse(await runEditGuard({
+      issue_id: '113',
+      task_type: 'implementation',
+      repo_path: '/workspace/source',
+      project_path: '/workspace/projects/agenticos/standards',
+      declared_target_files: [
+        'projects/agenticos/mcp-server/src/index.ts',
+        'README.md',
+      ],
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons.join(' ')).toContain('exceed the latest preflight scope');
+  });
+});

--- a/projects/agenticos/mcp-server/src/tools/__tests__/preflight.test.ts
+++ b/projects/agenticos/mcp-server/src/tools/__tests__/preflight.test.ts
@@ -94,6 +94,31 @@ describe('runPreflight', () => {
     expect(result.redirect_actions[0]).toContain('isolated issue branch/worktree');
   });
 
+  it('passes project_path through to guardrail evidence persistence when provided', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --abbrev-ref HEAD': 'feat/113-fail-closed-edit-boundaries\n',
+      'rev-parse HEAD': 'abc123\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo\nHEAD abc123\nbranch refs/heads/feat/113-fail-closed-edit-boundaries\n',
+      'log --format=%s origin/main..HEAD': '',
+    });
+
+    await runPreflight({
+      issue_id: '113',
+      task_type: 'implementation',
+      repo_path: '/repo',
+      project_path: '/repo/projects/agenticos/standards',
+      declared_target_files: ['projects/agenticos/mcp-server/src/index.ts'],
+      worktree_required: true,
+    });
+
+    expect(persistGuardrailEvidenceMock).toHaveBeenCalledWith(expect.objectContaining({
+      project_path: '/repo/projects/agenticos/standards',
+    }));
+  });
+
   it('returns BLOCK when branch contains unrelated commits relative to origin/main', async () => {
     mockGitResponses({
       'rev-parse --show-toplevel': '/repo\n',

--- a/projects/agenticos/mcp-server/src/tools/edit-guard.ts
+++ b/projects/agenticos/mcp-server/src/tools/edit-guard.ts
@@ -1,0 +1,250 @@
+import { readFile } from 'fs/promises';
+import { basename, join, resolve, sep } from 'path';
+import yaml from 'yaml';
+import { loadRegistry } from '../utils/registry.js';
+
+type TaskType = 'discussion_only' | 'analysis_or_doc' | 'implementation' | 'bootstrap';
+type GuardStatus = 'PASS' | 'BLOCK';
+
+interface EditGuardArgs {
+  issue_id?: string;
+  task_type?: TaskType;
+  repo_path?: string;
+  project_path?: string;
+  declared_target_files?: string[];
+}
+
+interface EditGuardResult {
+  status: GuardStatus;
+  summary: string;
+  active_project: string | null;
+  target_project: {
+    id: string;
+    name: string;
+    path: string;
+    state_path: string;
+  } | null;
+  preflight_ok: boolean;
+  scope_ok: boolean;
+  block_reasons: string[];
+  recovery_actions: string[];
+  evidence: {
+    repo_path: string | null;
+    project_path: string | null;
+    preflight_issue_id: string | null;
+    preflight_repo_path: string | null;
+    preflight_status: string | null;
+    preflight_declared_target_files: string[];
+  };
+}
+
+function normalizePath(path: string): string {
+  return resolve(path);
+}
+
+function resolveProjectStatePath(projectPath: string, projectYaml: any): string {
+  const configuredStatePath = projectYaml?.agent_context?.current_state;
+  if (typeof configuredStatePath === 'string' && configuredStatePath.trim().length > 0) {
+    return join(projectPath, configuredStatePath.trim());
+  }
+  return join(projectPath, '.context', 'state.yaml');
+}
+
+function isWithinProject(repoPath: string, projectPath: string): boolean {
+  return repoPath === projectPath || repoPath.startsWith(`${projectPath}${sep}`);
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await readFile(path, 'utf-8');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function normalizeDeclaredTargets(targets: string[]): string[] {
+  return targets
+    .map((target) => String(target || '').trim())
+    .filter((target) => target.length > 0);
+}
+
+async function resolveTargetProject(repoPath: string, explicitProjectPath?: string): Promise<EditGuardResult['target_project']> {
+  if (explicitProjectPath) {
+    const normalizedProjectPath = normalizePath(explicitProjectPath);
+    const projectYamlPath = join(normalizedProjectPath, '.project.yaml');
+    if (!(await fileExists(projectYamlPath))) {
+      return null;
+    }
+
+    const projectYaml = yaml.parse(await readFile(projectYamlPath, 'utf-8')) || {};
+    return {
+      id: String(projectYaml?.meta?.id || basename(normalizedProjectPath)),
+      name: String(projectYaml?.meta?.name || projectYaml?.meta?.id || basename(normalizedProjectPath)),
+      path: normalizedProjectPath,
+      state_path: resolveProjectStatePath(normalizedProjectPath, projectYaml),
+    };
+  }
+
+  const registry = await loadRegistry();
+  const normalizedRepoPath = normalizePath(repoPath);
+  const match = registry.projects
+    .map((project) => ({ ...project, path: normalizePath(project.path) }))
+    .filter((project) => isWithinProject(normalizedRepoPath, project.path))
+    .sort((a, b) => b.path.length - a.path.length)[0];
+
+  if (!match) {
+    return null;
+  }
+
+  const projectYamlPath = join(match.path, '.project.yaml');
+  if (!(await fileExists(projectYamlPath))) {
+    return null;
+  }
+
+  const projectYaml = yaml.parse(await readFile(projectYamlPath, 'utf-8')) || {};
+  return {
+    id: String(projectYaml?.meta?.id || match.id),
+    name: String(projectYaml?.meta?.name || match.name),
+    path: match.path,
+    state_path: resolveProjectStatePath(match.path, projectYaml),
+  };
+}
+
+export async function runEditGuard(args: EditGuardArgs): Promise<string> {
+  const {
+    issue_id,
+    task_type = 'implementation',
+    repo_path,
+    project_path,
+    declared_target_files = [],
+  } = args ?? {};
+
+  const result: EditGuardResult = {
+    status: 'BLOCK',
+    summary: '',
+    active_project: null,
+    target_project: null,
+    preflight_ok: false,
+    scope_ok: false,
+    block_reasons: [],
+    recovery_actions: [],
+    evidence: {
+      repo_path: repo_path || null,
+      project_path: project_path || null,
+      preflight_issue_id: null,
+      preflight_repo_path: null,
+      preflight_status: null,
+      preflight_declared_target_files: [],
+    },
+  };
+
+  if (task_type !== 'implementation') {
+    result.status = 'PASS';
+    result.summary = `edit guard not required for task_type=${task_type}`;
+    return JSON.stringify(result, null, 2);
+  }
+
+  if (!repo_path) {
+    result.block_reasons.push('repo_path is required');
+  }
+
+  if (!issue_id) {
+    result.block_reasons.push('issue_id is required for implementation edits');
+  }
+
+  const attemptedTargets = normalizeDeclaredTargets(declared_target_files);
+  if (attemptedTargets.length === 0) {
+    result.block_reasons.push('declared_target_files is required for implementation edits');
+  }
+
+  const registry = await loadRegistry();
+  result.active_project = registry.active_project || null;
+  if (!registry.active_project) {
+    result.block_reasons.push('no active project is set');
+    result.recovery_actions.push('call agenticos_switch before attempting implementation edits');
+  }
+
+  if (repo_path) {
+    result.target_project = await resolveTargetProject(repo_path, project_path);
+  }
+
+  if (!result.target_project) {
+    result.block_reasons.push(
+      project_path
+        ? `project_path is not a resolvable managed project: ${project_path}`
+        : 'target project could not be resolved from repo_path; pass project_path explicitly',
+    );
+    result.recovery_actions.push('pass project_path pointing at the managed project root');
+  }
+
+  if (result.active_project && result.target_project && result.active_project !== result.target_project.id) {
+    result.block_reasons.push(
+      `active project "${result.active_project}" does not match target project "${result.target_project.id}"`,
+    );
+    result.recovery_actions.push(`call agenticos_switch for project "${result.target_project.id}" before editing`);
+  }
+
+  let state: any = {};
+  if (result.target_project) {
+    try {
+      state = yaml.parse(await readFile(result.target_project.state_path, 'utf-8')) || {};
+    } catch {
+      result.block_reasons.push(`managed project state is missing or unreadable: ${result.target_project.state_path}`);
+      result.recovery_actions.push('ensure the managed project state exists before using the edit guard');
+    }
+  }
+
+  const preflight = state?.guardrail_evidence?.preflight;
+  if (!preflight) {
+    result.block_reasons.push('no preflight evidence is recorded for the target project');
+    result.recovery_actions.push('run agenticos_preflight and get PASS before implementation edits');
+  } else {
+    result.evidence.preflight_issue_id = typeof preflight.issue_id === 'string' ? preflight.issue_id : null;
+    result.evidence.preflight_repo_path = typeof preflight.repo_path === 'string' ? preflight.repo_path : null;
+    result.evidence.preflight_status = typeof preflight?.result?.status === 'string' ? preflight.result.status : null;
+    result.evidence.preflight_declared_target_files = Array.isArray(preflight.declared_target_files)
+      ? normalizeDeclaredTargets(preflight.declared_target_files)
+      : [];
+
+    if (issue_id && preflight.issue_id !== issue_id) {
+      result.block_reasons.push(
+        `latest preflight issue "${preflight.issue_id || 'unknown'}" does not match requested issue "${issue_id}"`,
+      );
+      result.recovery_actions.push(`rerun agenticos_preflight for issue #${issue_id}`);
+    }
+
+    if (repo_path && normalizePath(preflight.repo_path || '') !== normalizePath(repo_path)) {
+      result.block_reasons.push('latest preflight was recorded for a different repo_path');
+      result.recovery_actions.push('rerun agenticos_preflight for the current repo_path');
+    }
+
+    if (preflight?.result?.status !== 'PASS') {
+      result.block_reasons.push(`latest preflight status is ${preflight?.result?.status || 'unknown'} instead of PASS`);
+      result.recovery_actions.push('resolve the latest preflight outcome and rerun until it returns PASS');
+    } else {
+      result.preflight_ok = true;
+    }
+
+    const allowedTargets = new Set(result.evidence.preflight_declared_target_files);
+    const outOfScopeTargets = attemptedTargets.filter((target) => !allowedTargets.has(target));
+    if (outOfScopeTargets.length > 0) {
+      result.block_reasons.push(
+        `attempted targets exceed the latest preflight scope: ${outOfScopeTargets.join(', ')}`,
+      );
+      result.recovery_actions.push('rerun agenticos_preflight with the full intended target set before editing');
+    } else if (attemptedTargets.length > 0) {
+      result.scope_ok = true;
+    }
+  }
+
+  if (result.block_reasons.length > 0) {
+    result.status = 'BLOCK';
+    result.summary = result.block_reasons[0];
+  } else {
+    result.status = 'PASS';
+    result.summary = 'edit guard passed';
+  }
+
+  return JSON.stringify(result, null, 2);
+}

--- a/projects/agenticos/mcp-server/src/tools/index.ts
+++ b/projects/agenticos/mcp-server/src/tools/index.ts
@@ -6,6 +6,7 @@ export { runPreflight } from './preflight.js';
 export { runBranchBootstrap } from './branch-bootstrap.js';
 export { runPrScopeCheck } from './pr-scope-check.js';
 export { runHealth } from './health.js';
+export { runEditGuard } from './edit-guard.js';
 export { runEntrySurfaceRefresh } from './entry-surface-refresh.js';
 export { runStandardKitAdopt, runStandardKitUpgradeCheck } from './standard-kit.js';
 export { runNonCodeEvaluate } from './non-code-evaluate.js';

--- a/projects/agenticos/mcp-server/src/tools/preflight.ts
+++ b/projects/agenticos/mcp-server/src/tools/preflight.ts
@@ -12,6 +12,7 @@ interface PreflightArgs {
   issue_id?: string;
   task_type?: TaskType;
   repo_path?: string;
+  project_path?: string;
   remote_base_branch?: string;
   declared_target_files?: string[];
   structural_move?: boolean;
@@ -119,6 +120,7 @@ export async function runPreflight(args: PreflightArgs): Promise<string> {
     issue_id,
     task_type = 'discussion_only',
     repo_path,
+    project_path,
     remote_base_branch = 'origin/main',
     declared_target_files = [],
     structural_move = false,
@@ -157,8 +159,10 @@ export async function runPreflight(args: PreflightArgs): Promise<string> {
     finalized.persistence = await persistGuardrailEvidence({
       command: 'agenticos_preflight',
       repo_path,
+      project_path,
       payload: {
         issue_id: issue_id || null,
+        project_path: project_path || null,
         task_type,
         declared_target_files,
         structural_move,
@@ -225,8 +229,10 @@ export async function runPreflight(args: PreflightArgs): Promise<string> {
   finalized.persistence = await persistGuardrailEvidence({
     command: 'agenticos_preflight',
     repo_path,
+    project_path,
     payload: {
       issue_id: issue_id || null,
+      project_path: project_path || null,
       task_type,
       declared_target_files,
       structural_move,

--- a/projects/agenticos/mcp-server/src/utils/__tests__/guardrail-evidence.test.ts
+++ b/projects/agenticos/mcp-server/src/utils/__tests__/guardrail-evidence.test.ts
@@ -119,7 +119,6 @@ describe('persistGuardrailEvidence', () => {
     });
     accessMock
       .mockRejectedValueOnce(new Error('missing repo-level .project.yaml'))
-      .mockRejectedValueOnce(new Error('missing repo-level state'))
       .mockResolvedValueOnce(undefined)
       .mockResolvedValueOnce(undefined);
     readFileMock
@@ -142,6 +141,35 @@ describe('persistGuardrailEvidence', () => {
     expect(statePath).toBe('/workspace/source/projects/agenticos/.context/state.yaml');
     const writtenState = JSON.parse(content as string);
     expect(writtenState.guardrail_evidence.branch_bootstrap.issue_id).toBe('62');
+  });
+
+  it('uses explicit project_path when repo_path is a larger checkout root', async () => {
+    loadRegistryMock.mockResolvedValue({
+      active_project: null,
+      projects: [],
+    });
+    accessMock
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined);
+    readFileMock
+      .mockResolvedValueOnce(JSON.stringify({ meta: { id: 'agenticos-standards' }, agent_context: { current_state: '.context/state.yaml' } }))
+      .mockResolvedValueOnce(JSON.stringify({ session: {}, working_memory: { facts: [], decisions: [], pending: [] } }));
+
+    const result = await persistGuardrailEvidence({
+      command: 'agenticos_preflight',
+      repo_path: '/workspace/source',
+      project_path: '/workspace/source/projects/agenticos/standards',
+      payload: {
+        issue_id: '113',
+        result: { status: 'PASS' },
+      },
+    });
+
+    expect(result.persisted).toBe(true);
+    expect(result.project_id).toBe('agenticos-standards');
+
+    const [statePath] = writeFileMock.mock.calls[0];
+    expect(statePath).toBe('/workspace/source/projects/agenticos/standards/.context/state.yaml');
   });
 
   it('does not write state when repo_path is outside managed projects', async () => {

--- a/projects/agenticos/mcp-server/src/utils/guardrail-evidence.ts
+++ b/projects/agenticos/mcp-server/src/utils/guardrail-evidence.ts
@@ -1,5 +1,5 @@
 import { access, readFile, writeFile } from 'fs/promises';
-import { dirname, join, resolve, sep } from 'path';
+import { basename, dirname, join, resolve, sep } from 'path';
 import yaml from 'yaml';
 import { loadRegistry } from './registry.js';
 
@@ -34,16 +34,26 @@ export interface GuardrailPersistenceResult {
 interface PersistGuardrailEvidenceArgs {
   command: GuardrailCommand;
   repo_path?: string;
+  project_path?: string;
   payload: Record<string, unknown>;
 }
 
 interface ResolvedProjectTarget {
   id: string;
   path: string;
+  statePath: string;
 }
 
 function normalizePath(path: string): string {
   return resolve(path);
+}
+
+function resolveProjectStatePath(projectPath: string, projectYaml: any): string {
+  const configuredStatePath = projectYaml?.agent_context?.current_state;
+  if (typeof configuredStatePath === 'string' && configuredStatePath.trim().length > 0) {
+    return join(projectPath, configuredStatePath.trim());
+  }
+  return join(projectPath, '.context', 'state.yaml');
 }
 
 function isWithinProject(repoPath: string, projectPath: string): boolean {
@@ -76,14 +86,13 @@ async function findProjectRootFromRepoPath(repoPath: string): Promise<ResolvedPr
 
   while (true) {
     const projectYamlPath = join(currentPath, '.project.yaml');
-    const statePath = join(currentPath, '.context', 'state.yaml');
     const hasProjectYaml = await pathExists(projectYamlPath);
-    const hasState = await pathExists(statePath);
 
-    if (hasProjectYaml && hasState) {
+    if (hasProjectYaml) {
+      let projectYaml: any = {};
       let projectId = currentPath.split(sep).filter(Boolean).pop() || 'unknown-project';
       try {
-        const projectYaml = yaml.parse(await readFile(projectYamlPath, 'utf-8')) || {};
+        projectYaml = yaml.parse(await readFile(projectYamlPath, 'utf-8')) || {};
         if (projectYaml?.meta?.id) {
           projectId = String(projectYaml.meta.id);
         }
@@ -91,9 +100,21 @@ async function findProjectRootFromRepoPath(repoPath: string): Promise<ResolvedPr
         // Fall back to directory-derived project id.
       }
 
+      const statePath = resolveProjectStatePath(currentPath, projectYaml);
+      const hasState = await pathExists(statePath);
+      if (!hasState) {
+        const parentPath = dirname(currentPath);
+        if (parentPath === currentPath) {
+          return null;
+        }
+        currentPath = parentPath;
+        continue;
+      }
+
       return {
         id: projectId,
         path: currentPath,
+        statePath,
       };
     }
 
@@ -105,7 +126,37 @@ async function findProjectRootFromRepoPath(repoPath: string): Promise<ResolvedPr
   }
 }
 
-async function resolveProjectTarget(repoPath: string): Promise<ResolvedProjectTarget | null> {
+async function resolveExplicitProjectTarget(projectPath: string): Promise<ResolvedProjectTarget | null> {
+  const normalizedProjectPath = normalizePath(projectPath);
+  const projectYamlPath = join(normalizedProjectPath, '.project.yaml');
+  if (!(await pathExists(projectYamlPath))) {
+    return null;
+  }
+
+  let projectYaml: any = {};
+  try {
+    projectYaml = yaml.parse(await readFile(projectYamlPath, 'utf-8')) || {};
+  } catch {
+    projectYaml = {};
+  }
+
+  const statePath = resolveProjectStatePath(normalizedProjectPath, projectYaml);
+  if (!(await pathExists(statePath))) {
+    return null;
+  }
+
+  return {
+    id: String(projectYaml?.meta?.id || basename(normalizedProjectPath)),
+    path: normalizedProjectPath,
+    statePath,
+  };
+}
+
+async function resolveProjectTarget(repoPath: string, projectPath?: string): Promise<ResolvedProjectTarget | null> {
+  if (projectPath) {
+    return resolveExplicitProjectTarget(projectPath);
+  }
+
   const registry = await loadRegistry();
   const normalizedRepoPath = normalizePath(repoPath);
   const matchingProjects = registry.projects
@@ -118,6 +169,7 @@ async function resolveProjectTarget(repoPath: string): Promise<ResolvedProjectTa
     return {
       id: registryProject.id,
       path: registryProject.path,
+      statePath: join(registryProject.path, '.context', 'state.yaml'),
     };
   }
 
@@ -127,7 +179,7 @@ async function resolveProjectTarget(repoPath: string): Promise<ResolvedProjectTa
 export async function persistGuardrailEvidence(
   args: PersistGuardrailEvidenceArgs,
 ): Promise<GuardrailPersistenceResult> {
-  const { command, repo_path, payload } = args;
+  const { command, repo_path, project_path, payload } = args;
 
   if (!repo_path) {
     return {
@@ -137,16 +189,18 @@ export async function persistGuardrailEvidence(
     };
   }
 
-  const project = await resolveProjectTarget(repo_path);
+  const project = await resolveProjectTarget(repo_path, project_path);
   if (!project) {
     return {
       attempted: true,
       persisted: false,
-      reason: `repo_path is not within a resolvable AgenticOS project: ${repo_path}`,
+      reason: project_path
+        ? `project_path is not a resolvable AgenticOS project: ${project_path}`
+        : `repo_path is not within a resolvable AgenticOS project: ${repo_path}`,
     };
   }
 
-  const statePath = join(project.path, '.context', 'state.yaml');
+  const statePath = project.statePath;
   let state: StateYaml = {};
 
   try {

--- a/projects/agenticos/standards/knowledge/issue-113-design-brief-2026-03-29.md
+++ b/projects/agenticos/standards/knowledge/issue-113-design-brief-2026-03-29.md
@@ -1,0 +1,129 @@
+# Issue Design Brief
+
+## Issue
+- ID: `#113`
+- Title: `feat: fail closed when issue-first or active-project alignment is missing before edits`
+- Linked source: `gh issue view 113 --repo madlouse/AgenticOS`
+
+## Objective Synthesis
+- User-stated request: continue from the RCA and implement an actual optimization path, not just more explanation.
+- Inferred end goal: add an executable edit boundary so implementation-affecting work cannot silently bypass project alignment or issue/preflight alignment.
+- Constraints:
+  - stay inside isolated issue worktree `feat/113-fail-closed-edit-boundaries`
+  - preserve a clear split between analysis issue `#112` and implementation issue `#113`
+  - support both direct project repos and self-hosting/checkouts where the repository root is not itself the managed project root
+- Non-goals:
+  - do not redesign the full AgenticOS routing model
+  - do not require silent mutation of Codex or Claude user configs
+  - do not solve every registry migration problem in this issue
+
+## Project Context
+- Project long-term objective: AgenticOS should provide executable workflow boundaries, not just prompt-level reminders.
+- Relevant existing design:
+  - `agenticos_preflight` already classifies and validates implementation work
+  - guardrail evidence is already persisted into project state when the project root is resolvable
+  - `tools/record-reminder.sh` already proves the product accepts hook-friendly compatibility scripts
+- Related issues/risks:
+  - `#112` established that the missing guard is specifically at edit time
+  - clean worktrees created from `origin/main` may still carry older registry structures, so the implementation should not depend on one exact repository topology
+- Files or docs reviewed:
+  - `projects/agenticos/mcp-server/src/index.ts`
+  - `projects/agenticos/mcp-server/src/tools/preflight.ts`
+  - `projects/agenticos/mcp-server/src/utils/guardrail-evidence.ts`
+  - `projects/agenticos/mcp-server/src/utils/project-target.ts`
+  - `tools/record-reminder.sh`
+
+## Sub-Agent Inheritance Packet
+- Sub-agent needed: no
+- Delegated scope: none
+- Project identity to pass: AgenticOS product source implementation issue `#113`
+- Current task / issue context to pass: add minimal fail-closed edit boundary enforcement
+- Constraints / non-goals to pass: no scope expansion into generic routing redesign
+- Knowledge or task files to pass: this brief and issue `#112` RCA
+- Expected output shape: one new guard tool, one hookable wrapper, tests, and bootstrap docs
+- Verification the sub-agent must echo back: not applicable
+
+## Design Pass 1
+- Proposed approach:
+  - add `agenticos_edit_guard` as an MCP tool that validates edit-time conditions
+  - add `project_path` support so self-hosting/product-source checkouts can persist and read guardrail evidence even when `repo_path` is not itself inside a managed project root
+  - add `tools/check-edit-boundary.sh` as a hook-friendly wrapper that calls the MCP tool and fails closed on `BLOCK`
+- Why this approach:
+  - MCP-only enforcement is too opt-in
+  - hook-only enforcement without shared product logic would duplicate decision rules
+  - this split keeps one canonical decision engine with one operator-facing wrapper
+- Expected benefits:
+  - edit-time enforcement becomes executable
+  - the mechanism works for both direct project roots and nested product-source layouts
+  - Codex/Claude/bootstrap docs can point to one real guard entrypoint
+
+## Critique Pass 1
+- Weak assumptions:
+  - available edit hooks differ across agents, so wrapper adoption may still be tool-specific
+  - preflight evidence is the right minimum proof for implementation edits
+- Missing edge cases:
+  - read-only investigation should not require edit guard PASS
+  - declared target files may evolve after preflight
+- Risks:
+  - over-coupling the wrapper to one runtime layout
+  - requiring registry membership where only `project_path` is actually knowable
+- Better alternatives considered:
+  - a new MCP tool only, with no wrapper
+  - only a shell script, with no canonical MCP decision engine
+
+## Design Pass 2
+- Refined approach:
+  - `agenticos_edit_guard` blocks only `implementation` work
+  - it requires:
+    - active project to match the intended project
+    - issue id to be present
+    - latest persisted preflight for the same issue and repo to exist and be `PASS`
+    - attempted target files to remain within the preflight-declared target set
+  - `project_path` becomes the explicit bridge when `repo_path` is a self-hosting checkout root rather than the managed project directory
+- Changes from pass 1:
+  - make declared-target subset checking part of the first version
+  - make `project_path` explicit instead of trying to infer everything from the checkout root
+- Why pass 2 is stronger:
+  - it converts "did you remember to run preflight?" into a verifiable fact
+  - it fails closed when topology is ambiguous instead of guessing
+
+## Optional Design Pass 3
+- Trigger reason: not needed
+- Further refinement: not needed
+
+## Executable Acceptance
+- Behavioral checks:
+  - `agenticos_edit_guard` blocks implementation edits when active project mismatches the intended project
+  - `agenticos_edit_guard` blocks implementation edits when no matching `PASS` preflight evidence exists
+  - `agenticos_edit_guard` blocks implementation edits when attempted targets exceed preflight-declared targets
+  - `agenticos_edit_guard` passes once project alignment and matching preflight evidence exist
+- File/state assertions:
+  - guardrail evidence persistence accepts explicit `project_path`
+  - one hook-friendly wrapper exists at both `projects/agenticos/tools/` and top-level `tools/`
+- Verification commands:
+  - targeted `vitest` for guardrail evidence and edit guard
+  - `npm run build`
+  - direct wrapper invocations for pass/block fixtures
+- Evaluation rubric:
+  - fail-closed behavior
+  - no silent project inference when ambiguous
+  - clear recovery output
+
+## Implementation Plan
+- Files expected to change:
+  - `projects/agenticos/mcp-server/src/index.ts`
+  - `projects/agenticos/mcp-server/src/tools/index.ts`
+  - `projects/agenticos/mcp-server/src/tools/preflight.ts`
+  - `projects/agenticos/mcp-server/src/tools/edit-guard.ts`
+  - `projects/agenticos/mcp-server/src/tools/__tests__/edit-guard.test.ts`
+  - `projects/agenticos/mcp-server/src/utils/guardrail-evidence.ts`
+  - `projects/agenticos/mcp-server/src/utils/__tests__/guardrail-evidence.test.ts`
+  - `projects/agenticos/tools/check-edit-boundary.sh`
+  - `tools/check-edit-boundary.sh`
+  - `README.md`
+  - `projects/agenticos/mcp-server/README.md`
+- Worktree required: yes
+- Verification evidence to produce:
+  - passing targeted tests
+  - successful build
+  - one blocked and one passing wrapper invocation

--- a/projects/agenticos/tools/check-edit-boundary.sh
+++ b/projects/agenticos/tools/check-edit-boundary.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  check-edit-boundary.sh \
+    --repo-path /abs/repo \
+    --issue-id 113 \
+    --declared-target-file path/to/file \
+    [--declared-target-file other/file] \
+    [--project-path /abs/project/root] \
+    [--task-type implementation]
+
+Environment:
+  AGENTICOS_HOME             Required AgenticOS workspace root.
+  AGENTICOS_MCP_COMMAND      Optional MCP command path. Default: agenticos-mcp
+  AGENTICOS_MCP_ARGS_JSON    Optional JSON array of additional MCP command args.
+EOF
+}
+
+REPO_PATH=""
+PROJECT_PATH=""
+ISSUE_ID=""
+TASK_TYPE="implementation"
+TARGET_FILES=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo-path)
+      REPO_PATH="${2:-}"
+      shift 2
+      ;;
+    --project-path)
+      PROJECT_PATH="${2:-}"
+      shift 2
+      ;;
+    --issue-id)
+      ISSUE_ID="${2:-}"
+      shift 2
+      ;;
+    --task-type)
+      TASK_TYPE="${2:-}"
+      shift 2
+      ;;
+    --declared-target-file)
+      TARGET_FILES+=("${2:-}")
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 64
+      ;;
+  esac
+done
+
+if [[ -z "${AGENTICOS_HOME:-}" ]]; then
+  echo "AGENTICOS_HOME is required." >&2
+  exit 64
+fi
+
+if [[ -z "$REPO_PATH" || -z "$ISSUE_ID" || ${#TARGET_FILES[@]} -eq 0 ]]; then
+  usage >&2
+  exit 64
+fi
+
+TARGETS_JSON=$(printf '%s\n' "${TARGET_FILES[@]}" | node -e 'const fs=require("fs"); const lines=fs.readFileSync(0,"utf8").split("\n").filter(Boolean); process.stdout.write(JSON.stringify(lines));')
+
+RESULT_JSON=$(
+  REPO_PATH="$REPO_PATH" \
+  PROJECT_PATH="$PROJECT_PATH" \
+  ISSUE_ID="$ISSUE_ID" \
+  TASK_TYPE="$TASK_TYPE" \
+  TARGETS_JSON="$TARGETS_JSON" \
+  node --input-type=module <<'NODE'
+import { spawn } from 'child_process';
+
+const command = process.env.AGENTICOS_MCP_COMMAND || 'agenticos-mcp';
+const extraArgs = process.env.AGENTICOS_MCP_ARGS_JSON
+  ? JSON.parse(process.env.AGENTICOS_MCP_ARGS_JSON)
+  : [];
+
+const server = spawn(command, extraArgs, {
+  env: process.env,
+  stdio: ['pipe', 'pipe', 'pipe'],
+});
+
+let buf = '';
+let printed = false;
+
+function finish(code) {
+  server.kill();
+  process.exit(code);
+}
+
+server.stdout.on('data', (chunk) => {
+  buf += chunk.toString();
+  let idx;
+  while ((idx = buf.indexOf('\n')) >= 0) {
+    const line = buf.slice(0, idx).trim();
+    buf = buf.slice(idx + 1);
+    if (!line) continue;
+    const msg = JSON.parse(line);
+    if (msg.id === 1) {
+      server.stdin.write(JSON.stringify({
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: {
+          name: 'agenticos_edit_guard',
+          arguments: {
+            issue_id: process.env.ISSUE_ID,
+            task_type: process.env.TASK_TYPE,
+            repo_path: process.env.REPO_PATH,
+            project_path: process.env.PROJECT_PATH || undefined,
+            declared_target_files: JSON.parse(process.env.TARGETS_JSON || '[]'),
+          },
+        },
+      }) + '\n');
+      continue;
+    }
+    if (msg.id === 2) {
+      process.stdout.write(msg?.result?.content?.[0]?.text ?? JSON.stringify(msg));
+      printed = true;
+      finish(0);
+    }
+  }
+});
+
+server.stderr.on('data', (chunk) => process.stderr.write(chunk));
+server.on('exit', (code) => {
+  if (!printed) {
+    process.exit(code ?? 1);
+  }
+});
+
+server.stdin.write(JSON.stringify({
+  jsonrpc: '2.0',
+  id: 1,
+  method: 'initialize',
+  params: {
+    protocolVersion: '2024-11-05',
+    capabilities: {},
+    clientInfo: { name: 'agenticos-edit-guard', version: '1.0.0' },
+  },
+}) + '\n');
+
+setTimeout(() => finish(1), 8000);
+NODE
+)
+
+echo "$RESULT_JSON"
+
+STATUS=$(printf '%s' "$RESULT_JSON" | node -e 'const fs=require("fs"); const obj=JSON.parse(fs.readFileSync(0,"utf8")); process.stdout.write(obj.status || "BLOCK");')
+if [[ "$STATUS" != "PASS" ]]; then
+  exit 2
+fi

--- a/tools/check-edit-boundary.sh
+++ b/tools/check-edit-boundary.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+exec "$SCRIPT_DIR/../projects/agenticos/tools/check-edit-boundary.sh" "$@"


### PR DESCRIPTION
## Summary
- add `agenticos_edit_guard` so implementation-affecting edits fail closed unless active-project alignment and matching PASS preflight evidence already exist
- persist `project_path` in guardrail evidence and preflight so self-hosting and larger checkout layouts can resolve the managed project root explicitly
- add hook-friendly `check-edit-boundary.sh` wrappers plus tests and docs for the new enforcement path

## Testing
- `npm test -- --run src/tools/__tests__/edit-guard.test.ts src/utils/__tests__/guardrail-evidence.test.ts src/tools/__tests__/preflight.test.ts`
- `npm run build`
- `agenticos_pr_scope_check` against this branch now returns `PASS` after `#115` fixed dotted exact-path matching

Closes #113
