### PR TITLE
feat: enforce issue-start bootstrap before implementation

### DIFF
--- a/projects/agenticos/mcp-server/src/index.ts
+++ b/projects/agenticos/mcp-server/src/index.ts
@@ -34,7 +34,7 @@ import {
   ListResourcesRequestSchema,
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { initProject, switchProject, listProjects, getStatus, saveState, recordSession, runPreflight, runBranchBootstrap, runPrScopeCheck, runHealth, runEditGuard, runEntrySurfaceRefresh, runStandardKitAdopt, runStandardKitUpgradeCheck, runStandardKitConformanceCheck, runNonCodeEvaluate, runArchiveImportEvaluate } from './tools/index.js';
+import { initProject, switchProject, listProjects, getStatus, saveState, recordSession, runPreflight, runIssueBootstrap, runBranchBootstrap, runPrScopeCheck, runHealth, runEditGuard, runEntrySurfaceRefresh, runStandardKitAdopt, runStandardKitUpgradeCheck, runStandardKitConformanceCheck, runNonCodeEvaluate, runArchiveImportEvaluate } from './tools/index.js';
 import { getProjectContext } from './resources/index.js';
 
 const server = new Server(
@@ -178,6 +178,38 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
           },
         },
         required: ['repo_path', 'task_type', 'declared_target_files'],
