### PR TITLE
feat: bring 360teams into standard-kit conformance

### DIFF
--- a/projects/360teams/.context/state.yaml
+++ b/projects/360teams/.context/state.yaml
@@ -2,11 +2,22 @@ session:
   id: session-2026-03-19-001
   started: 2026-03-19T08:48:37.665Z
   agent: claude-sonnet-4.6
-current_task: null
+current_task:
+  id: null
+  title: null
+  status: pending
+  next_step: null
 working_memory:
   facts: []
   decisions: []
   pending: []
+memory_contract:
+  version: 1
+  quick_start_role: project_orientation
+  state_role: operational_working_state
+  conversations_role: append_only_session_history
+  knowledge_role: durable_synthesis
+  tasks_role: execution_artifacts
 loaded_context:
   - .project.yaml
   - .context/quick-start.md

--- a/projects/360teams/.project.yaml
+++ b/projects/360teams/.project.yaml
@@ -7,3 +7,21 @@ meta:
 agent_context:
   quick_start: .context/quick-start.md
   current_state: .context/state.yaml
+  conversations: .context/conversations/
+  knowledge: knowledge/
+  tasks: tasks/
+  artifacts: artifacts/
+
+memory_contract:
+  version: 1
+  quick_start_role: project_orientation
+  state_role: operational_working_state
+  conversations_role: append_only_session_history
+  knowledge_role: durable_synthesis
+  tasks_role: execution_artifacts
+  artifacts_role: deliverables
+
+status:
+  phase: planning
+  last_updated: 2026-03-30
+  next_action: Define project goals

--- a/projects/360teams/AGENTS.md
+++ b/projects/360teams/AGENTS.md
@@ -1,0 +1,79 @@
+<!-- agenticos-template: v4 -->
+# AGENTS.md — 360teams
+
+## Adapter Role
+
+`AGENTS.md` is the Codex/generic adapter surface for this project.
+It must expose the same canonical policy as other agent adapters rather than defining a different workflow.
+
+## Canonical Policy (Shared Across Agents)
+
+- This project has one canonical AgenticOS execution policy across Claude Code, Codex, and other supported agents.
+- Implementation work must stay issue-first, preflighted, and inside the guardrail-controlled branch/worktree flow.
+- PR creation or merge must not happen before executable scope validation passes.
+- Recording and save flow remain canonical project requirements rather than runtime-specific preferences.
+## Codex / Generic Runtime Notes
+
+- If natural-language routing is weak, use explicit `agenticos_*` tool calls before treating the issue as transport failure.
+- Bootstrap differences are runtime concerns rather than policy changes.
+## Guardrail Protocol (MANDATORY)
+
+Implementation work must use the executable guardrail flow:
+
+1. call `agenticos_preflight` before editing
+2. if preflight returns `REDIRECT`, call `agenticos_branch_bootstrap`
+3. do not submit a PR before running `agenticos_pr_scope_check`
+
+If any guardrail returns `BLOCK`, stop and resolve the blocking reason first.
+
+## Recording Protocol (MANDATORY)
+
+This project uses AgenticOS for persistent context management.
+All session activity MUST be recorded via MCP tools.
+
+### How to Record
+
+Call the MCP tool `agenticos_record` with:
+- `summary` (required): What happened in this session
+- `decisions`: Key decisions made
+- `outcomes`: What was accomplished
+- `pending`: What remains to be done
+- `current_task`: { title, status } to update current task
+
+### When to Record
+
+1. After completing any meaningful unit of work
+2. Before ending the session (MANDATORY — context is lost otherwise)
+
+After recording, call `agenticos_save` to commit to Git.
+
+### Session Start
+
+On session start, read these files for context:
+1. `.project.yaml` — Project metadata
+2. `.context/quick-start.md` — human-readable project summary
+3. `.context/state.yaml` — Current state and working memory
+4. `.context/conversations/` — Previous session records
+
+Then greet the user with: project name, last progress, current pending items, suggested next step.
+
+## Project
+
+**Name**: 360teams
+**Description**: 360teams项目管理
+
+## Directory Structure
+
+| Path | Purpose |
+|------|---------|
+| `.project.yaml` | Project metadata |
+| `.context/quick-start.md` | Quick project summary |
+| `.context/state.yaml` | Session state and working memory |
+| `.context/conversations/` | Session records (auto-generated) |
+| `knowledge/` | Persistent knowledge documents |
+| `tasks/` | Task tracking |
+| `tasks/templates/agent-preflight-checklist.yaml` | Preflight checklist template |
+| `tasks/templates/issue-design-brief.md` | Design-loop template |
+| `tasks/templates/non-code-evaluation-rubric.yaml` | Non-code evaluation rubric |
+| `tasks/templates/submission-evidence.md` | Submission evidence template |
+| `artifacts/` | Outputs and deliverables |

