### PR TITLE
docs: codify project topology decision rubric

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,15 @@ Create a new AgenticOS project called my-feature
 
 The agent will call `agenticos_init` and set up the project structure automatically, but new projects now require an explicit topology choice: `local_directory_only` or `github_versioned`.
 
+### Topology Choice
+
+- Use `local_directory_only` for private/local work such as ongoing writing, weekly planning, research notes, and project-specific knowledge evolution.
+- Use `github_versioned` for reusable capabilities such as tools, automation, standards, plugins, libraries, and other assets that should evolve through issue/PR/release flow.
+- If the boundary is ambiguous, stop and confirm instead of guessing.
+
+Projects may later upgrade from `local_directory_only` to `github_versioned`, but that upgrade must be explicit.
+Do not silently move a local project into GitHub Flow just because it starts containing code.
+
 ---
 
 ## MCP Tools
@@ -184,6 +193,10 @@ The agent will call `agenticos_init` and set up the project structure automatica
 | `agenticos_non_code_evaluate` | Validate a completed non-code rubric and persist latest structured evidence into project state | `project_path`, `rubric_path` |
 | `agenticos_record` | Record session progress | `summary`, `decisions`, `outcomes`, `pending`, `current_task` |
 | `agenticos_save` | Save state + git backup | `message` (commit message) |
+
+For the formal decision rubric, see:
+
+- `projects/agenticos/standards/knowledge/project-topology-decision-rubric-2026-04-07.md`
 
 ### Implementation Guardrail Flow
 

--- a/projects/agenticos/.meta/templates/.project.yaml
+++ b/projects/agenticos/.meta/templates/.project.yaml
@@ -6,7 +6,7 @@ meta:
   description: "Project description"
 
 source_control:
-  topology: "local_directory_only"  # local_directory_only/github_versioned
+  topology: "local_directory_only"  # local_directory_only for local work/knowledge; github_versioned for reusable capability surfaces
   # github_repo: "OWNER/REPO"       # Required when topology is github_versioned
   # branch_strategy: "github_flow"  # Required when topology is github_versioned
 
@@ -34,7 +34,7 @@ status:
 
 execution:
   source_repo_roots:
-    - "."  # Required for github_versioned projects. Relative to the managed project root.
+    - "."  # Only required for github_versioned projects. Relative to the managed project root.
 
 archive_import_policy:
   active_source_allowlist: []

--- a/projects/agenticos/mcp-server/README.md
+++ b/projects/agenticos/mcp-server/README.md
@@ -183,6 +183,16 @@ Create new project with standard structure.
 
 **Returns**: Project created confirmation with path and ID
 
+**Topology rubric**:
+- choose `local_directory_only` for ongoing local work, knowledge evolution, weekly writing, and private operating material
+- choose `github_versioned` for reusable capabilities that should evolve through issue/PR/release flow
+- if the boundary is unclear, require explicit confirmation instead of guessing
+
+**Upgrade path**:
+- a project may start as `local_directory_only`
+- later, re-run `agenticos_init` with `normalize_existing=true`, `topology=github_versioned`, and `github_repo=OWNER/REPO`
+- only do that when the project has clearly become a reusable capability surface
+
 ### agenticos_switch
 Switch to existing project and load context.
 

--- a/projects/agenticos/standards/knowledge/project-topology-decision-rubric-2026-04-07.md
+++ b/projects/agenticos/standards/knowledge/project-topology-decision-rubric-2026-04-07.md
@@ -1,0 +1,83 @@
+# Project Topology Decision Rubric
+
+## Purpose
+
+`AgenticOS` supports two explicit project topologies:
+
+- `local_directory_only`
+- `github_versioned`
+
+This rubric defines when to choose each one, when to stop and confirm, and how a local project can later upgrade into GitHub Flow.
+
+## Direct Rules
+
+Choose `local_directory_only` when the project is primarily:
+
+- ongoing work execution
+- weekly or periodic writing
+- local knowledge synthesis
+- private operating material
+- project-specific documentation that does not need public or shared version control
+
+Choose `github_versioned` when the project is primarily:
+
+- a reusable capability
+- a tool, CLI, plugin, skill, library, or automation surface
+- a standard, framework, or process asset expected to evolve through issue/PR review
+- something that will be released, reused across projects, or maintained as a durable product surface
+
+## Fail-Closed Rule For Ambiguous Projects
+
+Do not guess when the project sits between the two modes.
+
+An explicit confirmation is required when the project could plausibly be either:
+
+- a private knowledge/workstream project
+- a reusable product capability
+
+The confirmation question is:
+
+1. Is the long-term goal continuous content/work output, or continuous capability growth?
+2. Will this project need issue/PR/release style iteration as a first-class operating mode?
+
+If the answer is still unclear after those questions, default to confirmation rather than automatic topology selection.
+
+## Examples
+
+Use `local_directory_only` for:
+
+- weekly planning or reporting projects such as T5T
+- private research notebooks
+- local writing systems
+- role-specific operating playbooks
+
+Use `github_versioned` for:
+
+- OpenCLI adapters
+- release automation
+- reusable writing or publish tooling
+- a standard kit or review framework intended for repeated reuse
+
+## Upgrade Path
+
+`local_directory_only` is not a dead end.
+
+Projects may upgrade to `github_versioned` later when they cross the boundary from local work product to reusable capability.
+
+The upgrade rule is:
+
+1. create or identify the target GitHub repository
+2. re-run `agenticos_init` with `normalize_existing=true`, `topology=github_versioned`, and `github_repo=OWNER/REPO`
+3. treat the project as GitHub Flow managed from that point onward
+
+Do not silently upgrade a project just because it starts containing code.
+The upgrade must be explicit.
+
+## Policy Boundary
+
+GitHub Flow is for capability growth.
+
+A local project that only evolves private knowledge, writing, or working material should remain `local_directory_only` even if it changes frequently.
+
+Only the capability-like subset should move into GitHub Flow.
+When necessary, split that subset into its own project rather than forcing the whole local project into a versioned workflow.

--- a/projects/agenticos/tasks/issue-189-topology-decision-rubric.md
+++ b/projects/agenticos/tasks/issue-189-topology-decision-rubric.md
@@ -1,0 +1,21 @@
+# Issue #189: Codify Topology Decision Rubric and Upgrade Path
+
+## Summary
+
+`AgenticOS` already requires explicit topology selection, but it also needs a policy layer describing:
+
+- when to choose `local_directory_only`
+- when to choose `github_versioned`
+- when to stop and confirm instead of guessing
+- how a local project upgrades into GitHub Flow later
+
+## Scope
+
+- add a canonical rubric document
+- wire that guidance into top-level README and MCP README
+- make the template comments reflect the intended decision boundary
+
+## Non-Goals
+
+- do not add automatic topology inference
+- do not force all local projects into GitHub Flow


### PR DESCRIPTION
## Summary
- codify when to choose `local_directory_only` versus `github_versioned`
- define a fail-closed rule for ambiguous projects that require explicit confirmation
- document the explicit upgrade path from a local project into GitHub Flow

## Testing
- documentation and template guidance only
