### PR TITLE
feat: encode Claude and Codex adapter parity

### DIFF
--- a/projects/agenticos/.meta/bootstrap/agent-adapter-matrix.yaml
+++ b/projects/agenticos/.meta/bootstrap/agent-adapter-matrix.yaml
@@ -1,0 +1,39 @@
+version: 1
+primary_policy_surface: cross-agent-execution-contract
+adapters:
+  - agent_id: claude-code
+    support_tier: official
+    adapter_file: CLAUDE.md
+    adapter_family: claude
+    required_runtime_guidance:
+      - '`CLAUDE.md` is the Claude Code adapter surface for this project.'
+      - '## Claude Runtime Notes'
+      - 'Claude CLI-managed user MCP config'
+      - 'optional local stop-hook reminders'
+  - agent_id: codex
+    support_tier: official
+    adapter_file: AGENTS.md
+    adapter_family: generic
+    required_runtime_guidance:
+      - '`AGENTS.md` is the Codex/generic adapter surface for this project.'
+      - '## Codex / Generic Runtime Notes'
+      - 'use explicit `agenticos_*` tool calls'
+      - 'Bootstrap differences are runtime concerns'
+  - agent_id: cursor
+    support_tier: official
+    adapter_file: AGENTS.md
+    adapter_family: generic
+    required_runtime_guidance:
+      - '`AGENTS.md` is the Codex/generic adapter surface for this project.'
+      - '## Codex / Generic Runtime Notes'
+      - 'use explicit `agenticos_*` tool calls'
+      - 'Bootstrap differences are runtime concerns'
+  - agent_id: gemini-cli
+    support_tier: official
+    adapter_file: AGENTS.md
+    adapter_family: generic
+    required_runtime_guidance:
+      - '`AGENTS.md` is the Codex/generic adapter surface for this project.'
+      - '## Codex / Generic Runtime Notes'
+      - 'use explicit `agenticos_*` tool calls'
+      - 'Bootstrap differences are runtime concerns'

--- a/projects/agenticos/mcp-server/src/tools/__tests__/standard-kit.test.ts
+++ b/projects/agenticos/mcp-server/src/tools/__tests__/standard-kit.test.ts
@@ -139,6 +139,40 @@ async function setupKitHome(): Promise<{ home: string; projectRoot: string }> {
     }),
     'utf-8',
   );