--- a/projects/360teams/CLAUDE.md
+++ b/projects/360teams/CLAUDE.md
@@ -1,0 +1,117 @@
+<!-- agenticos-template: v4 -->
+# CLAUDE.md — 360teams
+
+## Adapter Role
+
+`CLAUDE.md` is the Claude Code adapter surface for this project.
+It must expose the same canonical policy as other agent adapters while allowing Claude-specific operator guidance.
+
+## Canonical Policy (Shared Across Agents)
+
+- This project has one canonical AgenticOS execution policy across Claude Code, Codex, and other supported agents.
+- Implementation work must stay issue-first, preflighted, and inside the guardrail-controlled branch/worktree flow.
+- PR creation or merge must not happen before executable scope validation passes.
+- Recording and save flow remain canonical project requirements rather than runtime-specific preferences.
+## Claude Runtime Notes
+
+- Claude CLI-managed user MCP config is the canonical Claude bootstrap surface.
+- Claude-specific stop hooks remain optional local stop-hook reminders rather than canonical guardrails.
+## Guardrail Protocol (MANDATORY)
+
+For implementation-affecting work:
+
+1. call `agenticos_preflight` before editing
+2. if the result is `REDIRECT`, call `agenticos_branch_bootstrap` and continue in the returned worktree
+3. before PR creation or merge, call `agenticos_pr_scope_check`
+
+If any guardrail command returns `BLOCK`, stop and resolve the blocking reason before continuing.
+
+## MANDATORY: Recording Protocol
+
+> This is an AgenticOS project. All session activity MUST be recorded.
+> Recording is not optional — it is the core function of this system.
+
+### During Session
+
+After completing any meaningful unit of work (feature, fix, design decision, analysis), call `agenticos_record`:
+
+```
+agenticos_record({
+  summary: "what happened",
+  decisions: ["decision 1", ...],
+  outcomes: ["outcome 1", ...],
+  pending: ["next step 1", ...],
+  current_task: { title: "task name", status: "in_progress" }
+})
+```
+
+### Before Session Ends
+
+When the user signals session end (says goodbye, thanks, done, or stops responding), you MUST:
+
+1. Call `agenticos_record` with a complete session summary
+2. Call `agenticos_save` to commit to Git
+
+**If you skip this step, all context from this session is permanently lost.**
+
+---
+
+## Session Start Protocol
+
+When you open this project in a new session, **immediately do the following**:
+
+1. Read the "Current State" section below
+2. Greet the user with a brief status report:
+
+```
+📍 项目：360teams
+📌 上次进展：[current_task title + status]
+🎯 当前待办：[top pending items]
+💡 建议下一步：[recommended next action]
+
+继续上次的工作，还是有新的方向？
+```
+
+3. Wait for the user's direction before proceeding
+
+---
+
+## Project DNA
+
+**一句话定位**: 360teams项目管理
+
+**核心设计原则**: (待补充 — 在项目推进中逐步完善)
+
+**技术栈**: (待补充)
+## Current State
+
+<!-- AGENT_CONTEXT_START -->
+**Last Updated**: 2026-03-29T16:31:43.133Z
+
+**Current Task**: No active task (status: unknown)
+
+**Active Items**:
+- Define project goals
+- Set up initial tasks
+
+
+**Next Action**: Define project goals
+<!-- AGENT_CONTEXT_END -->
+
+---
+
+## Navigation
+
+| 目录/文件 | 用途 |
+|-----------|------|
+| `.project.yaml` | 项目元信息 |
+| `.context/quick-start.md` | 快速项目概览 |
+| `.context/state.yaml` | 当前会话状态及工作记忆 |
+| `.context/conversations/` | 会话记录（自动生成） |
+| `knowledge/` | 持久化知识文档 |
+| `tasks/` | 任务追踪 |
+| `tasks/templates/agent-preflight-checklist.yaml` | preflight 模板 |
+| `tasks/templates/issue-design-brief.md` | 设计循环模板 |
+| `tasks/templates/non-code-evaluation-rubric.yaml` | 非代码评估模板 |
+| `tasks/templates/submission-evidence.md` | 提交证据模板 |
+| `artifacts/` | 产出物 |