+      },
+    },
+    {
+      name: 'agenticos_issue_bootstrap',
+      description: 'Record explicit issue-start bootstrap evidence for the current issue after a clear-equivalent reset and normal project hot-load.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          issue_id: { type: 'string', description: 'GitHub issue number or identifier for the current task.' },
+          issue_title: { type: 'string', description: 'Current issue title.' },
+          issue_body: { type: 'string', description: 'Current issue body or synthesized summary.' },
+          labels: { type: 'array', items: { type: 'string' }, description: 'Optional issue labels.' },
+          linked_artifacts: { type: 'array', items: { type: 'string' }, description: 'Optional linked docs or artifacts required at issue start.' },
+          additional_context: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                path: { type: 'string' },
+                reason: { type: 'string' },
+              },
+              required: ['path', 'reason'],
+            },
+            description: 'Optional additional documents loaded after startup surfaces, with explicit reasons.',
+          },
+          context_reset_performed: { type: 'boolean', description: 'Whether the current agent session performed a clear-equivalent reset.' },
+          project_hot_load_performed: { type: 'boolean', description: 'Whether the project then performed its normal startup context load.' },
+          issue_payload_attached: { type: 'boolean', description: 'Whether the current issue payload became the active issue-scoped packet.' },
+          repo_path: { type: 'string', description: 'Absolute repository or worktree path where this issue is being executed.' },
+          project_path: { type: 'string', description: 'Optional explicit managed project root when repo_path is a larger checkout or worktree.' },
+        },
+        required: ['issue_id', 'issue_title', 'context_reset_performed', 'project_hot_load_performed', 'issue_payload_attached', 'repo_path'],
       },
     },
     {
@@ -342,6 +374,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       return { content: [{ type: 'text', text: await getStatus() }] };
     case 'agenticos_preflight':
       return { content: [{ type: 'text', text: await runPreflight(args ?? {}) }] };
+    case 'agenticos_issue_bootstrap':
+      return { content: [{ type: 'text', text: await runIssueBootstrap(args ?? {}) }] };
     case 'agenticos_edit_guard':
       return { content: [{ type: 'text', text: await runEditGuard(args ?? {}) }] };
     case 'agenticos_branch_bootstrap':

--- a/projects/agenticos/mcp-server/src/resources/__tests__/context.test.ts
+++ b/projects/agenticos/mcp-server/src/resources/__tests__/context.test.ts
@@ -1,7 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+const yamlMock = vi.hoisted(() => ({
+  parse: vi.fn(),
+}));
+
 vi.mock('fs/promises', () => ({
   readFile: vi.fn(),
+}));
+
+vi.mock('yaml', () => ({
+  default: yamlMock,
 }));
 
 vi.mock('../../utils/project-target.js', () => ({
@@ -18,6 +26,7 @@ const resolveManagedProjectTargetMock = resolveManagedProjectTarget as unknown a
 describe('getProjectContext', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    yamlMock.parse.mockImplementation((content: string) => JSON.parse(content));
   });
 
   afterEach(() => {
@@ -37,7 +46,19 @@ describe('getProjectContext', () => {
     readFileMock
       .mockResolvedValueOnce('meta:\n  id: alpha\n')
       .mockResolvedValueOnce('# Quick Start\n\nAlpha summary')
-      .mockResolvedValueOnce('current_task:\n  title: Test\n');
+      .mockResolvedValueOnce(JSON.stringify({
+        current_task: { title: 'Test' },
+        issue_bootstrap: {
+          latest: {
+            issue_id: '179',
+            issue_title: 'Bootstrap issue',
+            recorded_at: '2026-04-06T00:00:00.000Z',
+            current_branch: 'feat/179-issue-start-bootstrap-evidence',
+            startup_context_paths: ['.project.yaml'],
+            additional_context: [],
+          },
+        },
+      }));
 
     const result = await getProjectContext();
 
@@ -45,6 +66,8 @@ describe('getProjectContext', () => {
     expect(result).toContain('Project ID: alpha');
     expect(result).toContain('Project Path: /workspace/alpha');
     expect(result).toContain('## Quick Start');
+    expect(result).toContain('## Latest Issue Bootstrap');
+    expect(result).toContain('Issue: #179');
     expect(result).toContain('## Current State');
   });
 

--- a/projects/agenticos/mcp-server/src/resources/context.ts
+++ b/projects/agenticos/mcp-server/src/resources/context.ts
@@ -1,5 +1,7 @@
 import { readFile } from 'fs/promises';
+import yaml from 'yaml';
 import { resolveManagedProjectTarget } from '../utils/project-target.js';
+import { extractLatestIssueBootstrap } from '../utils/guardrail-evidence.js';
 
 export async function getProjectContext(): Promise<string> {
   let resolved;
@@ -15,8 +17,13 @@ export async function getProjectContext(): Promise<string> {
     const projectYaml = await readFile(resolved.projectYamlPath, 'utf-8');
     const quickStart = await readFile(resolved.quickStartPath, 'utf-8');
     const state = await readFile(resolved.statePath, 'utf-8');
+    const parsedState = (yaml.parse(state) || {}) as Record<string, unknown>;
+    const latestBootstrap = extractLatestIssueBootstrap(parsedState as any);
+    const bootstrapSection = latestBootstrap
+      ? `## Latest Issue Bootstrap\n- Issue: #${latestBootstrap.issue_id || 'unknown'}\n- Title: ${latestBootstrap.issue_title || 'Untitled issue'}\n- Recorded: ${latestBootstrap.recorded_at || 'unknown'}\n- Branch: ${latestBootstrap.current_branch || 'unknown'}\n- Startup surfaces: ${(latestBootstrap.startup_context_paths || []).length}\n- Additional context: ${(latestBootstrap.additional_context || []).length}\n\n`
+      : '## Latest Issue Bootstrap\nNo issue bootstrap evidence recorded.\n\n';
 
-    return `# ${resolved.projectName}\n\nProject ID: ${resolved.projectId}\nProject Path: ${resolved.projectPath}\n\n## Project Configuration\n\`\`\`yaml\n${projectYaml}\`\`\`\n\n## Quick Start\n${quickStart}\n\n## Current State\n\`\`\`yaml\n${state}\`\`\``;
+    return `# ${resolved.projectName}\n\nProject ID: ${resolved.projectId}\nProject Path: ${resolved.projectPath}\n\n## Project Configuration\n\`\`\`yaml\n${projectYaml}\`\`\`\n\n## Quick Start\n${quickStart}\n\n${bootstrapSection}## Current State\n\`\`\`yaml\n${state}\`\`\``;
   } catch (error: any) {
     return `# Error Loading Context\n\n${error.message}`;
   }

--- a/projects/agenticos/mcp-server/src/tools/__tests__/issue-bootstrap.test.ts
+++ b/projects/agenticos/mcp-server/src/tools/__tests__/issue-bootstrap.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const execAsyncMock = vi.hoisted(() => vi.fn());
+const readFileMock = vi.hoisted(() => vi.fn());
+const existsSyncMock = vi.hoisted(() => vi.fn());
+const yamlMock = vi.hoisted(() => ({
+  parse: vi.fn(),
+}));
+const resolveGuardrailProjectTargetMock = vi.hoisted(() => vi.fn());
+const persistIssueBootstrapEvidenceMock = vi.hoisted(() => vi.fn().mockResolvedValue({
+  attempted: true,
+  persisted: true,
+  project_id: 'agenticos',
+  state_path: '/workspace/projects/agenticos/standards/.context/state.yaml',
+}));
+
+vi.mock('child_process', () => ({
+  exec: vi.fn(),
+}));
+
+vi.mock('util', () => ({
+  promisify: vi.fn(() => execAsyncMock),
+}));
+
+vi.mock('fs/promises', () => ({
+  readFile: readFileMock,
+}));
+
+vi.mock('fs', () => ({
+  existsSync: existsSyncMock,
+}));
+
+vi.mock('yaml', () => ({
+  default: yamlMock,
+}));
+
+vi.mock('../../utils/repo-boundary.js', () => ({
+  resolveGuardrailProjectTarget: resolveGuardrailProjectTargetMock,
+}));
+
+vi.mock('../../utils/guardrail-evidence.js', () => ({
+  persistIssueBootstrapEvidence: persistIssueBootstrapEvidenceMock,
+}));
+
+import { runIssueBootstrap } from '../issue-bootstrap.js';
+
+function mockGitResponses(responses: Record<string, string>): void {
+  execAsyncMock.mockImplementation(async (cmd: string) => {
+    for (const [pattern, stdout] of Object.entries(responses)) {
+      if (cmd.includes(pattern)) {
+        return { stdout, stderr: '' };
+      }
+    }
+    throw new Error(`Unexpected command: ${cmd}`);
+  });
+}
+
+describe('runIssueBootstrap', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resolveGuardrailProjectTargetMock.mockResolvedValue({
+      activeProjectId: 'agenticos',
+      resolutionSource: 'active_project',
+      resolutionErrors: [],
+      targetProject: {
+        id: 'agenticos',
+        name: 'AgenticOS',
+        path: '/workspace/projects/agenticos/standards',
+        statePath: '/workspace/projects/agenticos/standards/.context/state.yaml',
+        projectYamlPath: '/workspace/projects/agenticos/standards/.project.yaml',
+        sourceRepoRoots: ['/repo'],
+        sourceRepoRootsDeclared: true,
+      },
+    });
+    readFileMock.mockResolvedValue(JSON.stringify({
+      meta: { id: 'agenticos' },
+      agent_context: {
+        quick_start: '.context/quick-start.md',
+        current_state: '.context/state.yaml',
+      },
+    }));
+    existsSyncMock.mockReturnValue(true);
+    yamlMock.parse.mockImplementation((content: string) => JSON.parse(content));
+    persistIssueBootstrapEvidenceMock.mockResolvedValue({
+      attempted: true,
+      persisted: true,
+      project_id: 'agenticos',
+      state_path: '/workspace/projects/agenticos/standards/.context/state.yaml',
+    });
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --git-common-dir': '.git\n',
+      'rev-parse --abbrev-ref HEAD': 'feat/179-issue-start-bootstrap-evidence\n',
+      'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo\nHEAD abc123\nbranch refs/heads/feat/179-issue-start-bootstrap-evidence\n',
+    });
+  });
+
+  it('records issue bootstrap evidence when reset, hot-load, and issue payload steps are all confirmed', async () => {
+    const result = JSON.parse(await runIssueBootstrap({
+      issue_id: '179',
+      issue_title: 'Implement bootstrap evidence',
+      labels: ['enhancement'],
+      linked_artifacts: ['tasks/issue-179.md'],
+      additional_context: [{ path: 'knowledge/issue-158.md', reason: 'design reference' }],
+      context_reset_performed: true,
+      project_hot_load_performed: true,
+      issue_payload_attached: true,
+      repo_path: '/repo',
+      project_path: '/workspace/projects/agenticos/standards',
+    })) as { status: string; startup_context_paths: string[]; persistence?: { persisted: boolean } };
+
+    expect(result.status).toBe('RECORDED');
+    expect(result.startup_context_paths).toContain('/workspace/projects/agenticos/standards/.project.yaml');
+    expect(result.persistence?.persisted).toBe(true);
+    expect(persistIssueBootstrapEvidenceMock).toHaveBeenCalledWith(expect.objectContaining({
+      payload: expect.objectContaining({
+        issue_id: '179',
+        issue_title: 'Implement bootstrap evidence',
+        current_branch: 'feat/179-issue-start-bootstrap-evidence',
+        stages: {
+          context_reset_performed: true,
+          project_hot_load_performed: true,
+          issue_payload_attached: true,
+        },
+      }),
+    }));
+  });
+
+  it('blocks when the caller has not explicitly confirmed the clear-equivalent reset', async () => {
+    const result = JSON.parse(await runIssueBootstrap({
+      issue_id: '179',
+      issue_title: 'Implement bootstrap evidence',
+      context_reset_performed: false,
+      project_hot_load_performed: true,
+      issue_payload_attached: true,
+      repo_path: '/repo',
+      project_path: '/workspace/projects/agenticos/standards',
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons.join(' ')).toContain('context_reset_performed');
+    expect(persistIssueBootstrapEvidenceMock).not.toHaveBeenCalled();
+  });
+});

--- a/projects/agenticos/mcp-server/src/tools/__tests__/preflight.test.ts
+++ b/projects/agenticos/mcp-server/src/tools/__tests__/preflight.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const execAsyncMock = vi.hoisted(() => vi.fn());
+const readFileMock = vi.hoisted(() => vi.fn());
+const yamlMock = vi.hoisted(() => ({
+  parse: vi.fn(),
+}));
 
 vi.mock('child_process', () => ({
   exec: vi.fn(),
@@ -8,6 +12,14 @@ vi.mock('child_process', () => ({
 
 vi.mock('util', () => ({
   promisify: vi.fn(() => execAsyncMock),
+}));
+
+vi.mock('fs/promises', () => ({
+  readFile: readFileMock,
+}));
+
+vi.mock('yaml', () => ({
+  default: yamlMock,
 }));
 
 const persistGuardrailEvidenceMock = vi.hoisted(() => vi.fn().mockResolvedValue({
@@ -21,6 +33,7 @@ const resolveGuardrailProjectTargetMock = vi.hoisted(() => vi.fn());
 
 vi.mock('../../utils/guardrail-evidence.js', () => ({
   persistGuardrailEvidence: persistGuardrailEvidenceMock,
+  extractLatestIssueBootstrap: (state: any) => state?.issue_bootstrap?.latest || null,
 }));
 
 vi.mock('../../utils/repo-boundary.js', () => ({
@@ -64,6 +77,27 @@ describe('runPreflight', () => {
         sourceRepoRootsDeclared: true,
       },
     });
+    readFileMock.mockResolvedValue(JSON.stringify({
+      issue_bootstrap: {
+        updated_at: '2026-04-06T00:00:00.000Z',
+        latest: {
+          recorded_at: '2026-04-06T00:00:00.000Z',
+          issue_id: '36',
+          repo_path: '/repo',
+          current_branch: 'feat/36-guardrail-preflight',
+          startup_context_paths: [
+            '/workspace/projects/agenticos/standards/.project.yaml',
+            '/workspace/projects/agenticos/standards/.context/quick-start.md',
+          ],
+          stages: {
+            context_reset_performed: true,
+            project_hot_load_performed: true,
+            issue_payload_attached: true,
+          },
+        },
+      },
+    }));
+    yamlMock.parse.mockImplementation((content: string) => JSON.parse(content));
   });
 
   it('returns PASS for a correctly isolated implementation branch', async () => {
@@ -131,6 +165,21 @@ describe('runPreflight', () => {
       'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo\nHEAD abc123\nbranch refs/heads/feat/113-fail-closed-edit-boundaries\n',
       'log --format=%s origin/main..HEAD': '',
     });
+    readFileMock.mockResolvedValue(JSON.stringify({
+      issue_bootstrap: {
+        latest: {
+          issue_id: '113',
+          repo_path: '/repo',
+          current_branch: 'feat/113-fail-closed-edit-boundaries',
+          startup_context_paths: ['/repo/projects/agenticos/standards/.project.yaml'],
+          stages: {
+            context_reset_performed: true,
+            project_hot_load_performed: true,
+            issue_payload_attached: true,
+          },
+        },
+      },
+    }));
 
     await runPreflight({
       issue_id: '113',
@@ -172,6 +221,21 @@ describe('runPreflight', () => {
         sourceRepoRootsDeclared: true,
       },
     });
+    readFileMock.mockResolvedValue(JSON.stringify({
+      issue_bootstrap: {
+        latest: {
+          issue_id: '160',
+          repo_path: '/repo',
+          current_branch: 'feat/160-source-repo-boundary-enforcement',
+          startup_context_paths: ['/repo/projects/agenticos/standards/.project.yaml'],
+          stages: {
+            context_reset_performed: true,
+            project_hot_load_performed: true,
+            issue_payload_attached: true,
+          },
+        },
+      },
+    }));
 
     await runPreflight({
       issue_id: '160',
@@ -209,6 +273,72 @@ describe('runPreflight', () => {
 
     expect(result.status).toBe('BLOCK');
     expect(result.block_reasons[0]).toContain('unrelated commits');
+  });
+
+  it('returns BLOCK when no matching issue bootstrap evidence is recorded', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --git-common-dir': '.git\n',
+      'config --get remote.origin.url': 'git@github.com:madlouse/AgenticOS.git\n',
+      'rev-parse --abbrev-ref HEAD': 'feat/36-guardrail-preflight\n',
+      'rev-parse HEAD': 'abc123\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo\nHEAD abc123\nbranch refs/heads/feat/36-guardrail-preflight\n',
+      'log --format=%s origin/main..HEAD': '',
+    });
+    readFileMock.mockResolvedValue(JSON.stringify({}));
+
+    const result = JSON.parse(await runPreflight({
+      issue_id: '36',
+      task_type: 'implementation',
+      repo_path: '/repo',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/preflight.ts'],
+      worktree_required: true,
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons.join(' ')).toContain('no issue bootstrap evidence');
+  });
+
+  it('returns BLOCK when the latest issue bootstrap belongs to a different issue', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --git-common-dir': '.git\n',
+      'config --get remote.origin.url': 'git@github.com:madlouse/AgenticOS.git\n',
+      'rev-parse --abbrev-ref HEAD': 'feat/36-guardrail-preflight\n',
+      'rev-parse HEAD': 'abc123\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo\nHEAD abc123\nbranch refs/heads/feat/36-guardrail-preflight\n',
+      'log --format=%s origin/main..HEAD': '',
+    });
+    readFileMock.mockResolvedValue(JSON.stringify({
+      issue_bootstrap: {
+        latest: {
+          issue_id: '999',
+          repo_path: '/repo',
+          current_branch: 'feat/36-guardrail-preflight',
+          startup_context_paths: ['/workspace/projects/agenticos/standards/.project.yaml'],
+          stages: {
+            context_reset_performed: true,
+            project_hot_load_performed: true,
+            issue_payload_attached: true,
+          },
+        },
+      },
+    }));
+
+    const result = JSON.parse(await runPreflight({
+      issue_id: '36',
+      task_type: 'implementation',
+      repo_path: '/repo',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/preflight.ts'],
+      worktree_required: true,
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons.join(' ')).toContain('does not match requested issue');
   });
 
   it('returns BLOCK for structural move without root exception or reproducibility gate', async () => {

--- a/projects/agenticos/mcp-server/src/tools/__tests__/project.test.ts
+++ b/projects/agenticos/mcp-server/src/tools/__tests__/project.test.ts
@@ -287,6 +287,48 @@ describe('switchProject', () => {
     expect(result).toContain('create an isolated issue branch/worktree');
   });
 
+  it('shows the latest issue bootstrap summary in switch output when evidence exists', async () => {
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: null,
+      projects: [
+        {
+          id: 'my-project',
+          name: 'My Project',
+          path: '/test/path',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    fsPromisesMock.readFile
+      .mockResolvedValueOnce(JSON.stringify({ meta: { description: '' } }))
+      .mockResolvedValueOnce(JSON.stringify({
+        working_memory: { pending: [], decisions: [] },
+        issue_bootstrap: {
+          updated_at: '2025-01-02T15:00:00.000Z',
+          latest: {
+            issue_id: '179',
+            issue_title: 'Implement bootstrap evidence',
+            recorded_at: '2025-01-02T15:00:00.000Z',
+            current_branch: 'feat/179-issue-start-bootstrap-evidence',
+            startup_context_paths: ['.project.yaml', '.context/quick-start.md'],
+            additional_context: [{ path: 'knowledge/issue-158.md', reason: 'design reference' }],
+          },
+        },
+      }))
+      .mockResolvedValueOnce('# Quick Start\n\nProject summary');
+
+    const result = await switchProject({ project: 'my-project' });
+
+    expect(result).toContain('🧭 Latest issue bootstrap: #179 on feat/179-issue-start-bootstrap-evidence');
+    expect(result).toContain('Title: Implement bootstrap evidence');
+    expect(result).toContain('2 startup surface(s), 1 additional context document(s)');
+  });
+
   it('inlines actionable project context into switch output', async () => {
     registryMock.loadRegistry.mockResolvedValue({
       version: '1.0.0',
@@ -722,6 +764,76 @@ describe('getStatus', () => {
     const result = await getStatus();
 
     expect(result).toContain('🛡️ Latest guardrail: None recorded');
+  });
+
+  it('shows a friendly issue bootstrap placeholder when no issue bootstrap evidence exists', async () => {
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: 'test-project',
+      projects: [
+        {
+          id: 'test-project',
+          name: 'Test Project',
+          path: '/test/path',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    fsPromisesMock.readFile.mockResolvedValue(
+      JSON.stringify({
+        session: { last_backup: '2025-01-02T12:00:00.000Z' },
+        working_memory: { pending: [], decisions: [] },
+      })
+    );
+
+    const result = await getStatus();
+
+    expect(result).toContain('🧭 Latest issue bootstrap: None recorded');
+  });
+
+  it('shows the latest issue bootstrap summary in status output when evidence exists', async () => {
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: 'test-project',
+      projects: [
+        {
+          id: 'test-project',
+          name: 'Test Project',
+          path: '/test/path',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    fsPromisesMock.readFile.mockResolvedValue(
+      JSON.stringify({
+        session: { last_backup: '2025-01-02T12:00:00.000Z' },
+        working_memory: { pending: [], decisions: [] },
+        issue_bootstrap: {
+          updated_at: '2025-01-02T15:00:00.000Z',
+          latest: {
+            issue_id: '179',
+            issue_title: 'Implement bootstrap evidence',
+            recorded_at: '2025-01-02T15:00:00.000Z',
+            current_branch: 'feat/179-issue-start-bootstrap-evidence',
+            startup_context_paths: ['.project.yaml', '.context/quick-start.md'],
+            additional_context: [{ path: 'knowledge/issue-158.md', reason: 'design reference' }],
+          },
+        },
+      })
+    );
+
+    const result = await getStatus();
+
+    expect(result).toContain('🧭 Latest issue bootstrap: #179 on feat/179-issue-start-bootstrap-evidence');
+    expect(result).toContain('Title: Implement bootstrap evidence');
   });
 
   it('shows the latest BLOCK guardrail summary and reason', async () => {

--- a/projects/agenticos/mcp-server/src/tools/index.ts
+++ b/projects/agenticos/mcp-server/src/tools/index.ts
@@ -3,6 +3,7 @@ export { switchProject, listProjects, getStatus } from './project.js';
 export { saveState } from './save.js';
 export { recordSession } from './record.js';
 export { runPreflight } from './preflight.js';
+export { runIssueBootstrap } from './issue-bootstrap.js';
 export { runBranchBootstrap } from './branch-bootstrap.js';
 export { runPrScopeCheck } from './pr-scope-check.js';
 export { runHealth } from './health.js';

--- a/projects/agenticos/mcp-server/src/tools/issue-bootstrap.ts
+++ b/projects/agenticos/mcp-server/src/tools/issue-bootstrap.ts
@@ -1,0 +1,255 @@
+import { existsSync } from 'fs';
+import { readFile } from 'fs/promises';
+import { exec } from 'child_process';
+import { dirname, join, resolve } from 'path';
+import { promisify } from 'util';
+import yaml from 'yaml';
+import { persistIssueBootstrapEvidence, type GuardrailPersistenceResult, type IssueBootstrapAdditionalContextEntry } from '../utils/guardrail-evidence.js';
+import { resolveGuardrailProjectTarget } from '../utils/repo-boundary.js';
+import { resolveManagedProjectContextPaths } from '../utils/project-target.js';
+
+const execAsync = promisify(exec);
+
+type BootstrapStatus = 'RECORDED' | 'BLOCK';
+type WorkspaceType = 'main' | 'isolated_worktree';
+
+interface IssueBootstrapArgs {
+  issue_id?: string;
+  issue_title?: string;
+  issue_body?: string;
+  labels?: string[];
+  linked_artifacts?: string[];
+  additional_context?: IssueBootstrapAdditionalContextEntry[];
+  context_reset_performed?: boolean;
+  project_hot_load_performed?: boolean;
+  issue_payload_attached?: boolean;
+  repo_path?: string;
+  project_path?: string;
+}
+
+interface IssueBootstrapResult {
+  command: 'agenticos_issue_bootstrap';
+  status: BootstrapStatus;
+  summary: string;
+  active_project: string | null;
+  target_project: {
+    id: string;
+    name: string;
+    path: string;
+    state_path: string;
+    project_yaml_path: string;
+  } | null;
+  startup_context_paths: string[];
+  block_reasons: string[];
+  evidence: {
+    issue_id: string | null;
+    issue_title: string | null;
+    repo_path: string | null;
+    project_path: string | null;
+    current_branch: string | null;
+    workspace_type: WorkspaceType | null;
+    context_reset_performed: boolean;
+    project_hot_load_performed: boolean;
+    issue_payload_attached: boolean;
+    labels: string[];
+    linked_artifacts: string[];
+    additional_context: IssueBootstrapAdditionalContextEntry[];
+  };
+  persistence?: GuardrailPersistenceResult;
+}
+
+async function runGit(repoPath: string, args: string): Promise<string> {
+  const { stdout } = await execAsync(`git -C "${repoPath}" ${args}`);
+  return stdout.trim();
+}
+
+async function detectWorkspaceType(repoPath: string): Promise<WorkspaceType> {
+  try {
+    const output = await runGit(repoPath, 'worktree list --porcelain');
+    const worktreeLines = output
+      .split('\n')
+      .filter((line) => line.startsWith('worktree '))
+      .map((line) => line.replace(/^worktree\s+/, '').trim());
+
+    if (worktreeLines.length > 0 && worktreeLines[0] === repoPath) {
+      return 'main';
+    }
+    return 'isolated_worktree';
+  } catch {
+    return 'main';
+  }
+}
+
+function normalizeStringArray(values: unknown): string[] {
+  if (!Array.isArray(values)) return [];
+  return values
+    .map((value) => String(value || '').trim())
+    .filter((value) => value.length > 0);
+}
+
+function normalizeAdditionalContext(values: unknown): IssueBootstrapAdditionalContextEntry[] {
+  if (!Array.isArray(values)) return [];
+
+  return values
+    .map((value) => {
+      if (!value || typeof value !== 'object') return null;
+      const path = String((value as any).path || '').trim();
+      const reason = String((value as any).reason || '').trim();
+      if (!path || !reason) return null;
+      return { path, reason };
+    })
+    .filter((value): value is IssueBootstrapAdditionalContextEntry => value !== null);
+}
+
+export async function runIssueBootstrap(args: IssueBootstrapArgs): Promise<string> {
+  const {
+    issue_id,
+    issue_title,
+    issue_body,
+    labels = [],
+    linked_artifacts = [],
+    additional_context = [],
+    context_reset_performed = false,
+    project_hot_load_performed = false,
+    issue_payload_attached = false,
+    repo_path,
+    project_path,
+  } = args ?? {};
+
+  const result: IssueBootstrapResult = {
+    command: 'agenticos_issue_bootstrap',
+    status: 'BLOCK',
+    summary: '',
+    active_project: null,
+    target_project: null,
+    startup_context_paths: [],
+    block_reasons: [],
+    evidence: {
+      issue_id: issue_id || null,
+      issue_title: issue_title || null,
+      repo_path: repo_path || null,
+      project_path: project_path || null,
+      current_branch: null,
+      workspace_type: null,
+      context_reset_performed,
+      project_hot_load_performed,
+      issue_payload_attached,
+      labels: normalizeStringArray(labels),
+      linked_artifacts: normalizeStringArray(linked_artifacts),
+      additional_context: normalizeAdditionalContext(additional_context),
+    },
+  };
+
+  if (!repo_path) {
+    result.block_reasons.push('repo_path is required');
+  }
+  if (!issue_id) {
+    result.block_reasons.push('issue_id is required');
+  }
+  if (!issue_title) {
+    result.block_reasons.push('issue_title is required');
+  }
+  if (!context_reset_performed) {
+    result.block_reasons.push('context_reset_performed must be true before recording issue bootstrap');
+  }
+  if (!project_hot_load_performed) {
+    result.block_reasons.push('project_hot_load_performed must be true before recording issue bootstrap');
+  }
+  if (!issue_payload_attached) {
+    result.block_reasons.push('issue_payload_attached must be true before recording issue bootstrap');
+  }
+
+  const projectResolution = await resolveGuardrailProjectTarget({
+    commandName: 'agenticos_issue_bootstrap',
+    repoPath: repo_path,
+    projectPath: project_path,
+  });
+  result.active_project = projectResolution.activeProjectId;
+
+  if (!projectResolution.targetProject) {
+    result.block_reasons.push(...projectResolution.resolutionErrors);
+  } else {
+    result.target_project = {
+      id: projectResolution.targetProject.id,
+      name: projectResolution.targetProject.name,
+      path: projectResolution.targetProject.path,
+      state_path: projectResolution.targetProject.statePath,
+      project_yaml_path: projectResolution.targetProject.projectYamlPath,
+    };
+  }
+
+  let startupContextPaths: string[] = [];
+
+  if (repo_path && result.target_project) {
+    try {
+      const gitWorktreeRoot = await runGit(repo_path, 'rev-parse --show-toplevel');
+      const gitCommonDir = resolve(gitWorktreeRoot, await runGit(repo_path, 'rev-parse --git-common-dir'));
+      const gitCommonRepoRoot = dirname(gitCommonDir);
+      result.evidence.current_branch = await runGit(repo_path, 'rev-parse --abbrev-ref HEAD');
+      result.evidence.workspace_type = await detectWorkspaceType(repo_path);
+
+      const declaredSourceRepoRoots = projectResolution.targetProject?.sourceRepoRoots || [];
+      const sourceRootsDeclared = projectResolution.targetProject?.sourceRepoRootsDeclared || false;
+      if (!sourceRootsDeclared || declaredSourceRepoRoots.length === 0) {
+        result.block_reasons.push(
+          `target project "${projectResolution.targetProject?.id}" is missing execution.source_repo_roots in ${projectResolution.targetProject?.projectYamlPath}`,
+        );
+      } else if (!declaredSourceRepoRoots.includes(gitCommonRepoRoot)) {
+        result.block_reasons.push(
+          `git common repo root "${gitCommonRepoRoot}" is not declared for target project "${projectResolution.targetProject?.id}"`,
+        );
+      }
+
+      const projectYaml = yaml.parse(await readFile(result.target_project.project_yaml_path, 'utf-8')) || {};
+      const contextPaths = resolveManagedProjectContextPaths(result.target_project.path, projectYaml);
+      startupContextPaths = [
+        result.target_project.project_yaml_path,
+        contextPaths.quickStartPath,
+        contextPaths.statePath,
+        join(result.target_project.path, 'AGENTS.md'),
+        join(result.target_project.path, 'CLAUDE.md'),
+      ].filter((path, index, all) => existsSync(path) && all.indexOf(path) === index);
+      result.startup_context_paths = startupContextPaths;
+      result.evidence.project_path = result.target_project.path;
+    } catch (error) {
+      result.block_reasons.push(error instanceof Error ? error.message : 'failed to resolve git or project startup context for issue bootstrap');
+    }
+  }
+
+  if (result.startup_context_paths.length === 0 && result.target_project) {
+    result.block_reasons.push('no startup context paths could be resolved for the target project');
+  }
+
+  if (result.block_reasons.length > 0) {
+    result.status = 'BLOCK';
+    result.summary = result.block_reasons[0];
+    return JSON.stringify(result, null, 2);
+  }
+
+  result.status = 'RECORDED';
+  result.summary = `issue bootstrap recorded for #${issue_id}`;
+  result.persistence = await persistIssueBootstrapEvidence({
+    repo_path,
+    project_path: result.target_project?.path || project_path,
+    payload: {
+      issue_id,
+      issue_title,
+      issue_body: issue_body || null,
+      labels: result.evidence.labels,
+      linked_artifacts: result.evidence.linked_artifacts,
+      startup_context_paths: startupContextPaths,
+      additional_context: result.evidence.additional_context,
+      repo_path,
+      project_path: result.target_project?.path || project_path || null,
+      current_branch: result.evidence.current_branch,
+      workspace_type: result.evidence.workspace_type,
+      stages: {
+        context_reset_performed,
+        project_hot_load_performed,
+        issue_payload_attached,
+      },
+    },
+  });
+
+  return JSON.stringify(result, null, 2);
+}

--- a/projects/agenticos/mcp-server/src/tools/preflight.ts
+++ b/projects/agenticos/mcp-server/src/tools/preflight.ts
@@ -1,7 +1,9 @@
 import { exec } from 'child_process';
 import { dirname, resolve } from 'path';
 import { promisify } from 'util';
-import { persistGuardrailEvidence, type GuardrailPersistenceResult } from '../utils/guardrail-evidence.js';
+import { readFile } from 'fs/promises';
+import yaml from 'yaml';
+import { extractLatestIssueBootstrap, persistGuardrailEvidence, type GuardrailPersistenceResult } from '../utils/guardrail-evidence.js';
 import {
   isImplementationAffectingTask,
   resolveGuardrailProjectTarget,
@@ -54,6 +56,12 @@ interface PreflightResult {
     branch_fork_point: string;
     workspace_type: WorkspaceType;
     commit_subjects_since_base: string[];
+    issue_bootstrap: {
+      recorded_at: string | null;
+      issue_id: string | null;
+      repo_path: string | null;
+      current_branch: string | null;
+    } | null;
   };
   persistence?: GuardrailPersistenceResult;
 }
@@ -134,6 +142,7 @@ function makeBaseResult(remoteBaseBranch: string): PreflightResult {
       branch_fork_point: '',
       workspace_type: 'main',
       commit_subjects_since_base: [],
+      issue_bootstrap: null,
     },
   };
 }
@@ -289,6 +298,56 @@ export async function runPreflight(args: PreflightArgs): Promise<string> {
     }
 
     result.scope_ok = declared_target_files.length > 0;
+
+    if (projectResolution.targetProject && result.worktree_ok) {
+      try {
+        const state = yaml.parse(await readFile(projectResolution.targetProject.statePath, 'utf-8')) || {};
+        const latestBootstrap = extractLatestIssueBootstrap(state);
+        result.evidence.issue_bootstrap = latestBootstrap
+          ? {
+              recorded_at: latestBootstrap.recorded_at || null,
+              issue_id: latestBootstrap.issue_id || null,
+              repo_path: latestBootstrap.repo_path || null,
+              current_branch: latestBootstrap.current_branch || null,
+            }
+          : null;
+
+        if (!latestBootstrap) {
+          result.block_reasons.push('no issue bootstrap evidence is recorded for the target project');
+        } else {
+          if (issue_id && latestBootstrap.issue_id !== issue_id) {
+            result.block_reasons.push(
+              `latest issue bootstrap issue "${latestBootstrap.issue_id || 'unknown'}" does not match requested issue "${issue_id}"`,
+            );
+          }
+
+          if (repo_path && resolve(latestBootstrap.repo_path || '') !== resolve(repo_path)) {
+            result.block_reasons.push('latest issue bootstrap was recorded for a different repo_path');
+          }
+
+          if (latestBootstrap.current_branch && latestBootstrap.current_branch !== result.evidence.current_branch) {
+            result.block_reasons.push(
+              `latest issue bootstrap branch "${latestBootstrap.current_branch}" does not match current branch "${result.evidence.current_branch}"`,
+            );
+          }
+
+          if (!latestBootstrap.stages?.context_reset_performed) {
+            result.block_reasons.push('latest issue bootstrap does not prove a clear-equivalent context reset');
+          }
+          if (!latestBootstrap.stages?.project_hot_load_performed) {
+            result.block_reasons.push('latest issue bootstrap does not prove project hot-load occurred');
+          }
+          if (!latestBootstrap.stages?.issue_payload_attached) {
+            result.block_reasons.push('latest issue bootstrap does not prove issue payload attachment');
+          }
+          if (!Array.isArray(latestBootstrap.startup_context_paths) || latestBootstrap.startup_context_paths.length === 0) {
+            result.block_reasons.push('latest issue bootstrap is missing startup context evidence');
+          }
+        }
+      } catch {
+        result.block_reasons.push(`managed project state is missing or unreadable: ${projectResolution.targetProject.statePath}`);
+      }
+    }
   } else {
     result.branch_based_on_intended_remote = true;
     result.scope_ok = true;

--- a/projects/agenticos/mcp-server/src/tools/project.ts
+++ b/projects/agenticos/mcp-server/src/tools/project.ts
@@ -7,6 +7,7 @@ import { generateClaudeMd, generateAgentsMd, updateClaudeMdState, upgradeClaudeM
 import { writeFile } from 'fs/promises';
 import { buildArchivedReferenceMessage, isArchivedReferenceProject } from '../utils/project-contract.js';
 import { resolveManagedProjectContextPaths } from '../utils/project-target.js';
+import { type IssueBootstrapRecord, type IssueBootstrapState } from '../utils/guardrail-evidence.js';
 
 type GuardrailCommand = 'agenticos_preflight' | 'agenticos_branch_bootstrap' | 'agenticos_pr_scope_check';
 
@@ -31,6 +32,10 @@ interface GuardrailEvidenceState {
   preflight?: GuardrailEvidenceEntry;
   branch_bootstrap?: GuardrailEvidenceEntry;
   pr_scope_check?: GuardrailEvidenceEntry;
+}
+
+interface IssueBootstrapSummaryInput {
+  issueBootstrap?: IssueBootstrapState;
 }
 
 interface SwitchContextSummaryInput {
@@ -107,6 +112,43 @@ function buildGuardrailSummaryLines(guardrailEvidence?: GuardrailEvidenceState):
   }
 
   const detail = summarizeGuardrailDetail(latestGuardrail);
+  if (detail) {
+    lines.push(`   Detail: ${detail}`);
+  }
+
+  return lines;
+}
+
+function summarizeIssueBootstrapDetail(entry: IssueBootstrapRecord): string | null {
+  const startupCount = Array.isArray(entry.startup_context_paths) ? entry.startup_context_paths.length : 0;
+  const additionalCount = Array.isArray(entry.additional_context) ? entry.additional_context.length : 0;
+
+  if (startupCount > 0 || additionalCount > 0) {
+    return `${startupCount} startup surface(s), ${additionalCount} additional context document(s)`;
+  }
+
+  return null;
+}
+
+function buildIssueBootstrapSummaryLines(input: IssueBootstrapSummaryInput): string[] {
+  const latestBootstrap = input.issueBootstrap?.latest;
+  if (!latestBootstrap) {
+    return ['🧭 Latest issue bootstrap: None recorded'];
+  }
+
+  const recordedAt =
+    formatTimestamp(latestBootstrap.recorded_at) ||
+    formatTimestamp(input.issueBootstrap?.updated_at) ||
+    'Unknown time';
+  const issueLabel = latestBootstrap.issue_id ? `#${latestBootstrap.issue_id}` : 'unknown issue';
+  const branchDetail = latestBootstrap.current_branch ? ` on ${latestBootstrap.current_branch}` : '';
+  const lines = [`🧭 Latest issue bootstrap: ${issueLabel}${branchDetail} (${recordedAt})`];
+
+  if (latestBootstrap.issue_title) {
+    lines.push(`   Title: ${latestBootstrap.issue_title}`);
+  }
+
+  const detail = summarizeIssueBootstrapDetail(latestBootstrap);
   if (detail) {
     lines.push(`   Detail: ${detail}`);
   }
@@ -241,6 +283,9 @@ export async function switchProject(args: any): Promise<string> {
 
   const bootstrap = bootstrapNotes.length > 0 ? '\n\n' + bootstrapNotes.join('\n') : '';
   const guardrailSummary = buildGuardrailSummaryLines(state?.guardrail_evidence as GuardrailEvidenceState | undefined);
+  const issueBootstrapSummary = buildIssueBootstrapSummaryLines({
+    issueBootstrap: state?.issue_bootstrap as IssueBootstrapState | undefined,
+  });
   const contextSummary = buildSwitchContextSummaryLines({
     description,
     quickStart,
@@ -248,7 +293,7 @@ export async function switchProject(args: any): Promise<string> {
     lastRecorded: found.last_recorded,
   });
 
-  return `✅ Switched to project "${found.name}"\n\nPath: ${found.path}\nStatus: ${found.status}\n\n${contextSummary.join('\n')}\n\nContext loaded from:\n- ${found.path}/.project.yaml\n- ${contextPaths.quickStartPath}\n- ${contextPaths.statePath}\n\n${guardrailSummary.join('\n')}${bootstrap}`;
+  return `✅ Switched to project "${found.name}"\n\nPath: ${found.path}\nStatus: ${found.status}\n\n${contextSummary.join('\n')}\n\nContext loaded from:\n- ${found.path}/.project.yaml\n- ${contextPaths.quickStartPath}\n- ${contextPaths.statePath}\n\n${guardrailSummary.join('\n')}\n${issueBootstrapSummary.join('\n')}${bootstrap}`;
 }
 
 export async function listProjects(): Promise<string> {
@@ -322,6 +367,9 @@ export async function getStatus(): Promise<string> {
   }
 
   lines.push(...buildGuardrailSummaryLines(state.guardrail_evidence as GuardrailEvidenceState | undefined));
+  lines.push(...buildIssueBootstrapSummaryLines({
+    issueBootstrap: state.issue_bootstrap as IssueBootstrapState | undefined,
+  }));
 
   lines.push('');
   if (state.current_task) {

--- a/projects/agenticos/mcp-server/src/utils/guardrail-evidence.ts
+++ b/projects/agenticos/mcp-server/src/utils/guardrail-evidence.ts
@@ -8,6 +8,36 @@ type GuardrailCommand =
   | 'agenticos_branch_bootstrap'
   | 'agenticos_pr_scope_check';
 
+export interface IssueBootstrapAdditionalContextEntry {
+  path: string;
+  reason: string;
+}
+
+export interface IssueBootstrapRecord {
+  recorded_at?: string;
+  issue_id?: string | null;
+  issue_title?: string | null;
+  issue_body?: string | null;
+  labels?: string[];
+  linked_artifacts?: string[];
+  startup_context_paths?: string[];
+  additional_context?: IssueBootstrapAdditionalContextEntry[];
+  repo_path?: string | null;
+  project_path?: string | null;
+  current_branch?: string | null;
+  workspace_type?: 'main' | 'isolated_worktree' | null;
+  stages?: {
+    context_reset_performed?: boolean;
+    project_hot_load_performed?: boolean;
+    issue_payload_attached?: boolean;
+  };
+}
+
+export interface IssueBootstrapState {
+  updated_at?: string;
+  latest?: IssueBootstrapRecord | null;
+}
+
 interface GuardrailEvidenceState {
   updated_at?: string;
   last_command?: GuardrailCommand;
@@ -20,6 +50,7 @@ type GuardrailEvidenceSlot = 'preflight' | 'branch_bootstrap' | 'pr_scope_check'
 
 interface StateYaml {
   guardrail_evidence?: GuardrailEvidenceState;
+  issue_bootstrap?: IssueBootstrapState;
   [key: string]: unknown;
 }
 
@@ -36,6 +67,12 @@ interface PersistGuardrailEvidenceArgs {
   repo_path?: string;
   project_path?: string;
   payload: Record<string, unknown>;
+}
+
+interface PersistIssueBootstrapEvidenceArgs {
+  repo_path?: string;
+  project_path?: string;
+  payload: IssueBootstrapRecord;
 }
 
 interface ResolvedProjectTarget {
@@ -245,6 +282,68 @@ export async function persistGuardrailEvidence(
     recorded_at: recordedAt,
     repo_path,
     ...payload,
+  };
+
+  await writeFile(statePath, yaml.stringify(state), 'utf-8');
+
+  return {
+    attempted: true,
+    persisted: true,
+    project_id: project.id,
+    state_path: statePath,
+  };
+}
+
+export function extractLatestIssueBootstrap(state: StateYaml | null | undefined): IssueBootstrapRecord | null {
+  if (!state?.issue_bootstrap?.latest || typeof state.issue_bootstrap.latest !== 'object') {
+    return null;
+  }
+  return state.issue_bootstrap.latest;
+}
+
+export async function persistIssueBootstrapEvidence(
+  args: PersistIssueBootstrapEvidenceArgs,
+): Promise<GuardrailPersistenceResult> {
+  const { repo_path, project_path, payload } = args;
+
+  if (!repo_path) {
+    return {
+      attempted: false,
+      persisted: false,
+      reason: 'repo_path is required for issue bootstrap persistence',
+    };
+  }
+
+  const project = await resolveProjectTarget(repo_path, project_path);
+  if (!project) {
+    return {
+      attempted: true,
+      persisted: false,
+      reason: project_path
+        ? `project_path is not a resolvable AgenticOS project: ${project_path}`
+        : `repo_path is not within a resolvable AgenticOS project: ${repo_path}`,
+    };
+  }
+
+  const statePath = project.statePath;
+  let state: StateYaml = {};
+
+  try {
+    const content = await readFile(statePath, 'utf-8');
+    state = (yaml.parse(content) || {}) as StateYaml;
+  } catch {
+    state = {};
+  }
+
+  const recordedAt = payload.recorded_at || new Date().toISOString();
+  state.issue_bootstrap = {
+    updated_at: recordedAt,
+    latest: {
+      ...payload,
+      recorded_at: recordedAt,
+      project_path: payload.project_path || project.path,
+      repo_path: payload.repo_path || repo_path,
+    },
   };
 
   await writeFile(statePath, yaml.stringify(state), 'utf-8');


### PR DESCRIPTION
## Summary
- add a first-class `agenticos_issue_bootstrap` tool to record issue-start bootstrap evidence
- persist latest issue bootstrap separately from guardrail evidence and surface it in status, switch, and context outputs
- make `agenticos_preflight` fail closed for implementation work when matching bootstrap evidence is missing or stale

## Why
Issue #158 was only partially realized. The Task Intake Rule landed, but the executable runtime guardrail layer did not. This PR closes that gap with an inspectable issue-start evidence model and a real preflight gate.

Closes #179

## Verification
- `cd projects/agenticos/mcp-server && npm ci`
- `cd projects/agenticos/mcp-server && npm test -- --run src/tools/__tests__/preflight.test.ts src/tools/__tests__/issue-bootstrap.test.ts src/tools/__tests__/project.test.ts src/resources/__tests__/context.test.ts`
- `cd projects/agenticos/mcp-server && npm run build`