### PR TITLE
fix(agenticos): enforce source repo boundaries

### DIFF
--- a/projects/360teams/.project.yaml
+++ b/projects/360teams/.project.yaml
@@ -25,3 +25,7 @@ status:
   phase: planning
   last_updated: 2026-03-30
   next_action: Define project goals
+
+execution:
+  source_repo_roots:
+    - ../..

--- a/projects/agenticos/.meta/templates/.project.yaml
+++ b/projects/agenticos/.meta/templates/.project.yaml
@@ -27,6 +27,10 @@ status:
   last_updated: "YYYY-MM-DD"
   next_action: "Define project goals"
 
+execution:
+  source_repo_roots:
+    - "."  # Relative to the managed project root. Use ../.. when the canonical Git repo root is higher.
+
 tech:
   languages: []
   platforms: []

--- a/projects/agenticos/mcp-server/src/index.ts
+++ b/projects/agenticos/mcp-server/src/index.ts
@@ -130,7 +130,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
           issue_id: { type: 'string', description: 'GitHub issue number or identifier for the current task' },
           task_type: {
             type: 'string',
-            enum: ['discussion_only', 'analysis_or_doc', 'implementation', 'bootstrap'],
+            enum: ['discussion_only', 'analysis_or_doc', 'implementation', 'bugfix', 'bootstrap'],
             description: 'Classified task type',
           },
           repo_path: { type: 'string', description: 'Absolute repository or worktree path to evaluate' },
@@ -166,8 +166,8 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
           issue_id: { type: 'string', description: 'GitHub issue number or identifier for the current edit.' },
           task_type: {
             type: 'string',
-            enum: ['discussion_only', 'analysis_or_doc', 'implementation', 'bootstrap'],
-            description: 'Classified task type. Enforcement applies to implementation.',
+            enum: ['discussion_only', 'analysis_or_doc', 'implementation', 'bugfix', 'bootstrap'],
+            description: 'Classified task type. Enforcement applies to implementation-affecting tasks.',
           },
           repo_path: { type: 'string', description: 'Absolute repository or worktree path where the edit would occur.' },
           project_path: { type: 'string', description: 'Optional explicit managed project root when repo_path is not itself inside the managed project.' },
@@ -190,6 +190,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
           branch_type: { type: 'string', description: 'Branch prefix such as feat, fix, or chore' },
           slug: { type: 'string', description: 'Short task slug used to derive branch and worktree names' },
           repo_path: { type: 'string', description: 'Absolute repository path where the branch should be created' },
+          project_path: { type: 'string', description: 'Optional managed project root when repo_path is a larger checkout or worktree.' },
           remote_base_branch: { type: 'string', description: 'Remote base branch to branch from (default: origin/main)' },
           worktree_root: { type: 'string', description: 'Absolute root directory under which the new worktree should be created' },
         },
