### PR TITLE
feat: add executable standard-kit conformance checks

### DIFF
--- a/projects/agenticos/mcp-server/src/index.ts
+++ b/projects/agenticos/mcp-server/src/index.ts
@@ -34,7 +34,7 @@ import {
   ListResourcesRequestSchema,
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { initProject, switchProject, listProjects, getStatus, saveState, recordSession, runPreflight, runBranchBootstrap, runPrScopeCheck, runHealth, runEditGuard, runEntrySurfaceRefresh, runStandardKitAdopt, runStandardKitUpgradeCheck, runNonCodeEvaluate } from './tools/index.js';
+import { initProject, switchProject, listProjects, getStatus, saveState, recordSession, runPreflight, runBranchBootstrap, runPrScopeCheck, runHealth, runEditGuard, runEntrySurfaceRefresh, runStandardKitAdopt, runStandardKitUpgradeCheck, runStandardKitConformanceCheck, runNonCodeEvaluate } from './tools/index.js';
 import { getProjectContext } from './resources/index.js';
 
 const server = new Server(
@@ -279,6 +279,18 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
       },
     },
     {
+      name: 'agenticos_standard_kit_conformance_check',
+      description: 'Check whether a downstream project conforms to the canonical standard-kit workflow contract, not just the file package.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          project_path: { type: 'string', description: 'Absolute target project path. If omitted, uses the active project from the registry.' },
+          project_name: { type: 'string', description: 'Optional project name override used for reporting when .project.yaml is missing.' },
+          project_description: { type: 'string', description: 'Optional project description override used for reporting.' },
+        },
+      },
+    },
+    {
       name: 'agenticos_non_code_evaluate',
       description: 'Validate a completed non-code evaluation rubric against the canonical contract and persist the latest structured evidence into project state.',
       inputSchema: {
@@ -326,6 +338,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       return { content: [{ type: 'text', text: await runStandardKitAdopt(args ?? {}) }] };
     case 'agenticos_standard_kit_upgrade_check':
       return { content: [{ type: 'text', text: await runStandardKitUpgradeCheck(args ?? {}) }] };
+    case 'agenticos_standard_kit_conformance_check':
+      return { content: [{ type: 'text', text: await runStandardKitConformanceCheck(args ?? {}) }] };
     case 'agenticos_non_code_evaluate':
       return { content: [{ type: 'text', text: await runNonCodeEvaluate(args ?? {}) }] };
     default:

--- a/projects/agenticos/mcp-server/src/tools/__tests__/standard-kit.test.ts
+++ b/projects/agenticos/mcp-server/src/tools/__tests__/standard-kit.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, mkdir, readFile, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import yaml from 'yaml';
-import { runStandardKitAdopt, runStandardKitUpgradeCheck } from '../standard-kit.js';
+import { runStandardKitAdopt, runStandardKitConformanceCheck, runStandardKitUpgradeCheck } from '../standard-kit.js';
 import { generateAgentsMd } from '../../utils/distill.js';
 
 async function writeRegistry(home: string, registry: unknown): Promise<void> {
@@ -23,10 +23,14 @@ async function setupKitHome(): Promise<{ home: string; projectRoot: string }> {
   const home = await mkdtemp(join(tmpdir(), 'agenticos-standard-kit-'));
   const productRoot = join(home, 'projects', 'agenticos');
   const kitRoot = join(productRoot, '.meta', 'standard-kit');
+  const bootstrapRoot = join(productRoot, '.meta', 'bootstrap');
+  const canonicalServerRoot = join(productRoot, 'mcp-server', 'src');
   const templateRoot = join(productRoot, '.meta', 'templates');
   const projectRoot = join(home, 'projects', 'sample-project');
 
   await mkdir(kitRoot, { recursive: true });
+  await mkdir(bootstrapRoot, { recursive: true });
+  await mkdir(canonicalServerRoot, { recursive: true });
   await mkdir(templateRoot, { recursive: true });
   await mkdir(projectRoot, { recursive: true });
 
@@ -66,6 +70,17 @@ async function setupKitHome(): Promise<{ home: string; projectRoot: string }> {
         'tasks/templates/sub-agent-handoff.md',
         'tasks/templates/submission-evidence.md',
       ],
+      required_behavior: [
+        'memory_layer_contracts',
+        'cross_agent_policy_contract',
+        'implementation_preflight',
+        'issue_first_branching',
+        'isolated_worktree_execution',
+        'edit_boundary_enforcement',
+        'pr_scope_validation',
+        'official_agent_adapter_surfaces',
+        'sub_agent_context_inheritance',
+      ],
     },
   };
 
@@ -78,6 +93,52 @@ async function setupKitHome(): Promise<{ home: string; projectRoot: string }> {
   await writeFile(join(templateRoot, 'non-code-evaluation-rubric.yaml'), 'version: 0.1\nname: non-code-evaluation-rubric\n', 'utf-8');
   await writeFile(join(templateRoot, 'sub-agent-handoff.md'), '# Sub-Agent Handoff\n', 'utf-8');
   await writeFile(join(templateRoot, 'submission-evidence.md'), '# Submission Evidence\n', 'utf-8');
+  await writeFile(join(canonicalServerRoot, 'index.ts'), "name: 'agenticos_edit_guard'\n", 'utf-8');
+  await writeFile(
+    join(bootstrapRoot, 'agent-bootstrap-matrix.yaml'),
+    yaml.stringify({
+      version: 1,
+      primary_integration_mode: 'mcp-native',
+      supported_agents: [
+        {
+          id: 'claude-code',
+          label: 'Claude Code',
+          support_tier: 'official',
+          transport: 'stdio',
+          canonical_bootstrap_method: 'cli-command',
+          canonical_config_location: 'claude user config',
+          verification: ['call agenticos_list'],
+          transport_debug: ['restart Claude Code'],
+          routing_debug: ['use explicit tool calls'],
+        },
+        {
+          id: 'codex',
+          label: 'Codex',
+          support_tier: 'official',
+          transport: 'stdio',
+          canonical_bootstrap_method: 'cli-command',
+          canonical_config_location: 'codex config',
+          verification: ['call agenticos_list'],
+          transport_debug: ['restart Codex'],
+          routing_debug: ['use explicit tool calls'],
+        },
+      ],
+    }),
+    'utf-8',
+  );
+  await writeFile(
+    join(bootstrapRoot, 'cross-agent-execution-contract.yaml'),
+    yaml.stringify({
+      version: 1,
+      contract_id: 'cross-agent-execution-contract',
+      policy_invariants: [{ id: 'issue_first_execution' }],
+      adapter_surfaces: [
+        { id: 'codex-generic', generated_file: 'AGENTS.md' },
+        { id: 'claude-code', generated_file: 'CLAUDE.md' },
+      ],
+    }),
+    'utf-8',
+  );
 
   await writeRegistry(home, {
     version: '1.0.0',
@@ -240,6 +301,60 @@ describe('standard kit commands', () => {
       status: 'current',
       current_version: 4,
     });
+  });
+
+  it('conformance check passes after downstream adoption', async () => {
+    const { home, projectRoot } = await setupKitHome();
+    process.env.AGENTICOS_HOME = home;
+
+    await runStandardKitAdopt({
+      project_path: projectRoot,
+      project_name: 'Sample Project',
+      project_description: 'Conformance test project',
+    });
+
+    const result = JSON.parse(await runStandardKitConformanceCheck({
+      project_path: projectRoot,
+      project_name: 'Sample Project',
+    })) as {
+      status: string;
+      behavior_checks: Array<{ behavior: string; status: string }>;
+      adapter_checks: Array<{ agent_id: string; status: string; adapter_file: string }>;
+    };
+
+    expect(result.status).toBe('PASS');
+    expect(result.behavior_checks.every((item) => item.status === 'PASS')).toBe(true);
+    expect(result.adapter_checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ agent_id: 'claude-code', status: 'PASS', adapter_file: 'CLAUDE.md' }),
+        expect.objectContaining({ agent_id: 'codex', status: 'PASS', adapter_file: 'AGENTS.md' }),
+      ]),
+    );
+  });
+
+  it('conformance check fails when a generated adapter surface loses the shared policy block', async () => {
+    const { home, projectRoot } = await setupKitHome();
+    process.env.AGENTICOS_HOME = home;
+
+    await runStandardKitAdopt({
+      project_path: projectRoot,
+      project_name: 'Sample Project',
+      project_description: 'Broken conformance project',
+    });
+    await writeFile(join(projectRoot, 'AGENTS.md'), '<!-- agenticos-template: v4 -->\n# AGENTS.md — Sample Project\n', 'utf-8');
+
+    const result = JSON.parse(await runStandardKitConformanceCheck({
+      project_path: projectRoot,
+      project_name: 'Sample Project',
+    })) as {
+      status: string;
+      behavior_checks: Array<{ behavior: string; status: string }>;
+      adapter_checks: Array<{ agent_id: string; status: string }>;
+    };
+
+    expect(result.status).toBe('FAIL');
+    expect(result.behavior_checks.find((item) => item.behavior === 'cross_agent_policy_contract')).toMatchObject({ status: 'FAIL' });
+    expect(result.adapter_checks.find((item) => item.agent_id === 'codex')).toMatchObject({ status: 'PASS' });
   });
 
   it('upgrade check can resolve project identity from an existing .project.yaml through the active registry project', async () => {

--- a/projects/agenticos/mcp-server/src/tools/index.ts
+++ b/projects/agenticos/mcp-server/src/tools/index.ts
@@ -8,5 +8,5 @@ export { runPrScopeCheck } from './pr-scope-check.js';
 export { runHealth } from './health.js';
 export { runEditGuard } from './edit-guard.js';
 export { runEntrySurfaceRefresh } from './entry-surface-refresh.js';
-export { runStandardKitAdopt, runStandardKitUpgradeCheck } from './standard-kit.js';
+export { runStandardKitAdopt, runStandardKitUpgradeCheck, runStandardKitConformanceCheck } from './standard-kit.js';
 export { runNonCodeEvaluate } from './non-code-evaluate.js';

--- a/projects/agenticos/mcp-server/src/tools/standard-kit.ts
+++ b/projects/agenticos/mcp-server/src/tools/standard-kit.ts
@@ -1,4 +1,4 @@
-import { adoptStandardKit, checkStandardKitUpgrade } from '../utils/standard-kit.js';
+import { adoptStandardKit, checkStandardKitConformance, checkStandardKitUpgrade } from '../utils/standard-kit.js';
 
 export async function runStandardKitAdopt(args: any): Promise<string> {
   const result = await adoptStandardKit(args ?? {});
@@ -7,5 +7,10 @@ export async function runStandardKitAdopt(args: any): Promise<string> {
 
 export async function runStandardKitUpgradeCheck(args: any): Promise<string> {
   const result = await checkStandardKitUpgrade(args ?? {});
+  return JSON.stringify(result, null, 2);
+}
+
+export async function runStandardKitConformanceCheck(args: any): Promise<string> {
+  const result = await checkStandardKitConformance(args ?? {});
   return JSON.stringify(result, null, 2);
 }

--- a/projects/agenticos/mcp-server/src/utils/standard-kit.ts
+++ b/projects/agenticos/mcp-server/src/utils/standard-kit.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync } from 'fs';
 import { join, dirname } from 'path';
 import yaml from 'yaml';
 import { getAgenticOSHome, loadRegistry } from './registry.js';
+import { getOfficialBootstrapAgents, loadAgentBootstrapMatrix } from './bootstrap-matrix.js';
 import { CURRENT_TEMPLATE_VERSION, extractTemplateVersion, generateAgentsMd, generateClaudeMd, upgradeClaudeMd } from './distill.js';
 
 interface StandardKitEntry {
@@ -23,6 +24,7 @@ interface StandardKitManifest {
   };
   adoption?: {
     required_files?: string[];
+    required_behavior?: string[];
   };
 }
 
@@ -71,6 +73,36 @@ export interface UpgradeCheckResult {
   missing_required_files: string[];
   generated_files: UpgradeCheckGeneratedStatus[];
   copied_templates: UpgradeCheckTemplateStatus[];
+}
+
+export interface ConformanceBehaviorStatus {
+  behavior: string;
+  status: 'PASS' | 'FAIL';
+  summary: string;
+  evidence_paths: string[];
+}
+
+export interface ConformanceAdapterStatus {
+  agent_id: string;
+  adapter_file: string;
+  status: 'PASS' | 'FAIL';
+  summary: string;
+}
+
+export interface StandardKitConformanceResult {
+  command: 'agenticos_standard_kit_conformance_check';
+  status: 'PASS' | 'FAIL';
+  summary: string;
+  project_path: string;
+  project_name: string;
+  project_id: string;
+  kit_id: string;
+  kit_version: string;
+  missing_required_files: string[];
+  generated_files: UpgradeCheckGeneratedStatus[];
+  copied_templates: UpgradeCheckTemplateStatus[];
+  behavior_checks: ConformanceBehaviorStatus[];
+  adapter_checks: ConformanceAdapterStatus[];
 }
 
 export async function loadStandardKitManifest(): Promise<StandardKitManifest> {
@@ -227,6 +259,20 @@ function getCopiedTemplateEntries(manifest: StandardKitManifest): StandardKitEnt
   return manifest.layers.copied_templates?.entries || [];
 }
 
+async function readProjectFile(projectPath: string, relativePath: string): Promise<string | null> {
+  const absolutePath = join(projectPath, relativePath);
+  if (!existsSync(absolutePath)) return null;
+  return readFile(absolutePath, 'utf-8');
+}
+
+function fileContainsAll(content: string | null, needles: string[]): boolean {
+  return !!content && needles.every((needle) => content.includes(needle));
+}
+
+function resolveOfficialAdapterFile(agentId: string): string {
+  return agentId === 'claude-code' ? 'CLAUDE.md' : 'AGENTS.md';
+}
+
 export async function adoptStandardKit(args: { project_path?: string; project_name?: string; project_description?: string }): Promise<AdoptResult> {
   const manifest = await loadStandardKitManifest();
   const projectPath = await resolveProjectPath(args.project_path);
@@ -363,5 +409,193 @@ export async function checkStandardKitUpgrade(args: { project_path?: string; pro
     missing_required_files: missingRequiredFiles,
     generated_files: generatedFiles,
     copied_templates: copiedTemplates,
+  };
+}
+
+export async function checkStandardKitConformance(args: { project_path?: string; project_name?: string; project_description?: string }): Promise<StandardKitConformanceResult> {
+  const manifest = await loadStandardKitManifest();
+  const upgrade = await checkStandardKitUpgrade(args);
+  const projectYaml = yaml.parse((await readProjectFile(upgrade.project_path, '.project.yaml')) || '{}') as any;
+  const stateYaml = yaml.parse((await readProjectFile(upgrade.project_path, '.context/state.yaml')) || '{}') as any;
+  const agentsMd = await readProjectFile(upgrade.project_path, 'AGENTS.md');
+  const claudeMd = await readProjectFile(upgrade.project_path, 'CLAUDE.md');
+  const officialAgents = getOfficialBootstrapAgents(await loadAgentBootstrapMatrix());
+
+  const behaviorChecks: ConformanceBehaviorStatus[] = [];
+
+  for (const behavior of manifest.adoption?.required_behavior || []) {
+    switch (behavior) {
+      case 'memory_layer_contracts': {
+        const pass = !!projectYaml?.memory_contract?.version
+          && !!projectYaml?.agent_context?.quick_start
+          && !!projectYaml?.agent_context?.current_state
+          && !!stateYaml?.memory_contract?.version
+          && Array.isArray(stateYaml?.loaded_context)
+          && stateYaml.loaded_context.includes('.context/quick-start.md');
+        behaviorChecks.push({
+          behavior,
+          status: pass ? 'PASS' : 'FAIL',
+          summary: pass
+            ? 'Project metadata and state preserve the memory-layer contract.'
+            : 'Project metadata or state is missing required memory-layer contract fields.',
+          evidence_paths: ['.project.yaml', '.context/state.yaml'],
+        });
+        break;
+      }
+      case 'cross_agent_policy_contract': {
+        const pass = fileContainsAll(agentsMd, [
+          'Canonical Policy (Shared Across Agents)',
+          'This project has one canonical AgenticOS execution policy',
+        ]) && fileContainsAll(claudeMd, [
+          'Canonical Policy (Shared Across Agents)',
+          'This project has one canonical AgenticOS execution policy',
+        ]);
+        behaviorChecks.push({
+          behavior,
+          status: pass ? 'PASS' : 'FAIL',
+          summary: pass
+            ? 'Generated adapter docs expose the shared cross-agent policy block.'
+            : 'Generated adapter docs are missing the shared cross-agent policy block.',
+          evidence_paths: ['AGENTS.md', 'CLAUDE.md'],
+        });
+        break;
+      }
+      case 'implementation_preflight': {
+        const pass = fileContainsAll(agentsMd, ['agenticos_preflight']) && fileContainsAll(claudeMd, ['agenticos_preflight']);
+        behaviorChecks.push({
+          behavior,
+          status: pass ? 'PASS' : 'FAIL',
+          summary: pass
+            ? 'Both adapter surfaces require executable preflight before implementation edits.'
+            : 'One or more adapter surfaces are missing executable preflight guidance.',
+          evidence_paths: ['AGENTS.md', 'CLAUDE.md'],
+        });
+        break;
+      }
+      case 'issue_first_branching': {
+        const pass = fileContainsAll(agentsMd, ['issue-first']) && fileContainsAll(claudeMd, ['issue-first']);
+        behaviorChecks.push({
+          behavior,
+          status: pass ? 'PASS' : 'FAIL',
+          summary: pass
+            ? 'Both adapter surfaces preserve issue-first execution language.'
+            : 'One or more adapter surfaces are missing issue-first execution language.',
+          evidence_paths: ['AGENTS.md', 'CLAUDE.md'],
+        });
+        break;
+      }
+      case 'isolated_worktree_execution': {
+        const pass = fileContainsAll(agentsMd, ['agenticos_branch_bootstrap'])
+          && fileContainsAll(claudeMd, ['agenticos_branch_bootstrap', 'worktree']);
+        behaviorChecks.push({
+          behavior,
+          status: pass ? 'PASS' : 'FAIL',
+          summary: pass
+            ? 'Adapter surfaces preserve isolated branch/worktree execution guidance.'
+            : 'Adapter surfaces are missing isolated branch/worktree execution guidance.',
+          evidence_paths: ['AGENTS.md', 'CLAUDE.md'],
+        });
+        break;
+      }
+      case 'edit_boundary_enforcement': {
+        const indexSource = readFileSync(join(getAgenticOSHome(), 'projects', 'agenticos', 'mcp-server', 'src', 'index.ts'), 'utf-8');
+        const pass = indexSource.includes("name: 'agenticos_edit_guard'");
+        behaviorChecks.push({
+          behavior,
+          status: pass ? 'PASS' : 'FAIL',
+          summary: pass
+            ? 'Canonical MCP surface exposes executable edit-boundary enforcement.'
+            : 'Canonical MCP surface is missing executable edit-boundary enforcement.',
+          evidence_paths: ['projects/agenticos/mcp-server/src/index.ts'],
+        });
+        break;
+      }
+      case 'pr_scope_validation': {
+        const pass = fileContainsAll(agentsMd, ['agenticos_pr_scope_check']) && fileContainsAll(claudeMd, ['agenticos_pr_scope_check']);
+        behaviorChecks.push({
+          behavior,
+          status: pass ? 'PASS' : 'FAIL',
+          summary: pass
+            ? 'Both adapter surfaces require PR scope validation.'
+            : 'One or more adapter surfaces are missing PR scope validation guidance.',
+          evidence_paths: ['AGENTS.md', 'CLAUDE.md'],
+        });
+        break;
+      }
+      case 'official_agent_adapter_surfaces': {
+        const pass = officialAgents.every((agent) => existsSync(join(upgrade.project_path, resolveOfficialAdapterFile(agent.id))));
+        behaviorChecks.push({
+          behavior,
+          status: pass ? 'PASS' : 'FAIL',
+          summary: pass
+            ? 'Official agents map to present adapter surfaces.'
+            : 'One or more official agents do not map to a present adapter surface.',
+          evidence_paths: officialAgents.map((agent) => resolveOfficialAdapterFile(agent.id)),
+        });
+        break;
+      }
+      case 'sub_agent_context_inheritance': {
+        const pass = existsSync(join(upgrade.project_path, 'tasks', 'templates', 'sub-agent-handoff.md'));
+        behaviorChecks.push({
+          behavior,
+          status: pass ? 'PASS' : 'FAIL',
+          summary: pass
+            ? 'Sub-agent handoff template is present for downstream inheritance.'
+            : 'Sub-agent handoff template is missing.',
+          evidence_paths: ['tasks/templates/sub-agent-handoff.md'],
+        });
+        break;
+      }
+      default:
+        behaviorChecks.push({
+          behavior,
+          status: 'FAIL',
+          summary: `No executable conformance check is implemented for required behavior "${behavior}".`,
+          evidence_paths: [],
+        });
+        break;
+    }
+  }
+
+  const adapterChecks: ConformanceAdapterStatus[] = officialAgents.map((agent) => {
+    const adapterFile = resolveOfficialAdapterFile(agent.id);
+    const generatedStatus = upgrade.generated_files.find((item) => item.path === adapterFile);
+    const pass = generatedStatus?.status === 'current';
+    return {
+      agent_id: agent.id,
+      adapter_file: adapterFile,
+      status: pass ? 'PASS' : 'FAIL',
+      summary: pass
+        ? `${agent.id} is covered by a current generated adapter surface.`
+        : `${agent.id} is missing a current generated adapter surface.`,
+    };
+  });
+
+  const failedBehaviors = behaviorChecks.filter((item) => item.status === 'FAIL');
+  const failedAdapters = adapterChecks.filter((item) => item.status === 'FAIL');
+  const generatedDrift = upgrade.generated_files.filter((item) => item.status !== 'current');
+  const status = upgrade.missing_required_files.length === 0
+    && failedBehaviors.length === 0
+    && failedAdapters.length === 0
+    && generatedDrift.length === 0
+    ? 'PASS'
+    : 'FAIL';
+
+  return {
+    command: 'agenticos_standard_kit_conformance_check',
+    status,
+    summary: status === 'PASS'
+      ? 'standard-kit conformance passed'
+      : `standard-kit conformance failed: ${upgrade.missing_required_files.length} missing files, ${failedBehaviors.length} failed behaviors, ${failedAdapters.length} failed adapters`,
+    project_path: upgrade.project_path,
+    project_name: upgrade.project_name,
+    project_id: upgrade.project_id,
+    kit_id: manifest.kit_id,
+    kit_version: manifest.kit_version,
+    missing_required_files: upgrade.missing_required_files,
+    generated_files: upgrade.generated_files,
+    copied_templates: upgrade.copied_templates,
+    behavior_checks: behaviorChecks,
+    adapter_checks: adapterChecks,
   };
 }


### PR DESCRIPTION
## Summary
- add `agenticos_standard_kit_conformance_check` so downstream projects can be checked against workflow contract conformance, not just file presence
- validate manifest required behaviors, generated adapter surfaces, and official adapter coverage
- add end-to-end tests that adopt a temp downstream project and verify conformance PASS/FAIL states

## Testing
- `npm test -- --run src/tools/__tests__/standard-kit.test.ts`
- `npm test`
- `npm run build`

Closes #118
