### PR TITLE
docs: repair official MCP bootstrap paths (#135)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,36 @@ The machine-readable source of truth for this support matrix lives in:
 
 - `projects/agenticos/.meta/bootstrap/agent-bootstrap-matrix.yaml`
 
+### Repair Stale MCP Registrations
+
+The only supported runtime entrypoint is `agenticos-mcp`.
+Legacy source-checkout registrations such as `node /Users/jeking/dev/AgenticOS/mcp-server/build/index.js` are unsupported and should be replaced.
+
+Claude Code repair:
+
+```bash
+claude mcp get agenticos
+claude mcp remove agenticos -s user
+claude mcp add --transport stdio --scope user agenticos -- agenticos-mcp
+```
+
+Then restart Claude Code, confirm `agenticos` appears in `claude mcp list` and `/mcp`, and call `agenticos_list`.
+
+Codex repair:
+
+```bash
+codex mcp list
+codex mcp get agenticos
+codex mcp remove agenticos
+codex mcp add agenticos -- agenticos-mcp
+```
+
+If `codex mcp get agenticos` reports that no server exists, skip the remove step and add it directly.
+Then restart Codex, confirm `agenticos` appears in `codex mcp list`, and call `agenticos_list`.
+
+Bootstrap verification is intentionally manual and agent-local.
+`agenticos_health` stays repo/project scoped and does not inspect or mutate user MCP settings owned by Claude Code, Codex, Cursor, or Gemini CLI.
+
 ## Integration Modes
 
 AgenticOS supports multiple integration modes, but they are not equal:

--- a/projects/agenticos/.meta/bootstrap/agent-bootstrap-matrix.yaml
+++ b/projects/agenticos/.meta/bootstrap/agent-bootstrap-matrix.yaml
@@ -1,5 +1,12 @@
 version: 1
 primary_integration_mode: mcp-native
+verification_contract:
+  canonical_runtime_entrypoint: agenticos-mcp
+  legacy_source_checkout_paths_unsupported: true
+  automation_boundary: manual_agent_cli
+  automation_rationale:
+    - official MCP registrations live in agent-owned user config outside AGENTICOS_HOME
+    - agenticos_health remains repo/project scoped and does not rewrite per-agent MCP settings
 supported_agents:
   - id: claude-code
     label: Claude Code
@@ -15,9 +22,15 @@ supported_agents:
     transport_debug:
       - if `agenticos` is missing from `claude mcp list`, MCP registration failed
       - if the server is listed but unavailable, confirm `agenticos-mcp --version` works and restart Claude Code
+      - if `claude mcp get agenticos` shows `Command: node` with a legacy source-checkout build path, remove and re-add the server with `agenticos-mcp`
     routing_debug:
       - if tools are available but project-intent prompts do not trigger routing, load the project `CLAUDE.md` and `AGENTS.md`
       - call the relevant `agenticos_*` tool explicitly before treating the problem as transport failure
+    repair:
+      - run `claude mcp get agenticos`
+      - if the command is not `agenticos-mcp`, run `claude mcp remove agenticos -s user`
+      - re-register with `claude mcp add --transport stdio --scope user agenticos -- agenticos-mcp`
+      - restart Claude Code and verify with `claude mcp list`, `/mcp`, and `agenticos_list`
   - id: codex
     label: Codex
     support_tier: official
@@ -32,9 +45,15 @@ supported_agents:
     transport_debug:
       - if `agenticos` is missing from `codex mcp list`, registration did not land in the active config
       - if `agenticos` exists but fails to start, confirm `agenticos-mcp --version` works and restart Codex
+      - if `codex mcp get agenticos` shows a non-canonical command or a legacy source-checkout path, remove and re-add the server with `agenticos-mcp`
     routing_debug:
       - Codex transport success does not guarantee natural-language project-intent routing
       - if routing is weak, use explicit `agenticos_*` tool calls and ensure project instructions are loaded
+    repair:
+      - run `codex mcp list`
+      - if `agenticos` is missing, register it with `codex mcp add agenticos -- agenticos-mcp`
+      - if `codex mcp get agenticos` shows a command other than `agenticos-mcp`, run `codex mcp remove agenticos`
+      - re-register with `codex mcp add agenticos -- agenticos-mcp`, restart Codex, and verify with `codex mcp list` plus `agenticos_list`
   - id: cursor
     label: Cursor
     support_tier: official

--- a/projects/agenticos/homebrew-tap/Formula/agenticos.rb
+++ b/projects/agenticos/homebrew-tap/Formula/agenticos.rb
@@ -64,7 +64,21 @@ class Agenticos < Formula
       4. Verify activation by confirming the server is listed in the tool's MCP diagnostics
          and by explicitly calling agenticos_list.
 
-      5. Product policy: Homebrew is reminder-only today.
+      5. If Claude Code or Codex still points at a source checkout path, remove the stale entry
+         and re-add the canonical binary entrypoint:
+
+         Claude Code
+           claude mcp get agenticos
+           claude mcp remove agenticos -s user
+           claude mcp add --transport stdio --scope user agenticos -- agenticos-mcp
+
+         Codex
+           codex mcp list
+           codex mcp get agenticos
+           codex mcp remove agenticos
+           codex mcp add agenticos -- agenticos-mcp
+
+      6. Product policy: Homebrew is reminder-only today.
          It does not mutate user agent configs by default.
          A future opt-in bootstrap helper may be added later, but silent config mutation is out of scope.
     EOS

--- a/projects/agenticos/homebrew-tap/README.md
+++ b/projects/agenticos/homebrew-tap/README.md
@@ -56,6 +56,21 @@ Then restart the AI tool and confirm `agenticos_list` works.
 
 Homebrew policy is reminder-only today. It does not silently mutate user agent configs.
 
+If a previous registration still points at a source checkout instead of `agenticos-mcp`, repair it manually:
+
+```bash
+# Claude Code
+claude mcp get agenticos
+claude mcp remove agenticos -s user
+claude mcp add --transport stdio --scope user agenticos -- agenticos-mcp
+
+# Codex
+codex mcp list
+codex mcp get agenticos
+codex mcp remove agenticos
+codex mcp add agenticos -- agenticos-mcp
+```
+
 ## Upgrade
 
 ```bash

--- a/projects/agenticos/mcp-server/README.md
+++ b/projects/agenticos/mcp-server/README.md
@@ -122,6 +122,34 @@ Transport bootstrap and project-intent routing are different concerns.
 
 These are currently experimental. Do not describe them as first-class supported agents unless they have a documented bootstrap, verification, and debugging contract.
 
+### Repairing Stale Registrations
+
+The supported runtime entrypoint is `agenticos-mcp`.
+Do not keep legacy source-checkout registrations such as `node /Users/jeking/dev/AgenticOS/mcp-server/build/index.js`.
+
+Claude Code repair flow:
+
+```bash
+claude mcp get agenticos
+claude mcp remove agenticos -s user
+claude mcp add --transport stdio --scope user agenticos -- agenticos-mcp
+```
+
+Codex repair flow:
+
+```bash
+codex mcp list
+codex mcp get agenticos
+codex mcp remove agenticos
+codex mcp add agenticos -- agenticos-mcp
+```
+
+If Codex reports that `agenticos` does not exist yet, skip the remove step and add it directly.
+After any registration change, restart the agent, confirm the server appears in its MCP diagnostics, and call `agenticos_list`.
+
+This verification remains manual by design.
+`agenticos_health` is repo/project scoped and does not inspect or mutate per-agent MCP settings that live in user-owned config files.
+
 ## Integration Modes
 
 AgenticOS does not treat every fallback as equal:

--- a/projects/agenticos/mcp-server/src/utils/__tests__/bootstrap-matrix.test.ts
+++ b/projects/agenticos/mcp-server/src/utils/__tests__/bootstrap-matrix.test.ts
@@ -18,6 +18,12 @@ async function setupBootstrapHome(): Promise<string> {
     yaml.stringify({
       version: 1,
       primary_integration_mode: 'mcp-native',
+      verification_contract: {
+        canonical_runtime_entrypoint: 'agenticos-mcp',
+        legacy_source_checkout_paths_unsupported: true,
+        automation_boundary: 'manual_agent_cli',
+        automation_rationale: ['agent-owned config'],
+      },
       supported_agents: [
         {
           id: 'claude-code',
@@ -30,6 +36,7 @@ async function setupBootstrapHome(): Promise<string> {
           verification: ['claude mcp list'],
           transport_debug: ['transport'],
           routing_debug: ['routing'],
+          repair: ['claude mcp get agenticos'],
         },
       ],
       experimental_agents: [
@@ -60,6 +67,12 @@ async function setupBootstrapHomeWithoutExperimental(): Promise<string> {
     yaml.stringify({
       version: 1,
       primary_integration_mode: 'mcp-native',
+      verification_contract: {
+        canonical_runtime_entrypoint: 'agenticos-mcp',
+        legacy_source_checkout_paths_unsupported: true,
+        automation_boundary: 'manual_agent_cli',
+        automation_rationale: ['agent-owned config'],
+      },
       supported_agents: [
         {
           id: 'codex',
@@ -71,6 +84,7 @@ async function setupBootstrapHomeWithoutExperimental(): Promise<string> {
           verification: ['codex mcp list'],
           transport_debug: ['transport'],
           routing_debug: ['routing'],
+          repair: ['codex mcp list'],
         },
       ],
     }),
@@ -92,6 +106,7 @@ describe('bootstrap matrix', () => {
 
     expect(matrix.version).toBe(1);
     expect(matrix.primary_integration_mode).toBe('mcp-native');
+    expect(matrix.verification_contract.canonical_runtime_entrypoint).toBe('agenticos-mcp');
     expect(matrix.supported_agents.map((agent) => agent.id)).toEqual(['claude-code']);
   });
 
@@ -132,5 +147,17 @@ describe('bootstrap matrix', () => {
     const matrix = await loadAgentBootstrapMatrix();
 
     expect(getOfficialBootstrapAgents(matrix).map((agent) => agent.id)).toEqual(['claude-code']);
+  });
+
+  it('keeps repair guidance on official agent entries and records the manual verification boundary', async () => {
+    const home = await setupBootstrapHome();
+    process.env.AGENTICOS_HOME = home;
+
+    const matrix = await loadAgentBootstrapMatrix();
+    const agent = getBootstrapAgent(matrix, 'claude-code');
+
+    expect(matrix.verification_contract.legacy_source_checkout_paths_unsupported).toBe(true);
+    expect(matrix.verification_contract.automation_boundary).toBe('manual_agent_cli');
+    expect(agent.repair).toContain('claude mcp get agenticos');
   });
 });

--- a/projects/agenticos/mcp-server/src/utils/__tests__/homebrew-bootstrap-docs.test.ts
+++ b/projects/agenticos/mcp-server/src/utils/__tests__/homebrew-bootstrap-docs.test.ts
@@ -47,6 +47,10 @@ describe('homebrew bootstrap docs', () => {
       expect(normalized).not.toContain('seed workspace');
       expect(normalized).not.toContain('default: ~/agenticos');
       expect(normalized).not.toContain('product default: ~/agenticos');
+      expect(doc).toContain('claude mcp get agenticos');
+      expect(doc).toContain('claude mcp remove agenticos');
+      expect(doc).toContain('codex mcp get agenticos');
+      expect(doc).toContain('codex mcp remove agenticos');
     }
   });
 });

--- a/projects/agenticos/mcp-server/src/utils/bootstrap-matrix.ts
+++ b/projects/agenticos/mcp-server/src/utils/bootstrap-matrix.ts
@@ -15,11 +15,20 @@ export interface AgentBootstrapEntry {
   verification: string[];
   transport_debug: string[];
   routing_debug: string[];
+  repair?: string[];
+}
+
+export interface BootstrapVerificationContract {
+  canonical_runtime_entrypoint: string;
+  legacy_source_checkout_paths_unsupported: boolean;
+  automation_boundary: string;
+  automation_rationale: string[];
 }
 
 export interface AgentBootstrapMatrix {
   version: number;
   primary_integration_mode: string;
+  verification_contract: BootstrapVerificationContract;
   supported_agents: AgentBootstrapEntry[];
   experimental_agents?: AgentBootstrapEntry[];
 }


### PR DESCRIPTION
## Summary
- add structured repair metadata for official agent bootstrap paths, including the canonical runtime entrypoint and manual verification boundary
- document supported Claude Code and Codex remediation flows for stale source-checkout MCP registrations
- align Homebrew-facing docs and bootstrap tests with the new repair guidance

## Validation
- npm test
- npm run build
- local runtime repair:
  - `claude mcp get agenticos` now shows `Command: agenticos-mcp` and `Status: ✓ Connected`
  - `codex mcp get agenticos` now shows `command: agenticos-mcp`
  - `claude mcp list` and `codex mcp list` both include `agenticos`
