### PR TITLE
feat(agenticos): land archive import and runtime review surfaces (#171)

### DIFF
--- a/projects/agenticos/.meta/templates/.project.yaml
+++ b/projects/agenticos/.meta/templates/.project.yaml
@@ -31,6 +31,11 @@ execution:
   source_repo_roots:
     - "."  # Relative to the managed project root. Use ../.. when the canonical Git repo root is higher.
 
+archive_import_policy:
+  active_source_allowlist: []
+  provenance_only_allowlist: []
+  reject_list: []
+
 tech:
   languages: []
   platforms: []

--- a/projects/agenticos/mcp-server/src/index.ts
+++ b/projects/agenticos/mcp-server/src/index.ts
@@ -34,7 +34,7 @@ import {
   ListResourcesRequestSchema,
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { initProject, switchProject, listProjects, getStatus, saveState, recordSession, runPreflight, runBranchBootstrap, runPrScopeCheck, runHealth, runEditGuard, runEntrySurfaceRefresh, runStandardKitAdopt, runStandardKitUpgradeCheck, runStandardKitConformanceCheck, runNonCodeEvaluate } from './tools/index.js';
+import { initProject, switchProject, listProjects, getStatus, saveState, recordSession, runPreflight, runBranchBootstrap, runPrScopeCheck, runHealth, runEditGuard, runEntrySurfaceRefresh, runStandardKitAdopt, runStandardKitUpgradeCheck, runStandardKitConformanceCheck, runNonCodeEvaluate, runArchiveImportEvaluate } from './tools/index.js';
 import { getProjectContext } from './resources/index.js';
 
 const server = new Server(
@@ -304,6 +304,22 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         required: ['project_path', 'rubric_path'],
       },
     },
+    {
+      name: 'agenticos_archive_import_evaluate',
+      description: 'Classify candidate archived files into active-source, provenance-only, reject, or unclassified before import.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          project_path: { type: 'string', description: 'Absolute project path whose archive import policy should be used.' },
+          candidate_paths: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Archive-relative candidate file paths to classify before import.',
+          },
+        },
+        required: ['project_path', 'candidate_paths'],
+      },
+    },
   ],
 }));
 
@@ -344,6 +360,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       return { content: [{ type: 'text', text: await runStandardKitConformanceCheck(args ?? {}) }] };
     case 'agenticos_non_code_evaluate':
       return { content: [{ type: 'text', text: await runNonCodeEvaluate(args ?? {}) }] };
+    case 'agenticos_archive_import_evaluate':
+      return { content: [{ type: 'text', text: await runArchiveImportEvaluate(args ?? {}) }] };
     default:
       throw new Error(`Unknown tool: ${name}`);
   }

--- a/projects/agenticos/mcp-server/src/tools/__tests__/archive-import-evaluate.test.ts
+++ b/projects/agenticos/mcp-server/src/tools/__tests__/archive-import-evaluate.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtemp, mkdir, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { runArchiveImportEvaluate } from '../archive-import-evaluate.js';
+
+async function setupProject(projectYamlContent?: string): Promise<string> {
+  const projectRoot = await mkdtemp(join(tmpdir(), 'agenticos-archive-import-'));
+  await mkdir(projectRoot, { recursive: true });
+  if (projectYamlContent) {
+    await writeFile(join(projectRoot, '.project.yaml'), projectYamlContent, 'utf-8');
+  }
+  return projectRoot;
+}
+
+describe('runArchiveImportEvaluate', () => {
+  afterEach(() => {
+    delete process.env.AGENTICOS_HOME;
+  });
+
+  it('classifies archive candidates with the default policy and blocks reject or unclassified paths', async () => {
+    const projectRoot = await setupProject('meta:\n  id: sample\n  name: Sample\n');
+
+    const result = JSON.parse(await runArchiveImportEvaluate({
+      project_path: projectRoot,
+      candidate_paths: [
+        'README.md',
+        '.context/state.yaml',
+        '.DS_Store',
+        'local-backups/preferences.db',
+      ],
+    })) as {
+      status: string;
+      active_source_files: string[];
+      provenance_only_files: string[];
+      rejected_files: string[];
+      unclassified_files: string[];
+      block_reasons: string[];
+    };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.active_source_files).toEqual(['README.md']);
+    expect(result.provenance_only_files).toEqual(['.context/state.yaml']);
+    expect(result.rejected_files).toEqual(['.DS_Store']);
+    expect(result.unclassified_files).toEqual(['local-backups/preferences.db']);
+    expect(result.block_reasons.join(' ')).toContain('reject list matched');
+    expect(result.block_reasons.join(' ')).toContain('policy did not classify');
+  });
+
+  it('allows project-local additive patterns to classify additional active or provenance-only files', async () => {
+    const projectRoot = await setupProject([
+      'meta:',
+      '  id: sample',
+      '  name: Sample',
+      'archive_import_policy:',
+      '  active_source_allowlist:',
+      '    - "notes/**"',
+      '  provenance_only_allowlist:',
+      '    - "legacy-db/**"',
+      '',
+    ].join('\n'));
+
+    const result = JSON.parse(await runArchiveImportEvaluate({
+      project_path: projectRoot,
+      candidate_paths: [
+        'notes/runbook.md',
+        'legacy-db/schema.sql',
+      ],
+    })) as {
+      status: string;
+      active_source_files: string[];
+      provenance_only_files: string[];
+      rejected_files: string[];
+      unclassified_files: string[];
+    };
+
+    expect(result.status).toBe('PASS');
+    expect(result.active_source_files).toEqual(['notes/runbook.md']);
+    expect(result.provenance_only_files).toEqual(['legacy-db/schema.sql']);
+    expect(result.rejected_files).toEqual([]);
+    expect(result.unclassified_files).toEqual([]);
+  });
+
+  it('blocks when required arguments are missing', async () => {
+    const missingProject = JSON.parse(await runArchiveImportEvaluate({
+      candidate_paths: ['README.md'],
+    })) as { status: string; block_reasons: string[] };
+    const missingCandidates = JSON.parse(await runArchiveImportEvaluate({
+      project_path: '/tmp/demo',
+    })) as { status: string; block_reasons: string[] };
+
+    expect(missingProject.status).toBe('BLOCK');
+    expect(missingProject.block_reasons[0]).toContain('project_path is required');
+    expect(missingCandidates.status).toBe('BLOCK');
+    expect(missingCandidates.block_reasons[0]).toContain('candidate_paths is required');
+  });
+});

