### PR TITLE
feat: inherit task intake rule and prepare AgenticOS 0.4.0 release

### DIFF
--- a/projects/agenticos/.meta/bootstrap/agent-bootstrap-matrix.yaml
+++ b/projects/agenticos/.meta/bootstrap/agent-bootstrap-matrix.yaml
@@ -14,7 +14,7 @@ supported_agents:
     transport: stdio
     canonical_bootstrap_method: cli-command
     canonical_config_location: claude-managed user MCP config via `claude mcp add --scope user`
-    bootstrap_command: claude mcp add --transport stdio --scope user agenticos -- agenticos-mcp
+    bootstrap_command: claude mcp add --transport stdio --scope user -e AGENTICOS_HOME="$AGENTICOS_HOME" agenticos -- agenticos-mcp
     verification:
       - run `claude mcp list`
       - run `/mcp` inside Claude Code
@@ -22,14 +22,17 @@ supported_agents:
     transport_debug:
       - if `agenticos` is missing from `claude mcp list`, MCP registration failed
       - if the server is listed but unavailable, confirm `agenticos-mcp --version` works and restart Claude Code
+      - if a local source checkout was rebuilt but Claude still shows old MCP behavior, remember that rebuilding the repo does not replace the installed `agenticos-mcp` binary; reinstall or upgrade the binary, then restart Claude Code
       - if `claude mcp get agenticos` shows `Command: node` with a legacy source-checkout build path, remove and re-add the server with `agenticos-mcp`
+      - if `claude mcp get agenticos` does not show `AGENTICOS_HOME`, treat the registration as incomplete and re-add it with explicit env injection
     routing_debug:
       - if tools are available but project-intent prompts do not trigger routing, load the project `CLAUDE.md` and `AGENTS.md`
       - call the relevant `agenticos_*` tool explicitly before treating the problem as transport failure
     repair:
       - run `claude mcp get agenticos`
       - if the command is not `agenticos-mcp`, run `claude mcp remove agenticos -s user`
-      - re-register with `claude mcp add --transport stdio --scope user agenticos -- agenticos-mcp`
+      - if the stored environment does not include `AGENTICOS_HOME`, run `claude mcp remove agenticos -s user`
+      - re-register with `claude mcp add --transport stdio --scope user -e AGENTICOS_HOME="$AGENTICOS_HOME" agenticos -- agenticos-mcp`
       - restart Claude Code and verify with `claude mcp list`, `/mcp`, and `agenticos_list`
   - id: codex
     label: Codex
@@ -37,7 +40,7 @@ supported_agents:
     transport: stdio
     canonical_bootstrap_method: cli-command
     canonical_config_location: ~/.codex/config.toml managed via `codex mcp add`
-    bootstrap_command: codex mcp add agenticos -- agenticos-mcp
+    bootstrap_command: codex mcp add --env AGENTICOS_HOME="$AGENTICOS_HOME" agenticos -- agenticos-mcp
     verification:
       - run `codex mcp list`
       - confirm `agenticos` appears in the configured server list
@@ -45,15 +48,18 @@ supported_agents:
     transport_debug:
       - if `agenticos` is missing from `codex mcp list`, registration did not land in the active config
       - if `agenticos` exists but fails to start, confirm `agenticos-mcp --version` works and restart Codex
+      - if a local source checkout was rebuilt but Codex still shows old MCP behavior, remember that rebuilding the repo does not replace the installed `agenticos-mcp` binary; reinstall or upgrade the binary, then restart Codex
       - if `codex mcp get agenticos` shows a non-canonical command or a legacy source-checkout path, remove and re-add the server with `agenticos-mcp`
+      - if `codex mcp get agenticos` shows `env: -`, treat the registration as incomplete and re-add it with explicit `AGENTICOS_HOME`
     routing_debug:
       - Codex transport success does not guarantee natural-language project-intent routing
       - if routing is weak, use explicit `agenticos_*` tool calls and ensure project instructions are loaded
     repair:
       - run `codex mcp list`
-      - if `agenticos` is missing, register it with `codex mcp add agenticos -- agenticos-mcp`
+      - if `agenticos` is missing, register it with `codex mcp add --env AGENTICOS_HOME="$AGENTICOS_HOME" agenticos -- agenticos-mcp`
       - if `codex mcp get agenticos` shows a command other than `agenticos-mcp`, run `codex mcp remove agenticos`
-      - re-register with `codex mcp add agenticos -- agenticos-mcp`, restart Codex, and verify with `codex mcp list` plus `agenticos_list`
+      - if `codex mcp get agenticos` shows `env: -`, run `codex mcp remove agenticos`
+      - re-register with `codex mcp add --env AGENTICOS_HOME="$AGENTICOS_HOME" agenticos -- agenticos-mcp`, restart Codex, and verify with `codex mcp list` plus `agenticos_list`
   - id: cursor
     label: Cursor
     support_tier: official
