### PR TITLE
fix: ignore normalized local project roots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,8 @@ build/
 # Runtime-only workspace state
 .runtime/
 .claude/worktrees/
+
+# Local-only or standalone downstream project roots managed outside the AgenticOS
+# canonical repository lifecycle.
+projects/agent-cli-api/
+projects/agenticresearch/

--- a/projects/agenticos/tasks/issue-178-normalize-local-project-roots.md
+++ b/projects/agenticos/tasks/issue-178-normalize-local-project-roots.md
@@ -1,0 +1,36 @@
+# Issue #178: Normalize Local Project Roots Under `projects/`
+
+## Summary
+
+`projects/agent-cli-api` and `projects/agenticresearch` are real managed projects in live local state, but they do not exist in clean `origin/main`.
+
+They therefore need two separate kinds of normalization:
+
+1. parent repo normalization
+   - `AgenticOS` canonical must stop treating them as stray untracked paths
+2. project-local normalization
+   - each project must declare a valid `source_control.topology`
+
+## Decisions
+
+- `agent-cli-api`
+  - classify as `github_versioned`
+  - keep it as a standalone downstream repo with its own Git history and remote
+  - canonical `AgenticOS` should ignore its project root instead of pretending it belongs to the main repo tree
+
+- `agenticresearch`
+  - classify as `local_directory_only`
+  - keep it as a local-only managed project without any GitHub binding
+  - canonical `AgenticOS` should ignore its project root so local iteration does not pollute the main repo worktree
+
+## Scope
+
+- add explicit ignore rules for these two local roots in `AgenticOS`
+- record the normalization decision in project memory
+- separately normalize each project's `.project.yaml` to the new topology contract
+
+## Non-Goals
+
+- do not import either whole project tree into `AgenticOS` main
+- do not weaken repo-boundary guardrails
+- do not force a GitHub repo onto `agenticresearch`


### PR DESCRIPTION
## Summary
- ignore `projects/agent-cli-api` and `projects/agenticresearch` from the AgenticOS canonical repo worktree
- record the normalization decision for these two local roots under issue #178

## Testing
- repository metadata change only
