### PR TITLE
feat: freeze the cross-agent execution contract

### DIFF
--- a/projects/agenticos/.meta/bootstrap/cross-agent-execution-contract.yaml
+++ b/projects/agenticos/.meta/bootstrap/cross-agent-execution-contract.yaml
@@ -1,0 +1,64 @@
+version: 1
+contract_id: cross-agent-execution-contract
+status: canonical
+summary: >
+  Freeze one canonical AgenticOS execution policy that every supported agent must
+  obey, while allowing runtime-specific adapter surfaces and optional local
+  enhancements.
+
+policy_invariants:
+  - id: active_project_alignment
+    summary: Implementation work must align to the intended active project before edits begin.
+  - id: issue_first_execution
+    summary: Implementation work must start from an issue-scoped task rather than ad hoc mutation.
+  - id: implementation_preflight
+    summary: Implementation-affecting work must pass executable preflight before editing.
+  - id: isolated_worktree_execution
+    summary: Implementation work must move into an isolated issue branch and worktree when required by guardrails.
+  - id: edit_boundary_enforcement
+    summary: Implementation edits must fail closed when active-project alignment or matching preflight evidence is missing.
+  - id: pr_scope_validation
+    summary: PR creation and merge must pass executable issue-scope validation.
+  - id: recording_protocol
+    summary: Meaningful session work must be recorded through the canonical AgenticOS persistence flow.
+
+adapter_surfaces:
+  - id: codex-generic
+    generated_file: AGENTS.md
+    runtime_family: codex_and_generic_mcp_agents
+    role: >
+      Generic and Codex-facing adapter surface that exposes the canonical AgenticOS
+      execution policy without redefining it.
+    runtime_specific_concerns:
+      - MCP registration and bootstrap ergonomics
+      - explicit tool-routing hints when natural-language routing is weak
+  - id: claude-code
+    generated_file: CLAUDE.md
+    runtime_family: claude_code
+    role: >
+      Claude Code-facing adapter surface that exposes the canonical AgenticOS
+      execution policy while allowing Claude-specific operator guidance.
+    runtime_specific_concerns:
+      - Claude CLI-managed MCP configuration and restart expectations
+      - Claude-specific prompting and routing hints
+      - optional local stop-hook reminders
+
+optional_runtime_enhancements:
+  - id: claude-stop-hook
+    canonical: false
+    scope: local_optional_enhancement
+    summary: Optional Claude-local reminder layer that does not replace canonical AgenticOS persistence or guardrails.
+
+layer_boundaries:
+  canonical_policy:
+    description: >
+      Project policy and guardrail semantics that must remain identical across all
+      supported agents.
+  adapter_surface:
+    description: >
+      Runtime-specific generated instruction surfaces that translate the canonical
+      policy into the entry surface each agent actually reads.
+  runtime_enhancement:
+    description: >
+      Optional runtime-specific helpers such as hooks and reminders. These may
+      improve operator ergonomics but must never become the sole enforcement plane.

--- a/projects/agenticos/.meta/standard-kit/inheritance-rules.md
+++ b/projects/agenticos/.meta/standard-kit/inheritance-rules.md
@@ -33,6 +33,7 @@ These are generated or upgraded by the distillation layer.
 Implication:
 - downstream projects should not treat them as free-form scratch files
 - local project-specific content may exist, but upgrades must preserve the canonical guardrail protocol and template marker
+- generated adapter surfaces must preserve one canonical cross-agent execution contract even when runtime-specific guidance differs
 
 ### Copied templates
 
@@ -78,6 +79,7 @@ They should not need the full internal standards history unless they are doing s
 Generated files:
 - may be upgraded automatically when template markers change
 - must preserve user-extended sections where supported by the generator
+- must not drift into agent-specific policy forks
 
 Copied templates:
 - must not be silently replaced after project adoption
@@ -88,3 +90,14 @@ Copied templates:
 If older guidance elsewhere in `.meta/` conflicts with this package:
 - the standard kit wins
 - the conflicting file should be treated as legacy until updated
+
+## Rule 6: Adapter Surfaces Are Not Independent Policy Sources
+
+`AGENTS.md` and `CLAUDE.md` are adapter surfaces over the same canonical policy.
+
+They may vary in runtime-specific bootstrap and operator guidance, but they must not diverge on:
+
+- issue-first execution semantics
+- guardrail protocol meaning
+- recording protocol requirements
+- what counts as compliant implementation flow