@@ -65,7 +71,10 @@ supported_agents:
         "mcpServers": {
           "agenticos": {
             "command": "agenticos-mcp",
-            "args": []
+            "args": [],
+            "env": {
+              "AGENTICOS_HOME": "/absolute/path/to/your/AgenticOS-workspace"
+            }
           }
         }
       }
@@ -75,6 +84,7 @@ supported_agents:
       - confirm `agenticos` appears and can call `agenticos_list`
     transport_debug:
       - if `agenticos` is absent after restart, validate JSON syntax and confirm `agenticos-mcp --version`
+      - if a local source checkout was rebuilt but Cursor still shows old MCP behavior, remember that rebuilding the repo does not replace the installed `agenticos-mcp` binary; reinstall or upgrade the binary, then restart Cursor
       - if using `cursor-agent`, compare `cursor-agent mcp list` with the editor view to rule out config-scope confusion
     routing_debug:
       - project-specific `.cursor/mcp.json` exists, but AgenticOS bootstrap should stay user-global by default
@@ -85,7 +95,7 @@ supported_agents:
     transport: stdio
     canonical_bootstrap_method: cli-command
     canonical_config_location: ~/.gemini/settings.json managed via `gemini mcp add -s user`
-    bootstrap_command: gemini mcp add -s user agenticos agenticos-mcp
+    bootstrap_command: gemini mcp add -s user -e AGENTICOS_HOME="$AGENTICOS_HOME" agenticos agenticos-mcp
     verification:
       - run `gemini mcp list`
       - restart Gemini CLI after registration
@@ -93,6 +103,8 @@ supported_agents:
     transport_debug:
       - if `agenticos` is missing from `gemini mcp list`, the user-scope registration did not land
       - if `agenticos` is listed but unusable, confirm `agenticos-mcp --version` works and restart Gemini CLI
+      - if a local source checkout was rebuilt but Gemini CLI still shows old MCP behavior, remember that rebuilding the repo does not replace the installed `agenticos-mcp` binary; reinstall or upgrade the binary, then restart Gemini CLI
+      - if the stored server environment does not include `AGENTICOS_HOME`, treat the registration as incomplete and re-add it with explicit env injection
     routing_debug:
       - transport registration only proves MCP availability, not project-intent recognition
       - if intent routing does not trigger, use explicit `agenticos_*` calls and ensure the project instructions are loaded

--- a/projects/agenticos/.meta/standard-kit/README.md
+++ b/projects/agenticos/.meta/standard-kit/README.md
@@ -87,6 +87,27 @@ The canonical rationale lives in:
 
 - `projects/agenticos/standards/knowledge/sub-agent-inheritance-protocol-2026-03-25.md`
 
+## Operator Intent Intake Protocol
+
+The kit also carries a compact default rule for operator-intent resolution at task intake.
+
+Downstream projects inherit this in two lightweight forms:
+
+- generated adapter guidance in `AGENTS.md` and `CLAUDE.md`
+- intake structure inside `tasks/templates/issue-design-brief.md`
+
+The rule is intentionally compact in downstream runtime surfaces:
+
+- interpret user input first
+- recover intended outcome before treating named methods as the plan
+- collapse the result into a clean execution objective before deeper autonomous work continues
+
+Downstream projects should inherit the intake rule, not the whole standards-history discussion by default.
+
+The canonical rationale lives in:
+
+- `projects/agenticos/standards/knowledge/operator-intent-interpretation-protocol-2026-04-04.md`
+
 ## Package Contents
 
 See:

--- a/projects/agenticos/.meta/standard-kit/adoption-checklist.md
+++ b/projects/agenticos/.meta/standard-kit/adoption-checklist.md
@@ -19,10 +19,12 @@ Use this checklist when adopting the AgenticOS workflow standard in a downstream
 - [ ] generate or upgrade `AGENTS.md`
 - [ ] generate or upgrade `CLAUDE.md`
 - [ ] confirm the generated files contain the guardrail protocol
+- [ ] confirm the generated files contain the compact task-intake rule for operator-intent resolution
 - [ ] confirm the template marker version matches the current distill version
 
 ## Execution Expectations
 
+- [ ] task intake resolves operator intent before workflow fragments are treated as the plan
 - [ ] implementation work runs `agenticos_preflight`
 - [ ] redirected implementation work uses `agenticos_branch_bootstrap`
 - [ ] PR submission or merge runs `agenticos_pr_scope_check`

--- a/projects/agenticos/.meta/standard-kit/inheritance-rules.md
+++ b/projects/agenticos/.meta/standard-kit/inheritance-rules.md
@@ -34,6 +34,7 @@ Implication:
 - downstream projects should not treat them as free-form scratch files
 - local project-specific content may exist, but upgrades must preserve the canonical guardrail protocol and template marker
 - generated adapter surfaces must preserve one canonical cross-agent execution contract even when runtime-specific guidance differs