--- a/projects/360teams/tasks/templates/agent-preflight-checklist.yaml
+++ b/projects/360teams/tasks/templates/agent-preflight-checklist.yaml
@@ -1,0 +1,86 @@
+version: 0.2
+name: agent-preflight-checklist
+purpose: Preflight gate before any issue-driven work proceeds to editing or submission.
+
+task:
+  issue_id: ""
+  title: ""
+  type: discussion_only
+  allowed_types:
+    - discussion_only
+    - analysis_or_doc
+    - implementation
+    - bootstrap
+  risk_level: medium
+  allowed_risk_levels:
+    - low
+    - medium
+    - high
+
+repository:
+  repo_path: ""
+  repo_identity_confirmed: false
+  current_branch: ""
+  remote_name: origin
+  remote_base_branch: origin/main
+  current_head: ""
+  remote_base_head: ""
+  branch_fork_point: ""
+  branch_ancestry_verified: false
+  branch_based_on_intended_remote: false
+  has_initial_commit: false
+  active_workspace_type: main
+  allowed_workspace_types:
+    - main
+    - isolated_worktree
+  issue_link_confirmed: false
+
+context:
+  project_goal_restate: ""
+  issue_goal_restate: ""
+  constraints_restate: []
+  related_docs_read:
+    - .context/quick-start.md
+    - .context/state.yaml
+  issue_relevant_knowledge_files: []
+  adjacent_risks_checked: false
+
+classification:
+  structural_move: false
+  implementation_affecting_files: []
+  docs_only_files: []
+  declared_target_files: []
+  worktree_required: false
+  main_workspace_allowed: false
+  bootstrap_exception_used: false
+
+scope_control:
+  root_scoped_exceptions:
+    - .github/
+  exception_check_completed: false
+  pr_scope_check_required: false
+  changed_files_within_declared_scope: false
+  unrelated_commits_detected: false
+  diff_scope_notes: ""
+
+design_loop:
+  required_passes: 2
+  completed_passes: 0
+  critique_completed: false
+  acceptance_defined_before_edit: false
+
+verification_plan:
+  deliverable_type: non_code
+  allowed_deliverable_types:
+    - code
+    - non_code
+  planned_checks: []
+  clean_reproducibility_gate: []
+  coverage_target: changed_scope_100
+  rubric_defined: false
+  evidence_destination: ""
+
+gate:
+  preflight_passed: false
+  block_reason: ""
+  next_action: ""

--- a/projects/360teams/tasks/templates/issue-design-brief.md
+++ b/projects/360teams/tasks/templates/issue-design-brief.md
@@ -1,0 +1,59 @@
+# Issue Design Brief
+
+## Issue
+- ID:
+- Title:
+- Linked source:
+
+## Objective Synthesis
+- User-stated request:
+- Inferred end goal:
+- Constraints:
+- Non-goals:
+
+## Project Context
+- Project long-term objective:
+- Relevant existing design:
+- Related issues/risks:
+- Files or docs reviewed:
+
+## Sub-Agent Inheritance Packet
+- Sub-agent needed:
+- Delegated scope:
+- Project identity to pass:
+- Current task / issue context to pass:
+- Constraints / non-goals to pass:
+- Knowledge or task files to pass:
+- Expected output shape:
+- Verification the sub-agent must echo back:
+
+## Design Pass 1
+- Proposed approach:
+- Why this approach:
+- Expected benefits:
+
+## Critique Pass 1
+- Weak assumptions:
+- Missing edge cases:
+- Risks:
+- Better alternatives considered:
+
+## Design Pass 2
+- Refined approach:
+- Changes from pass 1:
+- Why pass 2 is stronger:
+
+## Optional Design Pass 3
+- Trigger reason:
+- Further refinement:
+
+## Executable Acceptance
+- Behavioral checks:
+- File/state assertions:
+- Verification commands:
+- Evaluation rubric:
+
+## Implementation Plan
+- Files expected to change:
+- Worktree required:
+- Verification evidence to produce:

