### PR TITLE
feat: archive agentic-os-development reference content (#133)

### DIFF
--- a/.agent-workspace/registry.yaml
+++ b/.agent-workspace/registry.yaml
@@ -1,6 +1,6 @@
 version: 1.0.0
 last_updated: 2026-03-20T07:05:35.299Z
-active_project: agentic-os-development
+active_project: null
 projects:
   - id: ghostty-optimization
     name: Ghostty Optimization
@@ -11,7 +11,7 @@ projects:
   - id: agentic-os-development
     name: AgenticOS Development
     path: projects/agentic-os-development
-    status: active
+    status: archived
     created: 2026-03-16
     last_accessed: 2026-03-20T07:04:07.050Z
   - id: agentic-devops
@@ -20,9 +20,3 @@ projects:
     status: active
     created: 2026-03-16
     last_accessed: 2026-03-16T08:24:00Z
-  - id: agentic-os-development
-    name: agentic-os-development
-    path: projects/agentic-os-development
-    status: active
-    created: 2026-03-20
-    last_accessed: 2026-03-20T07:05:35.299Z

--- a/projects/agentic-os-development/.context/quick-start.md
+++ b/projects/agentic-os-development/.context/quick-start.md
@@ -1,13 +1,16 @@
-# agentic-os-development - Quick Start
+# agentic-os-development Archive
 
-## Project Overview
+## Status
 
+- Classification: Archived reference
+- Managed project: No
+- Execution mode: Reference only
 
-## Current Status
-- Created: 2026-03-20
-- Status: Active
+## Redirect
 
-## Next Steps
-1. Define project goals
-2. Set up initial tasks
-3. Begin development
+- Use `projects/agenticos` for product implementation.
+- Use `projects/agenticos/standards` for the canonical workflow contract.
+
+## Purpose
+
+This directory preserves historical standalone AgenticOS development material after consolidation into the main product tree.

--- a/projects/agentic-os-development/.context/state.yaml
+++ b/projects/agentic-os-development/.context/state.yaml
@@ -1,72 +1,20 @@
 session:
-  id: session-2026-03-22-001
-  started: 2026-03-22T06:00:00.000Z
-  agent: claude-sonnet-4.6
-  last_backup: 2026-03-22T07:15:31.962Z
+  id: archived-reference
+  started: 2026-03-30T00:00:00.000Z
+  agent: archive-notice
 current_task:
-  title: v0.2.1 发布 + 文档规范更新
-  status: completed
-  updated: 2026-03-22T07:30:00.000Z
+  title: null
+  status: archived
+  updated: 2026-03-30T00:00:00.000Z
 working_memory:
   facts:
-    - zsh-autosuggestions 安装完成
-    - Zed 配置部署到 ~/.config/zed/settings.json
-    - Cmux hooks 部署到 ~/.claude/hooks/cmux-notify-hook.sh
-    - .zshrc 备份到 ~/.config-backup/ghostty-opt-20260321-133433/zshrc.bak
-    - Shell 快捷函数追加完成 (cw/cc/cb/z.)
-    - Ghostty copy-on-select 改为 false
-    - "PR #8 已创建：https://github.com/madlouse/AgenticOS/pull/8（模板版本化）"
-    - distill.ts 新增：CURRENT_TEMPLATE_VERSION、extractTemplateVersion()、upgradeClaudeMd()、ensureVersionMarker()
-    - project.ts 新增：switchProject 时检测版本并自动升级（保留用户内容）
-    - 两个 worktree 坑：1) repo 内部 worktree 导致 commit 打 main 2) reset --hard 会 revert 未提交的文件
-    - "PR #6 已创建：基础设施（CLAUDE.md/AGENTS.md 修订、模板、LICENSE）"
-    - "PR #8 已创建：MCP Server 模板版本化机制"
-    - "PR #10 已创建：CI lint/test 脚本准备（workflow 文件需手动添加）"
-    - 创建 homebrew-ghostty 仓库 (https://github.com/madlouse/homebrew-ghostty)
-    - ghostty-cmux.rb Formula 完成，SHA256 已验证
-    - README.md 重写为 Agent-friendly 版本并推送
-    - brew tap madlouse/ghostty 测试成功，formula 正常解析
-    - 175 tests pass across 4 test files
-    - SKILL.md v2.5.0 with docs + calendar commands
-    - DEVELOPMENT.md updated with miniapp-cdp.js, docs.js, calendar.js, calendar-parser.test.js
-    - "calendar-parser.test.js: 43 tests for calendar.js exported functions"
-    - "docs --action shared 正常列出 20 份文档"
-    - "docs --action read 对文字文档（docs/ 和 docx/ 路径）成功读取内容"
-    - "Canvas 表格（sheets/）返回明确提示，不再报 Document not found"
-    - "固定了 ~/.opencli/clis/360teams/ 与项目 clis/ 不同步的问题"
-    - 合并 PR #19（vitest 单测）和 PR #21（CI 修复）到 main
-    - 关闭 Issue #1 #2 #3 #13 #14 #15 #16（全部清零）
-    - 发布 v0.2.1：单测套件 + CI 修复
-    - 更新 Homebrew Formula sha256 为 v0.2.1 实际值 f87d5e1a...
-    - 更新 CONTRIBUTING.md：GitHub Flow 规范、发布流程、常见陷阱
-    - 更新 AGENTS.md：同步 Git Flow 规范
+    - This directory is archived reference content.
+    - Active implementation now lives under projects/agenticos.
+    - Canonical standards metadata now lives under projects/agenticos/standards.
   decisions:
-    - "bootstrap.sh 实际执行: 全部成功，无报错"
-    - Ghostty copy-on-select 改为 false (sed 直接修改)
-    - Worktree 应建立在 repo 外部而非内部，否则 git 命令会混淆
-    - commit 到错误分支后用 `git reset --hard HEAD~1` 撤销，但会同时 revert 文件——需重新应用变更
-    - 最终方案：在 repo 外建立独立 worktree 目录
-    - CI workflow 文件通过 GitHub API 推送需要 workflow scope，OAuth token 不够
-    - 解决方案：在 PR body 中提供 workflow 文件完整内容，用户手动添加
-    - "双仓库架构: ghostty-optimization(配置) + homebrew-ghostty(安装入口)"
-    - "Formula: ghostty-cmux.rb，自动安装 Cmux/Zed/starship 等 + 克隆配置仓库 + 运行 bootstrap"
-    - README 改为 Agent-friendly：明确安装命令、架构图、文件结构、开发状态
-    - Cmux 通过 manaflow-ai/cmux/cmux tap 安装，非直接 cask
-    - tests/helpers.test.js 中 T5T helper 函数应从 helpers.js 导入（非 t5t.js），因为 helpers.js 包含完整数据转换函数，t5t.js 只导出 innerText 解析函数
-    - parseCalendarDayFromText 需要 null guard 防止 null 输入导致 TypeError
-    - docs.js 由于跨域 iframe 限制，仅实现 status 动作，这是已知技术约束而非设计缺陷
-    - refreshIframeContext 从 miniapp-cdp.js 导入而非本地定义，避免重复代码和 bug
-    - canvas 文档返回特定提示而非报错，保持命令稳定性
-    - 导航使用 setTimeout 推迟 50ms，避免 context 在返回前被销毁
-    - iframe 导航使用 parent frame 的 iframe.src 设置，绕过跨域限制
-    - 使用 GitHub Flow（单 main 分支）替代 Git Flow，适合单人/AI-agent 协作项目
-    - branch protection 去掉 required reviews（GitHub 不允许自审），只保留 CI required
-    - 所有 workflow 用 npm install 替换 npm ci，避免 lock file 不同步问题
-    - Homebrew formula sha256 必须在每次 release 后立即更新，不留 placeholder
+    - Archived directories must fail fast when treated as active managed projects.
   pending:
-    - Homebrew tap 是否需要独立仓库发布（目前在主 repo 内）
-    - "Node.js 20 actions deprecation 警告（2026-06-02 前需升级到 Node 24）"
-    - agenticos_record 存在 bug：JSON 数组字符串被逐字符展开写入 YAML，需修复序列化逻辑
+    - Preserve historical material only.
 loaded_context:
   - .project.yaml
   - .context/quick-start.md

--- a/projects/agentic-os-development/.project.yaml
+++ b/projects/agentic-os-development/.project.yaml
@@ -1,9 +1,19 @@
 meta:
   name: agentic-os-development
   id: agentic-os-development
-  description: ""
+  description: Archived reference material from the pre-consolidation standalone AgenticOS development workspace.
   created: 2026-03-20
   version: 1.0.0
 agent_context:
   quick_start: .context/quick-start.md
   current_state: .context/state.yaml
+archive_contract:
+  version: 1
+  kind: archived_reference
+  managed_project: false
+  execution_mode: reference_only
+  replacement_project: agenticos-standards
+  canonical_code_root: ../agenticos
+  notes:
+    - Do not activate this directory with agenticos_switch.
+    - Use projects/agenticos for implementation and projects/agenticos/standards for canonical workflow metadata.

--- a/projects/agentic-os-development/AGENTS.md
+++ b/projects/agentic-os-development/AGENTS.md
@@ -1,51 +1,21 @@
-# AGENTS.md — AgenticOS Development
+# AGENTS.md — agentic-os-development Archive
 
-## Recording Protocol (MANDATORY)
+## Archive Notice
 
-This project uses AgenticOS for persistent context management.
-All session activity MUST be recorded via MCP tools.
+This directory is archived reference material, not an active project runtime.
 
-### How to Record
+- Do not switch into this directory with `agenticos_switch`.
+- Do not write new session state, guardrail evidence, or delivery artifacts here.
+- Treat the content as historical documentation only.
 
-Call the MCP tool `agenticos_record` with:
-- `summary` (required): What happened in this session
-- `decisions`: Key decisions made
-- `outcomes`: What was accomplished
-- `pending`: What remains to be done
-- `current_task`: { title, status } to update current task
+## Active Targets
 
-### When to Record
+- Product code: `projects/agenticos`
+- Canonical standards project: `projects/agenticos/standards`
 
-1. After completing any meaningful unit of work
-2. Before ending the session (MANDATORY — context is lost otherwise)
+## Allowed Work
 
-After recording, call `agenticos_save` to commit to Git.
-
-### Session Start
-
-On session start, read these files for context:
-1. `.project.yaml` — Project metadata
-2. `.context/state.yaml` — Current state and working memory
-3. `.context/conversations/` — Previous session records
-
-Then greet the user with: project name, last progress, current pending items, suggested next step.
-
-## Project
-
-**Name**: AgenticOS Development
-**Description**: Agent-first project management OS — AI Agent autonomously manages project state, cross-session context recovery, and cross-tool collaboration.
-
-## Directory Structure
-
-| Path | Purpose |
-|------|---------|
-| `.project.yaml` | Project metadata |
-| `.context/state.yaml` | Session state and working memory |
-| `.context/conversations/` | Session records (auto-generated) |
-| `knowledge/` | Persistent knowledge: architecture, decisions, trade-offs |
-| `knowledge/architecture.md` | Three-layer architecture design |
-| `knowledge/design-decisions.md` | 5 key design decisions with rationale |
-| `knowledge/complete-design.md` | Complete system design document |
-| `tasks/` | Task tracking |
-| `artifacts/` | Outputs and deliverables |
-| `changelog.md` | Project changelog |
+Only perform archival maintenance here:
+- clarify history
+- improve reference navigation
+- preserve provenance

--- a/projects/agentic-os-development/CLAUDE.md
+++ b/projects/agentic-os-development/CLAUDE.md
@@ -1,118 +1,19 @@
-# CLAUDE.md — AgenticOS Development
+# CLAUDE.md — agentic-os-development Archive
 
-## MANDATORY: Recording Protocol
+## Archive Notice
 
-> This is an AgenticOS project. All session activity MUST be recorded.
-> Recording is not optional — it is the core function of this system.
+This directory is archived reference content.
 
-### During Session
+- It is not an active managed project.
+- Do not call `agenticos_switch` to activate this directory.
+- Do not record new execution state here.
 
-After completing any meaningful unit of work (feature, fix, design decision, analysis), call `agenticos_record`:
+## Use These Active Locations Instead
 
-```
-agenticos_record({
-  summary: "what happened",
-  decisions: ["decision 1", ...],
-  outcomes: ["outcome 1", ...],
-  pending: ["next step 1", ...],
-  current_task: { title: "task name", status: "in_progress" }
-})
-```
+- Canonical implementation: `projects/agenticos`
+- Canonical workflow metadata and standards: `projects/agenticos/standards`
 
-### Before Session Ends
+## Archive Scope
 
-When the user signals session end (says goodbye, thanks, done, or stops responding), you MUST:
-
-1. Call `agenticos_record` with a complete session summary
-2. Call `agenticos_save` to commit to Git
-
-**If you skip this step, all context from this session is permanently lost.**
-
----
-
-## Session Start Protocol
-
-When you open this project in a new session, **immediately do the following**:
-
-1. Read the "Current State" section below
-2. Greet the user with a brief status report in this format:
-
-```
-📍 项目：AgenticOS Development
-📌 上次进展：[current_task title + status]
-🎯 当前待办：[top pending items]
-💡 建议下一步：[recommended next action]
-
-继续上次的工作，还是有新的方向？
-```
-
-3. Wait for the user's direction before proceeding
-
----
-
-## Project DNA
-
-**一句话定位**: Agent-first 的项目管理操作系统，让 AI Agent 能自主管理项目状态、跨会话恢复上下文、跨工具协作。
-
-**核心设计原则**:
-- **Agent First**: AI 是主要用户，一切结构为 AI 理解优化
-- **完整记录**: 所有决策、对话、变更完整留痕
-- **跨工具兼容**: Claude Code / Cursor / Codex 均可使用
-- **可移植性**: Git 备份，路径相对化存储，跨机器可用
-
-**三层架构**:
-1. **通用层** (Universal): `.project.yaml` + `.context/state.yaml` + `knowledge/` + `tasks/` — 纯文本+结构化数据，无工具依赖
-2. **MCP 层**: `agenticos-mcp` npm 包，5 个工具 (init/switch/list/record/save) + 1 个资源
-3. **Agent 适配层**: `CLAUDE.md` / `CURSOR.md` — 每个工具的专用配置和行为指令
-
-**技术栈**: TypeScript, Node.js (ES2022), MCP SDK, YAML, Git
-
-**关键设计约束**:
-- 路径在 YAML 中存储为相对路径，运行时解析为绝对路径
-- Registry 位于 `~/.agent-workspace/registry.yaml`（AgenticOS Home 下）
-- Git 操作从 workspace root 执行（整个 AgenticOS 是一个仓库）
-
----
-
-## Current State
-
-<!-- AGENT_CONTEXT_START -->
-**Last Updated**: 2026-03-21T05:49:33.899Z
-
-**Current Task**: Homebrew Tap + Agent-friendly README (status: completed)
-
-**Active Items**:
-- E2E manual verification: opencli 360teams docs, opencli 360teams calendar — 需要 360Teams 运行中
-- 如果需要，创建 docs-parser.test.js（但 docs.js 目前无可测试的导出函数）
-
-**Recent Decisions**:
-- tests/helpers.test.js 中 T5T helper 函数应从 helpers.js 导入（非 t5t.js），因为 helpers.js 包含完整数据转换函数，t5t.js 只导出 innerText 解析函数
-- parseCalendarDayFromText 需要 null guard 防止 null 输入导致 TypeError
-- docs.js 由于跨域 iframe 限制，仅实现 status 动作，这是已知技术约束而非设计缺陷
-
-**Next Action**: E2E manual verification: opencli 360teams docs, opencli 360teams calendar — 需要 360Teams 运行中
-<!-- AGENT_CONTEXT_END -->
-
----
-
-## Navigation
-
-| 目录/文件 | 用途 |
-|-----------|------|
-| `.project.yaml` | 项目元信息（名称、ID、版本、技术栈） |
-| `.context/state.yaml` | 当前会话状态、工作记忆、待办事项 |
-| `.context/quick-start.md` | 人类可读的项目概览 |
-| `.context/conversations/` | 历史对话记录 |
-| `knowledge/` | 持久化知识：架构设计、决策记录、权衡分析 |
-| `knowledge/architecture.md` | 核心架构设计（三层架构详解） |
-| `knowledge/design-decisions.md` | 5 个关键设计决策及理由 |
-| `knowledge/complete-design.md` | 完整系统设计文档 |
-| `tasks/` | 任务追踪 |
-| `artifacts/` | 产出物 |
-| `changelog.md` | 变更日志 |
-
-**获取更多上下文**:
-- 架构全貌 → `knowledge/architecture.md`
-- 为什么选 MCP 而非 CLI → `knowledge/cli-vs-mcp-analysis.md`
-- 设计权衡 → `knowledge/trade-offs.md`
-- MCP Server 源码 → `../../mcp-server/src/`
+Keep this directory read-only except for archival curation work.
+If content needs to become executable again, restore it into an active managed project with a fresh `.project.yaml` contract.

--- a/projects/agenticos/mcp-server/src/tools/__tests__/project.test.ts
+++ b/projects/agenticos/mcp-server/src/tools/__tests__/project.test.ts
@@ -365,6 +365,43 @@ describe('switchProject', () => {
 
     expect(result).toContain('📖 Project summary: Fallback project summary from quick-start.');
   });
+
+  it('refuses to switch into archived reference content', async () => {
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: null,
+      projects: [
+        {
+          id: 'archived-project',
+          name: 'Archived Project',
+          path: '/test/path',
+          status: 'archived' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    fsPromisesMock.readFile.mockResolvedValue(
+      JSON.stringify({
+        meta: { description: 'Archive' },
+        archive_contract: {
+          version: 1,
+          kind: 'archived_reference',
+          managed_project: false,
+          execution_mode: 'reference_only',
+          replacement_project: 'agenticos-standards',
+        },
+      })
+    );
+
+    const result = await switchProject({ project: 'archived-project' });
+
+    expect(result).toContain('archived reference content');
+    expect(result).toContain('agenticos-standards');
+    expect(registryMock.saveRegistry).not.toHaveBeenCalled();
+  });
 });
 
 describe('listProjects', () => {
@@ -700,5 +737,40 @@ describe('getStatus', () => {
 
     expect(result).toContain('agenticos_preflight -> REDIRECT');
     expect(result).toContain('create an isolated issue branch/worktree');
+  });
+
+  it('refuses status for an archived active project', async () => {
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: 'archived-project',
+      projects: [
+        {
+          id: 'archived-project',
+          name: 'Archived Project',
+          path: '/test/path',
+          status: 'archived' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    fsPromisesMock.readFile.mockResolvedValue(
+      JSON.stringify({
+        archive_contract: {
+          version: 1,
+          kind: 'archived_reference',
+          managed_project: false,
+          execution_mode: 'reference_only',
+          replacement_project: 'agenticos-standards',
+        },
+      })
+    );
+
+    const result = await getStatus();
+
+    expect(result).toContain('archived reference content');
+    expect(result).toContain('agenticos-standards');
   });
 });

--- a/projects/agenticos/mcp-server/src/tools/__tests__/standard-kit.test.ts
+++ b/projects/agenticos/mcp-server/src/tools/__tests__/standard-kit.test.ts
@@ -421,6 +421,47 @@ describe('standard kit commands', () => {
     expect(result.adapter_checks.find((item) => item.agent_id === 'codex')).toMatchObject({ status: 'PASS' });
   });
 
+  it('conformance check skips archived reference projects', async () => {
+    const { home, projectRoot } = await setupKitHome();
+    process.env.AGENTICOS_HOME = home;
+
+    await writeFile(
+      join(projectRoot, '.project.yaml'),
+      yaml.stringify({
+        meta: {
+          name: 'Archived Project',
+          id: 'archived-project',
+          description: 'Archived reference content',
+        },
+        archive_contract: {
+          version: 1,
+          kind: 'archived_reference',
+          managed_project: false,
+          execution_mode: 'reference_only',
+          replacement_project: 'agenticos-standards',
+        },
+      }),
+      'utf-8',
+    );
+
+    const result = JSON.parse(await runStandardKitConformanceCheck({
+      project_path: projectRoot,
+    })) as {
+      status: string;
+      summary: string;
+      behavior_checks: unknown[];
+      adapter_checks: unknown[];
+      missing_required_files: unknown[];
+    };
+
+    expect(result.status).toBe('SKIP');
+    expect(result.summary).toContain('archived reference content');
+    expect(result.summary).toContain('agenticos-standards');
+    expect(result.behavior_checks).toEqual([]);
+    expect(result.adapter_checks).toEqual([]);
+    expect(result.missing_required_files).toEqual([]);
+  });
+
   it('upgrade check can resolve project identity from an existing .project.yaml through the active registry project', async () => {
     const { home, projectRoot } = await setupKitHome();
     process.env.AGENTICOS_HOME = home;

--- a/projects/agenticos/mcp-server/src/tools/project.ts
+++ b/projects/agenticos/mcp-server/src/tools/project.ts
@@ -5,6 +5,7 @@ import yaml from 'yaml';
 import { loadRegistry, saveRegistry } from '../utils/registry.js';
 import { generateClaudeMd, generateAgentsMd, updateClaudeMdState, upgradeClaudeMd, CURRENT_TEMPLATE_VERSION, extractTemplateVersion } from '../utils/distill.js';
 import { writeFile } from 'fs/promises';
+import { buildArchivedReferenceMessage, isArchivedReferenceProject } from '../utils/project-contract.js';
 
 type GuardrailCommand = 'agenticos_preflight' | 'agenticos_branch_bootstrap' | 'agenticos_pr_scope_check';
 
@@ -181,6 +182,15 @@ export async function switchProject(args: any): Promise<string> {
     return `❌ Project "${project}" not found.\n\nAvailable projects:\n${registry.projects.map((p) => `- ${p.name} (${p.id})`).join('\n')}`;
   }
 
+  let projectYaml: any = {};
+  try {
+    projectYaml = yaml.parse(await readFile(join(found.path, '.project.yaml'), 'utf-8')) || {};
+  } catch {}
+
+  if (isArchivedReferenceProject(projectYaml, found.status)) {
+    return `❌ ${buildArchivedReferenceMessage(found.name, projectYaml?.archive_contract?.replacement_project)}`;
+  }
+
   registry.active_project = found.id;
   found.last_accessed = new Date().toISOString();
   await saveRegistry(registry);
@@ -193,10 +203,7 @@ export async function switchProject(args: any): Promise<string> {
   let description = '';
   let state: any = undefined;
   let quickStart = '';
-  try {
-    const projYaml = yaml.parse(await readFile(join(found.path, '.project.yaml'), 'utf-8'));
-    description = projYaml?.meta?.description || '';
-  } catch {}
+  description = projectYaml?.meta?.description || '';
   try {
     state = yaml.parse(await readFile(join(found.path, '.context', 'state.yaml'), 'utf-8'));
   } catch {}
@@ -277,6 +284,15 @@ export async function getStatus(): Promise<string> {
 
   const project = registry.projects.find((p) => p.id === registry.active_project);
   if (!project) return '❌ Active project not found in registry.';
+
+  let projectYaml: any = {};
+  try {
+    projectYaml = yaml.parse(await readFile(join(project.path, '.project.yaml'), 'utf-8')) || {};
+  } catch {}
+
+  if (isArchivedReferenceProject(projectYaml, project.status)) {
+    return `❌ ${buildArchivedReferenceMessage(project.name, projectYaml?.archive_contract?.replacement_project)}`;
+  }
 
   // Read state.yaml
   const statePath = join(project.path, '.context', 'state.yaml');

--- a/projects/agenticos/mcp-server/src/utils/__tests__/project-target.test.ts
+++ b/projects/agenticos/mcp-server/src/utils/__tests__/project-target.test.ts
@@ -306,4 +306,26 @@ describe('resolveManagedProjectTarget', () => {
       commandName: 'agenticos_record',
     })).rejects.toThrow('Project identity mismatch: registry name "Alpha Project" does not match .project.yaml meta.name "Wrong Project Name".');
   });
+
+  it('fails when the resolved project is archived reference content', async () => {
+    readFileMock.mockResolvedValue(JSON.stringify({
+      meta: {
+        id: 'alpha',
+        name: 'Alpha Project',
+      },
+      archive_contract: {
+        version: 1,
+        kind: 'archived_reference',
+        managed_project: false,
+        execution_mode: 'reference_only',
+        replacement_project: 'agenticos-standards',
+      },
+    }));
+
+    await expect(resolveManagedProjectTarget({
+      commandName: 'agenticos_record',
+    })).rejects.toThrow(
+      'Project "Alpha Project" is archived reference content, not an active managed project. Use "agenticos-standards" instead. agenticos_record only works with active managed projects.',
+    );
+  });
 });

--- a/projects/agenticos/mcp-server/src/utils/project-contract.ts
+++ b/projects/agenticos/mcp-server/src/utils/project-contract.ts
@@ -1,0 +1,35 @@
+interface ArchiveContract {
+  version?: number;
+  kind?: string;
+  managed_project?: boolean;
+  execution_mode?: string;
+  replacement_project?: string;
+}
+
+export function getArchiveContract(projectYaml: any): ArchiveContract | null {
+  const contract = projectYaml?.archive_contract;
+  if (!contract || typeof contract !== 'object') {
+    return null;
+  }
+  return contract as ArchiveContract;
+}
+
+export function isArchivedReferenceProject(projectYaml: any, registryStatus?: 'active' | 'archived'): boolean {
+  const contract = getArchiveContract(projectYaml);
+  if (registryStatus === 'archived') {
+    return true;
+  }
+  if (!contract) {
+    return false;
+  }
+  return contract.kind === 'archived_reference'
+    || contract.managed_project === false
+    || contract.execution_mode === 'reference_only';
+}
+
+export function buildArchivedReferenceMessage(projectName: string, replacementProject?: string): string {
+  const suffix = replacementProject
+    ? ` Use "${replacementProject}" instead.`
+    : '';
+  return `Project "${projectName}" is archived reference content, not an active managed project.${suffix}`;
+}

--- a/projects/agenticos/mcp-server/src/utils/project-target.ts
+++ b/projects/agenticos/mcp-server/src/utils/project-target.ts
@@ -2,6 +2,7 @@ import { readFile } from 'fs/promises';
 import { join } from 'path';
 import yaml from 'yaml';
 import { loadRegistry, type Project, type Registry } from './registry.js';
+import { buildArchivedReferenceMessage, isArchivedReferenceProject } from './project-contract.js';
 
 export interface ResolvedManagedProjectTarget {
   registry: Registry;
@@ -109,6 +110,12 @@ export async function resolveManagedProjectTarget(args: ResolveManagedProjectTar
   if (metaName && metaName !== project.name) {
     throw new Error(
       `Project identity mismatch: registry name "${project.name}" does not match .project.yaml meta.name "${metaName}".`
+    );
+  }
+
+  if (isArchivedReferenceProject(projectYaml, project.status)) {
+    throw new Error(
+      `${buildArchivedReferenceMessage(project.name, projectYaml?.archive_contract?.replacement_project)} ${args.commandName} only works with active managed projects.`
     );
   }
 

--- a/projects/agenticos/mcp-server/src/utils/standard-kit.ts
+++ b/projects/agenticos/mcp-server/src/utils/standard-kit.ts
@@ -5,6 +5,7 @@ import yaml from 'yaml';
 import { getAgenticOSHome, loadRegistry } from './registry.js';
 import { getOfficialAgentAdapters, loadAgentAdapterMatrix } from './agent-adapter-matrix.js';
 import { CURRENT_TEMPLATE_VERSION, extractTemplateVersion, generateAgentsMd, generateClaudeMd, upgradeClaudeMd } from './distill.js';
+import { buildArchivedReferenceMessage, isArchivedReferenceProject } from './project-contract.js';
 
 interface StandardKitEntry {
   path: string;
@@ -91,7 +92,7 @@ export interface ConformanceAdapterStatus {
 
 export interface StandardKitConformanceResult {
   command: 'agenticos_standard_kit_conformance_check';
-  status: 'PASS' | 'FAIL';
+  status: 'PASS' | 'FAIL' | 'SKIP';
   summary: string;
   project_path: string;
   project_name: string;
@@ -410,8 +411,33 @@ export async function checkStandardKitUpgrade(args: { project_path?: string; pro
 
 export async function checkStandardKitConformance(args: { project_path?: string; project_name?: string; project_description?: string }): Promise<StandardKitConformanceResult> {
   const manifest = await loadStandardKitManifest();
-  const upgrade = await checkStandardKitUpgrade(args);
-  const projectYaml = yaml.parse((await readProjectFile(upgrade.project_path, '.project.yaml')) || '{}') as any;
+  const projectPath = await resolveProjectPath(args.project_path);
+  const project = await resolveProjectIdentity(projectPath, args.project_name, args.project_description);
+  const projectYaml = yaml.parse((await readProjectFile(project.projectPath, '.project.yaml')) || '{}') as any;
+
+  if (isArchivedReferenceProject(projectYaml)) {
+    return {
+      command: 'agenticos_standard_kit_conformance_check',
+      status: 'SKIP',
+      summary: buildArchivedReferenceMessage(project.projectName, projectYaml?.archive_contract?.replacement_project),
+      project_path: project.projectPath,
+      project_name: project.projectName,
+      project_id: project.projectId,
+      kit_id: manifest.kit_id,
+      kit_version: manifest.kit_version,
+      missing_required_files: [],
+      generated_files: [],
+      copied_templates: [],
+      behavior_checks: [],
+      adapter_checks: [],
+    };
+  }
+
+  const upgrade = await checkStandardKitUpgrade({
+    project_path: project.projectPath,
+    project_name: project.projectName,
+    project_description: project.projectDescription,
+  });
   const stateYaml = yaml.parse((await readProjectFile(upgrade.project_path, '.context/state.yaml')) || '{}') as any;
   const agentsMd = await readProjectFile(upgrade.project_path, 'AGENTS.md');
   const claudeMd = await readProjectFile(upgrade.project_path, 'CLAUDE.md');


### PR DESCRIPTION
## Summary
- reclassify projects/agentic-os-development as archived reference content with an explicit archive contract
- refuse archived/reference projects in switch, status, and managed-project resolution paths
- skip standard-kit conformance for explicit archive/reference projects while preserving PASS behavior for active projects

## Validation
- npm test
- npm run build
- archived conformance check returns SKIP
- active project conformance check still returns PASS
- switchProject refuses the archived project