+- generated adapter surfaces should carry only a compact operator-intent intake rule, not the full internal standards rationale
 
 ### Copied templates
 
@@ -50,6 +51,7 @@ Implication:
 - downstream projects are expected to customize them
 - later upgrades should be explicit and reviewable, not silently overwritten
 - the copied templates still carry the canonical memory-layer contract and should not be repurposed arbitrarily
+- intake-oriented templates may carry explicit fields for operator signals, inferred goals, and contradictions because those help agents collapse fragmented user input into a cleaner execution objective
 
 ## Rule 2: Repository-Root Infrastructure Is Not Part Of The Project Kit
 
@@ -101,3 +103,4 @@ They may vary in runtime-specific bootstrap and operator guidance, but they must
 - guardrail protocol meaning
 - recording protocol requirements
 - what counts as compliant implementation flow
+- the compact task-intake rule for operator-intent resolution

--- a/projects/agenticos/.meta/standard-kit/manifest.yaml
+++ b/projects/agenticos/.meta/standard-kit/manifest.yaml
@@ -1,6 +1,6 @@
 version: 1
 kit_id: downstream-standard-kit
-kit_version: 0.1.0
+kit_version: 0.2.0
 status: active
 purpose: >
   Package the executable AgenticOS workflow standard for downstream projects.
@@ -100,8 +100,8 @@ layers:
 
 upgrade_rules:
   template_marker_version:
-    AGENTS.md: 6
-    CLAUDE.md: 6
+    AGENTS.md: 7
+    CLAUDE.md: 7
   compatibility_rule: >
     Generated files may be upgraded in place by distill when the template marker version changes.
   copied_template_rule: >
@@ -120,6 +120,7 @@ adoption:
     - tasks/templates/sub-agent-handoff.md
     - tasks/templates/submission-evidence.md
   required_behavior:
+    - operator_intent_resolution
     - memory_layer_contracts
     - cross_agent_policy_contract
     - implementation_preflight

--- a/projects/agenticos/.meta/templates/issue-design-brief.md
+++ b/projects/agenticos/.meta/templates/issue-design-brief.md
@@ -8,7 +8,9 @@
 ## Objective Synthesis
 - User-stated request:
 - Inferred end goal:
+- Operator signals / partial methods:
 - Constraints:
+- Contradictions or weak assumptions to resolve:
 - Non-goals:
 
 ## Project Context

--- a/projects/agenticos/homebrew-tap/Formula/agenticos.rb
+++ b/projects/agenticos/homebrew-tap/Formula/agenticos.rb
@@ -1,10 +1,12 @@
+require "language/node"
+
 class Agenticos < Formula
   desc "AI-native project management MCP server for Claude Code, Codex, Cursor, and Gemini CLI"
   homepage "https://github.com/madlouse/AgenticOS"
-  url "https://github.com/madlouse/AgenticOS/releases/download/v0.3.0/agenticos-mcp.tgz"
-  sha256 "54c755ec2150ea4e5217eec2dcba6cd96c2e8ed2352a4eb6439ec458e182f64b"
+  url "https://github.com/madlouse/AgenticOS/releases/download/v0.4.0/agenticos-mcp.tgz"
+  sha256 "13f45f9b81790968136254994a352d70d3d8b3aea51551f5da83466c1a1bdb8a"
   license "MIT"
-  version "0.3.0"
+  version "0.4.0"
 
   depends_on "node"
 
@@ -41,23 +43,26 @@ class Agenticos < Formula
       2. Bootstrap one officially supported agent:
 
          Claude Code
-           claude mcp add --transport stdio --scope user agenticos -- agenticos-mcp
+           claude mcp add --transport stdio --scope user -e AGENTICOS_HOME="$AGENTICOS_HOME" agenticos -- agenticos-mcp
 
          Codex
-           codex mcp add agenticos -- agenticos-mcp
+           codex mcp add --env AGENTICOS_HOME="$AGENTICOS_HOME" agenticos -- agenticos-mcp
 
          Cursor (~/.cursor/mcp.json)
            {
              "mcpServers": {
                "agenticos": {
                  "command": "agenticos-mcp",
-                 "args": []
+                 "args": [],
+                 "env": {
+                   "AGENTICOS_HOME": "#{var}/agenticos"
+                 }
                }
              }
            }
 
          Gemini CLI
-           gemini mcp add -s user agenticos agenticos-mcp
+           gemini mcp add -s user -e AGENTICOS_HOME="$AGENTICOS_HOME" agenticos agenticos-mcp
 
       3. Restart the AI tool.
 
@@ -70,13 +75,13 @@ class Agenticos < Formula
          Claude Code
            claude mcp get agenticos
            claude mcp remove agenticos -s user
-           claude mcp add --transport stdio --scope user agenticos -- agenticos-mcp
+           claude mcp add --transport stdio --scope user -e AGENTICOS_HOME="$AGENTICOS_HOME" agenticos -- agenticos-mcp
 
          Codex
            codex mcp list
            codex mcp get agenticos
            codex mcp remove agenticos