@@ -204,6 +205,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         properties: {
           issue_id: { type: 'string', description: 'GitHub issue number or identifier for the current task' },
           repo_path: { type: 'string', description: 'Absolute repository or worktree path to evaluate' },
+          project_path: { type: 'string', description: 'Optional managed project root when repo_path is a larger checkout or worktree.' },
           remote_base_branch: { type: 'string', description: 'Remote base branch to compare against (default: origin/main)' },
           declared_target_files: {
             type: 'array',

--- a/projects/agenticos/mcp-server/src/tools/__tests__/branch-bootstrap.test.ts
+++ b/projects/agenticos/mcp-server/src/tools/__tests__/branch-bootstrap.test.ts
@@ -18,9 +18,14 @@ const persistGuardrailEvidenceMock = vi.hoisted(() => vi.fn().mockResolvedValue(
   project_id: 'agenticos',
   state_path: '/repo/.context/state.yaml',
 }));
+const resolveGuardrailProjectTargetMock = vi.hoisted(() => vi.fn());
 
 vi.mock('../../utils/guardrail-evidence.js', () => ({
   persistGuardrailEvidence: persistGuardrailEvidenceMock,
+}));
+
+vi.mock('../../utils/repo-boundary.js', () => ({
+  resolveGuardrailProjectTarget: resolveGuardrailProjectTargetMock,
 }));
 
 vi.mock('fs/promises', () => ({
@@ -41,6 +46,20 @@ describe('runBranchBootstrap', () => {
       project_id: 'agenticos',
       state_path: '/repo/.context/state.yaml',
     });
+    resolveGuardrailProjectTargetMock.mockResolvedValue({
+      activeProjectId: 'agenticos',
+      resolutionSource: 'active_project',
+      resolutionErrors: [],
+      targetProject: {
+        id: 'agenticos',
+        name: 'AgenticOS',
+        path: '/workspace/projects/agenticos/standards',
+        statePath: '/workspace/projects/agenticos/standards/.context/state.yaml',
+        projectYamlPath: '/workspace/projects/agenticos/standards/.project.yaml',
+        sourceRepoRoots: ['/repo'],
+        sourceRepoRootsDeclared: true,
+      },
+    });
   });
 
   it('returns CREATED and issues git worktree add from the intended remote base', async () => {
@@ -48,10 +67,16 @@ describe('runBranchBootstrap', () => {
       if (cmd.includes('rev-parse origin/main')) {
         return { stdout: 'base123\n', stderr: '' };
       }
+      if (cmd.includes('rev-parse --show-toplevel')) {
+        return { stdout: '/repo/mcp-server\n', stderr: '' };
+      }
+      if (cmd.includes('rev-parse --git-common-dir')) {
+        return { stdout: '/repo/.git\n', stderr: '' };
+      }
       if (cmd.includes('show-ref --verify --quiet refs/heads/feat/36-guardrail-helper')) {
         throw new Error('branch missing');
       }
-      if (cmd.includes('worktree add "/tmp/worktrees/mcp-server-36-guardrail-helper" -b feat/36-guardrail-helper base123')) {
+      if (cmd.includes('worktree add "/tmp/worktrees/repo-36-guardrail-helper" -b feat/36-guardrail-helper base123')) {
         return { stdout: 'Preparing worktree\n', stderr: '' };
       }
       throw new Error(`Unexpected command: ${cmd}`);
@@ -69,7 +94,7 @@ describe('runBranchBootstrap', () => {
     expect(result.status).toBe('CREATED');
     expect(result.branch_name).toBe('feat/36-guardrail-helper');
     expect(result.base_commit).toBe('base123');
-    expect(result.worktree_path).toBe('/tmp/worktrees/mcp-server-36-guardrail-helper');
+    expect(result.worktree_path).toBe('/tmp/worktrees/repo-36-guardrail-helper');
     expect(result.notes.join(' ')).toContain('origin/main');
     expect(mkdirMock).toHaveBeenCalledWith('/tmp/worktrees', { recursive: true });
     expect(result.persistence?.persisted).toBe(true);
@@ -80,6 +105,12 @@ describe('runBranchBootstrap', () => {
     execAsyncMock.mockImplementation(async (cmd: string) => {
       if (cmd.includes('rev-parse origin/main')) {
         return { stdout: 'base123\n', stderr: '' };
+      }
+      if (cmd.includes('rev-parse --show-toplevel')) {
+        return { stdout: '/repo/mcp-server\n', stderr: '' };
+      }
+      if (cmd.includes('rev-parse --git-common-dir')) {
+        return { stdout: '/repo/.git\n', stderr: '' };
       }
       if (cmd.includes('show-ref --verify --quiet refs/heads/feat/36-guardrail-helper')) {
         return { stdout: '', stderr: '' };
@@ -105,6 +136,12 @@ describe('runBranchBootstrap', () => {
       if (cmd.includes('rev-parse origin/main')) {
         return { stdout: 'base123\n', stderr: '' };
       }
+      if (cmd.includes('rev-parse --show-toplevel')) {
+        return { stdout: '/repo/mcp-server\n', stderr: '' };
+      }
+      if (cmd.includes('rev-parse --git-common-dir')) {
+        return { stdout: '/repo/.git\n', stderr: '' };
+      }
       if (cmd.includes('show-ref --verify --quiet refs/heads/feat/36-guardrail-helper')) {
         throw new Error('branch missing');
       }
@@ -122,7 +159,7 @@ describe('runBranchBootstrap', () => {
 
     expect(result.status).toBe('BLOCK');
     expect(result.block_reasons[0]).toContain('worktree path already exists');
-    expect(result.worktree_path).toBe('/tmp/worktrees/mcp-server-36-guardrail-helper');
+    expect(result.worktree_path).toBe('/tmp/worktrees/repo-36-guardrail-helper');
     expect(mkdirMock).not.toHaveBeenCalled();
   });
 
@@ -140,5 +177,34 @@ describe('runBranchBootstrap', () => {
 
     expect(result.status).toBe('BLOCK');
     expect(result.block_reasons[0]).toContain('failed to resolve remote base');
+  });
+
+  it('returns BLOCK when the git common repo root is not declared for the target project', async () => {
+    execAsyncMock.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('rev-parse --show-toplevel')) {
+        return { stdout: '/repo/worktrees/issue-160\n', stderr: '' };
+      }
+      if (cmd.includes('rev-parse --git-common-dir')) {
+        return { stdout: '/external/.git\n', stderr: '' };
+      }
+      if (cmd.includes('rev-parse origin/main')) {
+        return { stdout: 'base123\n', stderr: '' };
+      }
+      if (cmd.includes('show-ref --verify --quiet refs/heads/fix/160-boundary')) {
+        throw new Error('branch missing');
+      }
+      throw new Error(`Unexpected command: ${cmd}`);
+    });
+
+    const result = JSON.parse(await runBranchBootstrap({
+      issue_id: '160',
+      branch_type: 'fix',
+      slug: 'boundary',
+      repo_path: '/repo/worktrees/issue-160',
+      worktree_root: '/tmp/worktrees',
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons.join(' ')).toContain('not declared for target project');
   });
 });

--- a/projects/agenticos/mcp-server/src/tools/__tests__/edit-guard.test.ts
+++ b/projects/agenticos/mcp-server/src/tools/__tests__/edit-guard.test.ts
@@ -1,7 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+const execAsyncMock = vi.hoisted(() => vi.fn());
 const yamlMock = vi.hoisted(() => ({
   parse: vi.fn(),
+}));
+const resolveGuardrailProjectTargetMock = vi.hoisted(() => vi.fn());
+
+vi.mock('child_process', () => ({
+  exec: vi.fn(),
+}));
+
+vi.mock('util', () => ({
+  promisify: vi.fn(() => execAsyncMock),
 }));
 
 vi.mock('fs/promises', () => ({
@@ -16,6 +26,11 @@ vi.mock('../../utils/registry.js', () => ({
   loadRegistry: vi.fn(),
 }));
 
+vi.mock('../../utils/repo-boundary.js', () => ({
+  isImplementationAffectingTask: (taskType: string) => taskType === 'implementation' || taskType === 'bugfix',
+  resolveGuardrailProjectTarget: resolveGuardrailProjectTargetMock,
+}));
+
 import { readFile } from 'fs/promises';
 import { loadRegistry } from '../../utils/registry.js';
 import { runEditGuard } from '../edit-guard.js';
@@ -28,27 +43,32 @@ describe('runEditGuard', () => {
     vi.clearAllMocks();
     loadRegistryMock.mockResolvedValue({
       active_project: 'agenticos-standards',
-      projects: [
-        {
-          id: 'agenticos-standards',
-          name: 'agenticos-standards',
-          path: '/workspace/projects/agenticos/standards',
-          status: 'active',
-          created: '2026-03-20',
-          last_accessed: '2026-03-20T00:00:00.000Z',
-        },
-      ],
+      projects: [],
+    });
+    resolveGuardrailProjectTargetMock.mockResolvedValue({
+      activeProjectId: 'agenticos-standards',
+      resolutionSource: 'active_project',
+      resolutionErrors: [],
+      targetProject: {
+        id: 'agenticos-standards',
+        name: 'agenticos-standards',
+        path: '/workspace/projects/agenticos/standards',
+        statePath: '/workspace/projects/agenticos/standards/.context/state.yaml',
+        projectYamlPath: '/workspace/projects/agenticos/standards/.project.yaml',
+        sourceRepoRoots: ['/workspace/source'],
+        sourceRepoRootsDeclared: true,
+      },
+    });
+    execAsyncMock.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('rev-parse --show-toplevel')) {
+        return { stdout: '/workspace/source\n', stderr: '' };
+      }
+      if (cmd.includes('rev-parse --git-common-dir')) {
+        return { stdout: '.git\n', stderr: '' };
+      }
+      throw new Error(`Unexpected command: ${cmd}`);
     });
     readFileMock.mockImplementation(async (path: string) => {
-      if (path.endsWith('/.project.yaml')) {
-        return JSON.stringify({
-          meta: {
-            id: 'agenticos-standards',
-            name: 'agenticos-standards',
-          },
-        });
-      }
-
       if (path.endsWith('/.context/state.yaml')) {
         return JSON.stringify({
           guardrail_evidence: {
@@ -89,9 +109,11 @@ describe('runEditGuard', () => {
   });
 
   it('blocks when active project does not match the intended target project', async () => {
-    loadRegistryMock.mockResolvedValue({
-      active_project: 'cc-switch',
-      projects: [],
+    resolveGuardrailProjectTargetMock.mockResolvedValue({
+      activeProjectId: 'cc-switch',
+      resolutionSource: null,
+      resolutionErrors: ['Requested project "beta" does not match active project "cc-switch".'],
+      targetProject: null,
     });
 
     const result = JSON.parse(await runEditGuard({
@@ -105,20 +127,11 @@ describe('runEditGuard', () => {
     })) as { status: string; block_reasons: string[] };
 
     expect(result.status).toBe('BLOCK');
-    expect(result.block_reasons.join(' ')).toContain('does not match target project');
+    expect(result.block_reasons.join(' ')).toContain('does not match active project');
   });
 
   it('blocks when no preflight evidence is recorded', async () => {
     readFileMock.mockImplementation(async (path: string) => {
-      if (path.endsWith('/.project.yaml')) {
-        return JSON.stringify({
-          meta: {
-            id: 'agenticos-standards',
-            name: 'agenticos-standards',
-          },
-        });
-      }
-
       if (path.endsWith('/.context/state.yaml')) {
         return JSON.stringify({});
       }
@@ -154,5 +167,30 @@ describe('runEditGuard', () => {
 
     expect(result.status).toBe('BLOCK');
     expect(result.block_reasons.join(' ')).toContain('exceed the latest preflight scope');
+  });
+
+  it('blocks bugfix edits when the git common repo root is not declared for the target project', async () => {
+    execAsyncMock.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('rev-parse --show-toplevel')) {
+        return { stdout: '/workspace/wrong-repo\n', stderr: '' };
+      }
+      if (cmd.includes('rev-parse --git-common-dir')) {
+        return { stdout: '.git\n', stderr: '' };
+      }
+      throw new Error(`Unexpected command: ${cmd}`);
+    });
+
+    const result = JSON.parse(await runEditGuard({
+      issue_id: '113',
+      task_type: 'bugfix',
+      repo_path: '/workspace/wrong-repo',
+      project_path: '/workspace/projects/agenticos/standards',
+      declared_target_files: [
+        'projects/agenticos/mcp-server/src/index.ts',
+      ],
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons.join(' ')).toContain('not declared for target project');
   });
 });

--- a/projects/agenticos/mcp-server/src/tools/__tests__/pr-scope-check.test.ts
+++ b/projects/agenticos/mcp-server/src/tools/__tests__/pr-scope-check.test.ts
@@ -16,9 +16,14 @@ const persistGuardrailEvidenceMock = vi.hoisted(() => vi.fn().mockResolvedValue(
   project_id: 'agenticos',
   state_path: '/repo/.context/state.yaml',
 }));
+const resolveGuardrailProjectTargetMock = vi.hoisted(() => vi.fn());
 
 vi.mock('../../utils/guardrail-evidence.js', () => ({
   persistGuardrailEvidence: persistGuardrailEvidenceMock,
+}));
+
+vi.mock('../../utils/repo-boundary.js', () => ({
+  resolveGuardrailProjectTarget: resolveGuardrailProjectTargetMock,
 }));
 
 import { runPrScopeCheck } from '../pr-scope-check.js';
@@ -43,10 +48,26 @@ describe('runPrScopeCheck', () => {
       project_id: 'agenticos',
       state_path: '/repo/.context/state.yaml',
     });
+    resolveGuardrailProjectTargetMock.mockResolvedValue({
+      activeProjectId: 'agenticos',
+      resolutionSource: 'active_project',
+      resolutionErrors: [],
+      targetProject: {
+        id: 'agenticos',
+        name: 'AgenticOS',
+        path: '/workspace/projects/agenticos/standards',
+        statePath: '/workspace/projects/agenticos/standards/.context/state.yaml',
+        projectYamlPath: '/workspace/projects/agenticos/standards/.project.yaml',
+        sourceRepoRoots: ['/repo'],
+        sourceRepoRootsDeclared: true,
+      },
+    });
   });
 
   it('returns PASS when commits and files stay within the intended issue scope', async () => {
     mockGitResponses({
+      'rev-parse --show-toplevel': '/repo/worktrees/issue-36\n',
+      'rev-parse --git-common-dir': '/repo/.git\n',
       'rev-parse origin/main': 'base999\n',
       'merge-base HEAD origin/main': 'base999\n',
       'log --format=%s origin/main..HEAD': 'feat(mcp-server): add agenticos_branch_bootstrap helper (#36)\n',
@@ -69,6 +90,8 @@ describe('runPrScopeCheck', () => {
 
   it('returns PASS when declared exact file paths contain dots', async () => {
     mockGitResponses({
+      'rev-parse --show-toplevel': '/repo/worktrees/issue-114\n',
+      'rev-parse --git-common-dir': '/repo/.git\n',
       'rev-parse origin/main': 'base999\n',
       'merge-base HEAD origin/main': 'base999\n',
       'log --format=%s origin/main..HEAD': 'fix(mcp-server): preserve literal dots in pr scope matching (#114)\n',
@@ -91,6 +114,8 @@ describe('runPrScopeCheck', () => {
 
   it('returns BLOCK when commit subjects do not match the current issue', async () => {
     mockGitResponses({
+      'rev-parse --show-toplevel': '/repo/worktrees/issue-36\n',
+      'rev-parse --git-common-dir': '/repo/.git\n',
       'rev-parse origin/main': 'base999\n',
       'merge-base HEAD origin/main': 'base999\n',
       'log --format=%s origin/main..HEAD': 'fix(record): defensively parse JSON-stringified array args (fixes #24)\n',
@@ -111,6 +136,8 @@ describe('runPrScopeCheck', () => {
 
   it('returns BLOCK when changed files escape the declared target scope', async () => {
     mockGitResponses({
+      'rev-parse --show-toplevel': '/repo/worktrees/issue-36\n',
+      'rev-parse --git-common-dir': '/repo/.git\n',
       'rev-parse origin/main': 'base999\n',
       'merge-base HEAD origin/main': 'base999\n',
       'log --format=%s origin/main..HEAD': 'feat(mcp-server): add agenticos_pr_scope_check (#36)\n',
@@ -142,5 +169,26 @@ describe('runPrScopeCheck', () => {
     expect(result.status).toBe('BLOCK');
     expect(result.branch_ancestry_verified).toBe(false);
     expect(result.block_reasons[0]).toContain('not comparable');
+  });
+
+  it('returns BLOCK when the git common repo root is not declared for the target project', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo/worktrees/issue-160\n',
+      'rev-parse --git-common-dir': '/external/.git\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'log --format=%s origin/main..HEAD': 'fix(mcp-server): enforce source repo bindings (#160)\n',
+      'diff --name-only origin/main...HEAD': 'projects/agenticos/mcp-server/src/tools/preflight.ts\n',
+    });
+
+    const result = JSON.parse(await runPrScopeCheck({
+      issue_id: '160',
+      repo_path: '/repo/worktrees/issue-160',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/**'],
+      expected_issue_scope: 'repo_boundary_enforcement',
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons.join(' ')).toContain('not declared for target project');
   });
 });

--- a/projects/agenticos/mcp-server/src/tools/__tests__/preflight.test.ts
+++ b/projects/agenticos/mcp-server/src/tools/__tests__/preflight.test.ts
@@ -17,8 +17,15 @@ const persistGuardrailEvidenceMock = vi.hoisted(() => vi.fn().mockResolvedValue(
   state_path: '/repo/.context/state.yaml',
 }));
 
+const resolveGuardrailProjectTargetMock = vi.hoisted(() => vi.fn());
+
 vi.mock('../../utils/guardrail-evidence.js', () => ({
   persistGuardrailEvidence: persistGuardrailEvidenceMock,
+}));
+
+vi.mock('../../utils/repo-boundary.js', () => ({
+  isImplementationAffectingTask: (taskType: string) => taskType === 'implementation' || taskType === 'bugfix',
+  resolveGuardrailProjectTarget: resolveGuardrailProjectTargetMock,
 }));
 
 import { runPreflight } from '../preflight.js';
@@ -43,11 +50,27 @@ describe('runPreflight', () => {
       project_id: 'agenticos',
       state_path: '/repo/.context/state.yaml',
     });
+    resolveGuardrailProjectTargetMock.mockResolvedValue({
+      activeProjectId: 'agenticos',
+      resolutionSource: 'active_project',
+      resolutionErrors: [],
+      targetProject: {
+        id: 'agenticos',
+        name: 'AgenticOS',
+        path: '/workspace/projects/agenticos/standards',
+        statePath: '/workspace/projects/agenticos/standards/.context/state.yaml',
+        projectYamlPath: '/workspace/projects/agenticos/standards/.project.yaml',
+        sourceRepoRoots: ['/repo'],
+        sourceRepoRootsDeclared: true,
+      },
+    });
   });
 
   it('returns PASS for a correctly isolated implementation branch', async () => {
     mockGitResponses({
       'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --git-common-dir': '.git\n',
+      'config --get remote.origin.url': 'git@github.com:madlouse/AgenticOS.git\n',
       'rev-parse --abbrev-ref HEAD': 'feat/36-guardrail-preflight\n',
       'rev-parse HEAD': 'abc123\n',
       'rev-parse origin/main': 'base999\n',
@@ -74,6 +97,8 @@ describe('runPreflight', () => {
   it('returns REDIRECT when implementation starts on main workspace', async () => {
     mockGitResponses({
       'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --git-common-dir': '.git\n',
+      'config --get remote.origin.url': 'git@github.com:madlouse/AgenticOS.git\n',
       'rev-parse --abbrev-ref HEAD': 'main\n',
       'rev-parse HEAD': 'abc123\n',
       'rev-parse origin/main': 'base999\n',
@@ -97,6 +122,8 @@ describe('runPreflight', () => {
   it('passes project_path through to guardrail evidence persistence when provided', async () => {
     mockGitResponses({
       'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --git-common-dir': '.git\n',
+      'config --get remote.origin.url': 'git@github.com:madlouse/AgenticOS.git\n',
       'rev-parse --abbrev-ref HEAD': 'feat/113-fail-closed-edit-boundaries\n',
       'rev-parse HEAD': 'abc123\n',
       'rev-parse origin/main': 'base999\n',
@@ -115,6 +142,46 @@ describe('runPreflight', () => {
     });
 
     expect(persistGuardrailEvidenceMock).toHaveBeenCalledWith(expect.objectContaining({
+      project_path: '/workspace/projects/agenticos/standards',
+    }));
+  });
+
+  it('persists the resolved active project path even when repo_path is a larger checkout root', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --git-common-dir': '.git\n',
+      'config --get remote.origin.url': 'git@github.com:madlouse/AgenticOS.git\n',
+      'rev-parse --abbrev-ref HEAD': 'feat/160-source-repo-boundary-enforcement\n',
+      'rev-parse HEAD': 'abc123\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo\nHEAD abc123\nbranch refs/heads/feat/160-source-repo-boundary-enforcement\n',
+      'log --format=%s origin/main..HEAD': '',
+    });
+    resolveGuardrailProjectTargetMock.mockResolvedValue({
+      activeProjectId: 'agenticos-standards',
+      resolutionSource: 'active_project',
+      resolutionErrors: [],
+      targetProject: {
+        id: 'agenticos-standards',
+        name: 'agenticos-standards',
+        path: '/repo/projects/agenticos/standards',
+        statePath: '/repo/projects/agenticos/standards/.context/state.yaml',
+        projectYamlPath: '/repo/projects/agenticos/standards/.project.yaml',
+        sourceRepoRoots: ['/repo'],
+        sourceRepoRootsDeclared: true,
+      },
+    });
+
+    await runPreflight({
+      issue_id: '160',
+      task_type: 'implementation',
+      repo_path: '/repo',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/preflight.ts'],
+      worktree_required: true,
+    });
+
+    expect(persistGuardrailEvidenceMock).toHaveBeenCalledWith(expect.objectContaining({
       project_path: '/repo/projects/agenticos/standards',
     }));
   });
@@ -122,6 +189,8 @@ describe('runPreflight', () => {
   it('returns BLOCK when branch contains unrelated commits relative to origin/main', async () => {
     mockGitResponses({
       'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --git-common-dir': '.git\n',
+      'config --get remote.origin.url': 'git@github.com:madlouse/AgenticOS.git\n',
       'rev-parse --abbrev-ref HEAD': 'fix/43-mcp-server-clean-install-baseline\n',
       'rev-parse HEAD': 'abc123\n',
       'rev-parse origin/main': 'base999\n',
@@ -145,6 +214,8 @@ describe('runPreflight', () => {
   it('returns BLOCK for structural move without root exception or reproducibility gate', async () => {
     mockGitResponses({
       'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --git-common-dir': '.git\n',
+      'config --get remote.origin.url': 'git@github.com:madlouse/AgenticOS.git\n',
       'rev-parse --abbrev-ref HEAD': 'feat/40-self-hosting\n',
       'rev-parse HEAD': 'abc123\n',
       'rev-parse origin/main': 'base999\n',
@@ -167,5 +238,30 @@ describe('runPreflight', () => {
     expect(result.status).toBe('BLOCK');
     expect(result.block_reasons.join(' ')).toContain('.github/');
     expect(result.block_reasons.join(' ')).toContain('clean_reproducibility_gate');
+  });
+
+  it('returns BLOCK when the git common repo root is not declared for the active project', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo/worktrees/issue-160\n',
+      'rev-parse --git-common-dir': '/external/.git\n',
+      'config --get remote.origin.url': 'git@github.com:wrong/repo.git\n',
+      'rev-parse --abbrev-ref HEAD': 'fix/160-source-repo-boundary-enforcement\n',
+      'rev-parse HEAD': 'abc123\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo/worktrees/issue-160\nHEAD abc123\nbranch refs/heads/fix/160-source-repo-boundary-enforcement\n',
+      'log --format=%s origin/main..HEAD': '',
+    });
+
+    const result = JSON.parse(await runPreflight({
+      issue_id: '160',
+      task_type: 'bugfix',
+      repo_path: '/repo/worktrees/issue-160',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/preflight.ts'],
+      worktree_required: true,
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons.join(' ')).toContain('not declared for target project');
   });
 });

--- a/projects/agenticos/mcp-server/src/tools/branch-bootstrap.ts
+++ b/projects/agenticos/mcp-server/src/tools/branch-bootstrap.ts
@@ -1,8 +1,9 @@
 import { exec } from 'child_process';
 import { access, mkdir } from 'fs/promises';
-import { basename, join } from 'path';
+import { basename, dirname, join, resolve } from 'path';
 import { promisify } from 'util';
 import { persistGuardrailEvidence, type GuardrailPersistenceResult } from '../utils/guardrail-evidence.js';
+import { resolveGuardrailProjectTarget } from '../utils/repo-boundary.js';
 
 const execAsync = promisify(exec);
 
@@ -11,6 +12,7 @@ interface BranchBootstrapArgs {
   branch_type?: string;
   slug?: string;
   repo_path?: string;
+  project_path?: string;
   remote_base_branch?: string;
   worktree_root?: string;
 }
@@ -64,6 +66,7 @@ export async function runBranchBootstrap(args: BranchBootstrapArgs): Promise<str
     branch_type = 'feat',
     slug,
     repo_path,
+    project_path,
     remote_base_branch = 'origin/main',
     worktree_root,
   } = args;
@@ -87,8 +90,10 @@ export async function runBranchBootstrap(args: BranchBootstrapArgs): Promise<str
     result.persistence = await persistGuardrailEvidence({
       command: 'agenticos_branch_bootstrap',
       repo_path,
+      project_path,
       payload: {
         issue_id: issue_id || null,
+        project_path: project_path || null,
         branch_type,
         slug: slug || null,
         remote_base_branch,
@@ -112,8 +117,10 @@ export async function runBranchBootstrap(args: BranchBootstrapArgs): Promise<str
     result.persistence = await persistGuardrailEvidence({
       command: 'agenticos_branch_bootstrap',
       repo_path,
+      project_path,
       payload: {
         issue_id,
+        project_path: project_path || null,
         branch_type,
         slug,
         remote_base_branch,
@@ -131,19 +138,53 @@ export async function runBranchBootstrap(args: BranchBootstrapArgs): Promise<str
     return JSON.stringify(result, null, 2);
   }
 
-  const repoName = sanitizeSegment(basename(repo_path)) || 'repo';
-  result.branch_name = `${branch_type}/${issue_id}-${sanitizedSlug}`;
-  result.worktree_path = join(worktree_root, `${repoName}-${issue_id}-${sanitizedSlug}`);
+  const projectResolution = await resolveGuardrailProjectTarget({
+    commandName: 'agenticos_branch_bootstrap',
+    repoPath: repo_path,
+    projectPath: project_path,
+  });
+  if (!projectResolution.targetProject) {
+    result.block_reasons.push(...projectResolution.resolutionErrors);
+  }
+
+  let gitCommonRepoRoot: string | null = null;
+  let gitRemoteOrigin: string | null = null;
 
   try {
+    const gitWorktreeRoot = await runGit(repo_path, 'rev-parse --show-toplevel');
+    const gitCommonDir = resolve(gitWorktreeRoot, await runGit(repo_path, 'rev-parse --git-common-dir'));
+    gitCommonRepoRoot = dirname(gitCommonDir);
+    gitRemoteOrigin = await runGit(repo_path, 'config --get remote.origin.url').catch(() => '');
+    const repoName = sanitizeSegment(basename(gitCommonRepoRoot)) || sanitizeSegment(basename(repo_path)) || 'repo';
+
+    result.branch_name = `${branch_type}/${issue_id}-${sanitizedSlug}`;
+    result.worktree_path = join(worktree_root, `${repoName}-${issue_id}-${sanitizedSlug}`);
     result.base_commit = await runGit(repo_path, `rev-parse ${remote_base_branch}`);
+
+    if (projectResolution.targetProject) {
+      if (!projectResolution.targetProject.sourceRepoRootsDeclared || projectResolution.targetProject.sourceRepoRoots.length === 0) {
+        result.block_reasons.push(
+          `target project "${projectResolution.targetProject.id}" is missing execution.source_repo_roots in ${projectResolution.targetProject.projectYamlPath}`,
+        );
+      } else if (!projectResolution.targetProject.sourceRepoRoots.includes(gitCommonRepoRoot)) {
+        result.block_reasons.push(
+          `git common repo root "${gitCommonRepoRoot}" is not declared for target project "${projectResolution.targetProject.id}"`,
+        );
+        result.notes.push(`declared source repo roots: ${projectResolution.targetProject.sourceRepoRoots.join(', ')}`);
+      }
+    }
   } catch {
     result.block_reasons.push(`failed to resolve remote base ${remote_base_branch}`);
     result.persistence = await persistGuardrailEvidence({
       command: 'agenticos_branch_bootstrap',
       repo_path,
+      project_path: projectResolution.targetProject?.path || project_path,
       payload: {
         issue_id,
+        target_project_id: projectResolution.targetProject?.id || null,
+        active_project: projectResolution.activeProjectId,
+        git_common_repo_root: gitCommonRepoRoot,
+        git_remote_origin: gitRemoteOrigin,
         branch_type,
         slug,
         remote_base_branch,
@@ -176,8 +217,13 @@ export async function runBranchBootstrap(args: BranchBootstrapArgs): Promise<str
     result.persistence = await persistGuardrailEvidence({
       command: 'agenticos_branch_bootstrap',
       repo_path,
+      project_path: projectResolution.targetProject?.path || project_path,
       payload: {
         issue_id,
+        target_project_id: projectResolution.targetProject?.id || null,
+        active_project: projectResolution.activeProjectId,
+        git_common_repo_root: gitCommonRepoRoot,
+        git_remote_origin: gitRemoteOrigin,
         branch_type,
         slug,
         remote_base_branch,
@@ -198,7 +244,7 @@ export async function runBranchBootstrap(args: BranchBootstrapArgs): Promise<str
   await mkdir(worktree_root, { recursive: true });
   await runGit(
     repo_path,
-    `worktree add "${result.worktree_path}" -b ${result.branch_name} ${result.base_commit}`
+    `worktree add "${result.worktree_path}" -b ${result.branch_name} ${result.base_commit}`,
   );
 
   result.status = 'CREATED';
@@ -207,8 +253,13 @@ export async function runBranchBootstrap(args: BranchBootstrapArgs): Promise<str
   result.persistence = await persistGuardrailEvidence({
     command: 'agenticos_branch_bootstrap',
     repo_path,
+    project_path: projectResolution.targetProject?.path || project_path,
     payload: {
       issue_id,
+      target_project_id: projectResolution.targetProject?.id || null,
+      active_project: projectResolution.activeProjectId,
+      git_common_repo_root: gitCommonRepoRoot,
+      git_remote_origin: gitRemoteOrigin,
       branch_type,
       slug,
       remote_base_branch,

--- a/projects/agenticos/mcp-server/src/tools/edit-guard.ts
+++ b/projects/agenticos/mcp-server/src/tools/edit-guard.ts
@@ -1,14 +1,19 @@
 import { readFile } from 'fs/promises';
-import { basename, join, resolve, sep } from 'path';
+import { exec } from 'child_process';
+import { dirname, resolve } from 'path';
+import { promisify } from 'util';
 import yaml from 'yaml';
-import { loadRegistry } from '../utils/registry.js';
-
-type TaskType = 'discussion_only' | 'analysis_or_doc' | 'implementation' | 'bootstrap';
+import {
+  isImplementationAffectingTask,
+  resolveGuardrailProjectTarget,
+  type GuardrailTaskType,
+} from '../utils/repo-boundary.js';
 type GuardStatus = 'PASS' | 'BLOCK';
+const execAsync = promisify(exec);
 
 interface EditGuardArgs {
   issue_id?: string;
-  task_type?: TaskType;
+  task_type?: GuardrailTaskType;
   repo_path?: string;
   project_path?: string;
   declared_target_files?: string[];
@@ -23,6 +28,8 @@ interface EditGuardResult {
     name: string;
     path: string;
     state_path: string;
+    project_yaml_path: string;
+    declared_source_repo_roots: string[];
   } | null;
   preflight_ok: boolean;
   scope_ok: boolean;
@@ -31,6 +38,9 @@ interface EditGuardResult {
   evidence: {
     repo_path: string | null;
     project_path: string | null;
+    active_project: string | null;
+    git_worktree_root: string | null;
+    git_common_repo_root: string | null;
     preflight_issue_id: string | null;
     preflight_repo_path: string | null;
     preflight_status: string | null;
@@ -38,77 +48,15 @@ interface EditGuardResult {
   };
 }
 
-function normalizePath(path: string): string {
-  return resolve(path);
-}
-
-function resolveProjectStatePath(projectPath: string, projectYaml: any): string {
-  const configuredStatePath = projectYaml?.agent_context?.current_state;
-  if (typeof configuredStatePath === 'string' && configuredStatePath.trim().length > 0) {
-    return join(projectPath, configuredStatePath.trim());
-  }
-  return join(projectPath, '.context', 'state.yaml');
-}
-
-function isWithinProject(repoPath: string, projectPath: string): boolean {
-  return repoPath === projectPath || repoPath.startsWith(`${projectPath}${sep}`);
-}
-
-async function fileExists(path: string): Promise<boolean> {
-  try {
-    await readFile(path, 'utf-8');
-    return true;
-  } catch {
-    return false;
-  }
+async function runGit(repoPath: string, args: string): Promise<string> {
+  const { stdout } = await execAsync(`git -C "${repoPath}" ${args}`);
+  return stdout.trim();
 }
 
 function normalizeDeclaredTargets(targets: string[]): string[] {
   return targets
     .map((target) => String(target || '').trim())
     .filter((target) => target.length > 0);
-}
-
-async function resolveTargetProject(repoPath: string, explicitProjectPath?: string): Promise<EditGuardResult['target_project']> {
-  if (explicitProjectPath) {
-    const normalizedProjectPath = normalizePath(explicitProjectPath);
-    const projectYamlPath = join(normalizedProjectPath, '.project.yaml');
-    if (!(await fileExists(projectYamlPath))) {
-      return null;
-    }
-
-    const projectYaml = yaml.parse(await readFile(projectYamlPath, 'utf-8')) || {};
-    return {
-      id: String(projectYaml?.meta?.id || basename(normalizedProjectPath)),
-      name: String(projectYaml?.meta?.name || projectYaml?.meta?.id || basename(normalizedProjectPath)),
-      path: normalizedProjectPath,
-      state_path: resolveProjectStatePath(normalizedProjectPath, projectYaml),
-    };
-  }
-
-  const registry = await loadRegistry();
-  const normalizedRepoPath = normalizePath(repoPath);
-  const match = registry.projects
-    .map((project) => ({ ...project, path: normalizePath(project.path) }))
-    .filter((project) => isWithinProject(normalizedRepoPath, project.path))
-    .sort((a, b) => b.path.length - a.path.length)[0];
-
-  if (!match) {
-    return null;
-  }
-
-  const projectYamlPath = join(match.path, '.project.yaml');
-  if (!(await fileExists(projectYamlPath))) {
-    return null;
-  }
-
-  const projectYaml = yaml.parse(await readFile(projectYamlPath, 'utf-8')) || {};
-  return {
-    id: String(projectYaml?.meta?.id || match.id),
-    name: String(projectYaml?.meta?.name || match.name),
-    path: match.path,
-    state_path: resolveProjectStatePath(match.path, projectYaml),
-  };
 }
 
 export async function runEditGuard(args: EditGuardArgs): Promise<string> {
@@ -132,6 +80,9 @@ export async function runEditGuard(args: EditGuardArgs): Promise<string> {
     evidence: {
       repo_path: repo_path || null,
       project_path: project_path || null,
+      active_project: null,
+      git_worktree_root: null,
+      git_common_repo_root: null,
       preflight_issue_id: null,
       preflight_repo_path: null,
       preflight_status: null,
@@ -139,7 +90,7 @@ export async function runEditGuard(args: EditGuardArgs): Promise<string> {
     },
   };
 
-  if (task_type !== 'implementation') {
+  if (!isImplementationAffectingTask(task_type)) {
     result.status = 'PASS';
     result.summary = `edit guard not required for task_type=${task_type}`;
     return JSON.stringify(result, null, 2);
@@ -150,39 +101,67 @@ export async function runEditGuard(args: EditGuardArgs): Promise<string> {
   }
 
   if (!issue_id) {
-    result.block_reasons.push('issue_id is required for implementation edits');
+    result.block_reasons.push(`issue_id is required for ${task_type} edits`);
   }
 
   const attemptedTargets = normalizeDeclaredTargets(declared_target_files);
   if (attemptedTargets.length === 0) {
-    result.block_reasons.push('declared_target_files is required for implementation edits');
+    result.block_reasons.push(`declared_target_files is required for ${task_type} edits`);
   }
 
-  const registry = await loadRegistry();
-  result.active_project = registry.active_project || null;
-  if (!registry.active_project) {
-    result.block_reasons.push('no active project is set');
-    result.recovery_actions.push('call agenticos_switch before attempting implementation edits');
+  const projectResolution = await resolveGuardrailProjectTarget({
+    commandName: 'agenticos_edit_guard',
+    repoPath: repo_path,
+    projectPath: project_path,
+  });
+  result.active_project = projectResolution.activeProjectId;
+  result.evidence.active_project = projectResolution.activeProjectId;
+
+  if (projectResolution.targetProject) {
+    result.target_project = {
+      id: projectResolution.targetProject.id,
+      name: projectResolution.targetProject.name,
+      path: projectResolution.targetProject.path,
+      state_path: projectResolution.targetProject.statePath,
+      project_yaml_path: projectResolution.targetProject.projectYamlPath,
+      declared_source_repo_roots: projectResolution.targetProject.sourceRepoRoots,
+    };
+  } else {
+    result.block_reasons.push(...projectResolution.resolutionErrors);
+    if (!projectResolution.activeProjectId) {
+      result.recovery_actions.push('call agenticos_switch before attempting implementation-affecting edits');
+    }
+    result.recovery_actions.push('pass project_path pointing at the managed project root when needed');
   }
 
   if (repo_path) {
-    result.target_project = await resolveTargetProject(repo_path, project_path);
-  }
+    try {
+      const gitWorktreeRoot = await runGit(repo_path, 'rev-parse --show-toplevel');
+      const gitCommonDir = resolve(gitWorktreeRoot, await runGit(repo_path, 'rev-parse --git-common-dir'));
+      const gitCommonRepoRoot = dirname(gitCommonDir);
+      result.evidence.git_worktree_root = gitWorktreeRoot;
+      result.evidence.git_common_repo_root = gitCommonRepoRoot;
 
-  if (!result.target_project) {
-    result.block_reasons.push(
-      project_path
-        ? `project_path is not a resolvable managed project: ${project_path}`
-        : 'target project could not be resolved from repo_path; pass project_path explicitly',
-    );
-    result.recovery_actions.push('pass project_path pointing at the managed project root');
-  }
-
-  if (result.active_project && result.target_project && result.active_project !== result.target_project.id) {
-    result.block_reasons.push(
-      `active project "${result.active_project}" does not match target project "${result.target_project.id}"`,
-    );
-    result.recovery_actions.push(`call agenticos_switch for project "${result.target_project.id}" before editing`);
+      if (result.target_project) {
+        if (result.target_project.declared_source_repo_roots.length === 0) {
+          result.block_reasons.push(
+            `target project "${result.target_project.id}" is missing execution.source_repo_roots in ${result.target_project.project_yaml_path}`,
+          );
+          result.recovery_actions.push(
+            `declare execution.source_repo_roots in ${result.target_project.project_yaml_path} before ${task_type} edits`,
+          );
+        } else if (!result.target_project.declared_source_repo_roots.includes(gitCommonRepoRoot)) {
+          result.block_reasons.push(
+            `git common repo root "${gitCommonRepoRoot}" is not declared for target project "${result.target_project.id}"`,
+          );
+          result.recovery_actions.push(
+            `rerun in a declared source repo root: ${result.target_project.declared_source_repo_roots.join(', ')}`,
+          );
+        }
+      }
+    } catch {
+      result.block_reasons.push('failed to resolve git repository identity for the requested edit');
+    }
   }
 
   let state: any = {};
@@ -214,7 +193,7 @@ export async function runEditGuard(args: EditGuardArgs): Promise<string> {
       result.recovery_actions.push(`rerun agenticos_preflight for issue #${issue_id}`);
     }
 
-    if (repo_path && normalizePath(preflight.repo_path || '') !== normalizePath(repo_path)) {
+    if (repo_path && resolve(preflight.repo_path || '') !== resolve(repo_path)) {
       result.block_reasons.push('latest preflight was recorded for a different repo_path');
       result.recovery_actions.push('rerun agenticos_preflight for the current repo_path');
     }

--- a/projects/agenticos/mcp-server/src/tools/pr-scope-check.ts
+++ b/projects/agenticos/mcp-server/src/tools/pr-scope-check.ts
@@ -1,12 +1,15 @@
 import { exec } from 'child_process';
+import { dirname, resolve } from 'path';
 import { promisify } from 'util';
 import { persistGuardrailEvidence, type GuardrailPersistenceResult } from '../utils/guardrail-evidence.js';
+import { resolveGuardrailProjectTarget } from '../utils/repo-boundary.js';
 
 const execAsync = promisify(exec);
 
 interface PrScopeCheckArgs {
   issue_id?: string;
   repo_path?: string;
+  project_path?: string;
   remote_base_branch?: string;
   declared_target_files?: string[];
   expected_issue_scope?: string;
@@ -100,12 +103,18 @@ export async function runPrScopeCheck(args: PrScopeCheckArgs): Promise<string> {
   const {
     issue_id,
     repo_path,
+    project_path,
     remote_base_branch = 'origin/main',
     declared_target_files = [],
     expected_issue_scope = 'unspecified',
   } = args;
 
   const result = makeBaseResult(remote_base_branch, expected_issue_scope);
+  const projectResolution = await resolveGuardrailProjectTarget({
+    commandName: 'agenticos_pr_scope_check',
+    repoPath: repo_path,
+    projectPath: project_path,
+  });
 
   if (!issue_id) {
     result.block_reasons.push('issue_id is required');
@@ -116,14 +125,19 @@ export async function runPrScopeCheck(args: PrScopeCheckArgs): Promise<string> {
   if (declared_target_files.length === 0) {
     result.block_reasons.push('declared_target_files is required');
   }
+  if (!projectResolution.targetProject) {
+    result.block_reasons.push(...projectResolution.resolutionErrors);
+  }
 
   if (result.block_reasons.length > 0 || !repo_path || !issue_id || declared_target_files.length === 0) {
     result.summary = result.block_reasons.join('; ');
     result.persistence = await persistGuardrailEvidence({
       command: 'agenticos_pr_scope_check',
       repo_path,
+      project_path: projectResolution.targetProject?.path || project_path,
       payload: {
         issue_id: issue_id || null,
+        target_project_id: projectResolution.targetProject?.id || null,
         remote_base_branch,
         declared_target_files,
         expected_issue_scope,
@@ -145,7 +159,25 @@ export async function runPrScopeCheck(args: PrScopeCheckArgs): Promise<string> {
     return JSON.stringify(result, null, 2);
   }
 
+  let gitCommonRepoRoot: string | null = null;
+  let gitRemoteOrigin: string | null = null;
+
   try {
+    const gitWorktreeRoot = await runGit(repo_path, 'rev-parse --show-toplevel');
+    const gitCommonDir = resolve(gitWorktreeRoot, await runGit(repo_path, 'rev-parse --git-common-dir'));
+    gitCommonRepoRoot = dirname(gitCommonDir);
+    gitRemoteOrigin = await runGit(repo_path, 'config --get remote.origin.url').catch(() => null);
+
+    if (!projectResolution.targetProject?.sourceRepoRootsDeclared || projectResolution.targetProject.sourceRepoRoots.length === 0) {
+      result.block_reasons.push(
+        `target project "${projectResolution.targetProject?.id || 'unknown'}" is missing execution.source_repo_roots in ${projectResolution.targetProject?.projectYamlPath || 'unknown project metadata'}`,
+      );
+    } else if (!projectResolution.targetProject.sourceRepoRoots.includes(gitCommonRepoRoot)) {
+      result.block_reasons.push(
+        `git common repo root "${gitCommonRepoRoot}" is not declared for target project "${projectResolution.targetProject.id}"`,
+      );
+    }
+
     await runGit(repo_path, `rev-parse ${remote_base_branch}`);
     result.branch_fork_point = await runGit(repo_path, `merge-base HEAD ${remote_base_branch}`);
     result.branch_ancestry_verified = true;
@@ -155,8 +187,13 @@ export async function runPrScopeCheck(args: PrScopeCheckArgs): Promise<string> {
     result.persistence = await persistGuardrailEvidence({
       command: 'agenticos_pr_scope_check',
       repo_path,
+      project_path: projectResolution.targetProject?.path || project_path,
       payload: {
         issue_id,
+        target_project_id: projectResolution.targetProject?.id || null,
+        active_project: projectResolution.activeProjectId,
+        git_common_repo_root: gitCommonRepoRoot,
+        git_remote_origin: gitRemoteOrigin,
         remote_base_branch,
         declared_target_files,
         expected_issue_scope,
@@ -179,10 +216,10 @@ export async function runPrScopeCheck(args: PrScopeCheckArgs): Promise<string> {
   }
 
   const subjects = normalizeLines(
-    await runGit(repo_path, `log --format=%s ${remote_base_branch}..HEAD`).catch(() => '')
+    await runGit(repo_path, `log --format=%s ${remote_base_branch}..HEAD`).catch(() => ''),
   );
   const changedFiles = normalizeLines(
-    await runGit(repo_path, `diff --name-only ${remote_base_branch}...HEAD`).catch(() => '')
+    await runGit(repo_path, `diff --name-only ${remote_base_branch}...HEAD`).catch(() => ''),
   );
 
   result.commit_count = subjects.length;
@@ -204,8 +241,13 @@ export async function runPrScopeCheck(args: PrScopeCheckArgs): Promise<string> {
     result.persistence = await persistGuardrailEvidence({
       command: 'agenticos_pr_scope_check',
       repo_path,
+      project_path: projectResolution.targetProject?.path || project_path,
       payload: {
         issue_id,
+        target_project_id: projectResolution.targetProject?.id || null,
+        active_project: projectResolution.activeProjectId,
+        git_common_repo_root: gitCommonRepoRoot,
+        git_remote_origin: gitRemoteOrigin,
         remote_base_branch,
         declared_target_files,
         expected_issue_scope,
@@ -232,8 +274,13 @@ export async function runPrScopeCheck(args: PrScopeCheckArgs): Promise<string> {
   result.persistence = await persistGuardrailEvidence({
     command: 'agenticos_pr_scope_check',
     repo_path,
+    project_path: projectResolution.targetProject?.path || project_path,
     payload: {
       issue_id,
+      target_project_id: projectResolution.targetProject?.id || null,
+      active_project: projectResolution.activeProjectId,
+      git_common_repo_root: gitCommonRepoRoot,
+      git_remote_origin: gitRemoteOrigin,
       remote_base_branch,
       declared_target_files,
       expected_issue_scope,

--- a/projects/agenticos/mcp-server/src/tools/preflight.ts
+++ b/projects/agenticos/mcp-server/src/tools/preflight.ts
@@ -1,16 +1,21 @@
 import { exec } from 'child_process';
+import { dirname, resolve } from 'path';
 import { promisify } from 'util';
 import { persistGuardrailEvidence, type GuardrailPersistenceResult } from '../utils/guardrail-evidence.js';
+import {
+  isImplementationAffectingTask,
+  resolveGuardrailProjectTarget,
+  type GuardrailTaskType,
+} from '../utils/repo-boundary.js';
 
 const execAsync = promisify(exec);
 
-type TaskType = 'discussion_only' | 'analysis_or_doc' | 'implementation' | 'bootstrap';
 type WorkspaceType = 'main' | 'isolated_worktree';
 type GuardrailStatus = 'PASS' | 'BLOCK' | 'REDIRECT';
 
 interface PreflightArgs {
   issue_id?: string;
-  task_type?: TaskType;
+  task_type?: GuardrailTaskType;
   repo_path?: string;
   project_path?: string;
   remote_base_branch?: string;
@@ -33,6 +38,15 @@ interface PreflightResult {
   block_reasons: string[];
   redirect_actions: string[];
   evidence: {
+    active_project: string | null;
+    target_project_id: string | null;
+    target_project_path: string | null;
+    target_project_yaml_path: string | null;
+    declared_source_repo_roots: string[];
+    git_worktree_root: string;
+    git_common_dir: string;
+    git_common_repo_root: string;
+    git_remote_origin: string | null;
     current_branch: string;
     current_head: string;
     remote_base_branch: string;
@@ -105,6 +119,15 @@ function makeBaseResult(remoteBaseBranch: string): PreflightResult {
     redirect_actions: [],
     evidence: {
       current_branch: '',
+      active_project: null,
+      target_project_id: null,
+      target_project_path: null,
+      target_project_yaml_path: null,
+      declared_source_repo_roots: [],
+      git_worktree_root: '',
+      git_common_dir: '',
+      git_common_repo_root: '',
+      git_remote_origin: null,
       current_head: '',
       remote_base_branch: remoteBaseBranch,
       remote_base_head: '',
@@ -124,7 +147,7 @@ export async function runPreflight(args: PreflightArgs): Promise<string> {
     remote_base_branch = 'origin/main',
     declared_target_files = [],
     structural_move = false,
-    worktree_required = task_type === 'implementation',
+    worktree_required = isImplementationAffectingTask(task_type),
     root_scoped_exceptions = ['.github/'],
     clean_reproducibility_gate = [],
   } = args;
@@ -136,33 +159,80 @@ export async function runPreflight(args: PreflightArgs): Promise<string> {
     return JSON.stringify(finalizeResult(result), null, 2);
   }
 
-  if (task_type === 'implementation' && !issue_id) {
-    result.block_reasons.push('issue_id is required for implementation work');
+  if (isImplementationAffectingTask(task_type) && !issue_id) {
+    result.block_reasons.push(`issue_id is required for ${task_type} work`);
   }
 
-  if (task_type === 'implementation' && declared_target_files.length === 0) {
-    result.block_reasons.push('declared_target_files is required for implementation work');
+  if (isImplementationAffectingTask(task_type) && declared_target_files.length === 0) {
+    result.block_reasons.push(`declared_target_files is required for ${task_type} work`);
+  }
+
+  const projectResolution = await resolveGuardrailProjectTarget({
+    commandName: 'agenticos_preflight',
+    repoPath: repo_path,
+    projectPath: project_path,
+  });
+  result.evidence.active_project = projectResolution.activeProjectId;
+  result.evidence.target_project_id = projectResolution.targetProject?.id || null;
+  result.evidence.target_project_path = projectResolution.targetProject?.path || null;
+  result.evidence.target_project_yaml_path = projectResolution.targetProject?.projectYamlPath || null;
+  result.evidence.declared_source_repo_roots = projectResolution.targetProject?.sourceRepoRoots || [];
+
+  if (!projectResolution.targetProject) {
+    result.block_reasons.push(...projectResolution.resolutionErrors);
+    if (!projectResolution.activeProjectId) {
+      result.redirect_actions.push('call agenticos_switch or pass project_path before implementation-affecting work');
+    } else {
+      result.redirect_actions.push('pass project_path explicitly if the active project is not the intended target');
+    }
   }
 
   try {
-    const gitRoot = await runGit(repo_path, 'rev-parse --show-toplevel');
-    result.repo_identity_confirmed = gitRoot.length > 0;
+    const gitWorktreeRoot = await runGit(repo_path, 'rev-parse --show-toplevel');
+    const gitCommonDirRaw = await runGit(repo_path, 'rev-parse --git-common-dir');
+    const gitCommonDir = resolve(gitWorktreeRoot, gitCommonDirRaw);
+    const gitCommonRepoRoot = dirname(gitCommonDir);
+
+    result.evidence.git_worktree_root = gitWorktreeRoot;
+    result.evidence.git_common_dir = gitCommonDir;
+    result.evidence.git_common_repo_root = gitCommonRepoRoot;
+    result.evidence.git_remote_origin = await runGit(repo_path, 'config --get remote.origin.url').catch(() => null);
     result.evidence.current_branch = await runGit(repo_path, 'rev-parse --abbrev-ref HEAD');
     result.evidence.current_head = await runGit(repo_path, 'rev-parse HEAD');
     result.evidence.remote_base_head = await runGit(repo_path, `rev-parse ${remote_base_branch}`);
     result.evidence.branch_fork_point = await runGit(repo_path, `merge-base HEAD ${remote_base_branch}`);
     result.branch_ancestry_verified = true;
     result.evidence.workspace_type = await detectWorkspaceType(repo_path);
+
+    if (projectResolution.targetProject) {
+      if (!projectResolution.targetProject.sourceRepoRootsDeclared || projectResolution.targetProject.sourceRepoRoots.length === 0) {
+        result.block_reasons.push(
+          `target project "${projectResolution.targetProject.id}" is missing execution.source_repo_roots in ${projectResolution.targetProject.projectYamlPath}`,
+        );
+        result.redirect_actions.push(
+          `declare execution.source_repo_roots in ${projectResolution.targetProject.projectYamlPath} before ${task_type} work`,
+        );
+      } else if (!projectResolution.targetProject.sourceRepoRoots.includes(gitCommonRepoRoot)) {
+        result.block_reasons.push(
+          `git common repo root "${gitCommonRepoRoot}" is not declared for target project "${projectResolution.targetProject.id}"`,
+        );
+        result.redirect_actions.push(
+          `rerun in a declared source repo root: ${projectResolution.targetProject.sourceRepoRoots.join(', ')}`,
+        );
+      } else {
+        result.repo_identity_confirmed = true;
+      }
+    }
   } catch {
     result.block_reasons.push('failed to resolve git repository identity or remote base');
     const finalized = finalizeResult(result);
     finalized.persistence = await persistGuardrailEvidence({
       command: 'agenticos_preflight',
       repo_path,
-      project_path,
+      project_path: projectResolution.targetProject?.path || project_path,
       payload: {
         issue_id: issue_id || null,
-        project_path: project_path || null,
+        project_path: projectResolution.targetProject?.path || project_path || null,
         task_type,
         declared_target_files,
         structural_move,
@@ -186,7 +256,7 @@ export async function runPreflight(args: PreflightArgs): Promise<string> {
     result.worktree_ok = true;
   }
 
-  if (task_type === 'implementation') {
+  if (isImplementationAffectingTask(task_type)) {
     const subjectsRaw = await runGit(repo_path, `log --format=%s ${remote_base_branch}..HEAD`).catch(() => '');
     const subjects = normalizeLines(subjectsRaw);
     result.evidence.commit_subjects_since_base = subjects;
@@ -229,10 +299,10 @@ export async function runPreflight(args: PreflightArgs): Promise<string> {
   finalized.persistence = await persistGuardrailEvidence({
     command: 'agenticos_preflight',
     repo_path,
-    project_path,
+    project_path: projectResolution.targetProject?.path || project_path,
     payload: {
       issue_id: issue_id || null,
-      project_path: project_path || null,
+      project_path: projectResolution.targetProject?.path || project_path || null,
       task_type,
       declared_target_files,
       structural_move,

--- a/projects/agenticos/mcp-server/src/utils/__tests__/repo-boundary.test.ts
+++ b/projects/agenticos/mcp-server/src/utils/__tests__/repo-boundary.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const accessMock = vi.hoisted(() => vi.fn());
+const readFileMock = vi.hoisted(() => vi.fn());
+const yamlMock = vi.hoisted(() => ({
+  parse: vi.fn(),
+}));
+const loadRegistryMock = vi.hoisted(() => vi.fn());
+const resolveManagedProjectTargetMock = vi.hoisted(() => vi.fn());
+
+vi.mock('fs/promises', () => ({
+  access: accessMock,
+  readFile: readFileMock,
+}));
+
+vi.mock('yaml', () => ({
+  default: yamlMock,
+}));
+
+vi.mock('../registry.js', () => ({
+  loadRegistry: loadRegistryMock,
+}));
+
+vi.mock('../project-target.js', () => ({
+  resolveManagedProjectTarget: resolveManagedProjectTargetMock,
+}));
+
+import { resolveGuardrailProjectTarget } from '../repo-boundary.js';
+
+describe('resolveGuardrailProjectTarget', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    yamlMock.parse.mockImplementation((content: string) => JSON.parse(content));
+    accessMock.mockResolvedValue(undefined);
+    readFileMock.mockResolvedValue(JSON.stringify({
+      meta: {
+        id: 'alpha',
+        name: 'Alpha Project',
+      },
+      agent_context: {
+        current_state: '.context/state.yaml',
+      },
+      execution: {
+        source_repo_roots: ['../..'],
+      },
+    }));
+  });
+
+  it('prefers the active managed project and resolves relative source repo roots', async () => {
+    loadRegistryMock.mockResolvedValue({
+      active_project: 'alpha',
+      projects: [
+        {
+          id: 'alpha',
+          name: 'Alpha Project',
+          path: '/workspace/projects/alpha',
+          status: 'active',
+          created: '2026-04-06',
+          last_accessed: '2026-04-06T00:00:00.000Z',
+        },
+      ],
+    });
+    resolveManagedProjectTargetMock.mockResolvedValue({
+      projectId: 'alpha',
+      projectName: 'Alpha Project',
+      projectPath: '/workspace/projects/alpha',
+    });
+
+    const result = await resolveGuardrailProjectTarget({
+      commandName: 'agenticos_preflight',
+      repoPath: '/workspace/repo/worktrees/alpha-160',
+    });
+
+    expect(result.activeProjectId).toBe('alpha');
+    expect(result.targetProject?.id).toBe('alpha');
+    expect(result.targetProject?.sourceRepoRoots).toEqual(['/workspace']);
+    expect(result.resolutionSource).toBe('active_project');
+  });
+
+  it('falls back to repo_path containment when no active project is set', async () => {
+    loadRegistryMock.mockResolvedValue({
+      active_project: null,
+      projects: [
+        {
+          id: 'alpha',
+          name: 'Alpha Project',
+          path: '/workspace/projects/alpha',
+          status: 'active',
+          created: '2026-04-06',
+          last_accessed: '2026-04-06T00:00:00.000Z',
+        },
+      ],
+    });
+
+    const result = await resolveGuardrailProjectTarget({
+      commandName: 'agenticos_preflight',
+      repoPath: '/workspace/projects/alpha/src',
+    });
+
+    expect(result.targetProject?.id).toBe('alpha');
+    expect(result.resolutionSource).toBe('repo_path_match');
+  });
+
+  it('returns a fail-closed resolution error when project metadata cannot be proven', async () => {
+    loadRegistryMock.mockResolvedValue({
+      active_project: 'alpha',
+      projects: [],
+    });
+    resolveManagedProjectTargetMock.mockRejectedValue(new Error('Project identity could not be proven.'));
+
+    const result = await resolveGuardrailProjectTarget({
+      commandName: 'agenticos_preflight',
+      repoPath: '/workspace/repo',
+    });
+
+    expect(result.targetProject).toBeNull();
+    expect(result.resolutionErrors[0]).toContain('could not be proven');
+    expect(result.resolutionSource).toBeNull();
+  });
+});

--- a/projects/agenticos/mcp-server/src/utils/repo-boundary.ts
+++ b/projects/agenticos/mcp-server/src/utils/repo-boundary.ts
@@ -1,0 +1,203 @@
+import { access, readFile } from 'fs/promises';
+import { basename, isAbsolute, join, resolve, sep } from 'path';
+import yaml from 'yaml';
+import { resolveManagedProjectTarget } from './project-target.js';
+import { loadRegistry } from './registry.js';
+
+export type GuardrailTaskType =
+  | 'discussion_only'
+  | 'analysis_or_doc'
+  | 'implementation'
+  | 'bugfix'
+  | 'bootstrap';
+
+export interface GuardrailProjectTarget {
+  id: string;
+  name: string;
+  path: string;
+  statePath: string;
+  projectYamlPath: string;
+  sourceRepoRoots: string[];
+  sourceRepoRootsDeclared: boolean;
+}
+
+export interface GuardrailProjectResolution {
+  activeProjectId: string | null;
+  resolutionSource: 'explicit_project_path' | 'active_project' | 'repo_path_match' | null;
+  targetProject: GuardrailProjectTarget | null;
+  resolutionErrors: string[];
+}
+
+function normalizePath(path: string): string {
+  return resolve(path);
+}
+
+function resolveProjectStatePath(projectPath: string, projectYaml: any): string {
+  const configuredStatePath = projectYaml?.agent_context?.current_state;
+  if (typeof configuredStatePath === 'string' && configuredStatePath.trim().length > 0) {
+    return join(projectPath, configuredStatePath.trim());
+  }
+  return join(projectPath, '.context', 'state.yaml');
+}
+
+function isWithinProject(repoPath: string, projectPath: string): boolean {
+  return repoPath === projectPath || repoPath.startsWith(`${projectPath}${sep}`);
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolveDeclaredSourceRepoRoots(projectPath: string, projectYaml: any): {
+  roots: string[];
+  declared: boolean;
+} {
+  const rawRoots = projectYaml?.execution?.source_repo_roots;
+  if (!Array.isArray(rawRoots)) {
+    return {
+      roots: [],
+      declared: false,
+    };
+  }
+
+  const roots = Array.from(new Set(
+    rawRoots
+      .map((value) => String(value || '').trim())
+      .filter((value) => value.length > 0)
+      .map((value) => normalizePath(isAbsolute(value) ? value : join(projectPath, value))),
+  ));
+
+  return {
+    roots,
+    declared: true,
+  };
+}
+
+async function buildTargetFromProjectPath(
+  projectPath: string,
+  fallbackId?: string,
+  fallbackName?: string,
+): Promise<GuardrailProjectTarget | null> {
+  const normalizedProjectPath = normalizePath(projectPath);
+  const projectYamlPath = join(normalizedProjectPath, '.project.yaml');
+  if (!(await pathExists(projectYamlPath))) {
+    return null;
+  }
+
+  const projectYaml = yaml.parse(await readFile(projectYamlPath, 'utf-8')) || {};
+  const sourceRepoRoots = resolveDeclaredSourceRepoRoots(normalizedProjectPath, projectYaml);
+
+  return {
+    id: String(projectYaml?.meta?.id || fallbackId || basename(normalizedProjectPath)),
+    name: String(projectYaml?.meta?.name || fallbackName || fallbackId || basename(normalizedProjectPath)),
+    path: normalizedProjectPath,
+    statePath: resolveProjectStatePath(normalizedProjectPath, projectYaml),
+    projectYamlPath,
+    sourceRepoRoots: sourceRepoRoots.roots,
+    sourceRepoRootsDeclared: sourceRepoRoots.declared,
+  };
+}
+
+export function isImplementationAffectingTask(taskType: GuardrailTaskType): boolean {
+  return taskType === 'implementation' || taskType === 'bugfix';
+}
+
+export async function resolveGuardrailProjectTarget(args: {
+  commandName: string;
+  repoPath?: string;
+  projectPath?: string;
+}): Promise<GuardrailProjectResolution> {
+  const { commandName, repoPath, projectPath } = args;
+  const registry = await loadRegistry();
+  const activeProjectId = registry.active_project || null;
+
+  if (projectPath) {
+    try {
+      const resolved = await resolveManagedProjectTarget({
+        commandName,
+        project: projectPath,
+      });
+      const targetProject = await buildTargetFromProjectPath(
+        resolved.projectPath,
+        resolved.projectId,
+        resolved.projectName,
+      );
+      return {
+        activeProjectId,
+        resolutionSource: 'explicit_project_path',
+        targetProject,
+        resolutionErrors: targetProject ? [] : [`project_path is not a resolvable managed project: ${projectPath}`],
+      };
+    } catch (error) {
+      return {
+        activeProjectId,
+        resolutionSource: null,
+        targetProject: null,
+        resolutionErrors: [error instanceof Error ? error.message : `failed to resolve project_path: ${projectPath}`],
+      };
+    }
+  }
+
+  if (activeProjectId) {
+    try {
+      const resolved = await resolveManagedProjectTarget({
+        commandName,
+      });
+      const targetProject = await buildTargetFromProjectPath(
+        resolved.projectPath,
+        resolved.projectId,
+        resolved.projectName,
+      );
+      return {
+        activeProjectId,
+        resolutionSource: 'active_project',
+        targetProject,
+        resolutionErrors: targetProject ? [] : [`active project "${activeProjectId}" is missing a readable .project.yaml`],
+      };
+    } catch (error) {
+      return {
+        activeProjectId,
+        resolutionSource: null,
+        targetProject: null,
+        resolutionErrors: [error instanceof Error ? error.message : 'failed to resolve active project'],
+      };
+    }
+  }
+
+  if (!repoPath) {
+    return {
+      activeProjectId,
+      resolutionSource: null,
+      targetProject: null,
+      resolutionErrors: ['no active project is set'],
+    };
+  }
+
+  const normalizedRepoPath = normalizePath(repoPath);
+  const match = registry.projects
+    .map((project) => ({ ...project, path: normalizePath(project.path) }))
+    .filter((project) => isWithinProject(normalizedRepoPath, project.path))
+    .sort((a, b) => b.path.length - a.path.length)[0];
+
+  if (!match) {
+    return {
+      activeProjectId,
+      resolutionSource: null,
+      targetProject: null,
+      resolutionErrors: ['target project could not be resolved from repo_path; pass project_path explicitly'],
+    };
+  }
+
+  const targetProject = await buildTargetFromProjectPath(match.path, match.id, match.name);
+  return {
+    activeProjectId,
+    resolutionSource: targetProject ? 'repo_path_match' : null,
+    targetProject,
+    resolutionErrors: targetProject ? [] : [`project_path is not a resolvable managed project: ${match.path}`],
+  };
+}

--- a/projects/agenticos/standards/.project.yaml
+++ b/projects/agenticos/standards/.project.yaml
@@ -7,3 +7,6 @@ meta:
 agent_context:
   quick_start: .context/quick-start.md
   current_state: .context/state.yaml
+execution:
+  source_repo_roots:
+    - ../../..

--- a/projects/agenticos/tasks/issue-160-source-repo-boundary-enforcement.md
+++ b/projects/agenticos/tasks/issue-160-source-repo-boundary-enforcement.md
@@ -1,0 +1,37 @@
+# Issue #160: Source Repo Boundary Enforcement
+
+## Summary
+
+AgenticOS guardrails currently allow implementation work to proceed when the active managed project is correct but the actual Git repository is wrong.
+
+This was first reproduced during `360teams` work on 2026-04-05, before the canonical source was migrated into the managed `projects/360teams` location.
+
+The failure mode was:
+
+- the active managed project looked correct
+- the execution path still accepted the wrong Git repository root
+- branch/PR flow could start before the repo boundary was proven
+
+GitHub issue:
+
+- https://github.com/madlouse/AgenticOS/issues/160
+
+## Why This Matters
+
+- Project-path resolution is not enough when a managed project lives inside a larger container repository.
+- A larger checkout can still look valid if tooling only proves project-path containment.
+- The safer contract is: implementation-affecting work must prove both the managed project identity and the allowed source repo root before edits, branching, or PR validation continue.
+
+## Required Changes
+
+1. Add explicit source-repo binding to managed project metadata.
+2. Make preflight/edit/branch/PR guardrails fail closed when the resolved Git root is not declared for the target project.
+3. Apply the same boundary enforcement to `bugfix` work, not only `implementation`.
+4. Return a redirect action pointing to the expected repo root/worktree.
+5. Persist both project identity and resolved repo identity evidence for downstream guardrails.
+
+## Acceptance Criteria
+
+- The wrong-repo case returns `BLOCK` before any edit or PR step.
+- Bugfix tasks no longer bypass repo-boundary enforcement.
+- Guardrail output tells the operator which repo should be used instead.

--- a/projects/agenticos/tasks/issue-164-issue-intake-boundary-guardrail.md
+++ b/projects/agenticos/tasks/issue-164-issue-intake-boundary-guardrail.md
@@ -1,0 +1,38 @@
+# Issue #164: Issue-Intake Boundary Guardrail
+
+## Summary
+
+AgenticOS now has fail-closed project and source-repo checks before implementation-affecting edits, branch bootstrap, and PR scope validation.
+
+The remaining gap is the issue-intake stage itself.
+
+There is no canonical AgenticOS guardrail that proves:
+
+- the active project is correct
+- the intended managed project is correct
+- the current source repo binding is correct
+
+before a new GitHub issue is created or linked.
+
+GitHub issue:
+
+- https://github.com/madlouse/AgenticOS/issues/164
+
+## Why This Matters
+
+- Operators can still start from the wrong project context before the current guardrails begin.
+- The execution path is now protected, but the task-intake path is not.
+- A dedicated issue-intake guardrail would make project intent explicit earlier and reduce cross-project drift.
+
+## Requested Changes
+
+1. Add an issue-intake helper or guardrail that proves active project identity before creating or binding a GitHub issue.
+2. Validate the intended managed project and declared source repo roots at issue-intake time.
+3. Return a fail-closed redirect when the operator is in the wrong project context or wrong source repo.
+4. Persist issue-intake evidence into project state so downstream preflight/edit/PR tools can reuse it.
+
+## Acceptance Criteria
+
+- Creating or binding an issue from the wrong active project fails closed.
+- The guardrail reports the expected managed project and canonical repo root/worktree.
+- Downstream tools can see the latest issue-intake evidence in project state.


### PR DESCRIPTION
## Summary

- add a shared repo-boundary resolver for guardrail tools
- fail closed in preflight, edit guard, branch bootstrap, and PR scope check when the current git common repo root is not declared for the target project
- treat `bugfix` as implementation-affecting work and add explicit source repo bindings to managed project metadata
- add task files for #160 and follow-up #164

## Testing

- npm run lint
- npm test

## Follow-up

- closes #160
- tracks remaining issue-intake gap in #164
