### PR TITLE
fix: register missing projects and upgrade AGENTS.md to v6 (#142)

### DIFF
--- a/.agent-workspace/registry.yaml
+++ b/.agent-workspace/registry.yaml
@@ -1,5 +1,5 @@
 version: 1.0.0
-last_updated: 2026-03-20T07:05:35.299Z
+last_updated: 2026-04-01T06:30:00.000Z
 active_project: null
 projects:
   - id: ghostty-optimization
@@ -20,3 +20,45 @@ projects:
     status: active
     created: 2026-03-16
     last_accessed: 2026-03-16T08:24:00Z
+  - id: agenticos
+    name: AgenticOS
+    path: projects/agenticos
+    status: active
+    created: 2026-03-23
+    last_accessed: 2026-04-01T06:00:00.000Z
+  - id: 360teams
+    name: 360teams
+    path: projects/360teams
+    status: active
+    created: 2026-03-19
+    last_accessed: 2026-04-01T06:00:00.000Z
+  - id: 2026okr
+    name: 2026 OKR
+    path: projects/2026okr
+    status: active
+    created: 2026-03-17
+    last_accessed: 2026-04-01T06:00:00.000Z
+  - id: okr-management
+    name: OKR Management
+    path: projects/okr-management
+    status: active
+    created: 2026-03-25
+    last_accessed: 2026-04-01T06:00:00.000Z
+  - id: t5t
+    name: T5T
+    path: projects/t5t
+    status: active
+    created: 2026-03-25
+    last_accessed: 2026-04-01T06:00:00.000Z
+  - id: cc-switch
+    name: CC Switch 配置优化
+    path: projects/cc-switch-配置优化
+    status: active
+    created: 2026-03-29
+    last_accessed: 2026-04-01T06:00:00.000Z
+  - id: 2025-review
+    name: 2025 评优项目
+    path: projects/2025评优项目
+    status: active
+    created: 2026-03-30
+    last_accessed: 2026-04-01T06:00:00.000Z

--- a/projects/2026okr/AGENTS.md
+++ b/projects/2026okr/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- agenticos-template: v4 -->
+<!-- agenticos-template: v6 -->
 # AGENTS.md — 2026okr
 
 ## Adapter Role
@@ -21,8 +21,9 @@ It must expose the same canonical policy as other agent adapters rather than def
 Implementation work must use the executable guardrail flow:
 
 1. call `agenticos_preflight` before editing
-2. if preflight returns `REDIRECT`, call `agenticos_branch_bootstrap`
-3. do not submit a PR before running `agenticos_pr_scope_check`
+2. if preflight returns `REDIRECT` because workspace isolation is missing, call `agenticos_branch_bootstrap`
+3. if preflight returns `REDIRECT` because declared change classes are mixed, split the work into phases before editing
+4. do not submit a PR before running `agenticos_pr_scope_check`
 
 If any guardrail returns `BLOCK`, stop and resolve the blocking reason first.
 
@@ -46,6 +47,22 @@ Call the MCP tool `agenticos_record` with:
 2. Before ending the session (MANDATORY — context is lost otherwise)
 
 After recording, call `agenticos_save` to commit to Git.
+
+## Cumulative Review Log Protocol (MANDATORY for multi-step work)
+
+When work spans multiple landed steps, broad cleanup, migration, or any change set that should later be reviewed as one sequence:
+
+1. create one stable cumulative log under `tasks/`, for example `tasks/topic-global-log.md`
+2. if available, start from `tasks/templates/global-review-log.md`
+3. append each landed step with:
+   - intent
+   - changed surfaces
+   - verification
+   - residual risks
+4. use that one stable log as the basis for later whole-pass review
+
+Do not leave the review narrative scattered only across dated scratch notes or implicit chat history.
+
 
 ### Session Start
 
@@ -75,5 +92,6 @@ Then greet the user with: project name, last progress, current pending items, su
 | `tasks/templates/agent-preflight-checklist.yaml` | Preflight checklist template |
 | `tasks/templates/issue-design-brief.md` | Design-loop template |
 | `tasks/templates/non-code-evaluation-rubric.yaml` | Non-code evaluation rubric |
+| `tasks/templates/global-review-log.md` | Cumulative review log template |
 | `tasks/templates/submission-evidence.md` | Submission evidence template |
 | `artifacts/` | Outputs and deliverables |

--- a/projects/360teams/AGENTS.md
+++ b/projects/360teams/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- agenticos-template: v4 -->
+<!-- agenticos-template: v6 -->
 # AGENTS.md — 360teams
 
 ## Adapter Role
@@ -21,8 +21,9 @@ It must expose the same canonical policy as other agent adapters rather than def
 Implementation work must use the executable guardrail flow:
 
 1. call `agenticos_preflight` before editing
-2. if preflight returns `REDIRECT`, call `agenticos_branch_bootstrap`
-3. do not submit a PR before running `agenticos_pr_scope_check`
+2. if preflight returns `REDIRECT` because workspace isolation is missing, call `agenticos_branch_bootstrap`
+3. if preflight returns `REDIRECT` because declared change classes are mixed, split the work into phases before editing
+4. do not submit a PR before running `agenticos_pr_scope_check`
 
 If any guardrail returns `BLOCK`, stop and resolve the blocking reason first.
 
@@ -46,6 +47,21 @@ Call the MCP tool `agenticos_record` with:
 2. Before ending the session (MANDATORY — context is lost otherwise)
 
 After recording, call `agenticos_save` to commit to Git.
+
+## Cumulative Review Log Protocol (MANDATORY for multi-step work)
+
+When work spans multiple landed steps, broad cleanup, migration, or any change set that should later be reviewed as one sequence:
+
+1. create one stable cumulative log under `tasks/`, for example `tasks/topic-global-log.md`
+2. if available, start from `tasks/templates/global-review-log.md`
+3. append each landed step with:
+   - intent
+   - changed surfaces
+   - verification
+   - residual risks
+4. use that one stable log as the basis for later whole-pass review
+
+Do not leave the review narrative scattered only across dated scratch notes or implicit chat history.
 
 ### Session Start
 
@@ -75,5 +91,6 @@ Then greet the user with: project name, last progress, current pending items, su
 | `tasks/templates/agent-preflight-checklist.yaml` | Preflight checklist template |
 | `tasks/templates/issue-design-brief.md` | Design-loop template |
 | `tasks/templates/non-code-evaluation-rubric.yaml` | Non-code evaluation rubric |
+| `tasks/templates/global-review-log.md` | Cumulative review log template |
 | `tasks/templates/submission-evidence.md` | Submission evidence template |
 | `artifacts/` | Outputs and deliverables |

--- a/projects/agenticos/.meta/standard-kit/manifest.yaml
+++ b/projects/agenticos/.meta/standard-kit/manifest.yaml
@@ -49,6 +49,10 @@ layers:
         canonical_source: projects/agenticos/.meta/templates/sub-agent-handoff.md
         inheritance: copied_template
         customizable: yes
+      - path: tasks/templates/global-review-log.md
+        canonical_source: projects/agenticos/.meta/templates/global-review-log.md
+        inheritance: copied_template
+        customizable: yes
       - path: tasks/templates/submission-evidence.md
         canonical_source: projects/agenticos/.meta/templates/submission-evidence.md
         inheritance: copied_template
@@ -66,8 +70,8 @@ layers:
 
 upgrade_rules:
   template_marker_version:
-    AGENTS.md: 4
-    CLAUDE.md: 4
+    AGENTS.md: 6
+    CLAUDE.md: 6
   compatibility_rule: >
     Generated files may be upgraded in place by distill when the template marker version changes.
   copied_template_rule: >

--- a/projects/agenticos/.meta/templates/global-review-log.md
+++ b/projects/agenticos/.meta/templates/global-review-log.md
@@ -1,0 +1,51 @@
+# Global Review Log
+
+## Purpose
+
+Use this file as the stable cumulative log for multi-step work that should later be reviewed as one sequence.
+
+Typical triggers:
+
+- mechanism passes
+- cleanup waves
+- migrations
+- broad review-driven change sets
+
+## Review Standard
+
+For each landed step, capture:
+
+- intent
+- changed surfaces
+- verification
+- residual risk
+
+Later, use this one file as the basis for whole-pass review.
+
+---
+
+## Step N
+
+**Title**:
+
+**Status**:
+
+**Intent**:
+
+- 
+
+**Mechanism**:
+
+- 
+
+**Primary implementation surfaces**:
+
+- 
+
+**Verification**:
+
+- 
+
+**Residual risk / follow-up**:
+
+- 

--- a/projects/okr-management/AGENTS.md
+++ b/projects/okr-management/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- agenticos-template: v4 -->
+<!-- agenticos-template: v6 -->
 # AGENTS.md — OKR Management
 
 ## Adapter Role
@@ -21,8 +21,9 @@ It must expose the same canonical policy as other agent adapters rather than def
 Implementation work must use the executable guardrail flow:
 
 1. call `agenticos_preflight` before editing
-2. if preflight returns `REDIRECT`, call `agenticos_branch_bootstrap`
-3. do not submit a PR before running `agenticos_pr_scope_check`
+2. if preflight returns `REDIRECT` because workspace isolation is missing, call `agenticos_branch_bootstrap`
+3. if preflight returns `REDIRECT` because declared change classes are mixed, split the work into phases before editing
+4. do not submit a PR before running `agenticos_pr_scope_check`
 
 If any guardrail returns `BLOCK`, stop and resolve the blocking reason first.
 
@@ -46,6 +47,22 @@ Call the MCP tool `agenticos_record` with:
 2. Before ending the session (MANDATORY — context is lost otherwise)
 
 After recording, call `agenticos_save` to commit to Git.
+
+## Cumulative Review Log Protocol (MANDATORY for multi-step work)
+
+When work spans multiple landed steps, broad cleanup, migration, or any change set that should later be reviewed as one sequence:
+
+1. create one stable cumulative log under `tasks/`, for example `tasks/topic-global-log.md`
+2. if available, start from `tasks/templates/global-review-log.md`
+3. append each landed step with:
+   - intent
+   - changed surfaces
+   - verification
+   - residual risks
+4. use that one stable log as the basis for later whole-pass review
+
+Do not leave the review narrative scattered only across dated scratch notes or implicit chat history.
+
 
 ### Session Start
 
@@ -75,5 +92,6 @@ Then greet the user with: project name, last progress, current pending items, su
 | `tasks/templates/agent-preflight-checklist.yaml` | Preflight checklist template |
 | `tasks/templates/issue-design-brief.md` | Design-loop template |
 | `tasks/templates/non-code-evaluation-rubric.yaml` | Non-code evaluation rubric |
+| `tasks/templates/global-review-log.md` | Cumulative review log template |
 | `tasks/templates/submission-evidence.md` | Submission evidence template |
 | `artifacts/` | Outputs and deliverables |

--- a/projects/t5t/AGENTS.md
+++ b/projects/t5t/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- agenticos-template: v4 -->
+<!-- agenticos-template: v6 -->
 # AGENTS.md — T5T
 
 ## Adapter Role
@@ -21,8 +21,9 @@ It must expose the same canonical policy as other agent adapters rather than def
 Implementation work must use the executable guardrail flow:
 
 1. call `agenticos_preflight` before editing
-2. if preflight returns `REDIRECT`, call `agenticos_branch_bootstrap`
-3. do not submit a PR before running `agenticos_pr_scope_check`
+2. if preflight returns `REDIRECT` because workspace isolation is missing, call `agenticos_branch_bootstrap`
+3. if preflight returns `REDIRECT` because declared change classes are mixed, split the work into phases before editing
+4. do not submit a PR before running `agenticos_pr_scope_check`
 
 If any guardrail returns `BLOCK`, stop and resolve the blocking reason first.
 
@@ -46,6 +47,22 @@ Call the MCP tool `agenticos_record` with:
 2. Before ending the session (MANDATORY — context is lost otherwise)
 
 After recording, call `agenticos_save` to commit to Git.
+
+## Cumulative Review Log Protocol (MANDATORY for multi-step work)
+
+When work spans multiple landed steps, broad cleanup, migration, or any change set that should later be reviewed as one sequence:
+
+1. create one stable cumulative log under `tasks/`, for example `tasks/topic-global-log.md`
+2. if available, start from `tasks/templates/global-review-log.md`
+3. append each landed step with:
+   - intent
+   - changed surfaces
+   - verification
+   - residual risks
+4. use that one stable log as the basis for later whole-pass review
+
+Do not leave the review narrative scattered only across dated scratch notes or implicit chat history.
+
 
 ### Session Start
 
@@ -75,5 +92,6 @@ Then greet the user with: project name, last progress, current pending items, su
 | `tasks/templates/agent-preflight-checklist.yaml` | Preflight checklist template |
 | `tasks/templates/issue-design-brief.md` | Design-loop template |
 | `tasks/templates/non-code-evaluation-rubric.yaml` | Non-code evaluation rubric |
+| `tasks/templates/global-review-log.md` | Cumulative review log template |
 | `tasks/templates/submission-evidence.md` | Submission evidence template |
 | `artifacts/` | Outputs and deliverables |


### PR DESCRIPTION
Closes #142

## Summary

- **Register 7 missing projects** in `.agent-workspace/registry.yaml`: `agenticos`, `360teams`, `2026okr`, `okr-management`, `t5t`, `cc-switch`, `2025-review`
- **Upgrade AGENTS.md v4 → v6** for tracked projects: `360teams`, `2026okr`, `okr-management`, `t5t`
  - Split Guardrail Protocol REDIRECT into two explicit cases (isolation missing vs mixed change classes)
  - Add Cumulative Review Log Protocol section
  - Add `global-review-log.md` to Directory Structure
- **Add `global-review-log.md` template** to `projects/agenticos/.meta/templates/` and register in `manifest.yaml`
- **Update `standard-kit/manifest.yaml`** template_marker_version: 4 → 6

## Out of scope (local-only, not in git)

- `2025评优项目`: upgraded locally (v2→v6, added tasks/templates/)
- `cc-switch-配置优化`: added tasks/templates/ locally
- `agent-cli-api`: excluded per user request

## Test plan

- [ ] `agenticos_list` now shows all 11 projects
- [ ] `agenticos_switch` works for previously missing projects
- [ ] AGENTS.md v6 marker on 360teams, 2026okr, okr-management, t5t
- [ ] `global-review-log.md` template present in `.meta/templates/`