-           codex mcp add agenticos -- agenticos-mcp
+           codex mcp add --env AGENTICOS_HOME="$AGENTICOS_HOME" agenticos -- agenticos-mcp
 
       6. Product policy: Homebrew is reminder-only today.
          It does not mutate user agent configs by default.

--- a/projects/agenticos/homebrew-tap/README.md
+++ b/projects/agenticos/homebrew-tap/README.md
@@ -29,14 +29,17 @@ After installation, set `AGENTICOS_HOME` explicitly, bootstrap one officially su
 mkdir -p "$(brew --prefix)/var/agenticos"
 export AGENTICOS_HOME="$(brew --prefix)/var/agenticos"
 
+# Recommended: detect supported agents and register them automatically
+agenticos-bootstrap --workspace "$AGENTICOS_HOME" --first-run
+
 # Claude Code
-claude mcp add --transport stdio --scope user agenticos -- agenticos-mcp
+claude mcp add --transport stdio --scope user -e AGENTICOS_HOME="$AGENTICOS_HOME" agenticos -- agenticos-mcp
 
 # Codex
-codex mcp add agenticos -- agenticos-mcp
+codex mcp add --env AGENTICOS_HOME="$AGENTICOS_HOME" agenticos -- agenticos-mcp
 
 # Gemini CLI
-gemini mcp add -s user agenticos agenticos-mcp
+gemini mcp add -s user -e AGENTICOS_HOME="$AGENTICOS_HOME" agenticos agenticos-mcp
 ```
 
 For Cursor, add this to `~/.cursor/mcp.json`:
@@ -46,13 +49,22 @@ For Cursor, add this to `~/.cursor/mcp.json`:
   "mcpServers": {
     "agenticos": {
       "command": "agenticos-mcp",
-      "args": []
+      "args": [],
+      "env": {
+        "AGENTICOS_HOME": "/absolute/path/to/your/AgenticOS-workspace"
+      }
     }
   }
 }
 ```
 
 Then restart the AI tool and confirm `agenticos_list` works.
+If you prefer not to edit your shell profile, omit `--first-run` and use the explicit MCP commands below instead.
+On macOS, `--first-run` also enables `launchctl` persistence so GUI/session processes inherit `AGENTICOS_HOME`.
+Use `agenticos-bootstrap --verify` with the same flags to audit the current machine state without mutating it.
+
+If you are developing AgenticOS from a source checkout, remember that `npm run build` in the repo does **not** replace the Homebrew-installed `agenticos-mcp` binary on your PATH.
+If your MCP client is registered to `agenticos-mcp`, it will keep launching the installed binary until you explicitly reinstall or upgrade that binary and restart the AI tool.
 
 Homebrew policy is reminder-only today. It does not silently mutate user agent configs.
 
@@ -62,13 +74,13 @@ If a previous registration still points at a source checkout instead of `agentic
 # Claude Code
 claude mcp get agenticos
 claude mcp remove agenticos -s user
-claude mcp add --transport stdio --scope user agenticos -- agenticos-mcp
+claude mcp add --transport stdio --scope user -e AGENTICOS_HOME="$AGENTICOS_HOME" agenticos -- agenticos-mcp
 
 # Codex
 codex mcp list
 codex mcp get agenticos
 codex mcp remove agenticos
-codex mcp add agenticos -- agenticos-mcp
+codex mcp add --env AGENTICOS_HOME="$AGENTICOS_HOME" agenticos -- agenticos-mcp
 ```
 
 ## Upgrade
@@ -76,3 +88,5 @@ codex mcp add agenticos -- agenticos-mcp
 ```bash
 brew upgrade agenticos
 ```
+
+After upgrade, restart the AI tool so it launches the new `agenticos-mcp` process instead of any older long-lived session copy.

--- a/projects/agenticos/mcp-server/README.md
+++ b/projects/agenticos/mcp-server/README.md
@@ -18,7 +18,13 @@ A project management system designed for AI collaboration. When you work on comp
 
 ### Quick Start
 
-Install AgenticOS, set `AGENTICOS_HOME` explicitly, bootstrap one supported agent, restart that agent, then explicitly verify `agenticos_list` works before relying on project-intent routing.
+Install AgenticOS, set `AGENTICOS_HOME` explicitly, then either run `agenticos-bootstrap --workspace "$AGENTICOS_HOME" --first-run` or bootstrap one supported agent manually, restart that agent, and explicitly verify `agenticos_list` works before relying on project-intent routing.
+On macOS, `--first-run` also enables `launchctl` persistence for GUI/session inheritance.
+Use `agenticos-bootstrap --verify` to audit the selected agents and optional persistence layers without mutating them.
+`--apply` and `--first-run` also record bootstrap metadata in `$AGENTICOS_HOME/.agent-workspace/bootstrap-state.yaml`.
+
+After any local upgrade, reinstall, or source rebuild of `agenticos-mcp`, restart the current AI client before assuming its MCP tools reflect the new server behavior.
+MCP registration can be correct while the live client session is still holding an older server process.
 
 When the client supports a pre-edit hook or local command wrapper, point that layer at `tools/check-edit-boundary.sh` so implementation edits fail closed unless project alignment and matching PASS preflight evidence already exist.
 
