### PR TITLE
fix(agenticos): declare ghostty downstream source root (#177)

### DIFF
--- a/projects/agenticos/tasks/issue-177-downstream-source-repo-roots.md
+++ b/projects/agenticos/tasks/issue-177-downstream-source-repo-roots.md
@@ -1,0 +1,27 @@
+# Issue #177: Declare Downstream Source Repo Roots
+
+## Summary
+
+Policy issue `#175` confirmed that some roots under `projects/` are active managed downstream projects, but not all of them are in the same canonical source state.
+
+This issue covers the tracked downstream project metadata that already exists on `origin/main` and still lacks explicit `execution.source_repo_roots`.
+
+GitHub issue:
+
+- https://github.com/madlouse/AgenticOS/issues/177
+
+## Scope
+
+1. Add `execution.source_repo_roots` for tracked downstream project metadata that is already in canonical source control.
+2. Verify the declaration matches the actual Git common repo root.
+3. Keep local-only downstream roots out of scope and route them through their own normalization issue.
+
+## Split
+
+- `projects/ghostty-optimization` is present on `origin/main` and is handled here.
+- `projects/agent-cli-api` and `projects/agenticresearch` are local-only roots in the canonical dirty tree and are handled separately under issue `#178`.
+
+## Acceptance Criteria
+
+- `projects/ghostty-optimization/.project.yaml` declares the correct repo root.
+- Guardrail resolution can prove the project's source root without a missing-declaration failure.

--- a/projects/ghostty-optimization/.project.yaml
+++ b/projects/ghostty-optimization/.project.yaml
@@ -4,6 +4,10 @@ meta:
   version: "1.0.0"
   created: "2026-03-16"
 
+execution:
+  source_repo_roots:
+    - ../..
+
 agent_context:
   quick_start: ".context/quick-start.md"
   current_state: ".context/state.yaml"


### PR DESCRIPTION
## Summary
- declare `execution.source_repo_roots` for `projects/ghostty-optimization`
- record the issue split so local-only roots `agent-cli-api` and `agenticresearch` stay out of this metadata-only fix
- align ghostty's managed-project metadata with the repo-boundary guardrails landed in #160

## Testing
- `agenticos_preflight` PASS with `project_path=projects/ghostty-optimization`
- `agenticos_pr_scope_check` PASS