--- a/projects/360teams/tasks/templates/non-code-evaluation-rubric.yaml
+++ b/projects/360teams/tasks/templates/non-code-evaluation-rubric.yaml
@@ -1,0 +1,50 @@
+version: 0.1
+name: non-code-evaluation-rubric
+purpose: Evaluate protocol, documentation, design, or analysis outputs before submission.
+
+artifact:
+  path: ""
+  type: protocol_doc
+  allowed_types:
+    - protocol_doc
+    - design_doc
+    - knowledge_doc
+    - issue_draft
+    - workflow_spec
+
+goal:
+  intended_outcome: ""
+  linked_issue: ""
+
+criteria:
+  - name: goal_alignment
+    question: Does the artifact solve the stated issue rather than only improving wording?
+    pass_threshold: explicit_and_substantive
+    result: pending
+    notes: ""
+  - name: executability
+    question: Are the rules or acceptance criteria operational enough to be implemented or checked?
+    pass_threshold: contains_checks_or_pseudocode
+    result: pending
+    notes: ""
+  - name: consistency
+    question: Is the artifact consistent with current project positioning, workflow model, and adjacent standards?
+    pass_threshold: no_material_conflicts
+    result: pending
+    notes: ""
+  - name: completeness
+    question: Does the artifact cover entry conditions, core flow, edge cases, and failure states?
+    pass_threshold: all_major_sections_present
+    result: pending
+    notes: ""
+  - name: downstream_usability
+    question: Could another agent use this artifact without the original chat history?
+    pass_threshold: yes
+    result: pending
+    notes: ""
+
+evaluation:
+  method: llm_rubric_review
+  passes_required: 1
+  overall_result: pending
+  residual_risks: []

--- a/projects/360teams/tasks/templates/sub-agent-handoff.md
+++ b/projects/360teams/tasks/templates/sub-agent-handoff.md
@@ -1,0 +1,28 @@
+# Sub-Agent Handoff
+
+## Project Identity
+- Project:
+- Project ID:
+- Project Path:
+
+## Task Scope
+- Issue:
+- Delegated sub-task:
+- Expected output:
+
+## Required Context
+- Current task:
+- Constraints / non-goals:
+- Relevant knowledge files:
+- Relevant task files:
+
+## Verification Before Work
+- Restate the project:
+- Restate the task:
+- Restate key constraints:
+- State what evidence will be returned:
+
+## Return Contract
+- Code or document output:
+- Verification evidence:
+- Residual risks:

--- a/projects/360teams/tasks/templates/submission-evidence.md
+++ b/projects/360teams/tasks/templates/submission-evidence.md
@@ -1,0 +1,37 @@
+# Submission Evidence
+
+## Scope
+- Issue:
+- Task type:
+- Branch:
+- Worktree:
+
+## Preflight
+- Preflight passed:
+- Blocking exceptions:
+
+## Design Loop
+- Design pass count:
+- Critique completed:
+- Acceptance defined before edit:
+
+## Sub-Agent Verification
+- Sub-agents used:
+- Inheritance packet defined:
+- Sub-agent understanding verified before work:
+- Parent agent distilled important results back into canonical files:
+
+## Verification
+- Deliverable type:
+- Commands run:
+- Coverage result:
+- Rubric evaluation result:
+- Evidence files:
+
+## Residual Risk
+- Remaining limitations:
+- Explicit exceptions:
+
+## Ready To Submit
+- Yes/No:
+- If no, what is blocked:


### PR DESCRIPTION
## Summary
- adopt the current standard-kit surfaces for `projects/360teams`, including generated `AGENTS.md` / `CLAUDE.md` and missing task templates
- repair the downstream project-owned `.project.yaml` and `.context/state.yaml` so the memory-layer contract is complete
- validate the real downstream project end to end with `agenticos_standard_kit_conformance_check`

## Verification
- `npm test`
- `npm run build`
- `agenticos_standard_kit_conformance_check` before adoption: FAIL on missing adapter surfaces, missing templates, and missing memory-layer contract fields
- `agenticos_standard_kit_adopt` on `projects/360teams`
- `agenticos_standard_kit_conformance_check` after downstream metadata repair: PASS
- `agenticos_pr_scope_check` on this branch: PASS

Closes #123