@@ -75,7 +81,7 @@ Transport bootstrap and project-intent routing are different concerns.
 
 ### Claude Code
 
-- canonical bootstrap: `claude mcp add --transport stdio --scope user agenticos -- agenticos-mcp`
+- canonical bootstrap: `claude mcp add --transport stdio --scope user -e AGENTICOS_HOME="$AGENTICOS_HOME" agenticos -- agenticos-mcp`
 - verify:
   - `claude mcp list`
   - `/mcp`
@@ -86,7 +92,7 @@ Transport bootstrap and project-intent routing are different concerns.
 
 ### Codex
 
-- canonical bootstrap: `codex mcp add agenticos -- agenticos-mcp`
+- canonical bootstrap: `codex mcp add --env AGENTICOS_HOME="$AGENTICOS_HOME" agenticos -- agenticos-mcp`
 - canonical config location: `~/.codex/config.toml`
 - verify:
   - `codex mcp list`
@@ -97,7 +103,7 @@ Transport bootstrap and project-intent routing are different concerns.
 
 ### Cursor
 
-- canonical bootstrap: add `agenticos` to `~/.cursor/mcp.json`
+- canonical bootstrap: add `agenticos` with explicit `env.AGENTICOS_HOME` to `~/.cursor/mcp.json`
 - verify:
   - restart Cursor
   - check Cursor MCP settings or `cursor-agent mcp list` if the Cursor CLI is installed
@@ -108,7 +114,7 @@ Transport bootstrap and project-intent routing are different concerns.
 
 ### Gemini CLI
 
-- canonical bootstrap: `gemini mcp add -s user agenticos agenticos-mcp`
+- canonical bootstrap: `gemini mcp add -s user -e AGENTICOS_HOME="$AGENTICOS_HOME" agenticos agenticos-mcp`
 - canonical config location: `~/.gemini/settings.json`
 - verify:
   - `gemini mcp list`
@@ -132,7 +138,7 @@ Claude Code repair flow:
 ```bash
 claude mcp get agenticos
 claude mcp remove agenticos -s user
-claude mcp add --transport stdio --scope user agenticos -- agenticos-mcp
+claude mcp add --transport stdio --scope user -e AGENTICOS_HOME="$AGENTICOS_HOME" agenticos -- agenticos-mcp
 ```
 
 Codex repair flow:
@@ -141,10 +147,11 @@ Codex repair flow:
 codex mcp list
 codex mcp get agenticos
 codex mcp remove agenticos