--- a/projects/agenticos/.meta/standard-kit/manifest.yaml
+++ b/projects/agenticos/.meta/standard-kit/manifest.yaml
@@ -66,8 +66,8 @@ layers:
 
 upgrade_rules:
   template_marker_version:
-    AGENTS.md: 3
-    CLAUDE.md: 3
+    AGENTS.md: 4
+    CLAUDE.md: 4
   compatibility_rule: >
     Generated files may be upgraded in place by distill when the template marker version changes.
   copied_template_rule: >
@@ -87,8 +87,11 @@ adoption:
     - tasks/templates/submission-evidence.md
   required_behavior:
     - memory_layer_contracts
+    - cross_agent_policy_contract
     - implementation_preflight
     - issue_first_branching
     - isolated_worktree_execution
+    - edit_boundary_enforcement
     - pr_scope_validation
+    - official_agent_adapter_surfaces
     - sub_agent_context_inheritance

--- a/projects/agenticos/mcp-server/src/tools/__tests__/standard-kit.test.ts
+++ b/projects/agenticos/mcp-server/src/tools/__tests__/standard-kit.test.ts
@@ -145,8 +145,8 @@ describe('standard kit commands', () => {
 
     const agentsMd = await readFile(join(projectRoot, 'AGENTS.md'), 'utf-8');
     const claudeMd = await readFile(join(projectRoot, 'CLAUDE.md'), 'utf-8');
-    expect(agentsMd).toContain('agenticos-template: v3');
-    expect(claudeMd).toContain('agenticos-template: v3');
+    expect(agentsMd).toContain('agenticos-template: v4');
+    expect(claudeMd).toContain('agenticos-template: v4');
   });
 
   it('upgrade check reports missing, stale, matching, and diverged files', async () => {
@@ -216,7 +216,7 @@ describe('standard kit commands', () => {
     expect(result.created_files).toContain('.project.yaml');
 
     const claudeMd = await readFile(join(projectRoot, 'CLAUDE.md'), 'utf-8');
-    expect(claudeMd).toContain('agenticos-template: v3');
+    expect(claudeMd).toContain('agenticos-template: v4');
     expect(claudeMd).toContain('custom dna');
     expect(claudeMd).toContain('## Current State');
   });
@@ -226,7 +226,7 @@ describe('standard kit commands', () => {
     process.env.AGENTICOS_HOME = home;
 
     await writeFile(join(projectRoot, 'AGENTS.md'), generateAgentsMd('Sample Project', ''), 'utf-8');
-    await writeFile(join(projectRoot, 'CLAUDE.md'), '<!-- agenticos-template: v3 -->\ncurrent claude\n', 'utf-8');
+    await writeFile(join(projectRoot, 'CLAUDE.md'), '<!-- agenticos-template: v4 -->\ncurrent claude\n', 'utf-8');
 
     const result = JSON.parse(await runStandardKitUpgradeCheck({ project_path: projectRoot })) as {
       generated_files: Array<{ path: string; status: string; current_version: number | null }>;
@@ -234,11 +234,11 @@ describe('standard kit commands', () => {
 
     expect(result.generated_files.find((item) => item.path === 'AGENTS.md')).toMatchObject({
       status: 'current',
-      current_version: 3,
+      current_version: 4,
     });
     expect(result.generated_files.find((item) => item.path === 'CLAUDE.md')).toMatchObject({
       status: 'current',
-      current_version: 3,
+      current_version: 4,
     });
   });
 
@@ -276,7 +276,7 @@ describe('standard kit commands', () => {
 
     expect(result.upgraded_generated_files).toContain('AGENTS.md');
     const agentsMd = await readFile(join(projectRoot, 'AGENTS.md'), 'utf-8');
-    expect(agentsMd).toContain('agenticos-template: v3');
+    expect(agentsMd).toContain('agenticos-template: v4');
     expect(agentsMd).toContain('Guardrail Protocol');
   });
 

--- a/projects/agenticos/mcp-server/src/utils/__tests__/distill.test.ts
+++ b/projects/agenticos/mcp-server/src/utils/__tests__/distill.test.ts
@@ -1,12 +1,27 @@
 import { describe, expect, it } from 'vitest';
-import { CURRENT_TEMPLATE_VERSION, generateAgentsMd, generateClaudeMd } from '../distill.js';
+import {
+  AGENTS_ADAPTER_LINES,
+  CLAUDE_ADAPTER_LINES,
+  CURRENT_TEMPLATE_VERSION,
+  SHARED_POLICY_BULLETS,
+  SHARED_POLICY_TITLE,
+  generateAgentsMd,
+  generateClaudeMd,
+} from '../distill.js';
 
 describe('distill templates', () => {
-  it('generates AGENTS.md with the current template marker and guardrail flow', () => {
+  it('generates AGENTS.md with the current template marker, adapter role, and guardrail flow', () => {
     const content = generateAgentsMd('Demo Project', 'Guardrail test');
 
-    expect(CURRENT_TEMPLATE_VERSION).toBe(3);
-    expect(content).toContain('<!-- agenticos-template: v3 -->');
+    expect(CURRENT_TEMPLATE_VERSION).toBe(4);
+    expect(content).toContain('<!-- agenticos-template: v4 -->');
+    expect(content).toContain('## Adapter Role');
+    expect(content).toContain(AGENTS_ADAPTER_LINES[0]);
+    expect(content).toContain(AGENTS_ADAPTER_LINES[1]);
+    expect(content).toContain(`## ${SHARED_POLICY_TITLE}`);
+    for (const bullet of SHARED_POLICY_BULLETS) {
+      expect(content).toContain(bullet);
+    }
     expect(content).toContain('## Guardrail Protocol (MANDATORY)');
     expect(content).toContain('agenticos_preflight');
     expect(content).toContain('agenticos_branch_bootstrap');
@@ -16,9 +31,16 @@ describe('distill templates', () => {
     expect(content).toContain('tasks/templates/non-code-evaluation-rubric.yaml');
   });
 
-  it('generates CLAUDE.md with guardrail flow and template navigation', () => {
+  it('generates CLAUDE.md with adapter role, shared policy, and template navigation', () => {
     const content = generateClaudeMd('Demo Project', 'Guardrail test');
 
+    expect(content).toContain('## Adapter Role');
+    expect(content).toContain(CLAUDE_ADAPTER_LINES[0]);
+    expect(content).toContain(CLAUDE_ADAPTER_LINES[1]);
+    expect(content).toContain(`## ${SHARED_POLICY_TITLE}`);
+    for (const bullet of SHARED_POLICY_BULLETS) {
+      expect(content).toContain(bullet);
+    }
     expect(content).toContain('## Guardrail Protocol (MANDATORY)');
     expect(content).toContain('agenticos_preflight');
     expect(content).toContain('agenticos_branch_bootstrap');

--- a/projects/agenticos/mcp-server/src/utils/distill.ts
+++ b/projects/agenticos/mcp-server/src/utils/distill.ts
@@ -5,10 +5,28 @@ import { readFileSync } from 'fs';
  * Current template version. Increment when templates change.
  * Used for auto-upgrade on project switch.
  */
-export const CURRENT_TEMPLATE_VERSION = 3;
+export const CURRENT_TEMPLATE_VERSION = 4;
 
 /** Version marker format in generated files */
 const VERSION_MARKER = `<!-- agenticos-template: v${CURRENT_TEMPLATE_VERSION} -->`;
+
+export const SHARED_POLICY_TITLE = 'Canonical Policy (Shared Across Agents)';
+export const SHARED_POLICY_BULLETS = [
+  'This project has one canonical AgenticOS execution policy across Claude Code, Codex, and other supported agents.',
+  'Implementation work must stay issue-first, preflighted, and inside the guardrail-controlled branch/worktree flow.',
+  'PR creation or merge must not happen before executable scope validation passes.',
+  'Recording and save flow remain canonical project requirements rather than runtime-specific preferences.',
+] as const;
+
+export const AGENTS_ADAPTER_LINES = [
+  '`AGENTS.md` is the Codex/generic adapter surface for this project.',
+  'It must expose the same canonical policy as other agent adapters rather than defining a different workflow.',
+] as const;
+
+export const CLAUDE_ADAPTER_LINES = [
+  '`CLAUDE.md` is the Claude Code adapter surface for this project.',
+  'It must expose the same canonical policy as other agent adapters while allowing Claude-specific operator guidance.',
+] as const;
 
 /** Extract template version from an existing file. Returns 0 if no marker found (v1 or earlier). */
 export function extractTemplateVersion(content: string): number {
@@ -23,6 +41,15 @@ function ensureVersionMarker(content: string): string {
   return `${VERSION_MARKER}\n${cleaned}`;
 }
 
+function renderSharedPolicySection(): string {
+  return [
+    `## ${SHARED_POLICY_TITLE}`,
+    '',
+    ...SHARED_POLICY_BULLETS.map((line) => `- ${line}`),
+    '',
+  ].join('\n');
+}
+
 // ---------------------------------------------------------------------------
 // AGENTS.md template
 // ---------------------------------------------------------------------------
@@ -31,7 +58,12 @@ export function generateAgentsMd(name: string, description: string): string {
   return `${VERSION_MARKER}
 # AGENTS.md — ${name}
 
-## Guardrail Protocol (MANDATORY)
+## Adapter Role
+
+${AGENTS_ADAPTER_LINES[0]}
+${AGENTS_ADAPTER_LINES[1]}
+
+${renderSharedPolicySection()}## Guardrail Protocol (MANDATORY)
 
 Implementation work must use the executable guardrail flow:
 
@@ -168,7 +200,12 @@ function buildClaudeMdContent(name: string, description: string, state?: StateYa
   return `${VERSION_MARKER}
 # CLAUDE.md — ${name}
 
-## Guardrail Protocol (MANDATORY)
+## Adapter Role
+
+${CLAUDE_ADAPTER_LINES[0]}
+${CLAUDE_ADAPTER_LINES[1]}
+
+${renderSharedPolicySection()}## Guardrail Protocol (MANDATORY)
 
 For implementation-affecting work:
 

--- a/projects/agenticos/standards/knowledge/cross-agent-execution-contract-2026-03-29.md
+++ b/projects/agenticos/standards/knowledge/cross-agent-execution-contract-2026-03-29.md
@@ -1,0 +1,71 @@
+# Cross-Agent Execution Contract - 2026-03-29
+
+## Design Reflection
+
+AgenticOS should not maintain one workflow for Claude Code and a different workflow for Codex.
+
+That would turn runtime integration details into policy drift.
+
+The correct split is:
+
+1. one canonical execution policy
+2. multiple runtime-specific adapter surfaces
+3. optional runtime-specific enhancements
+
+## Canonical Rule
+
+The following concerns are policy invariants and must stay identical across all supported agents:
+
+- active-project alignment before implementation edits
+- issue-first execution
+- executable preflight before implementation edits
+- isolated issue branch and worktree execution when guardrails require it
+- edit-boundary fail-closed behavior
+- PR scope validation before PR creation or merge
+- canonical recording and save flow
+
+## Adapter Rule
+
+Generated agent-facing files are adapters over the same policy, not separate policy definitions.
+
+Current canonical adapter surfaces:
+
+- `AGENTS.md` for Codex and generic MCP-capable agents
+- `CLAUDE.md` for Claude Code
+
+These files may differ in:
+
+- bootstrap wording
+- routing hints
+- runtime-specific operator guidance
+
+They must not differ in:
+
+- workflow semantics
+- guardrail meaning
+- recording requirements
+- what counts as compliant implementation flow
+
+## Hook Rule
+
+Runtime-specific hooks remain optional local enhancements.
+
+They may:
+
+- remind
+- surface local state
+- improve operator ergonomics
+
+They must not:
+
+- replace canonical guardrails
+- replace canonical persistence
+- become the only place where a required rule is enforced
+
+## Canonical Source Of Truth
+
+The machine-readable source of truth is:
+
+- `projects/agenticos/.meta/bootstrap/cross-agent-execution-contract.yaml`
+
+Generated instruction surfaces and downstream conformance checks should align to that contract rather than inventing agent-local rule variants.


### PR DESCRIPTION
## Summary
- add canonical cross-agent execution contract metadata and supporting design note
- upgrade generated `AGENTS.md` and `CLAUDE.md` templates so they explicitly declare themselves adapter surfaces over the same policy
- extend standard-kit metadata to require the cross-agent policy contract and official adapter surfaces

## Testing
- `npm test`
- `npm run build`

Closes #117
