### PR TITLE
fix: require explicit AGENTICOS_HOME (#134)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ brew install agenticos
 Homebrew installs:
 
 - the `agenticos-mcp` binary
-- a seed workspace directory under Homebrew `var`
 
 Homebrew does **not**:
 
+- create or select a workspace for you
 - edit Claude Code, Codex, Cursor, or Gemini CLI configuration for you
 - restart your AI tool
 - prove activation by itself
@@ -162,7 +162,7 @@ For implementation work in AgenticOS-managed repositories:
 Each project is a self-contained directory:
 
 ```
-~/AgenticOS/projects/my-feature/
+$AGENTICOS_HOME/projects/my-feature/
 ├── .project.yaml          # Project metadata
 ├── .context/
 │   ├── quick-start.md     # 30-second context summary (AI reads this first)
@@ -173,7 +173,7 @@ Each project is a self-contained directory:
 └── artifacts/             # Code, configs, outputs
 ```
 
-The global registry lives at `~/AgenticOS/.agent-workspace/registry.yaml` and tracks all projects with relative paths — making the whole workspace portable.
+The global registry lives at `$AGENTICOS_HOME/.agent-workspace/registry.yaml` and tracks all projects with relative paths — making the whole workspace portable.
 
 Runtime-only byproducts should not be treated as canonical source:
 
@@ -195,7 +195,7 @@ The orphaned gitlink residues `okr-management` and `t5t` were not recoverable as
 
 ## Environment Variable
 
-By default, AgenticOS stores everything in `~/AgenticOS`. Override with:
+AgenticOS requires `AGENTICOS_HOME` to be set explicitly before you start `agenticos-mcp` or call workspace-backed tools:
 
 ```bash
 # Add to ~/.zshrc or ~/.bashrc
@@ -205,7 +205,7 @@ export AGENTICOS_HOME="$HOME/my-custom-path"
 Recommended layout:
 
 - product source checkout: any normal development path such as `~/src/AgenticOS`
-- live workspace: `AGENTICOS_HOME`, such as `~/AgenticOS`
+- live workspace: `AGENTICOS_HOME`, such as `~/AgenticOS-workspace`
 
 ## GitHub Publish Troubleshooting
 
@@ -231,8 +231,8 @@ If the no-proxy retry still fails with `LibreSSL SSL_connect: SSL_ERROR_SYSCALL`
 # 1. Install
 brew tap madlouse/agenticos && brew install agenticos
 
-# 2. Set workspace (optional, ~/AgenticOS is the default)
-echo 'export AGENTICOS_HOME="$HOME/AgenticOS"' >> ~/.zshrc
+# 2. Set workspace
+echo 'export AGENTICOS_HOME="$HOME/AgenticOS-workspace"' >> ~/.zshrc
 source ~/.zshrc
 
 # 3. Bootstrap one of the supported agents above and restart it
@@ -242,14 +242,14 @@ source ~/.zshrc
 
 ```bash
 # On old machine — push your workspace to Git
-cd ~/AgenticOS
+cd "$AGENTICOS_HOME"
 git remote add origin https://github.com/yourname/your-agenticos-workspace.git
 git push -u origin main
 
 # On new machine
 brew tap madlouse/agenticos && brew install agenticos
-git clone https://github.com/yourname/your-agenticos-workspace.git ~/AgenticOS
-echo 'export AGENTICOS_HOME="$HOME/AgenticOS"' >> ~/.zshrc
+git clone https://github.com/yourname/your-agenticos-workspace.git "$HOME/AgenticOS-workspace"
+echo 'export AGENTICOS_HOME="$HOME/AgenticOS-workspace"' >> ~/.zshrc
 source ~/.zshrc
 ```
 
@@ -264,7 +264,7 @@ AI Tool (Claude / Cursor / Codex)
         ↓  MCP protocol (stdio)
   agenticos-mcp server
         ↓  reads/writes
-  ~/AgenticOS/
+  $AGENTICOS_HOME/
     .agent-workspace/registry.yaml   ← active project + project list
     projects/
       my-feature/

--- a/projects/agenticos/homebrew-tap/Formula/agenticos.rb
+++ b/projects/agenticos/homebrew-tap/Formula/agenticos.rb
@@ -11,21 +11,18 @@ class Agenticos < Formula
   def install
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)
     bin.install_symlink Dir["#{libexec}/bin/*"]
-
-    # Create default workspace directory
-    (var/"agenticos/.agent-workspace").mkpath
   end
 
   def post_install
     ohai "AgenticOS installed!"
     ohai "Installed:"
     ohai "  - agenticos-mcp"
-    ohai "  - workspace seed at #{var}/agenticos/.agent-workspace"
     ohai ""
     ohai "Homebrew does not edit Claude Code, Codex, Cursor, or Gemini CLI configs for you."
-    ohai "Choose a supported agent bootstrap path, restart the tool, then verify with agenticos_list."
+    ohai "Set AGENTICOS_HOME explicitly, choose a supported agent bootstrap path, restart the tool, then verify with agenticos_list."
     ohai ""
-    ohai "Recommended workspace override:"
+    ohai "Example workspace setup:"
+    ohai "  mkdir -p #{var}/agenticos"
     ohai "  export AGENTICOS_HOME=#{var}/agenticos"
   end
 
@@ -33,13 +30,13 @@ class Agenticos < Formula
     <<~EOS
       AgenticOS has been installed.
 
-      Homebrew installs the binary and a seed workspace. It does not edit AI tool configs,
-      restart the tool, or prove activation automatically.
+      Homebrew installs the binary only. It does not create or select a workspace, edit AI tool
+      configs, restart the tool, or prove activation automatically.
 
-      1. Set your workspace location (add to ~/.zshrc or ~/.bashrc) if you want to use the
-         Homebrew-managed workspace seed:
+      1. Set your workspace location before starting agenticos-mcp (add to ~/.zshrc or ~/.bashrc).
+         Example:
+           mkdir -p "#{var}/agenticos"
            export AGENTICOS_HOME="#{var}/agenticos"
-         Otherwise leave AGENTICOS_HOME unset and use the product default: ~/AgenticOS
 
       2. Bootstrap one officially supported agent:
 

--- a/projects/agenticos/homebrew-tap/README.md
+++ b/projects/agenticos/homebrew-tap/README.md
@@ -14,18 +14,19 @@ brew install agenticos
 Homebrew installs:
 
 - the `agenticos-mcp` binary
-- a seed workspace at Homebrew `var`
 
 Homebrew does **not**:
 
 - edit Claude Code, Codex, Cursor, or Gemini CLI configuration automatically
+- create or select a workspace for you
 - restart your AI tool
 - verify activation for you
 
-After installation, set your workspace if needed, bootstrap one officially supported agent, restart it, and verify `agenticos_list`:
+After installation, set `AGENTICOS_HOME` explicitly, bootstrap one officially supported agent, restart it, and verify `agenticos_list`:
 
 ```bash
-# Optional: customize workspace location
+# Example workspace path
+mkdir -p "$(brew --prefix)/var/agenticos"
 export AGENTICOS_HOME="$(brew --prefix)/var/agenticos"
 
 # Claude Code

--- a/projects/agenticos/mcp-server/README.md
+++ b/projects/agenticos/mcp-server/README.md
@@ -18,7 +18,7 @@ A project management system designed for AI collaboration. When you work on comp
 
 ### Quick Start
 
-Install AgenticOS, bootstrap one supported agent, restart that agent, then explicitly verify `agenticos_list` works before relying on project-intent routing.
+Install AgenticOS, set `AGENTICOS_HOME` explicitly, bootstrap one supported agent, restart that agent, then explicitly verify `agenticos_list` works before relying on project-intent routing.
 
 When the client supports a pre-edit hook or local command wrapper, point that layer at `tools/check-edit-boundary.sh` so implementation edits fail closed unless project alignment and matching PASS preflight evidence already exist.
 
@@ -26,7 +26,8 @@ When the client supports a pre-edit hook or local command wrapper, point that la
 
 If the user installed AgenticOS with Homebrew:
 
-- Homebrew installs the binary and a seed workspace
+- Homebrew installs the binary only
+- Homebrew does **not** create or select a workspace
 - Homebrew does **not** edit Claude Code, Codex, Cursor, or Gemini CLI configuration
 - Homebrew does **not** restart the AI tool
 - Homebrew does **not** prove activation by itself
@@ -140,7 +141,7 @@ Create new project with standard structure.
 **Parameters**:
 - `name` (required) - Project name
 - `description` (optional) - What this project is about
-- `path` (optional) - Custom location (default: ~/AgenticOS/projects/{id})
+- `path` (optional) - Custom location (otherwise uses $AGENTICOS_HOME/projects/{id})
 
 **Returns**: Project created confirmation with path and ID
 
@@ -276,7 +277,7 @@ Get complete context for active project.
 
 ## 🔒 Privacy & Security
 
-- All data stored locally in `~/AgenticOS/`
+- All data stored locally under `AGENTICOS_HOME`
 - No external servers or telemetry
 - Git backup is optional and user-controlled
 - Safe for public npm distribution

--- a/projects/agenticos/mcp-server/src/index.ts
+++ b/projects/agenticos/mcp-server/src/index.ts
@@ -22,7 +22,7 @@ if (process.argv.includes('--help') || process.argv.includes('-h')) {
   console.log('  { "command": "agenticos-mcp", "args": [] }');
   console.log('');
   console.log('Environment:');
-  console.log('  AGENTICOS_HOME  Workspace root (default: ~/AgenticOS)');
+  console.log('  AGENTICOS_HOME  Workspace root (required)');
   process.exit(0);
 }
 
@@ -61,7 +61,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         properties: {
           name: { type: 'string', description: 'Project name' },
           description: { type: 'string', description: 'Project description' },
-          path: { type: 'string', description: 'Optional custom path (defaults to $AGENTICOS_HOME/projects/{id}, i.e. ~/AgenticOS/projects/{id})' },
+          path: { type: 'string', description: 'Optional custom path (otherwise uses $AGENTICOS_HOME/projects/{id})' },
         },
         required: ['name'],
       },