-codex mcp add agenticos -- agenticos-mcp
+codex mcp add --env AGENTICOS_HOME="$AGENTICOS_HOME" agenticos -- agenticos-mcp
 ```
 
 If Codex reports that `agenticos` does not exist yet, skip the remove step and add it directly.
+If `codex mcp get agenticos` shows `env: -`, treat that registration as incomplete and re-add it with explicit `AGENTICOS_HOME`.
 After any registration change, restart the agent, confirm the server appears in its MCP diagnostics, and call `agenticos_list`.
 
 This verification remains manual by design.

--- a/projects/agenticos/mcp-server/package-lock.json
+++ b/projects/agenticos/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenticos-mcp",
-  "version": "0.2.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenticos-mcp",
-      "version": "0.2.1",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/projects/agenticos/mcp-server/package.json
+++ b/projects/agenticos/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-mcp",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "MCP Server for AgenticOS - AI-native project management system",
   "type": "module",
   "bin": {

--- a/projects/agenticos/mcp-server/src/tools/__tests__/standard-kit.test.ts
+++ b/projects/agenticos/mcp-server/src/tools/__tests__/standard-kit.test.ts
@@ -71,6 +71,7 @@ async function setupKitHome(): Promise<{ home: string; projectRoot: string }> {
         'tasks/templates/submission-evidence.md',
       ],
       required_behavior: [
+        'operator_intent_resolution',
         'memory_layer_contracts',
         'cross_agent_policy_contract',
         'implementation_preflight',
@@ -89,7 +90,7 @@ async function setupKitHome(): Promise<{ home: string; projectRoot: string }> {
   await writeFile(join(templateRoot, 'quick-start.md'), '# Quick Start\n\n> Contract: concise project-level orientation for fast resume.\n> Do not store full session history, exhaustive decision logs, or issue-by-issue execution details here.\n\n## Project Snapshot\n- **Project**: [Project Name]\n- **Goal**: [Main objective]\n- **Status**: [Current phase]\n- **Last Action**: [What was done last]\n- **Current Focus**: [What to do next]\n- **Resume Here**: [What to do next]\n\n## Key Facts\n- [Important fact 1]\n- [Important fact 2]\n\n## Canonical Layers\n- Operational state: `.context/state.yaml`\n- Session history: `.context/conversations/`\n- Durable knowledge: `knowledge/`\n- Execution plans: `tasks/`\n- Deliverables: `artifacts/`\n', 'utf-8');
   await writeFile(join(templateRoot, 'state.yaml'), '# Contract:\n# - Mutable operational working state only\n# - Keep current task, working memory, and latest guardrail evidence here\n# - Do not append raw conversation transcripts here\n# - Durable synthesis belongs in knowledge/\nsession:\n  id: "session-001"\n  started: "YYYY-MM-DDTHH:MM:SSZ"\n  agent: "claude-sonnet-4.6"\ncurrent_task:\n  id: null\n  title: null\n  status: "pending"\n  next_step: null\nworking_memory:\n  facts: []\n  decisions: []\n  pending: []\nmemory_contract:\n  version: 1\n  quick_start_role: "project_orientation"\n  state_role: "operational_working_state"\n  conversations_role: "append_only_session_history"\n  knowledge_role: "durable_synthesis"\n  tasks_role: "execution_artifacts"\nloaded_context:\n  - ".project.yaml"\n', 'utf-8');
   await writeFile(join(templateRoot, 'agent-preflight-checklist.yaml'), 'version: 0.2\n', 'utf-8');
-  await writeFile(join(templateRoot, 'issue-design-brief.md'), '# Issue Design Brief\n', 'utf-8');
+  await writeFile(join(templateRoot, 'issue-design-brief.md'), '# Issue Design Brief\n\n## Objective Synthesis\n- User-stated request:\n- Inferred end goal:\n- Operator signals / partial methods:\n- Constraints:\n- Contradictions or weak assumptions to resolve:\n- Non-goals:\n', 'utf-8');
   await writeFile(join(templateRoot, 'non-code-evaluation-rubric.yaml'), 'version: 0.1\nname: non-code-evaluation-rubric\n', 'utf-8');
   await writeFile(join(templateRoot, 'sub-agent-handoff.md'), '# Sub-Agent Handoff\n', 'utf-8');
   await writeFile(join(templateRoot, 'submission-evidence.md'), '# Submission Evidence\n', 'utf-8');
@@ -240,8 +241,10 @@ describe('standard kit commands', () => {
 
     const agentsMd = await readFile(join(projectRoot, 'AGENTS.md'), 'utf-8');
     const claudeMd = await readFile(join(projectRoot, 'CLAUDE.md'), 'utf-8');
-    expect(agentsMd).toContain('agenticos-template: v4');
-    expect(claudeMd).toContain('agenticos-template: v4');
+    expect(agentsMd).toContain('agenticos-template: v7');
+    expect(claudeMd).toContain('agenticos-template: v7');
+    expect(agentsMd).toContain('## Task Intake Rule');
+    expect(claudeMd).toContain('recover operator intent');
   });
 
   it('upgrade check reports missing, stale, matching, and diverged files', async () => {
@@ -311,7 +314,7 @@ describe('standard kit commands', () => {
     expect(result.created_files).toContain('.project.yaml');
 
     const claudeMd = await readFile(join(projectRoot, 'CLAUDE.md'), 'utf-8');
-    expect(claudeMd).toContain('agenticos-template: v4');
+    expect(claudeMd).toContain('agenticos-template: v7');
     expect(claudeMd).toContain('custom dna');
     expect(claudeMd).toContain('## Current State');
   });
@@ -321,7 +324,7 @@ describe('standard kit commands', () => {
     process.env.AGENTICOS_HOME = home;
 
     await writeFile(join(projectRoot, 'AGENTS.md'), generateAgentsMd('Sample Project', ''), 'utf-8');
-    await writeFile(join(projectRoot, 'CLAUDE.md'), '<!-- agenticos-template: v4 -->\ncurrent claude\n', 'utf-8');
+    await writeFile(join(projectRoot, 'CLAUDE.md'), '<!-- agenticos-template: v7 -->\ncurrent claude\n', 'utf-8');
 
     const result = JSON.parse(await runStandardKitUpgradeCheck({ project_path: projectRoot })) as {
       generated_files: Array<{ path: string; status: string; current_version: number | null }>;
@@ -329,11 +332,11 @@ describe('standard kit commands', () => {
 
     expect(result.generated_files.find((item) => item.path === 'AGENTS.md')).toMatchObject({
       status: 'current',
-      current_version: 4,
+      current_version: 7,
     });
     expect(result.generated_files.find((item) => item.path === 'CLAUDE.md')).toMatchObject({
       status: 'current',
-      current_version: 4,
+      current_version: 7,
     });
   });
 
@@ -375,7 +378,7 @@ describe('standard kit commands', () => {
       project_name: 'Sample Project',
       project_description: 'Broken conformance project',
     });
-    await writeFile(join(projectRoot, 'AGENTS.md'), '<!-- agenticos-template: v4 -->\n# AGENTS.md — Sample Project\n', 'utf-8');
+    await writeFile(join(projectRoot, 'AGENTS.md'), '<!-- agenticos-template: v7 -->\n# AGENTS.md — Sample Project\n', 'utf-8');
 
     const result = JSON.parse(await runStandardKitConformanceCheck({
       project_path: projectRoot,
@@ -496,7 +499,7 @@ describe('standard kit commands', () => {
 
     expect(result.upgraded_generated_files).toContain('AGENTS.md');
     const agentsMd = await readFile(join(projectRoot, 'AGENTS.md'), 'utf-8');
-    expect(agentsMd).toContain('agenticos-template: v4');
+    expect(agentsMd).toContain('agenticos-template: v7');
     expect(agentsMd).toContain('Guardrail Protocol');
   });
 

--- a/projects/agenticos/mcp-server/src/utils/__tests__/distill.test.ts
+++ b/projects/agenticos/mcp-server/src/utils/__tests__/distill.test.ts
@@ -9,6 +9,8 @@ import {
   CURRENT_TEMPLATE_VERSION,
   SHARED_POLICY_BULLETS,
   SHARED_POLICY_TITLE,
+  TASK_INTAKE_RULE_BULLETS,
+  TASK_INTAKE_RULE_TITLE,
   generateAgentsMd,
   generateClaudeMd,
 } from '../distill.js';
@@ -17,8 +19,8 @@ describe('distill templates', () => {
   it('generates AGENTS.md with the current template marker, adapter role, and guardrail flow', () => {
     const content = generateAgentsMd('Demo Project', 'Guardrail test');
 
-    expect(CURRENT_TEMPLATE_VERSION).toBe(4);
-    expect(content).toContain('<!-- agenticos-template: v4 -->');
+    expect(CURRENT_TEMPLATE_VERSION).toBe(7);
+    expect(content).toContain('<!-- agenticos-template: v7 -->');
     expect(content).toContain('## Adapter Role');
     expect(content).toContain(AGENTS_ADAPTER_LINES[0]);
     expect(content).toContain(AGENTS_ADAPTER_LINES[1]);
@@ -28,6 +30,10 @@ describe('distill templates', () => {
     }
     expect(content).toContain(`## ${AGENTS_RUNTIME_GUIDANCE_TITLE}`);
     for (const bullet of AGENTS_RUNTIME_GUIDANCE_BULLETS) {
+      expect(content).toContain(bullet);
+    }
+    expect(content).toContain(`## ${TASK_INTAKE_RULE_TITLE}`);
+    for (const bullet of TASK_INTAKE_RULE_BULLETS) {
       expect(content).toContain(bullet);
     }
     expect(content).toContain('## Guardrail Protocol (MANDATORY)');