--- a/projects/agenticos/mcp-server/src/tools/__tests__/pr-scope-check.test.ts
+++ b/projects/agenticos/mcp-server/src/tools/__tests__/pr-scope-check.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const execAsyncMock = vi.hoisted(() => vi.fn());
+const readFileMock = vi.hoisted(() => vi.fn());
+const yamlMock = vi.hoisted(() => ({
+  parse: vi.fn(),
+}));
 
 vi.mock('child_process', () => ({
   exec: vi.fn(),
@@ -8,6 +12,14 @@ vi.mock('child_process', () => ({
 
 vi.mock('util', () => ({
   promisify: vi.fn(() => execAsyncMock),
+}));
+
+vi.mock('fs/promises', () => ({
+  readFile: readFileMock,
+}));
+
+vi.mock('yaml', () => ({
+  default: yamlMock,
 }));
 
 const persistGuardrailEvidenceMock = vi.hoisted(() => vi.fn().mockResolvedValue({
@@ -42,6 +54,10 @@ function mockGitResponses(responses: Record<string, string>): void {
 describe('runPrScopeCheck', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    readFileMock.mockResolvedValue('{"meta":{"id":"agenticos","name":"AgenticOS"}}');
+    yamlMock.parse.mockImplementation((content: string) => {
+      try { return JSON.parse(content); } catch { return undefined; }
+    });
     persistGuardrailEvidenceMock.mockResolvedValue({
       attempted: true,
       persisted: true,
@@ -79,9 +95,10 @@ describe('runPrScopeCheck', () => {
       repo_path: '/repo',
       declared_target_files: ['projects/agenticos/mcp-server/src/tools/**', 'projects/agenticos/mcp-server/src/index.ts'],
       expected_issue_scope: 'single_guardrail_feature',
-    })) as { status: string; unexpected_files: string[]; unrelated_commit_subjects: string[]; persistence?: { persisted: boolean } };
+    })) as { status: string; runtime_managed_files: string[]; unexpected_files: string[]; unrelated_commit_subjects: string[]; persistence?: { persisted: boolean } };
 
     expect(result.status).toBe('PASS');
+    expect(result.runtime_managed_files).toEqual([]);
     expect(result.unexpected_files).toEqual([]);
     expect(result.unrelated_commit_subjects).toEqual([]);
     expect(result.persistence?.persisted).toBe(true);
@@ -154,6 +171,71 @@ describe('runPrScopeCheck', () => {
     expect(result.status).toBe('BLOCK');
     expect(result.unexpected_files).toContain('README.md');
     expect(result.block_reasons.join(' ')).toContain('declared target scope');
+  });
+
+  it('returns PASS when the diff is runtime-managed only', async () => {
+    readFileMock.mockResolvedValue(JSON.stringify({
+      meta: { id: 'agenticos', name: 'AgenticOS' },
+      agent_context: {
+        current_state: 'standards/.context/state.yaml',
+        conversations: 'standards/.context/conversations/',
+        last_record_marker: 'standards/.context/.last_record',
+      },
+    }));
+
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo/worktrees/issue-171\n',
+      'rev-parse --git-common-dir': '/repo/.git\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'log --format=%s origin/main..HEAD': 'feat(mcp-server): isolate runtime review surfaces (#171)\n',
+      'diff --name-only origin/main...HEAD': 'standards/.context/state.yaml\nstandards/.context/.last_record\n',
+    });
+
+    const result = JSON.parse(await runPrScopeCheck({
+      issue_id: '171',
+      repo_path: '/repo/worktrees/issue-171',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/**'],
+      expected_issue_scope: 'runtime_review_surface',
+    })) as { status: string; runtime_managed_files: string[]; unexpected_files: string[] };
+
+    expect(result.status).toBe('PASS');
+    expect(result.runtime_managed_files).toEqual([
+      'standards/.context/state.yaml',
+      'standards/.context/.last_record',
+    ]);
+    expect(result.unexpected_files).toEqual([]);
+  });
+
+  it('returns BLOCK when runtime-managed files are mixed into a normal product review slice', async () => {
+    readFileMock.mockResolvedValue(JSON.stringify({
+      meta: { id: 'agenticos', name: 'AgenticOS' },
+      agent_context: {
+        current_state: 'standards/.context/state.yaml',
+        conversations: 'standards/.context/conversations/',
+        last_record_marker: 'standards/.context/.last_record',
+      },
+    }));
+
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo/worktrees/issue-171\n',
+      'rev-parse --git-common-dir': '/repo/.git\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'log --format=%s origin/main..HEAD': 'feat(mcp-server): isolate runtime review surfaces (#171)\n',
+      'diff --name-only origin/main...HEAD': 'projects/agenticos/mcp-server/src/tools/save.ts\nstandards/.context/state.yaml\n',
+    });
+
+    const result = JSON.parse(await runPrScopeCheck({
+      issue_id: '171',
+      repo_path: '/repo/worktrees/issue-171',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/**'],
+      expected_issue_scope: 'runtime_review_surface',
+    })) as { status: string; runtime_managed_files: string[]; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.runtime_managed_files).toEqual(['standards/.context/state.yaml']);
+    expect(result.block_reasons.join(' ')).toContain('runtime-managed files are mixed');
   });
 
   it('returns BLOCK when the branch is not comparable to the intended remote base', async () => {

--- a/projects/agenticos/mcp-server/src/tools/__tests__/record.test.ts
+++ b/projects/agenticos/mcp-server/src/tools/__tests__/record.test.ts
@@ -445,6 +445,16 @@ describe('recordSession', () => {
     expect(result).toContain('✅ Session recorded');
   });
 
+  it('does not read or rewrite quick-start.md during record', async () => {
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry());
+    mockProjectFiles({ state: { session: {}, working_memory: { decisions: [], facts: [], pending: [] } } });
+
+    await recordSession({ summary: 'runtime-only update' });
+
+    expect(fsPromisesMock.readFile.mock.calls.some((call) => String(call[0]).endsWith('/quick-start.md'))).toBe(false);
+    expect(fsPromisesMock.writeFile.mock.calls.some((call) => String(call[0]).endsWith('/quick-start.md'))).toBe(false);
+  });
+
   it('creates a new conversation file and default state when conversation and state files do not exist yet', async () => {
     registryMock.loadRegistry.mockResolvedValue(buildRegistry());
     fsPromisesMock.readFile.mockImplementation(async (path: string) => {

--- a/projects/agenticos/mcp-server/src/tools/__tests__/save.test.ts
+++ b/projects/agenticos/mcp-server/src/tools/__tests__/save.test.ts
@@ -211,6 +211,33 @@ describe('saveState', () => {
     expect(result).toContain('Test Project');
   });
 
+  it('stages only runtime-managed paths instead of the whole project tree', async () => {
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry());
+    mockProjectFiles({ state: { session: {} } });
+
+    const commands: string[] = [];
+    childProcessMock.exec.mockImplementation(
+      (cmd: string, cb: (err: Error | null, stdout?: string, stderr?: string) => void) => {
+        commands.push(cmd);
+        if (cmd.includes('rev-parse --show-toplevel')) {
+          cb(null, '/test/path\n', '');
+          return;
+        }
+        cb(null, '', '');
+      }
+    );
+
+    await saveState({ message: 'runtime-only save' });
+
+    const addCommand = commands.find((cmd) => cmd.includes(' add -A -- '));
+    expect(addCommand).toBeDefined();
+    expect(addCommand).toContain('/test/path/.context/state.yaml');
+    expect(addCommand).toContain('/test/path/.context/.last_record');
+    expect(addCommand).toContain('/test/path/.context/conversations');
+    expect(addCommand).toContain('/test/path/CLAUDE.md');
+    expect(addCommand).not.toContain('add "/test/path/"');
+  });
+
   it('notes when CLAUDE.md had to be auto-generated during save', async () => {
     registryMock.loadRegistry.mockResolvedValue(buildRegistry());
     mockProjectFiles({ state: { session: {} } });

--- a/projects/agenticos/mcp-server/src/tools/archive-import-evaluate.ts
+++ b/projects/agenticos/mcp-server/src/tools/archive-import-evaluate.ts
@@ -1,0 +1,6 @@
+import { evaluateArchiveImportPolicy } from '../utils/archive-import-policy.js';
+
+export async function runArchiveImportEvaluate(args: any): Promise<string> {
+  const result = await evaluateArchiveImportPolicy(args ?? {});
+  return JSON.stringify(result, null, 2);
+}

--- a/projects/agenticos/mcp-server/src/tools/index.ts
+++ b/projects/agenticos/mcp-server/src/tools/index.ts
@@ -10,3 +10,4 @@ export { runEditGuard } from './edit-guard.js';
 export { runEntrySurfaceRefresh } from './entry-surface-refresh.js';
 export { runStandardKitAdopt, runStandardKitUpgradeCheck, runStandardKitConformanceCheck } from './standard-kit.js';
 export { runNonCodeEvaluate } from './non-code-evaluate.js';
+export { runArchiveImportEvaluate } from './archive-import-evaluate.js';

--- a/projects/agenticos/mcp-server/src/tools/pr-scope-check.ts
+++ b/projects/agenticos/mcp-server/src/tools/pr-scope-check.ts
@@ -1,8 +1,11 @@
 import { exec } from 'child_process';
+import { readFile } from 'fs/promises';
 import { dirname, resolve } from 'path';
 import { promisify } from 'util';
+import yaml from 'yaml';
 import { persistGuardrailEvidence, type GuardrailPersistenceResult } from '../utils/guardrail-evidence.js';
 import { resolveGuardrailProjectTarget } from '../utils/repo-boundary.js';
+import { matchesRuntimeReviewExcludedPath, resolveRuntimeReviewSurfacePaths } from '../utils/runtime-review-surface.js';
 
 const execAsync = promisify(exec);
 
@@ -20,6 +23,7 @@ interface PrScopeCheckResult {
   summary: string;
   commit_count: number;
   changed_files: string[];
+  runtime_managed_files: string[];
   unexpected_files: string[];
   unrelated_commit_subjects: string[];
   branch_ancestry_verified: boolean;
@@ -33,6 +37,10 @@ interface PrScopeCheckResult {
 async function runGit(repoPath: string, args: string): Promise<string> {
   const { stdout } = await execAsync(`git -C "${repoPath}" ${args}`);
   return stdout.trim();
+}
+
+async function loadProjectYaml(projectYamlPath: string): Promise<any> {
+  return yaml.parse(await readFile(projectYamlPath, 'utf-8')) || {};
 }
 
 function normalizeLines(content: string): string[] {
@@ -89,6 +97,7 @@ function makeBaseResult(remoteBaseBranch: string, expectedIssueScope: string): P
     summary: '',
     commit_count: 0,
     changed_files: [],
+    runtime_managed_files: [],
     unexpected_files: [],
     unrelated_commit_subjects: [],
     branch_ancestry_verified: false,
@@ -146,6 +155,7 @@ export async function runPrScopeCheck(args: PrScopeCheckArgs): Promise<string> {
           summary: result.summary,
           commit_count: result.commit_count,
           changed_files: result.changed_files,
+          runtime_managed_files: result.runtime_managed_files,
           unexpected_files: result.unexpected_files,
           unrelated_commit_subjects: result.unrelated_commit_subjects,
           branch_ancestry_verified: result.branch_ancestry_verified,
@@ -202,6 +212,7 @@ export async function runPrScopeCheck(args: PrScopeCheckArgs): Promise<string> {
           summary: result.summary,
           commit_count: result.commit_count,
           changed_files: result.changed_files,
+          runtime_managed_files: result.runtime_managed_files,
           unexpected_files: result.unexpected_files,
           unrelated_commit_subjects: result.unrelated_commit_subjects,
           branch_ancestry_verified: result.branch_ancestry_verified,
@@ -221,14 +232,26 @@ export async function runPrScopeCheck(args: PrScopeCheckArgs): Promise<string> {
   const changedFiles = normalizeLines(
     await runGit(repo_path, `diff --name-only ${remote_base_branch}...HEAD`).catch(() => ''),
   );
+  const projectYaml = await loadProjectYaml(projectResolution.targetProject!.projectYamlPath);
+  const runtimeTrackedPaths = resolveRuntimeReviewSurfacePaths(
+    projectResolution.targetProject!.path,
+    projectYaml,
+    { include_claude_state_mirror: true },
+  ).tracked_review_excluded_paths;
 
   result.commit_count = subjects.length;
   result.changed_files = changedFiles;
+  result.runtime_managed_files = changedFiles.filter((file) => matchesRuntimeReviewExcludedPath(file, runtimeTrackedPaths));
   result.unrelated_commit_subjects = subjects.filter((subject) => !subject.includes(`#${issue_id}`));
-  result.unexpected_files = changedFiles.filter((file) => !fileMatchesDeclaredScope(file, declared_target_files));
+  const productReviewFiles = changedFiles.filter((file) => !matchesRuntimeReviewExcludedPath(file, runtimeTrackedPaths));
+  result.unexpected_files = productReviewFiles.filter((file) => !fileMatchesDeclaredScope(file, declared_target_files));
 
   if (result.unrelated_commit_subjects.length > 0) {
     result.block_reasons.push(`branch includes unrelated commits relative to ${remote_base_branch}`);
+  }
+
+  if (result.runtime_managed_files.length > 0 && productReviewFiles.length > 0) {
+    result.block_reasons.push('runtime-managed files are mixed into a normal product review slice');
   }
 
   if (result.unexpected_files.length > 0) {
@@ -256,6 +279,7 @@ export async function runPrScopeCheck(args: PrScopeCheckArgs): Promise<string> {
           summary: result.summary,
           commit_count: result.commit_count,
           changed_files: result.changed_files,
+          runtime_managed_files: result.runtime_managed_files,
           unexpected_files: result.unexpected_files,
           unrelated_commit_subjects: result.unrelated_commit_subjects,
           branch_ancestry_verified: result.branch_ancestry_verified,
@@ -289,6 +313,7 @@ export async function runPrScopeCheck(args: PrScopeCheckArgs): Promise<string> {
         summary: result.summary,
         commit_count: result.commit_count,
         changed_files: result.changed_files,
+        runtime_managed_files: result.runtime_managed_files,
         unexpected_files: result.unexpected_files,
         unrelated_commit_subjects: result.unrelated_commit_subjects,
         branch_ancestry_verified: result.branch_ancestry_verified,

--- a/projects/agenticos/mcp-server/src/tools/record.ts
+++ b/projects/agenticos/mcp-server/src/tools/record.ts
@@ -35,7 +35,7 @@ export async function recordSession(args: any): Promise<string> {
     return `❌ ${error.message}`;
   }
 
-  const { registry, project, projectPath, statePath, quickStartPath, conversationsDir: convDir, markerPath } = resolved;
+  const { registry, project, projectPath, statePath, conversationsDir: convDir, markerPath } = resolved;
   const now = new Date();
   const today = now.toISOString().split('T')[0];
   const time = now.toISOString().substring(11, 16);
@@ -111,40 +111,10 @@ export async function recordSession(args: any): Promise<string> {
   const claudeMdPath = `${projectPath}/CLAUDE.md`;
   await updateClaudeMdState(claudeMdPath, state, project.name);
 
-  // 4. Auto-enrich quick-start.md if it still contains boilerplate
-  try {
-    const qsContent = await readFile(quickStartPath, 'utf-8');
-    if (qsContent.includes('1. Define project goals')) {
-      const outcomeLines = outcomes.length > 0
-        ? outcomes.map((o: string) => `- ${o}`).join('\n')
-        : '';
-      const pendingLines = pending.length > 0
-        ? pending.map((p: string, i: number) => `${i + 1}. ${p}`).join('\n')
-        : '1. Continue development';
-
-      const enriched = `# ${project.name} - Quick Start
-
-## Project Overview
-${summary}
-
-## Current Status
-- Started: ${today}
-- Status: Active
-${outcomeLines}
-
-## Next Steps
-${pendingLines}
-`;
-      await writeFile(quickStartPath, enriched, 'utf-8');
-    }
-  } catch {
-    // quick-start.md doesn't exist — skip enrichment
-  }
-
-  // 5. Touch marker file for hook-based reminder system
+  // 4. Touch marker file for hook-based reminder system
   await writeFile(markerPath, now.toISOString(), 'utf-8');
 
-  // 6. Update registry with last_recorded timestamp
+  // 5. Update registry with last_recorded timestamp
   registry.projects = registry.projects.map((p) =>
     p.id === project.id
       ? { ...p, last_recorded: now.toISOString() }

--- a/projects/agenticos/mcp-server/src/tools/save.ts
+++ b/projects/agenticos/mcp-server/src/tools/save.ts
@@ -3,6 +3,7 @@ import { updateClaudeMdState } from '../utils/distill.js';
 import { readFile, writeFile } from 'fs/promises';
 import yaml from 'yaml';
 import { resolveManagedProjectTarget } from '../utils/project-target.js';
+import { resolveRuntimeReviewSurfacePaths, toProjectAbsoluteRuntimePath } from '../utils/runtime-review-surface.js';
 
 async function execCommand(command: string): Promise<{ stdout: string; stderr: string }> {
   return await new Promise((resolve, reject) => {
@@ -45,7 +46,7 @@ export async function saveState(args: any): Promise<string> {
     return `❌ ${error.message}`;
   }
 
-  const { project, projectPath, statePath } = resolved;
+  const { project, projectPath, projectYaml, statePath } = resolved;
 
   try {
     // Update state.yaml with backup timestamp
@@ -70,11 +71,17 @@ export async function saveState(args: any): Promise<string> {
       return `⚠️ State saved but no git repo found at ${projectPath}\n\nTimestamp: ${state.session.last_backup}${claudeMdNote}`;
     }
 
-    // Project-scoped git: only stage this project's files + registry
+    // Project-scoped git: stage only runtime-managed paths plus the CLAUDE state mirror.
     const gitCmd = `git -C "${gitRoot}"`;
+    const runtimePaths = resolveRuntimeReviewSurfacePaths(projectPath, projectYaml, {
+      include_claude_state_mirror: true,
+    }).tracked_review_excluded_paths;
+    const stageTargets = runtimePaths
+      .map((trackedPath) => `"${toProjectAbsoluteRuntimePath(projectPath, trackedPath)}"`)
+      .join(' ');
 
     // Phase 1: git add
-    await execCommand(`${gitCmd} add "${projectPath}/"`);
+    await execCommand(`${gitCmd} add -A -- ${stageTargets}`);
 
     // Phase 2: git commit
     let committed = false;

--- a/projects/agenticos/mcp-server/src/utils/archive-import-policy.ts
+++ b/projects/agenticos/mcp-server/src/utils/archive-import-policy.ts
@@ -1,0 +1,271 @@
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+import yaml from 'yaml';
+
+export type ArchiveImportDecision = 'active_source' | 'provenance_only' | 'reject' | 'unclassified';
+
+export interface ArchiveImportPolicy {
+  active_source_allowlist: string[];
+  provenance_only_allowlist: string[];
+  reject_list: string[];
+}
+
+export interface ArchiveImportEvaluationItem {
+  path: string;
+  decision: ArchiveImportDecision;
+  matched_pattern: string | null;
+  reason: string;
+}
+
+export interface ArchiveImportEvaluateResult {
+  command: 'agenticos_archive_import_evaluate';
+  status: 'PASS' | 'BLOCK';
+  summary: string;
+  project_path: string;
+  candidate_count: number;
+  policy: ArchiveImportPolicy;
+  evaluations: ArchiveImportEvaluationItem[];
+  active_source_files: string[];
+  provenance_only_files: string[];
+  rejected_files: string[];
+  unclassified_files: string[];
+  block_reasons: string[];
+}
+
+const DEFAULT_ACTIVE_SOURCE_ALLOWLIST = [
+  'README.md',
+  'CHANGELOG.md',
+  'LICENSE',
+  'LICENSE.*',
+  '.gitignore',
+  '.editorconfig',
+  'AGENTS.md',
+  'CLAUDE.md',
+  '*.md',
+  'docs/**',
+  'knowledge/**',
+  'tasks/**',
+  'artifacts/**',
+  'src/**',
+  'app/**',
+  'lib/**',
+  'scripts/**',
+  'config/**',
+  'benchmarks/**',
+  'resources/**',
+  'setup/**',
+  'optimizations/**',
+  'current-config/**',
+] as const;
+
+const DEFAULT_PROVENANCE_ONLY_ALLOWLIST = [
+  '.context/**',
+  '.meta/transcripts/**',
+  'archive/**',
+  'archives/**',
+  'provenance/**',
+  'artifacts/source-history/**',
+  '**/*.bundle',
+  '**/*.patch',
+  '**/*.diff',
+  '**/*.log',
+  '**/*.trace',
+] as const;
+
+const DEFAULT_REJECT_LIST = [
+  '.DS_Store',
+  '**/.DS_Store',
+  'Thumbs.db',
+  '**/Thumbs.db',
+  '.git/**',
+  '.gitmodules',
+  '.Spotlight-V100/**',
+  '.Trashes/**',
+  '__MACOSX/**',
+  '.agent-workspace/**',
+  'node_modules/**',
+  '**/*.swp',
+  '**/*~',
+  '**/*.tmp',
+] as const;
+
+function normalizePath(candidate: string): string {
+  return candidate.replace(/\\/g, '/').replace(/^\.\//, '').replace(/^\/+/, '');
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function patternToRegex(pattern: string): RegExp {
+  const normalized = normalizePath(pattern);
+  const tokens = normalized.match(/\*\*|\*|[^*.]+|\./g) ?? [];
+  const source = tokens.map((token) => {
+    if (token === '**') return '.*';
+    if (token === '*') return '[^/]*';
+    return escapeRegex(token);
+  }).join('');
+  return new RegExp(`^${source}$`);
+}
+
+function matchPattern(path: string, patterns: string[]): string | null {
+  for (const pattern of patterns) {
+    if (patternToRegex(pattern).test(path)) {
+      return pattern;
+    }
+  }
+  return null;
+}
+
+function parseStringArray(candidate: unknown): string[] {
+  if (!Array.isArray(candidate)) return [];
+  return candidate
+    .filter((item): item is string => typeof item === 'string')
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+}
+
+async function loadProjectYaml(projectPath: string): Promise<any> {
+  try {
+    const content = await readFile(join(projectPath, '.project.yaml'), 'utf-8');
+    return yaml.parse(content) || {};
+  } catch {
+    return {};
+  }
+}
+
+export async function resolveArchiveImportPolicy(projectPath: string): Promise<ArchiveImportPolicy> {
+  const projectYaml = await loadProjectYaml(projectPath);
+  const configured = projectYaml?.archive_import_policy || {};
+
+  return {
+    active_source_allowlist: [
+      ...DEFAULT_ACTIVE_SOURCE_ALLOWLIST,
+      ...parseStringArray(configured.active_source_allowlist),
+    ],
+    provenance_only_allowlist: [
+      ...DEFAULT_PROVENANCE_ONLY_ALLOWLIST,
+      ...parseStringArray(configured.provenance_only_allowlist),
+    ],
+    reject_list: [
+      ...DEFAULT_REJECT_LIST,
+      ...parseStringArray(configured.reject_list),
+    ],
+  };
+}
+
+function classifyCandidate(path: string, policy: ArchiveImportPolicy): ArchiveImportEvaluationItem {
+  const normalizedPath = normalizePath(path);
+
+  const rejectPattern = matchPattern(normalizedPath, policy.reject_list);
+  if (rejectPattern) {
+    return {
+      path: normalizedPath,
+      decision: 'reject',
+      matched_pattern: rejectPattern,
+      reason: `matches reject pattern ${rejectPattern}`,
+    };
+  }
+
+  const provenancePattern = matchPattern(normalizedPath, policy.provenance_only_allowlist);
+  if (provenancePattern) {
+    return {
+      path: normalizedPath,
+      decision: 'provenance_only',
+      matched_pattern: provenancePattern,
+      reason: `matches provenance-only allowlist pattern ${provenancePattern}`,
+    };
+  }
+
+  const activePattern = matchPattern(normalizedPath, policy.active_source_allowlist);
+  if (activePattern) {
+    return {
+      path: normalizedPath,
+      decision: 'active_source',
+      matched_pattern: activePattern,
+      reason: `matches active-source allowlist pattern ${activePattern}`,
+    };
+  }
+
+  return {
+    path: normalizedPath,
+    decision: 'unclassified',
+    matched_pattern: null,
+    reason: 'does not match the active-source allowlist, provenance-only allowlist, or reject list',
+  };
+}
+
+export async function evaluateArchiveImportPolicy(args: {
+  project_path?: string;
+  candidate_paths?: string[];
+}): Promise<ArchiveImportEvaluateResult> {
+  const projectPath = args.project_path?.trim();
+  const candidatePaths = Array.isArray(args.candidate_paths) ? args.candidate_paths : [];
+
+  const emptyResult = {
+    command: 'agenticos_archive_import_evaluate' as const,
+    status: 'BLOCK' as const,
+    summary: '',
+    project_path: projectPath || '',
+    candidate_count: candidatePaths.length,
+    policy: {
+      active_source_allowlist: [...DEFAULT_ACTIVE_SOURCE_ALLOWLIST],
+      provenance_only_allowlist: [...DEFAULT_PROVENANCE_ONLY_ALLOWLIST],
+      reject_list: [...DEFAULT_REJECT_LIST],
+    },
+    evaluations: [] as ArchiveImportEvaluationItem[],
+    active_source_files: [] as string[],
+    provenance_only_files: [] as string[],
+    rejected_files: [] as string[],
+    unclassified_files: [] as string[],
+    block_reasons: [] as string[],
+  };
+
+  if (!projectPath) {
+    emptyResult.block_reasons.push('project_path is required');
+    emptyResult.summary = emptyResult.block_reasons.join('; ');
+    return emptyResult;
+  }
+
+  if (candidatePaths.length === 0) {
+    emptyResult.project_path = projectPath;
+    emptyResult.block_reasons.push('candidate_paths is required');
+    emptyResult.summary = emptyResult.block_reasons.join('; ');
+    return emptyResult;
+  }
+
+  const policy = await resolveArchiveImportPolicy(projectPath);
+  const evaluations = candidatePaths.map((path) => classifyCandidate(path, policy));
+  const activeSourceFiles = evaluations.filter((item) => item.decision === 'active_source').map((item) => item.path);
+  const provenanceOnlyFiles = evaluations.filter((item) => item.decision === 'provenance_only').map((item) => item.path);
+  const rejectedFiles = evaluations.filter((item) => item.decision === 'reject').map((item) => item.path);
+  const unclassifiedFiles = evaluations.filter((item) => item.decision === 'unclassified').map((item) => item.path);
+  const blockReasons: string[] = [];
+
+  if (rejectedFiles.length > 0) {
+    blockReasons.push(`reject list matched ${rejectedFiles.length} candidate paths`);
+  }
+  if (unclassifiedFiles.length > 0) {
+    blockReasons.push(`policy did not classify ${unclassifiedFiles.length} candidate paths`);
+  }
+
+  const status = blockReasons.length > 0 ? 'BLOCK' : 'PASS';
+  const summary = status === 'PASS'
+    ? `archive import evaluation passed: ${activeSourceFiles.length} active-source, ${provenanceOnlyFiles.length} provenance-only`
+    : blockReasons.join('; ');
+
+  return {
+    command: 'agenticos_archive_import_evaluate',
+    status,
+    summary,
+    project_path: projectPath,
+    candidate_count: candidatePaths.length,
+    policy,
+    evaluations,
+    active_source_files: activeSourceFiles,
+    provenance_only_files: provenanceOnlyFiles,
+    rejected_files: rejectedFiles,
+    unclassified_files: unclassifiedFiles,
+    block_reasons: blockReasons,
+  };
+}

--- a/projects/agenticos/mcp-server/src/utils/runtime-review-surface.ts
+++ b/projects/agenticos/mcp-server/src/utils/runtime-review-surface.ts
@@ -1,0 +1,63 @@
+import { join, relative } from 'path';
+import { resolveManagedProjectContextPaths } from './project-target.js';
+
+export interface RuntimeReviewSurfacePaths {
+  tracked_review_excluded_paths: string[];
+  sidecar_only_paths: string[];
+}
+
+interface ResolveRuntimeReviewSurfaceOptions {
+  include_claude_state_mirror?: boolean;
+}
+
+function normalizeRepoRelativePath(projectPath: string, absolutePath: string, treatAsDirectory = false): string {
+  const relativePath = relative(projectPath, absolutePath).replace(/\\/g, '/');
+  if (!relativePath || relativePath.startsWith('..')) {
+    throw new Error(`Runtime review surface path escapes project root: ${absolutePath}`);
+  }
+  return treatAsDirectory && !relativePath.endsWith('/') ? `${relativePath}/` : relativePath;
+}
+
+function normalizeCandidatePath(path: string): string {
+  return path.replace(/\\/g, '/').replace(/^\.\//, '');
+}
+
+export function resolveRuntimeReviewSurfacePaths(
+  projectPath: string,
+  projectYaml: any,
+  options: ResolveRuntimeReviewSurfaceOptions = {},
+): RuntimeReviewSurfacePaths {
+  const contextPaths = resolveManagedProjectContextPaths(projectPath, projectYaml);
+  const tracked = new Set<string>([
+    normalizeRepoRelativePath(projectPath, contextPaths.statePath),
+    normalizeRepoRelativePath(projectPath, contextPaths.markerPath),
+    normalizeRepoRelativePath(projectPath, contextPaths.conversationsDir, true),
+  ]);
+
+  if (options.include_claude_state_mirror) {
+    tracked.add('CLAUDE.md');
+  }
+
+  return {
+    tracked_review_excluded_paths: Array.from(tracked),
+    sidecar_only_paths: [
+      '.private/conversations/',
+      '.meta/transcripts/',
+    ],
+  };
+}
+
+export function matchesRuntimeReviewExcludedPath(filePath: string, trackedPaths: string[]): boolean {
+  const normalizedFile = normalizeCandidatePath(filePath);
+  return trackedPaths.some((trackedPath) => {
+    const normalizedTracked = normalizeCandidatePath(trackedPath);
+    if (normalizedTracked.endsWith('/')) {
+      return normalizedFile === normalizedTracked.slice(0, -1) || normalizedFile.startsWith(normalizedTracked);
+    }
+    return normalizedFile === normalizedTracked;
+  });
+}
+
+export function toProjectAbsoluteRuntimePath(projectPath: string, trackedPath: string): string {
+  return join(projectPath, trackedPath.replace(/\/$/, ''));
+}

--- a/projects/agenticos/mcp-server/tsconfig.json
+++ b/projects/agenticos/mcp-server/tsconfig.json
@@ -11,5 +11,5 @@
     "forceConsistentCasingInFileNames": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "src/utils/runtime-review-surface.ts"]
+  "exclude": ["node_modules"]
 }

--- a/projects/agenticos/tasks/issue-171-archive-import-runtime-surface.md
+++ b/projects/agenticos/tasks/issue-171-archive-import-runtime-surface.md
@@ -1,0 +1,37 @@
+# Issue #171: Archive Import And Runtime Review Surface
+
+## GitHub
+
+- Issue: https://github.com/madlouse/AgenticOS/issues/171
+- Title: `Land archive-import and runtime review-surface mechanisms from cleanup triage`
+
+## Scope
+
+This slice normalizes the cleanup-triage mechanism work for:
+
+- archive import allowlist / reject-list policy
+- runtime-managed review surface classification
+
+Primary targets:
+
+- `projects/agenticos/mcp-server/src/utils/archive-import-policy.ts`
+- `projects/agenticos/mcp-server/src/tools/archive-import-evaluate.ts`
+- `projects/agenticos/mcp-server/src/utils/runtime-review-surface.ts`
+- `projects/agenticos/mcp-server/src/tools/pr-scope-check.ts`
+- `projects/agenticos/mcp-server/src/tools/save.ts`
+- `projects/agenticos/mcp-server/src/tools/record.ts`
+- `projects/agenticos/mcp-server/src/index.ts`
+- `projects/agenticos/mcp-server/src/tools/index.ts`
+- related tests and template metadata
+
+## Intended Outcome
+
+- archived file imports are classified before entering active project scope
+- runtime-managed files are excluded from normal product review slices by default
+- `save` stages only runtime-managed surfaces plus the CLAUDE state mirror
+- `record` no longer rewrites `quick-start.md` opportunistically
+
+## Notes
+
+- This slice is extracted from the canonical dirty worktree tracked by issue `#169`.
+- The branch should land as a coherent mechanism pass, not as another mixed cleanup batch.


### PR DESCRIPTION
## Summary

- add archive-import policy evaluation and expose it as a new MCP tool
- classify runtime-managed review surfaces and apply that policy in pr-scope-check and save
- stop record from opportunistically rewriting quick-start.md and cover the new behavior with tests

## Verification

- `cd projects/agenticos/mcp-server && npm ci`
- `cd projects/agenticos/mcp-server && npx vitest run src/tools/__tests__/archive-import-evaluate.test.ts src/tools/__tests__/pr-scope-check.test.ts src/tools/__tests__/save.test.ts src/tools/__tests__/record.test.ts`
- `cd projects/agenticos/mcp-server && npm test`

Closes #171