--- a/projects/agenticos/mcp-server/src/tools/__tests__/init.test.ts
+++ b/projects/agenticos/mcp-server/src/tools/__tests__/init.test.ts
@@ -52,7 +52,7 @@ const osMock = os as typeof os & { homedir: ReturnType<typeof vi.fn> };
 describe('initProject', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    delete process.env.AGENTICOS_HOME;
+    process.env.AGENTICOS_HOME = '/home/testuser/AgenticOS';
     // Default: simulate registry file does not exist (causes loadRegistry to return default)
     fsMock.existsSync.mockReturnValue(false);
     fsPromisesMock.readFile.mockRejectedValue(new Error('ENOENT'));
@@ -62,6 +62,14 @@ describe('initProject', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it('fails fast when AGENTICOS_HOME is not configured', async () => {
+    delete process.env.AGENTICOS_HOME;
+
+    await expect(
+      initProject({ name: 'Test Project', description: 'A test project' }),
+    ).rejects.toThrow('AGENTICOS_HOME is not set.');
   });
 
   it('creates directories with correct structure', async () => {

--- a/projects/agenticos/mcp-server/src/utils/__tests__/homebrew-bootstrap-docs.test.ts
+++ b/projects/agenticos/mcp-server/src/utils/__tests__/homebrew-bootstrap-docs.test.ts
@@ -43,6 +43,10 @@ describe('homebrew bootstrap docs', () => {
       expect(normalized).toContain('does not');
       expect(doc).toContain('agenticos_list');
       expect(normalized).toContain('restart');
+      expect(doc).toContain('AGENTICOS_HOME');
+      expect(normalized).not.toContain('seed workspace');
+      expect(normalized).not.toContain('default: ~/agenticos');
+      expect(normalized).not.toContain('product default: ~/agenticos');
     }
   });
 });

--- a/projects/agenticos/mcp-server/src/utils/__tests__/registry.test.ts
+++ b/projects/agenticos/mcp-server/src/utils/__tests__/registry.test.ts
@@ -41,25 +41,18 @@ vi.mock('fs/promises', () => ({
   access: vi.fn(),
 }));
 
-vi.mock('fs', () => ({
-  existsSync: vi.fn(),
-  default: {},
-}));
-
-vi.mock('os', () => ({
-  homedir: vi.fn(() => '/home/testuser'),
-  default: {},
-}));
-
 vi.mock('yaml', () => ({
   default: yamlMock,
 }));
 
 // Must import after mocks are set up
-import { loadRegistry, saveRegistry, getAgenticOSHome } from '../registry.js';
+import {
+  loadRegistry,
+  saveRegistry,
+  getAgenticOSHome,
+  MISSING_AGENTICOS_HOME_MESSAGE,
+} from '../registry.js';
 import * as fsPromises from 'fs/promises';
-import * as fs from 'fs';
-import * as os from 'os';
 
 const fsPromisesMock = fsPromises as typeof fsPromises & {
   readFile: ReturnType<typeof vi.fn>;
@@ -67,13 +60,11 @@ const fsPromisesMock = fsPromises as typeof fsPromises & {
   mkdir: ReturnType<typeof vi.fn>;
   access: ReturnType<typeof vi.fn>;
 };
-const fsMock = fs as typeof fs & { existsSync: ReturnType<typeof vi.fn> };
-const osMock = os as typeof os & { homedir: ReturnType<typeof vi.fn> };
 
 describe('registry utilities', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    delete process.env.AGENTICOS_HOME;
+    process.env.AGENTICOS_HOME = '/home/testuser/AgenticOS';
   });
 
   afterEach(() => {
@@ -87,27 +78,13 @@ describe('registry utilities', () => {
   describe('getAgenticOSHome', () => {
     it('respects AGENTICOS_HOME env var', () => {
       process.env.AGENTICOS_HOME = '/custom/path';
-      // Need to re-import to pick up the env change; the function reads
-      // process.env at call time, so no re-import is needed.
       const result = getAgenticOSHome();
       expect(result).toBe('/custom/path');
     });
 
-    it('falls back to ~/AgenticOS when env var is not set', () => {
-      osMock.homedir.mockReturnValue('/home/testuser');
-      fsMock.existsSync.mockReturnValue(false);
-      const result = getAgenticOSHome();
-      expect(result).toBe('/home/testuser/AgenticOS');
-    });
-
-    it('returns dev location when default lacks registry but dev location has it', () => {
-      osMock.homedir.mockReturnValue('/home/testuser');
-      // First call: default home lacks registry, second call: dev home has it
-      fsMock.existsSync
-        .mockReturnValueOnce(false)  // default home lacks registry
-        .mockReturnValueOnce(true);   // dev home has registry
-      const result = getAgenticOSHome();
-      expect(result).toBe('/home/testuser/dev/AgenticOS');
+    it('fails fast when AGENTICOS_HOME is not set', () => {
+      delete process.env.AGENTICOS_HOME;
+      expect(() => getAgenticOSHome()).toThrow(MISSING_AGENTICOS_HOME_MESSAGE);
     });
   });
 
@@ -122,12 +99,15 @@ describe('registry utilities', () => {
       yamlMock.stringify.mockReset();
     });
 
+    it('fails fast when AGENTICOS_HOME is not set', async () => {
+      delete process.env.AGENTICOS_HOME;
+
+      await expect(loadRegistry()).rejects.toThrow(MISSING_AGENTICOS_HOME_MESSAGE);
+    });
 
     it('returns default registry when file does not exist', async () => {
       yamlMock.parse.mockRejectedValue(new Error('ENOENT'));
       fsPromisesMock.readFile.mockRejectedValue(new Error('ENOENT'));
-      osMock.homedir.mockReturnValue('/home/testuser');
-      fsMock.existsSync.mockReturnValue(false);
 
       const registry = await loadRegistry();
 
@@ -154,8 +134,6 @@ describe('registry utilities', () => {
       };
       yamlMock.parse.mockReturnValue(storedYaml as any);
       fsPromisesMock.readFile.mockResolvedValue('version: 1.0.0\nactive_project: my-project');
-      osMock.homedir.mockReturnValue('/home/testuser');
-      fsMock.existsSync.mockReturnValue(true);
 
       const registry = await loadRegistry();
 
@@ -166,8 +144,6 @@ describe('registry utilities', () => {
     it('returns default registry when YAML parse fails', async () => {
       yamlMock.parse.mockRejectedValue(new Error('parse error'));
       fsPromisesMock.readFile.mockResolvedValue('invalid: yaml: content:');
-      osMock.homedir.mockReturnValue('/home/testuser');
-      fsMock.existsSync.mockReturnValue(false);
 
       const registry = await loadRegistry();
 
@@ -183,9 +159,6 @@ describe('registry utilities', () => {
   describe('saveRegistry', () => {
     it('converts absolute paths to relative before writing', async () => {
       // The yaml mock at module level already returns YAML with field values
-      osMock.homedir.mockReturnValue('/home/testuser');
-      fsMock.existsSync.mockReturnValue(true);
-
       const registry = {
         version: '1.0.0',
         last_updated: '2025-01-01T00:00:00.000Z',
@@ -215,9 +188,6 @@ describe('registry utilities', () => {
     });
 
     it('stores non-absolute paths as-is', async () => {
-      osMock.homedir.mockReturnValue('/home/testuser');
-      fsMock.existsSync.mockReturnValue(true);
-
       const registry = {
         version: '1.0.0',
         last_updated: '2025-01-01T00:00:00.000Z',

--- a/projects/agenticos/mcp-server/src/utils/registry.ts
+++ b/projects/agenticos/mcp-server/src/utils/registry.ts
@@ -1,26 +1,17 @@
-import { readFile, writeFile, mkdir, access } from 'fs/promises';
+import { readFile, writeFile, mkdir } from 'fs/promises';
 import { join, isAbsolute, relative } from 'path';
-import { homedir } from 'os';
-import { existsSync } from 'fs';
 import yaml from 'yaml';
 
-/** Resolve AGENTICOS_HOME with fallback detection */
+export const MISSING_AGENTICOS_HOME_MESSAGE =
+  'AGENTICOS_HOME is not set. AgenticOS requires an explicit workspace root. Set AGENTICOS_HOME before starting agenticos-mcp.';
+
+/** Resolve AGENTICOS_HOME with fail-fast semantics */
 export function getAgenticOSHome(): string {
-  // 1. Explicit env var — highest priority
-  if (process.env.AGENTICOS_HOME) return process.env.AGENTICOS_HOME;
-
-  // 2. Default: ~/AgenticOS
-  const defaultHome = join(homedir(), 'AgenticOS');
-
-  // 3. If default doesn't have a registry, check common dev locations
-  if (!existsSync(join(defaultHome, '.agent-workspace', 'registry.yaml'))) {
-    const devHome = join(homedir(), 'dev', 'AgenticOS');
-    if (existsSync(join(devHome, '.agent-workspace', 'registry.yaml'))) {
-      return devHome;
-    }
+  const configuredHome = process.env.AGENTICOS_HOME?.trim();
+  if (!configuredHome) {
+    throw new Error(MISSING_AGENTICOS_HOME_MESSAGE);
   }
-
-  return defaultHome;
+  return configuredHome;
 }
 
 /** Convert an absolute path under AGENTICOS_HOME to a relative path for storage */
@@ -61,8 +52,9 @@ export interface Registry {
 }
 
 export async function loadRegistry(): Promise<Registry> {
+  const registryPath = getRegistryPath();
   try {
-    const content = await readFile(getRegistryPath(), 'utf-8');
+    const content = await readFile(registryPath, 'utf-8');
     const raw: Registry = yaml.parse(content);
     // Resolve relative paths to absolute at load time
     raw.projects = raw.projects.map((p) => ({


### PR DESCRIPTION
## Summary
- make AGENTICOS_HOME mandatory in the runtime instead of silently falling back to implicit workspace paths
- align CLI help, Homebrew docs, and READMEs with the explicit workspace contract
- add regression coverage proving both fail-fast behavior and Homebrew/bootstrap doc alignment

## Validation
- npm test
- npm run build
- env -u AGENTICOS_HOME node --input-type=module -e "import { initProject } from './build/tools/init.js'; try { await initProject({ name: 'Fail Fast Demo' }); console.log('unexpected-success'); } catch (error) { console.log(error.message); }"
- AGENTICOS_HOME=<tmpdir> node --input-type=module -e "import { initProject } from './build/tools/init.js'; console.log(await initProject({ name: 'Configured Demo', description: 'configured workspace' }));"
- env -u AGENTICOS_HOME node build/index.js --help
