### PR TITLE
fix(agenticos): resolve self-hosting root project identity

### DIFF
--- a/projects/agenticos/.project.yaml
+++ b/projects/agenticos/.project.yaml
@@ -1,0 +1,33 @@
+meta:
+  name: AgenticOS
+  id: agenticos
+  description: Self-hosting AgenticOS product project. Canonical operational context lives under standards/.context while the root .context files remain compatibility shims.
+  created: 2026-03-23
+  version: 1.0.0
+
+agent_context:
+  quick_start: standards/.context/quick-start.md
+  current_state: standards/.context/state.yaml
+  conversations: standards/.context/conversations/
+  last_record_marker: standards/.context/.last_record
+  knowledge: knowledge/
+  tasks: tasks/
+  artifacts: artifacts/
+
+memory_contract:
+  version: 1
+  quick_start_role: project_orientation
+  state_role: operational_working_state
+  conversations_role: append_only_session_history
+  knowledge_role: durable_synthesis
+  tasks_role: execution_artifacts
+  artifacts_role: deliverables
+
+status:
+  phase: active
+  last_updated: 2026-04-06
+  next_action: Keep root compatibility surfaces aligned while standards/.context remains the canonical operational state.
+
+execution:
+  source_repo_roots:
+    - ../..

--- a/projects/agenticos/mcp-server/src/tools/__tests__/project.test.ts
+++ b/projects/agenticos/mcp-server/src/tools/__tests__/project.test.ts
@@ -332,6 +332,45 @@ describe('switchProject', () => {
     expect(result).toContain('💡 Suggested next step: Close issue #23');
   });
 
