### PR TITLE
docs(agenticos): extract root product docs into product source

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 AI-native project management system. MCP server that persists context across sessions for Claude Code, Cursor, Codex, and any MCP-compatible tool.
 
+> Compatibility entrypoint: the canonical operator guide now lives in [projects/agenticos/AGENTS.md](projects/agenticos/AGENTS.md). Use the workspace-root copy only as a transitional pointer while root Git responsibilities are being retired.
+
 ## Quick Start
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Thank you for your interest in contributing to AgenticOS!
 
+> Compatibility entrypoint: the canonical contribution guide now lives in [projects/agenticos/CONTRIBUTING.md](projects/agenticos/CONTRIBUTING.md). Use the workspace-root copy only as a transitional pointer while root Git responsibilities are being retired.
+
 ## Prerequisites
 
 - Node.js 20+

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 AI-native project management system for Claude Code, Codex, Cursor, Gemini CLI, and other MCP-capable tools. Persists context and state across sessions so your AI agent always knows where it left off.
 
+> Compatibility entrypoint: the canonical AgenticOS product-source docs now live in [projects/agenticos/README.md](projects/agenticos/README.md). Treat the workspace root as a transitional entry surface while root Git responsibilities are being removed.
+
 ## Install
 
 ### Option A — Homebrew (recommended for macOS)

--- a/projects/agenticos/AGENTS.md
+++ b/projects/agenticos/AGENTS.md
@@ -1,0 +1,40 @@
+# AGENTS.md — AgenticOS Product Source
+
+This file is the canonical operator and implementation guide for AgenticOS product work.
+
+If you are editing AgenticOS itself, use this file instead of relying on the workspace-root compatibility copy.
+
+## Quick Start
+
+```bash
+cd projects/agenticos/mcp-server
+npm install
+npm run build
+npm test
+```
+
+## Product-Source Map
+
+| Path | Purpose |
+|------|---------|
+| `projects/agenticos/mcp-server/src/` | MCP server source |
+| `projects/agenticos/mcp-server/src/tools/` | Tool implementations |
+| `projects/agenticos/mcp-server/src/utils/` | Shared utilities |
+| `projects/agenticos/standards/` | Standards and product-definition area |
+| `projects/agenticos/.meta/` | Templates and agent protocol guides |
+| `projects/agenticos/.meta/standard-kit/` | Downstream reusable workflow kit |
+| `projects/agenticos/homebrew-tap/` | Homebrew distribution formula |
+
+## Working Rules
+
+1. Every change starts from a GitHub issue.
+2. Use an isolated issue branch/worktree from `origin/main`.
+3. Run `agenticos_preflight` before implementation-affecting work.
+4. Run `agenticos_pr_scope_check` before opening or merging a PR.
+5. Treat `projects/agenticos/` as the canonical product-source boundary.
+
+## Canonical References
+
+- contribution flow: [CONTRIBUTING.md](CONTRIBUTING.md)
+- MCP package and install surface: [mcp-server/README.md](mcp-server/README.md)
+- standards knowledge: [standards/knowledge/](standards/knowledge/)

--- a/projects/agenticos/CONTRIBUTING.md
+++ b/projects/agenticos/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing to AgenticOS Product Source
+
+This file is the canonical contribution guide for AgenticOS product work.
+
+The workspace-root `CONTRIBUTING.md` remains a compatibility entrypoint while the root-Git split is in progress, but contribution flow should be anchored here.
+
+## Development Setup
+
+```bash
+git clone https://github.com/madlouse/AgenticOS.git
+cd AgenticOS/projects/agenticos/mcp-server
+npm install
+npm run build
+npm test
+```
+
+## Expected Flow
+
+1. Create a GitHub issue.
+2. Bootstrap an isolated issue branch/worktree from `origin/main`.
+3. Run `agenticos_preflight`.
+4. Implement only inside declared scope.
+5. Run `agenticos_pr_scope_check`.
+6. Open a PR that closes the issue.
+
+## Release Surface
+
+- MCP package source: `projects/agenticos/mcp-server/`
+- Homebrew formula: `projects/agenticos/homebrew-tap/Formula/agenticos.rb`
+- canonical standards and contracts: `projects/agenticos/standards/knowledge/`
+
+## Notes
+
+- `npm install` is the supported install path for local development and CI.
+- Treat root-level `tools/` as compatibility shims unless a contract explicitly requires them.
+- Do not treat workspace-runtime files as product source.

--- a/projects/agenticos/README.md
+++ b/projects/agenticos/README.md
@@ -1,0 +1,42 @@
+# AgenticOS Product Source
+
+This directory is the canonical product-source project for AgenticOS.
+
+If you are changing AgenticOS itself, start here instead of treating the workspace root as the authoritative product repository.
+
+## Scope
+
+`projects/agenticos/` owns:
+
+- product documentation and operator contracts
+- MCP server source under `mcp-server/`
+- standards, templates, and downstream workflow kit
+- Homebrew distribution assets under `homebrew-tap/`
+
+The enclosing workspace root may still expose compatibility entrypoints while the root-Git split is in progress, but those root files are not the long-term authority path.
+
+## Quick Start
+
+```bash
+cd projects/agenticos/mcp-server
+npm install
+npm run build
+npm test
+```
+
+## Canonical Documents
+
+- product overview and install surface:
+  [mcp-server/README.md](mcp-server/README.md)
+- implementation and operator instructions:
+  [AGENTS.md](AGENTS.md)
+- contribution and release flow:
+  [CONTRIBUTING.md](CONTRIBUTING.md)
+- standards and design knowledge:
+  [standards/knowledge/](standards/knowledge/)
+
+## Current Boundary Rule
+
+- `projects/agenticos/` is the only canonical AgenticOS product-source project under `projects/`
+- the workspace root is evolving toward `workspace home`, not permanent product-source Git root
+- root-level `README.md`, `AGENTS.md`, and `CONTRIBUTING.md` currently remain as compatibility entrypoints during that migration

--- a/projects/agenticos/tasks/issue-203-root-product-docs-extraction.md
+++ b/projects/agenticos/tasks/issue-203-root-product-docs-extraction.md
@@ -1,0 +1,17 @@
+# Issue #203 — Root Product Docs Extraction
+
+## Goal
+
+Move authoritative product and operator documentation into `projects/agenticos` so the workspace root can shrink toward a compatibility layer.
+
+## Scope
+
+- add canonical `README.md`, `AGENTS.md`, and `CONTRIBUTING.md` under `projects/agenticos`
+- update root `README.md`, `AGENTS.md`, and `CONTRIBUTING.md` to point at those canonical documents
+
+## Validation
+
+- `rg -n "canonical product-source|compatibility entrypoint" README.md AGENTS.md CONTRIBUTING.md`
+- `test -f projects/agenticos/README.md`
+- `test -f projects/agenticos/AGENTS.md`
+- `test -f projects/agenticos/CONTRIBUTING.md`


### PR DESCRIPTION
## Summary
- add canonical product-source README, AGENTS, and CONTRIBUTING docs under `projects/agenticos`
- mark the workspace-root copies as compatibility entrypoints
- record the extraction slice for root Git dependency cleanup

## Validation
- rg -n "Compatibility entrypoint|canonical" README.md AGENTS.md CONTRIBUTING.md
- test -f projects/agenticos/README.md
- test -f projects/agenticos/AGENTS.md
- test -f projects/agenticos/CONTRIBUTING.md
- git diff --cached --stat

Closes #203