@@ -51,6 +57,10 @@ describe('distill templates', () => {
     }
     expect(content).toContain(`## ${CLAUDE_RUNTIME_GUIDANCE_TITLE}`);
     for (const bullet of CLAUDE_RUNTIME_GUIDANCE_BULLETS) {
+      expect(content).toContain(bullet);
+    }
+    expect(content).toContain(`## ${TASK_INTAKE_RULE_TITLE}`);
+    for (const bullet of TASK_INTAKE_RULE_BULLETS) {
       expect(content).toContain(bullet);
     }
     expect(content).toContain('## Guardrail Protocol (MANDATORY)');

--- a/projects/agenticos/mcp-server/src/utils/distill.ts
+++ b/projects/agenticos/mcp-server/src/utils/distill.ts
@@ -5,7 +5,7 @@ import { readFileSync } from 'fs';
  * Current template version. Increment when templates change.
  * Used for auto-upgrade on project switch.
  */
-export const CURRENT_TEMPLATE_VERSION = 4;
+export const CURRENT_TEMPLATE_VERSION = 7;
 
 /** Version marker format in generated files */
 const VERSION_MARKER = `<!-- agenticos-template: v${CURRENT_TEMPLATE_VERSION} -->`;
@@ -38,6 +38,13 @@ export const CLAUDE_RUNTIME_GUIDANCE_TITLE = 'Claude Runtime Notes';
 export const CLAUDE_RUNTIME_GUIDANCE_BULLETS = [
   'Claude CLI-managed user MCP config is the canonical Claude bootstrap surface.',
   'Claude-specific stop hooks remain optional local stop-hook reminders rather than canonical guardrails.',
+] as const;
+
+export const TASK_INTAKE_RULE_TITLE = 'Task Intake Rule';
+export const TASK_INTAKE_RULE_BULLETS = [
+  'At task intake, recover operator intent before treating named methods or workflow fragments as the full plan.',
+  'Separate goals, hard constraints, useful signals, and candidate methods before choosing an execution path.',
+  'Once intent is resolved, collapse it into a clean execution objective instead of carrying the full intake rubric through every later step.',
 ] as const;
 
 /** Extract template version from an existing file. Returns 0 if no marker found (v1 or earlier). */
@@ -84,7 +91,7 @@ export function generateAgentsMd(name: string, description: string): string {
 ${AGENTS_ADAPTER_LINES[0]}
 ${AGENTS_ADAPTER_LINES[1]}
 
-${renderSharedPolicySection()}${renderRuntimeGuidanceSection(AGENTS_RUNTIME_GUIDANCE_TITLE, AGENTS_RUNTIME_GUIDANCE_BULLETS)}## Guardrail Protocol (MANDATORY)
+${renderSharedPolicySection()}${renderRuntimeGuidanceSection(AGENTS_RUNTIME_GUIDANCE_TITLE, AGENTS_RUNTIME_GUIDANCE_BULLETS)}${renderRuntimeGuidanceSection(TASK_INTAKE_RULE_TITLE, TASK_INTAKE_RULE_BULLETS)}## Guardrail Protocol (MANDATORY)
 
 Implementation work must use the executable guardrail flow:
 
@@ -226,7 +233,7 @@ function buildClaudeMdContent(name: string, description: string, state?: StateYa
 ${CLAUDE_ADAPTER_LINES[0]}
 ${CLAUDE_ADAPTER_LINES[1]}
 
-${renderSharedPolicySection()}${renderRuntimeGuidanceSection(CLAUDE_RUNTIME_GUIDANCE_TITLE, CLAUDE_RUNTIME_GUIDANCE_BULLETS)}## Guardrail Protocol (MANDATORY)
+${renderSharedPolicySection()}${renderRuntimeGuidanceSection(CLAUDE_RUNTIME_GUIDANCE_TITLE, CLAUDE_RUNTIME_GUIDANCE_BULLETS)}${renderRuntimeGuidanceSection(TASK_INTAKE_RULE_TITLE, TASK_INTAKE_RULE_BULLETS)}## Guardrail Protocol (MANDATORY)
 
 For implementation-affecting work:
 

--- a/projects/agenticos/mcp-server/src/utils/standard-kit.ts
+++ b/projects/agenticos/mcp-server/src/utils/standard-kit.ts
@@ -441,12 +441,38 @@ export async function checkStandardKitConformance(args: { project_path?: string;
   const stateYaml = yaml.parse((await readProjectFile(upgrade.project_path, '.context/state.yaml')) || '{}') as any;
   const agentsMd = await readProjectFile(upgrade.project_path, 'AGENTS.md');
   const claudeMd = await readProjectFile(upgrade.project_path, 'CLAUDE.md');
+  const designBrief = await readProjectFile(upgrade.project_path, 'tasks/templates/issue-design-brief.md');
   const officialAdapters = getOfficialAgentAdapters(await loadAgentAdapterMatrix());
 
   const behaviorChecks: ConformanceBehaviorStatus[] = [];
 
   for (const behavior of manifest.adoption?.required_behavior || []) {
     switch (behavior) {
+      case 'operator_intent_resolution': {
+        const adaptersPass = fileContainsAll(agentsMd, [
+          '## Task Intake Rule',
+          'recover operator intent',
+          'workflow fragments',
+        ]) && fileContainsAll(claudeMd, [
+          '## Task Intake Rule',
+          'recover operator intent',
+          'workflow fragments',
+        ]);
+        const templatePass = fileContainsAll(designBrief, [
+          'Operator signals / partial methods:',
+          'Contradictions or weak assumptions to resolve:',
+        ]);
+        const pass = adaptersPass && templatePass;
+        behaviorChecks.push({
+          behavior,
+          status: pass ? 'PASS' : 'FAIL',
+          summary: pass
+            ? 'Adapter surfaces and the design-brief template preserve the compact operator-intent intake rule.'
+            : 'Operator-intent intake guidance is missing from generated adapters or the issue-design-brief template.',
+          evidence_paths: ['AGENTS.md', 'CLAUDE.md', 'tasks/templates/issue-design-brief.md'],
+        });
+        break;
+      }
       case 'memory_layer_contracts': {
         const pass = !!projectYaml?.memory_contract?.version
           && !!projectYaml?.agent_context?.quick_start


### PR DESCRIPTION
## Summary
- add a compact task-intake rule to generated AGENTS.md and CLAUDE.md surfaces
- enforce operator intent resolution in standard-kit conformance and issue design templates
- bump agenticos-mcp to 0.4.0 and update the Homebrew formula, caveats, and release metadata
- fix the Homebrew formula install path by requiring language/node

## Verification
- npm test -- src/tools/__tests__/standard-kit.test.ts src/utils/__tests__/distill.test.ts src/utils/__tests__/homebrew-bootstrap-docs.test.ts
- npm run build
- local Homebrew reinstall verified agenticos-mcp 0.4.0 on PATH

## Issue
- closes #158