+  it('uses configured canonical context paths for self-hosting switch output', async () => {
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: null,
+      projects: [
+        {
+          id: 'agenticos',
+          name: 'AgenticOS',
+          path: '/workspace/projects/agenticos',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    fsPromisesMock.readFile
+      .mockResolvedValueOnce(JSON.stringify({
+        meta: { description: 'Self-hosting product' },
+        agent_context: {
+          quick_start: 'standards/.context/quick-start.md',
+          current_state: 'standards/.context/state.yaml',
+        },
+      }))
+      .mockResolvedValueOnce(JSON.stringify({
+        current_task: { title: 'Canonical state', status: 'active' },
+        working_memory: { pending: [], decisions: [] },
+      }))
+      .mockResolvedValueOnce('# Quick Start\n\nCanonical quick start');
+
+    const result = await switchProject({ project: 'agenticos' });
+
+    expect(fsPromisesMock.readFile).toHaveBeenCalledWith('/workspace/projects/agenticos/standards/.context/state.yaml', 'utf-8');
+    expect(fsPromisesMock.readFile).toHaveBeenCalledWith('/workspace/projects/agenticos/standards/.context/quick-start.md', 'utf-8');
+    expect(result).toContain('/workspace/projects/agenticos/standards/.context/quick-start.md');
+    expect(result).toContain('/workspace/projects/agenticos/standards/.context/state.yaml');
+  });
+
   it('falls back to quick-start summary when project description is missing', async () => {
     registryMock.loadRegistry.mockResolvedValue({
       version: '1.0.0',
@@ -566,6 +605,39 @@ describe('getStatus', () => {
     expect(result).toContain('in_progress');
     expect(result).toContain('task 1');
     expect(result).toContain('decision 1');
+  });
+
+  it('uses configured canonical state paths for self-hosting status output', async () => {
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: 'agenticos',
+      projects: [
+        {
+          id: 'agenticos',
+          name: 'AgenticOS',
+          path: '/workspace/projects/agenticos',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    fsPromisesMock.readFile
+      .mockResolvedValueOnce(JSON.stringify({
+        meta: { id: 'agenticos', name: 'AgenticOS' },
+        agent_context: { current_state: 'standards/.context/state.yaml' },
+      }))
+      .mockResolvedValueOnce(JSON.stringify({
+        current_task: { title: 'Canonical status', status: 'active' },
+        working_memory: { pending: [], decisions: [] },
+      }));
+
+    const result = await getStatus();
+
+    expect(fsPromisesMock.readFile).toHaveBeenCalledWith('/workspace/projects/agenticos/standards/.context/state.yaml', 'utf-8');
+    expect(result).toContain('Canonical status');
   });
 
   it('handles project with no state.yaml', async () => {

--- a/projects/agenticos/mcp-server/src/tools/project.ts
+++ b/projects/agenticos/mcp-server/src/tools/project.ts
@@ -6,6 +6,7 @@ import { loadRegistry, saveRegistry } from '../utils/registry.js';
 import { generateClaudeMd, generateAgentsMd, updateClaudeMdState, upgradeClaudeMd, CURRENT_TEMPLATE_VERSION, extractTemplateVersion } from '../utils/distill.js';
 import { writeFile } from 'fs/promises';
 import { buildArchivedReferenceMessage, isArchivedReferenceProject } from '../utils/project-contract.js';
+import { resolveManagedProjectContextPaths } from '../utils/project-target.js';
 
 type GuardrailCommand = 'agenticos_preflight' | 'agenticos_branch_bootstrap' | 'agenticos_pr_scope_check';
 
@@ -204,11 +205,12 @@ export async function switchProject(args: any): Promise<string> {
   let state: any = undefined;
   let quickStart = '';
   description = projectYaml?.meta?.description || '';
+  const contextPaths = resolveManagedProjectContextPaths(found.path, projectYaml);
   try {
-    state = yaml.parse(await readFile(join(found.path, '.context', 'state.yaml'), 'utf-8'));
+    state = yaml.parse(await readFile(contextPaths.statePath, 'utf-8'));
   } catch {}
   try {
-    quickStart = await readFile(join(found.path, '.context', 'quick-start.md'), 'utf-8');
+    quickStart = await readFile(contextPaths.quickStartPath, 'utf-8');
   } catch {}
 
   // CLAUDE.md: create if missing, upgrade if stale template version
@@ -246,7 +248,7 @@ export async function switchProject(args: any): Promise<string> {
     lastRecorded: found.last_recorded,
   });
 
-  return `✅ Switched to project "${found.name}"\n\nPath: ${found.path}\nStatus: ${found.status}\n\n${contextSummary.join('\n')}\n\nContext loaded from:\n- ${found.path}/.project.yaml\n- ${found.path}/.context/quick-start.md\n- ${found.path}/.context/state.yaml\n\n${guardrailSummary.join('\n')}${bootstrap}`;
+  return `✅ Switched to project "${found.name}"\n\nPath: ${found.path}\nStatus: ${found.status}\n\n${contextSummary.join('\n')}\n\nContext loaded from:\n- ${found.path}/.project.yaml\n- ${contextPaths.quickStartPath}\n- ${contextPaths.statePath}\n\n${guardrailSummary.join('\n')}${bootstrap}`;
 }
 
 export async function listProjects(): Promise<string> {
@@ -294,8 +296,8 @@ export async function getStatus(): Promise<string> {
     return `❌ ${buildArchivedReferenceMessage(project.name, projectYaml?.archive_contract?.replacement_project)}`;
   }
 
-  // Read state.yaml
-  const statePath = join(project.path, '.context', 'state.yaml');
+  const contextPaths = resolveManagedProjectContextPaths(project.path, projectYaml);
+  const statePath = contextPaths.statePath;
   let state: any = {};
   try {
     const content = await readFile(statePath, 'utf-8');

--- a/projects/agenticos/mcp-server/src/utils/__tests__/guardrail-evidence.test.ts
+++ b/projects/agenticos/mcp-server/src/utils/__tests__/guardrail-evidence.test.ts
@@ -58,6 +58,16 @@ describe('persistGuardrailEvidence', () => {
   });
 
   it('persists latest preflight evidence into the matching managed project state', async () => {
+    readFileMock.mockImplementation(async (path: string) => {
+      if (path.endsWith('/.project.yaml')) {
+        return JSON.stringify({
+          meta: { id: 'agenticos', name: 'AgenticOS' },
+          agent_context: { current_state: 'standards/.context/state.yaml' },
+        });
+      }
+      return JSON.stringify({ session: {}, working_memory: { facts: [], decisions: [], pending: [] } });
+    });
+
     const result = await persistGuardrailEvidence({
       command: 'agenticos_preflight',
       repo_path: '/workspace/projects/agenticos/mcp-server',
@@ -70,6 +80,7 @@ describe('persistGuardrailEvidence', () => {
     expect(result.persisted).toBe(true);
     expect(result.project_id).toBe('agenticos');
     expect(writeFileMock).toHaveBeenCalledTimes(1);
+    expect(writeFileMock.mock.calls[0]?.[0]).toBe('/workspace/projects/agenticos/standards/.context/state.yaml');
 
     const [, content] = writeFileMock.mock.calls[0];
     const writtenState = JSON.parse(content as string);
@@ -79,22 +90,30 @@ describe('persistGuardrailEvidence', () => {
   });
 
   it('overwrites the previous latest entry for the same command instead of appending', async () => {
-    readFileMock.mockResolvedValue(JSON.stringify({
-      guardrail_evidence: {
-        last_command: 'agenticos_preflight',
-        preflight: {
-          command: 'agenticos_preflight',
-          recorded_at: '2026-03-23T09:00:00.000Z',
-          issue_id: '36',
-          result: { status: 'BLOCK' },
+    readFileMock.mockImplementation(async (path: string) => {
+      if (path.endsWith('/.project.yaml')) {
+        return JSON.stringify({
+          meta: { id: 'agenticos', name: 'AgenticOS' },
+          agent_context: { current_state: 'standards/.context/state.yaml' },
+        });
+      }
+      return JSON.stringify({
+        guardrail_evidence: {
+          last_command: 'agenticos_preflight',
+          preflight: {
+            command: 'agenticos_preflight',
+            recorded_at: '2026-03-23T09:00:00.000Z',
+            issue_id: '36',
+            result: { status: 'BLOCK' },
+          },
+          pr_scope_check: {
+            command: 'agenticos_pr_scope_check',
+            issue_id: '36',
+            result: { status: 'PASS' },
+          },
         },
-        pr_scope_check: {
-          command: 'agenticos_pr_scope_check',
-          issue_id: '36',
-          result: { status: 'PASS' },
-        },
-      },
-    }));
+      });
+    });
 
     await persistGuardrailEvidence({
       command: 'agenticos_preflight',
@@ -170,6 +189,29 @@ describe('persistGuardrailEvidence', () => {
 
     const [statePath] = writeFileMock.mock.calls[0];
     expect(statePath).toBe('/workspace/source/projects/agenticos/standards/.context/state.yaml');
+  });
+
+  it('uses registry project metadata to resolve canonical state paths for self-hosting roots', async () => {
+    readFileMock.mockImplementation(async (path: string) => {
+      if (path.endsWith('/.project.yaml')) {
+        return JSON.stringify({
+          meta: { id: 'agenticos', name: 'AgenticOS' },
+          agent_context: { current_state: 'standards/.context/state.yaml' },
+        });
+      }
+      return JSON.stringify({ session: {}, working_memory: { facts: [], decisions: [], pending: [] } });
+    });
+
+    await persistGuardrailEvidence({
+      command: 'agenticos_branch_bootstrap',
+      repo_path: '/workspace/projects/agenticos/mcp-server',
+      payload: {
+        issue_id: '167',
+        result: { status: 'CREATED', branch_name: 'fix/167-self-hosting-root-project-identity-resolution' },
+      },
+    });
+
+    expect(writeFileMock.mock.calls[0]?.[0]).toBe('/workspace/projects/agenticos/standards/.context/state.yaml');
   });
 
   it('does not write state when repo_path is outside managed projects', async () => {

--- a/projects/agenticos/mcp-server/src/utils/__tests__/project-target.test.ts
+++ b/projects/agenticos/mcp-server/src/utils/__tests__/project-target.test.ts
@@ -19,7 +19,7 @@ vi.mock('../registry.js', () => ({
 
 import { readFile } from 'fs/promises';
 import { loadRegistry } from '../registry.js';
-import { resolveManagedProjectTarget } from '../project-target.js';
+import { resolveManagedProjectContextPaths, resolveManagedProjectTarget } from '../project-target.js';
 
 const readFileMock = readFile as unknown as ReturnType<typeof vi.fn>;
 const loadRegistryMock = loadRegistry as unknown as ReturnType<typeof vi.fn>;
@@ -79,6 +79,30 @@ describe('resolveManagedProjectTarget', () => {
     expect(result.projectId).toBe('alpha');
     expect(result.projectPath).toBe('/workspace/alpha');
     expect(result.projectYamlPath).toBe('/workspace/alpha/.project.yaml');
+  });
+
+  it('honors configured agent_context paths for self-hosting layouts', async () => {
+    readFileMock.mockResolvedValue(JSON.stringify({
+      meta: {
+        id: 'alpha',
+        name: 'Alpha Project',
+      },
+      agent_context: {
+        quick_start: 'standards/.context/quick-start.md',
+        current_state: 'standards/.context/state.yaml',
+        conversations: 'standards/.context/conversations/',
+        last_record_marker: 'standards/.context/.last_record',
+      },
+    }));
+
+    const result = await resolveManagedProjectTarget({
+      commandName: 'agenticos_record',
+    });
+
+    expect(result.quickStartPath).toBe('/workspace/alpha/standards/.context/quick-start.md');
+    expect(result.statePath).toBe('/workspace/alpha/standards/.context/state.yaml');
+    expect(result.conversationsDir).toBe('/workspace/alpha/standards/.context/conversations/');
+    expect(result.markerPath).toBe('/workspace/alpha/standards/.context/.last_record');
   });
 
   it('fails when there is no active project and no explicit project', async () => {
@@ -327,5 +351,16 @@ describe('resolveManagedProjectTarget', () => {
     })).rejects.toThrow(
       'Project "Alpha Project" is archived reference content, not an active managed project. Use "agenticos-standards" instead. agenticos_record only works with active managed projects.',
     );
+  });
+});
+
+describe('resolveManagedProjectContextPaths', () => {
+  it('falls back to root .context defaults when agent_context paths are not declared', () => {
+    expect(resolveManagedProjectContextPaths('/workspace/alpha', {})).toEqual({
+      quickStartPath: '/workspace/alpha/.context/quick-start.md',
+      statePath: '/workspace/alpha/.context/state.yaml',
+      conversationsDir: '/workspace/alpha/.context/conversations',
+      markerPath: '/workspace/alpha/.context/.last_record',
+    });
   });
 });

--- a/projects/agenticos/mcp-server/src/utils/guardrail-evidence.ts
+++ b/projects/agenticos/mcp-server/src/utils/guardrail-evidence.ts
@@ -152,6 +152,31 @@ async function resolveExplicitProjectTarget(projectPath: string): Promise<Resolv
   };
 }
 
+async function resolveRegistryProjectTarget(projectPath: string, fallbackId: string): Promise<ResolvedProjectTarget | null> {
+  const normalizedProjectPath = normalizePath(projectPath);
+  const projectYamlPath = join(normalizedProjectPath, '.project.yaml');
+
+  let projectYaml: any = {};
+  if (await pathExists(projectYamlPath)) {
+    try {
+      projectYaml = yaml.parse(await readFile(projectYamlPath, 'utf-8')) || {};
+    } catch {
+      projectYaml = {};
+    }
+  }
+
+  const statePath = resolveProjectStatePath(normalizedProjectPath, projectYaml);
+  if (!(await pathExists(statePath))) {
+    return null;
+  }
+
+  return {
+    id: String(projectYaml?.meta?.id || fallbackId || basename(normalizedProjectPath)),
+    path: normalizedProjectPath,
+    statePath,
+  };
+}
+
 async function resolveProjectTarget(repoPath: string, projectPath?: string): Promise<ResolvedProjectTarget | null> {
   if (projectPath) {
     return resolveExplicitProjectTarget(projectPath);
@@ -166,11 +191,7 @@ async function resolveProjectTarget(repoPath: string, projectPath?: string): Pro
 
   const registryProject = matchingProjects[0];
   if (registryProject) {
-    return {
-      id: registryProject.id,
-      path: registryProject.path,
-      statePath: join(registryProject.path, '.context', 'state.yaml'),
-    };
+    return resolveRegistryProjectTarget(registryProject.path, registryProject.id);
   }
 
   return findProjectRootFromRepoPath(normalizedRepoPath);

--- a/projects/agenticos/mcp-server/src/utils/project-target.ts
+++ b/projects/agenticos/mcp-server/src/utils/project-target.ts
@@ -1,5 +1,5 @@
 import { readFile } from 'fs/promises';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import yaml from 'yaml';
 import { loadRegistry, type Project, type Registry } from './registry.js';
 import { buildArchivedReferenceMessage, isArchivedReferenceProject } from './project-contract.js';
@@ -21,6 +21,13 @@ export interface ResolvedManagedProjectTarget {
 interface ResolveManagedProjectTargetArgs {
   project?: string;
   commandName: string;
+}
+
+export interface ManagedProjectContextPaths {
+  quickStartPath: string;
+  statePath: string;
+  conversationsDir: string;
+  markerPath: string;
 }
 
 function uniqueMatch<T>(matches: T[], notFound: string, ambiguous: string): T {
@@ -48,6 +55,29 @@ function assertRegistryUniqueness(registry: Registry, project: Project, requeste
   if (sameName.length > 1) {
     throw new Error(`Project identity is ambiguous because registry name "${project.name}" is duplicated.`);
   }
+}
+
+export function resolveManagedProjectContextPaths(projectPath: string, projectYaml: any): ManagedProjectContextPaths {
+  const agentContext = projectYaml?.agent_context || {};
+  const statePath = join(projectPath, typeof agentContext.current_state === 'string' && agentContext.current_state.trim().length > 0
+    ? agentContext.current_state.trim()
+    : '.context/state.yaml');
+  const quickStartPath = join(projectPath, typeof agentContext.quick_start === 'string' && agentContext.quick_start.trim().length > 0
+    ? agentContext.quick_start.trim()
+    : '.context/quick-start.md');
+  const conversationsDir = join(projectPath, typeof agentContext.conversations === 'string' && agentContext.conversations.trim().length > 0
+    ? agentContext.conversations.trim()
+    : '.context/conversations');
+  const markerPath = typeof agentContext.last_record_marker === 'string' && agentContext.last_record_marker.trim().length > 0
+    ? join(projectPath, agentContext.last_record_marker.trim())
+    : join(dirname(statePath), '.last_record');
+
+  return {
+    quickStartPath,
+    statePath,
+    conversationsDir,
+    markerPath,
+  };
 }
 
 export async function resolveManagedProjectTarget(args: ResolveManagedProjectTargetArgs): Promise<ResolvedManagedProjectTarget> {
@@ -119,6 +149,8 @@ export async function resolveManagedProjectTarget(args: ResolveManagedProjectTar
     );
   }
 
+  const contextPaths = resolveManagedProjectContextPaths(project.path, projectYaml);
+
   return {
     registry,
     project,
@@ -127,9 +159,9 @@ export async function resolveManagedProjectTarget(args: ResolveManagedProjectTar
     projectName: project.name,
     projectPath: project.path,
     projectYamlPath,
-    quickStartPath: join(project.path, '.context', 'quick-start.md'),
-    statePath: join(project.path, '.context', 'state.yaml'),
-    conversationsDir: join(project.path, '.context', 'conversations'),
-    markerPath: join(project.path, '.context', '.last_record'),
+    quickStartPath: contextPaths.quickStartPath,
+    statePath: contextPaths.statePath,
+    conversationsDir: contextPaths.conversationsDir,
+    markerPath: contextPaths.markerPath,
   };
 }

--- a/projects/agenticos/tasks/issue-167-self-hosting-root-project-identity-resolution.md
+++ b/projects/agenticos/tasks/issue-167-self-hosting-root-project-identity-resolution.md
@@ -1,0 +1,34 @@
+# Issue #167: Self-Hosting Root Project Identity Resolution
+
+## Summary
+
+The root managed AgenticOS project at `projects/agenticos` cannot currently be resolved as a normal active project for `agenticos_record` / `agenticos_save`.
+
+The immediate causes are:
+
+- `projects/agenticos/.project.yaml` is missing
+- `resolveManagedProjectTarget()` assumes root `.context/*` instead of honoring configured `agent_context` paths
+- self-hosting compatibility shims redirect root `.context/*` to canonical `standards/.context/*`, but resolver and status paths do not treat that explicitly
+
+GitHub issue:
+
+- https://github.com/madlouse/AgenticOS/issues/167
+
+## Why This Matters
+
+- root `AgenticOS` project identity is not currently provable for write commands
+- `record/save/context/status` can resolve to redirect-only compatibility files instead of canonical state
+- this contradicts the self-hosting topology already documented in issue `#158`
+
+## Required Changes
+
+1. Add root `projects/agenticos/.project.yaml` metadata for the self-hosting product project.
+2. Make managed-project resolution honor configured `agent_context` paths instead of assuming root `.context/*`.
+3. Update switch/status and any relevant helpers to use canonical context paths from project metadata.
+4. Add regression tests covering self-hosting root project resolution and canonical context redirects.
+
+## Acceptance Criteria
+
+- `agenticos_record` and `agenticos_save` can prove root `AgenticOS` project identity.
+- canonical context paths resolve to `standards/.context/*` for the self-hosting root project.
+- status/switch/context flows no longer depend on redirect-only root `.context/*` for live operational state.


### PR DESCRIPTION
## Summary

- add root `projects/agenticos/.project.yaml` for the self-hosting product project
- honor configured `agent_context` paths when resolving managed project context files
- make switch/status and guardrail evidence use canonical context paths instead of redirect-only root shims
- add regression coverage for self-hosting root resolution

## Testing

- npm run lint
- npx vitest run src/utils/__tests__/project-target.test.ts src/utils/__tests__/guardrail-evidence.test.ts src/tools/__tests__/project.test.ts
- npm test
- node smoke for `getStatus()` and `resolveManagedProjectTarget()` using worktree-local AGENTICOS_HOME

## Follow-up

- closes #167
