### PR TITLE
fix: ignore excluded local helper roots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ build/
 # Runtime-only workspace state
 .runtime/
 .claude/worktrees/
+.private/
+worktrees/
 
 # Local-only or standalone downstream project roots managed outside the AgenticOS
 # canonical repository lifecycle.

--- a/projects/agenticos/tasks/issue-187-ignore-helper-roots.md
+++ b/projects/agenticos/tasks/issue-187-ignore-helper-roots.md
@@ -1,0 +1,20 @@
+# Issue #187: Ignore Excluded Local Helper Roots
+
+## Summary
+
+After normalizing local project roots, the canonical `AgenticOS` worktree still remained dirty because two excluded local helper roots were not ignored:
+
+- `.private/`
+- `worktrees/`
+
+These paths are local helper state, not canonical product source.
+
+## Scope
+
+- add explicit ignore rules for `.private/` and `worktrees/`
+- keep the canonical checkout focused on tracked source only
+
+## Non-Goals
+
+- do not delete existing helper state
+- do not change the semantics of managed projects


### PR DESCRIPTION
## Summary
- ignore `.private/` and `worktrees/` from the AgenticOS canonical repo worktree
- record the cleanup decision under issue #187

## Testing
- repository metadata change only