+  await writeFile(
+    join(bootstrapRoot, 'agent-adapter-matrix.yaml'),
+    yaml.stringify({
+      version: 1,
+      primary_policy_surface: 'cross-agent-execution-contract',
+      adapters: [
+        {
+          agent_id: 'claude-code',
+          support_tier: 'official',
+          adapter_file: 'CLAUDE.md',
+          adapter_family: 'claude',
+          required_runtime_guidance: [
+            '`CLAUDE.md` is the Claude Code adapter surface for this project.',
+            '## Claude Runtime Notes',
+            'Claude CLI-managed user MCP config',
+            'optional local stop-hook reminders',
+          ],
+        },
+        {
+          agent_id: 'codex',
+          support_tier: 'official',
+          adapter_file: 'AGENTS.md',
+          adapter_family: 'generic',
+          required_runtime_guidance: [
+            '`AGENTS.md` is the Codex/generic adapter surface for this project.',
+            '## Codex / Generic Runtime Notes',
+            'use explicit `agenticos_*` tool calls',
+            'Bootstrap differences are runtime concerns',
+          ],
+        },
+      ],
+    }),
+    'utf-8',
+  );
 
   await writeRegistry(home, {
     version: '1.0.0',
@@ -354,6 +388,36 @@ describe('standard kit commands', () => {
 
     expect(result.status).toBe('FAIL');
     expect(result.behavior_checks.find((item) => item.behavior === 'cross_agent_policy_contract')).toMatchObject({ status: 'FAIL' });
+    expect(result.adapter_checks.find((item) => item.agent_id === 'codex')).toMatchObject({ status: 'FAIL' });
+  });
+
+  it('conformance check fails Claude parity when Claude-specific runtime guidance is removed', async () => {
+    const { home, projectRoot } = await setupKitHome();
+    process.env.AGENTICOS_HOME = home;
+
+    await runStandardKitAdopt({
+      project_path: projectRoot,
+      project_name: 'Sample Project',
+      project_description: 'Claude parity project',
+    });
+
+    const claudeMd = await readFile(join(projectRoot, 'CLAUDE.md'), 'utf-8');
+    await writeFile(
+      join(projectRoot, 'CLAUDE.md'),
+      claudeMd.replace(/## Claude Runtime Notes[\s\S]*?## Guardrail Protocol \(MANDATORY\)/, '## Guardrail Protocol (MANDATORY)'),
+      'utf-8',
+    );
+
+    const result = JSON.parse(await runStandardKitConformanceCheck({
+      project_path: projectRoot,
+      project_name: 'Sample Project',
+    })) as {
+      status: string;
+      adapter_checks: Array<{ agent_id: string; status: string }>;
+    };
+
+    expect(result.status).toBe('FAIL');
+    expect(result.adapter_checks.find((item) => item.agent_id === 'claude-code')).toMatchObject({ status: 'FAIL' });
     expect(result.adapter_checks.find((item) => item.agent_id === 'codex')).toMatchObject({ status: 'PASS' });
   });
 

--- a/projects/agenticos/mcp-server/src/utils/__tests__/agent-adapter-matrix.test.ts
+++ b/projects/agenticos/mcp-server/src/utils/__tests__/agent-adapter-matrix.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtemp, mkdir, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import yaml from 'yaml';
+import {
+  getAgentAdapter,
+  getOfficialAgentAdapters,
+  loadAgentAdapterMatrix,
+} from '../agent-adapter-matrix.js';
+
+async function setupAdapterHome(): Promise<string> {
+  const home = await mkdtemp(join(tmpdir(), 'agenticos-adapter-matrix-'));
+  const bootstrapDir = join(home, 'projects', 'agenticos', '.meta', 'bootstrap');
+  await mkdir(bootstrapDir, { recursive: true });
+  await writeFile(
+    join(bootstrapDir, 'agent-adapter-matrix.yaml'),
+    yaml.stringify({
+      version: 1,
+      primary_policy_surface: 'cross-agent-execution-contract',
+      adapters: [
+        {
+          agent_id: 'claude-code',
+          support_tier: 'official',
+          adapter_file: 'CLAUDE.md',
+          adapter_family: 'claude',
+          required_runtime_guidance: ['Claude Runtime Notes'],
+        },
+        {
+          agent_id: 'codex',
+          support_tier: 'official',
+          adapter_file: 'AGENTS.md',
+          adapter_family: 'generic',
+          required_runtime_guidance: ['Codex / Generic Runtime Notes'],
+        },
+        {
+          agent_id: 'generic-mcp-tool',
+          support_tier: 'experimental',
+          adapter_file: 'AGENTS.md',
+          adapter_family: 'generic',
+          required_runtime_guidance: ['Codex / Generic Runtime Notes'],
+        },
+      ],
+    }),
+    'utf-8',
+  );
+  return home;
+}
+
+describe('agent adapter matrix', () => {
+  afterEach(() => {
+    delete process.env.AGENTICOS_HOME;
+  });
+
+  it('loads the canonical adapter matrix from AGENTICOS_HOME', async () => {
+    const home = await setupAdapterHome();
+    process.env.AGENTICOS_HOME = home;
+
+    const matrix = await loadAgentAdapterMatrix();
+
+    expect(matrix.primary_policy_surface).toBe('cross-agent-execution-contract');
+    expect(matrix.adapters.map((adapter) => adapter.agent_id)).toEqual(['claude-code', 'codex', 'generic-mcp-tool']);
+  });
+
+  it('returns only official agent adapters for parity enforcement', async () => {
+    const home = await setupAdapterHome();
+    process.env.AGENTICOS_HOME = home;
+
+    const matrix = await loadAgentAdapterMatrix();
+
+    expect(getOfficialAgentAdapters(matrix).map((adapter) => adapter.agent_id)).toEqual(['claude-code', 'codex']);
+  });
+
+  it('fails closed for unknown adapter ids', async () => {
+    const home = await setupAdapterHome();
+    process.env.AGENTICOS_HOME = home;
+
+    const matrix = await loadAgentAdapterMatrix();
+
+    expect(() => getAgentAdapter(matrix, 'missing-agent')).toThrow('Unknown agent adapter "missing-agent".');
+  });
+});

--- a/projects/agenticos/mcp-server/src/utils/__tests__/distill.test.ts
+++ b/projects/agenticos/mcp-server/src/utils/__tests__/distill.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
   AGENTS_ADAPTER_LINES,
+  AGENTS_RUNTIME_GUIDANCE_BULLETS,
+  AGENTS_RUNTIME_GUIDANCE_TITLE,
   CLAUDE_ADAPTER_LINES,
+  CLAUDE_RUNTIME_GUIDANCE_BULLETS,
+  CLAUDE_RUNTIME_GUIDANCE_TITLE,
   CURRENT_TEMPLATE_VERSION,
   SHARED_POLICY_BULLETS,
   SHARED_POLICY_TITLE,
@@ -22,6 +26,10 @@ describe('distill templates', () => {
     for (const bullet of SHARED_POLICY_BULLETS) {
       expect(content).toContain(bullet);
     }
+    expect(content).toContain(`## ${AGENTS_RUNTIME_GUIDANCE_TITLE}`);
+    for (const bullet of AGENTS_RUNTIME_GUIDANCE_BULLETS) {
+      expect(content).toContain(bullet);
+    }
     expect(content).toContain('## Guardrail Protocol (MANDATORY)');
     expect(content).toContain('agenticos_preflight');
     expect(content).toContain('agenticos_branch_bootstrap');
@@ -39,6 +47,10 @@ describe('distill templates', () => {
     expect(content).toContain(CLAUDE_ADAPTER_LINES[1]);
     expect(content).toContain(`## ${SHARED_POLICY_TITLE}`);
     for (const bullet of SHARED_POLICY_BULLETS) {
+      expect(content).toContain(bullet);
+    }
+    expect(content).toContain(`## ${CLAUDE_RUNTIME_GUIDANCE_TITLE}`);
+    for (const bullet of CLAUDE_RUNTIME_GUIDANCE_BULLETS) {
       expect(content).toContain(bullet);
     }
     expect(content).toContain('## Guardrail Protocol (MANDATORY)');

--- a/projects/agenticos/mcp-server/src/utils/agent-adapter-matrix.ts
+++ b/projects/agenticos/mcp-server/src/utils/agent-adapter-matrix.ts
@@ -1,0 +1,43 @@
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+import yaml from 'yaml';
+import { getAgenticOSHome } from './registry.js';
+
+export interface AgentAdapterEntry {
+  agent_id: string;
+  support_tier: 'official' | 'experimental';
+  adapter_file: string;
+  adapter_family: string;
+  required_runtime_guidance: string[];
+}
+
+export interface AgentAdapterMatrix {
+  version: number;
+  primary_policy_surface: string;
+  adapters: AgentAdapterEntry[];
+}
+
+export async function loadAgentAdapterMatrix(): Promise<AgentAdapterMatrix> {
+  const matrixPath = join(
+    getAgenticOSHome(),
+    'projects',
+    'agenticos',
+    '.meta',
+    'bootstrap',
+    'agent-adapter-matrix.yaml',
+  );
+  const content = await readFile(matrixPath, 'utf-8');
+  return yaml.parse(content) as AgentAdapterMatrix;
+}
+
+export function getOfficialAgentAdapters(matrix: AgentAdapterMatrix): AgentAdapterEntry[] {
+  return matrix.adapters.filter((adapter) => adapter.support_tier === 'official');
+}
+
+export function getAgentAdapter(matrix: AgentAdapterMatrix, agentId: string): AgentAdapterEntry {
+  const match = matrix.adapters.find((adapter) => adapter.agent_id === agentId);
+  if (!match) {
+    throw new Error(`Unknown agent adapter "${agentId}".`);
+  }
+  return match;
+}

--- a/projects/agenticos/mcp-server/src/utils/distill.ts
+++ b/projects/agenticos/mcp-server/src/utils/distill.ts
@@ -23,9 +23,21 @@ export const AGENTS_ADAPTER_LINES = [
   'It must expose the same canonical policy as other agent adapters rather than defining a different workflow.',
 ] as const;
 
+export const AGENTS_RUNTIME_GUIDANCE_TITLE = 'Codex / Generic Runtime Notes';
+export const AGENTS_RUNTIME_GUIDANCE_BULLETS = [
+  'If natural-language routing is weak, use explicit `agenticos_*` tool calls before treating the issue as transport failure.',
+  'Bootstrap differences are runtime concerns rather than policy changes.',
+] as const;
+
 export const CLAUDE_ADAPTER_LINES = [
   '`CLAUDE.md` is the Claude Code adapter surface for this project.',
   'It must expose the same canonical policy as other agent adapters while allowing Claude-specific operator guidance.',
+] as const;
+
+export const CLAUDE_RUNTIME_GUIDANCE_TITLE = 'Claude Runtime Notes';
+export const CLAUDE_RUNTIME_GUIDANCE_BULLETS = [
+  'Claude CLI-managed user MCP config is the canonical Claude bootstrap surface.',
+  'Claude-specific stop hooks remain optional local stop-hook reminders rather than canonical guardrails.',
 ] as const;
 
 /** Extract template version from an existing file. Returns 0 if no marker found (v1 or earlier). */
@@ -50,6 +62,15 @@ function renderSharedPolicySection(): string {
   ].join('\n');
 }
 
+function renderRuntimeGuidanceSection(title: string, bullets: readonly string[]): string {
+  return [
+    `## ${title}`,
+    '',
+    ...bullets.map((line) => `- ${line}`),
+    '',
+  ].join('\n');
+}
+
 // ---------------------------------------------------------------------------
 // AGENTS.md template
 // ---------------------------------------------------------------------------
@@ -63,7 +84,7 @@ export function generateAgentsMd(name: string, description: string): string {
 ${AGENTS_ADAPTER_LINES[0]}
 ${AGENTS_ADAPTER_LINES[1]}
 
-${renderSharedPolicySection()}## Guardrail Protocol (MANDATORY)
+${renderSharedPolicySection()}${renderRuntimeGuidanceSection(AGENTS_RUNTIME_GUIDANCE_TITLE, AGENTS_RUNTIME_GUIDANCE_BULLETS)}## Guardrail Protocol (MANDATORY)
 
 Implementation work must use the executable guardrail flow:
 
@@ -205,7 +226,7 @@ function buildClaudeMdContent(name: string, description: string, state?: StateYa
 ${CLAUDE_ADAPTER_LINES[0]}
 ${CLAUDE_ADAPTER_LINES[1]}
 
-${renderSharedPolicySection()}## Guardrail Protocol (MANDATORY)
+${renderSharedPolicySection()}${renderRuntimeGuidanceSection(CLAUDE_RUNTIME_GUIDANCE_TITLE, CLAUDE_RUNTIME_GUIDANCE_BULLETS)}## Guardrail Protocol (MANDATORY)
 
 For implementation-affecting work:
 

--- a/projects/agenticos/mcp-server/src/utils/standard-kit.ts
+++ b/projects/agenticos/mcp-server/src/utils/standard-kit.ts
@@ -3,7 +3,7 @@ import { existsSync, readFileSync } from 'fs';
 import { join, dirname } from 'path';
 import yaml from 'yaml';
 import { getAgenticOSHome, loadRegistry } from './registry.js';
-import { getOfficialBootstrapAgents, loadAgentBootstrapMatrix } from './bootstrap-matrix.js';
+import { getOfficialAgentAdapters, loadAgentAdapterMatrix } from './agent-adapter-matrix.js';
 import { CURRENT_TEMPLATE_VERSION, extractTemplateVersion, generateAgentsMd, generateClaudeMd, upgradeClaudeMd } from './distill.js';
 
 interface StandardKitEntry {
@@ -269,10 +269,6 @@ function fileContainsAll(content: string | null, needles: string[]): boolean {
   return !!content && needles.every((needle) => content.includes(needle));
 }
 
-function resolveOfficialAdapterFile(agentId: string): string {
-  return agentId === 'claude-code' ? 'CLAUDE.md' : 'AGENTS.md';
-}
-
 export async function adoptStandardKit(args: { project_path?: string; project_name?: string; project_description?: string }): Promise<AdoptResult> {
   const manifest = await loadStandardKitManifest();
   const projectPath = await resolveProjectPath(args.project_path);
@@ -419,7 +415,7 @@ export async function checkStandardKitConformance(args: { project_path?: string;
   const stateYaml = yaml.parse((await readProjectFile(upgrade.project_path, '.context/state.yaml')) || '{}') as any;
   const agentsMd = await readProjectFile(upgrade.project_path, 'AGENTS.md');
   const claudeMd = await readProjectFile(upgrade.project_path, 'CLAUDE.md');
-  const officialAgents = getOfficialBootstrapAgents(await loadAgentBootstrapMatrix());
+  const officialAdapters = getOfficialAgentAdapters(await loadAgentAdapterMatrix());
 
   const behaviorChecks: ConformanceBehaviorStatus[] = [];
 
@@ -523,14 +519,14 @@ export async function checkStandardKitConformance(args: { project_path?: string;
         break;
       }
       case 'official_agent_adapter_surfaces': {
-        const pass = officialAgents.every((agent) => existsSync(join(upgrade.project_path, resolveOfficialAdapterFile(agent.id))));
+        const pass = officialAdapters.every((adapter) => existsSync(join(upgrade.project_path, adapter.adapter_file)));
         behaviorChecks.push({
           behavior,
           status: pass ? 'PASS' : 'FAIL',
           summary: pass
             ? 'Official agents map to present adapter surfaces.'
             : 'One or more official agents do not map to a present adapter surface.',
-          evidence_paths: officialAgents.map((agent) => resolveOfficialAdapterFile(agent.id)),
+          evidence_paths: officialAdapters.map((adapter) => adapter.adapter_file),
         });
         break;
       }
@@ -557,17 +553,18 @@ export async function checkStandardKitConformance(args: { project_path?: string;
     }
   }
 
-  const adapterChecks: ConformanceAdapterStatus[] = officialAgents.map((agent) => {
-    const adapterFile = resolveOfficialAdapterFile(agent.id);
-    const generatedStatus = upgrade.generated_files.find((item) => item.path === adapterFile);
-    const pass = generatedStatus?.status === 'current';
+  const adapterChecks: ConformanceAdapterStatus[] = officialAdapters.map((adapter) => {
+    const content = adapter.adapter_file === 'CLAUDE.md' ? claudeMd : agentsMd;
+    const generatedStatus = upgrade.generated_files.find((item) => item.path === adapter.adapter_file);
+    const pass = generatedStatus?.status === 'current'
+      && fileContainsAll(content, adapter.required_runtime_guidance);
     return {
-      agent_id: agent.id,
-      adapter_file: adapterFile,
+      agent_id: adapter.agent_id,
+      adapter_file: adapter.adapter_file,
       status: pass ? 'PASS' : 'FAIL',
       summary: pass
-        ? `${agent.id} is covered by a current generated adapter surface.`
-        : `${agent.id} is missing a current generated adapter surface.`,
+        ? `${adapter.agent_id} is covered by a current generated adapter surface with required runtime guidance.`
+        : `${adapter.agent_id} is missing a current generated adapter surface or required runtime guidance.`,
     };
   });
 

--- a/projects/agenticos/standards/knowledge/claude-codex-adapter-parity-2026-03-29.md
+++ b/projects/agenticos/standards/knowledge/claude-codex-adapter-parity-2026-03-29.md
@@ -1,0 +1,49 @@
+# Claude / Codex Adapter Parity - 2026-03-29
+
+## Design Reflection
+
+Claude Code and Codex do not need identical bootstrap or hook surfaces.
+
+They do need identical policy semantics.
+
+So parity does not mean "make the docs look the same."
+
+Parity means:
+
+- the same canonical policy block
+- different runtime-specific guidance blocks
+- one executable conformance path that knows the difference
+
+## Canonical Adapter Rule
+
+The canonical adapter surfaces are:
+
+- `CLAUDE.md` for Claude Code
+- `AGENTS.md` for Codex and the generic MCP-capable family
+
+`CLAUDE.md` must carry Claude-specific guidance such as:
+
+- Claude CLI-managed MCP config expectations
+- restart expectations
+- optional stop-hook boundary
+
+`AGENTS.md` must carry Codex/generic guidance such as:
+
+- explicit `agenticos_*` tool-call fallback when routing is weak
+- bootstrap differences remain runtime concerns rather than policy concerns
+
+## Conformance Rule
+
+Adapter parity should be enforced by:
+
+1. machine-readable adapter metadata
+2. generated adapter docs
+3. executable conformance checks over a downstream adopted project
+
+If the runtime-specific guidance block is removed from one adapter, conformance should fail for that adapter without redefining the shared policy.
+
+## Canonical Source Of Truth
+
+The machine-readable source of truth is:
+
+- `projects/agenticos/.meta/bootstrap/agent-adapter-matrix.yaml`


### PR DESCRIPTION
## Summary
- add canonical agent-adapter metadata so Claude and Codex parity is machine-readable rather than heuristic
- extend generated adapter docs with runtime-specific guidance blocks while preserving one shared policy block
- make conformance checks validate adapter-specific runtime guidance and add end-to-end parity failure coverage

## Testing
- `npm test -- --run src/utils/__tests__/agent-adapter-matrix.test.ts src/utils/__tests__/distill.test.ts src/tools/__tests__/standard-kit.test.ts`
- `npm test`
- `npm run build`

Closes #119
