### PR TITLE
docs(agenticos): replace root path assumptions with workspace semantics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ Repository boundary rule:
 6. **Release**: Tag `v*` → triggers Release workflow → update Homebrew sha256
 7. **Runtime separation**: Treat `.runtime/` and `.claude/worktrees/` as runtime-only, never as product source
 8. **Git transport fallback**: If HTTPS push breaks because of local proxy or credential plumbing, use the documented command-scoped no-proxy + `GIT_ASKPASS` fallback in `CONTRIBUTING.md`; if needed, add command-scoped `-c http.version=HTTP/1.1`; do not embed tokens in remote URLs
-9. **Canonical sync**: Before treating `/Users/jeking/dev/AgenticOS` as a trusted starting point, resync it to `origin/main` with the canonical sync contract in `projects/agenticos/standards/knowledge/canonical-sync-contract-2026-03-25.md`; do not infer live project state from a behind or dirty canonical checkout
+9. **Canonical sync**: Before treating the current AgenticOS source checkout as a trusted starting point, resync it to `origin/main` with the canonical sync contract in `projects/agenticos/standards/knowledge/canonical-sync-contract-2026-03-25.md`; do not infer live project state from a behind or dirty canonical checkout
 
 ## Guardrail Flow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,13 +70,14 @@ Full Git Flow (with `develop` + `release/*`) is designed for large teams with in
 
 ### Canonical Local Sync
 
-Before you treat `/Users/jeking/dev/AgenticOS` as a trusted local starting point, resync it:
+Before you treat the current AgenticOS source checkout as a trusted local starting point, set `AGENTICOS_SOURCE_ROOT` and resync it:
 
 ```bash
-git -C /Users/jeking/dev/AgenticOS fetch origin --prune
-git -C /Users/jeking/dev/AgenticOS checkout main
-git -C /Users/jeking/dev/AgenticOS pull --ff-only origin main
-git -C /Users/jeking/dev/AgenticOS status --short --branch
+export AGENTICOS_SOURCE_ROOT="/absolute/path/to/current-agenticos-source-root"
+git -C "$AGENTICOS_SOURCE_ROOT" fetch origin --prune
+git -C "$AGENTICOS_SOURCE_ROOT" checkout main
+git -C "$AGENTICOS_SOURCE_ROOT" pull --ff-only origin main
+git -C "$AGENTICOS_SOURCE_ROOT" status --short --branch
 ```
 
 Trusted output is a clean:
@@ -85,7 +86,7 @@ Trusted output is a clean:
 ## main...origin/main
 ```
 
-If the checkout is dirty, ahead, or behind, do not use it as your trusted local reasoning base. Resync first, then open or use an isolated worktree for real implementation work.
+If the checkout is dirty, ahead, or behind, do not use it as your trusted local reasoning base. Resync first, then open or use an isolated worktree for real implementation work. This section describes the current source-root contract during the root-Git migration; it is not a requirement that the workspace home itself remain the source root.
 
 ## Commit Types
 

--- a/projects/agenticos/standards/knowledge/canonical-sync-contract-2026-03-25.md
+++ b/projects/agenticos/standards/knowledge/canonical-sync-contract-2026-03-25.md
@@ -2,7 +2,12 @@
 
 ## Purpose
 
-This contract defines when `/Users/jeking/dev/AgenticOS` may be trusted as the canonical local AgenticOS checkout and when the live standards entry surfaces may be treated as fresh resume context.
+This contract defines when the current local AgenticOS source checkout may be trusted as the canonical local base and when the live standards entry surfaces may be treated as fresh resume context.
+
+For the current layout, use:
+
+- `AGENTICOS_SOURCE_ROOT` = the current local AgenticOS source checkout root
+- `AGENTICOS_PRODUCT_SOURCE` = `$AGENTICOS_SOURCE_ROOT/projects/agenticos`
 
 The goal is to prevent a familiar failure mode:
 
@@ -17,20 +22,21 @@ When these differ, trust order is:
 
 1. `origin/main`
 2. an isolated issue worktree branched from the current `origin/main`
-3. the local canonical checkout `/Users/jeking/dev/AgenticOS`
+3. the local canonical source checkout at `AGENTICOS_SOURCE_ROOT`
 4. archived snapshots and retired project history
 
 The local canonical checkout is only trustworthy when it has been explicitly resynced to `origin/main`.
 
 ## Canonical Sync Procedure
 
-Run from the local canonical checkout:
+Run from the local AgenticOS source checkout:
 
 ```bash
-git -C /Users/jeking/dev/AgenticOS fetch origin --prune
-git -C /Users/jeking/dev/AgenticOS checkout main
-git -C /Users/jeking/dev/AgenticOS pull --ff-only origin main
-git -C /Users/jeking/dev/AgenticOS status --short --branch
+export AGENTICOS_SOURCE_ROOT="/absolute/path/to/current-agenticos-source-root"
+git -C "$AGENTICOS_SOURCE_ROOT" fetch origin --prune
+git -C "$AGENTICOS_SOURCE_ROOT" checkout main
+git -C "$AGENTICOS_SOURCE_ROOT" pull --ff-only origin main
+git -C "$AGENTICOS_SOURCE_ROOT" status --short --branch
 ```
 
 Expected result:
@@ -79,8 +85,10 @@ After a merged issue lands, use this rule:
 After sync, verify:
 
 ```bash
-ruby -e 'require "yaml"; YAML.load_file("/Users/jeking/dev/AgenticOS/projects/agenticos/standards/.context/state.yaml"); puts "state-ok"'
-rg -n "#98|canonical sync|higher-order backlog|#99|#97|#96|#95|#94" /Users/jeking/dev/AgenticOS/projects/agenticos/standards/.context/quick-start.md /Users/jeking/dev/AgenticOS/projects/agenticos/standards/.context/state.yaml
+export AGENTICOS_SOURCE_ROOT="/absolute/path/to/current-agenticos-source-root"
+export AGENTICOS_PRODUCT_SOURCE="$AGENTICOS_SOURCE_ROOT/projects/agenticos"
+ruby -e 'require "yaml"; YAML.load_file(ENV.fetch("AGENTICOS_PRODUCT_SOURCE") + "/standards/.context/state.yaml"); puts "state-ok"'
+rg -n "#98|canonical sync|higher-order backlog|#99|#97|#96|#95|#94" "$AGENTICOS_PRODUCT_SOURCE/standards/.context/quick-start.md" "$AGENTICOS_PRODUCT_SOURCE/standards/.context/state.yaml"
 ```
 
 Verification intent:
@@ -99,6 +107,6 @@ This contract does not:
 
 ## Outcome
 
-The local canonical checkout is a trusted base checkout only after explicit fast-forward sync.
+The local AgenticOS source checkout is a trusted base checkout only after explicit fast-forward sync.
 
 The live standards entry surfaces are fresh only when they reflect the current post-merge resume reality for the next Agent, not just the last time someone edited those files.

--- a/projects/agenticos/standards/knowledge/operator-checklist-v1-2026-03-23.md
+++ b/projects/agenticos/standards/knowledge/operator-checklist-v1-2026-03-23.md
@@ -5,9 +5,9 @@
 
 ## 1. Frozen Baseline Inputs
 
-At planning time, the current baseline values are:
+At planning time, the baseline values were:
 
-- source repo path: `/Users/jeking/dev/AgenticOS`
+- source repo path: `AGENTICOS_SOURCE_ROOT`
 - current branch: `main`
 - upstream branch: `origin/main`
 - current HEAD: `fc401332bea49fdecdc2f4e489e30545d5061043`
@@ -30,7 +30,7 @@ It only prepares a safe execution baseline by:
 Run:
 
 ```bash
-cd /Users/jeking/dev/AgenticOS
+cd "$AGENTICOS_SOURCE_ROOT"
 git status --short --branch
 git rev-parse HEAD
 git rev-parse --abbrev-ref --symbolic-full-name @{upstream}
@@ -49,7 +49,7 @@ Run:
 
 ```bash
 mkdir -p /Users/jeking/worktrees/agenticos-migration-backups
-cd /Users/jeking/dev/AgenticOS
+cd "$AGENTICOS_SOURCE_ROOT"
 git diff > /Users/jeking/worktrees/agenticos-migration-backups/root-working.patch
 git diff --cached > /Users/jeking/worktrees/agenticos-migration-backups/root-staged.patch
 git status --short --branch > /Users/jeking/worktrees/agenticos-migration-backups/root-status.txt
@@ -84,7 +84,7 @@ Pass condition:
 Run:
 
 ```bash
-cd /Users/jeking/dev/AgenticOS
+cd "$AGENTICOS_SOURCE_ROOT"
 git worktree add /Users/jeking/worktrees/agenticos-self-hosting -b feat/self-hosting-migration fc401332bea49fdecdc2f4e489e30545d5061043
 ```
 
@@ -151,8 +151,8 @@ At this point:
 If isolation setup itself must be abandoned:
 
 ```bash
-git -C /Users/jeking/dev/AgenticOS worktree remove /Users/jeking/worktrees/agenticos-self-hosting
-git -C /Users/jeking/dev/AgenticOS branch -D feat/self-hosting-migration
+git -C "$AGENTICOS_SOURCE_ROOT" worktree remove /Users/jeking/worktrees/agenticos-self-hosting
+git -C "$AGENTICOS_SOURCE_ROOT" branch -D feat/self-hosting-migration
 ```
 
 Only do this if:
@@ -161,7 +161,7 @@ Only do this if:
 
 ## 5. Operator Notes
 
-- Do not run structural move commands in `/Users/jeking/dev/AgenticOS`
+- Do not run structural move commands in the current AgenticOS source checkout
 - Do not use `.claude/worktrees/` as the migration worktree path
 - Do not destroy the original dirty state while preparing isolation
 

--- a/projects/agenticos/standards/knowledge/workspace-migration-runbook-2026-04-07.md
+++ b/projects/agenticos/standards/knowledge/workspace-migration-runbook-2026-04-07.md
@@ -2,7 +2,7 @@
 
 > Date: 2026-04-07
 > Issue: #195
-> Purpose: move the live AgenticOS workspace off the product source checkout and verify that workspace operations no longer pollute product source
+> Purpose: move the live AgenticOS workspace off the current source checkout and verify that workspace operations no longer pollute product source
 
 ## 1. Rules
 
@@ -28,10 +28,10 @@
 6. run a topology audit over `projects/*` in the new workspace
 7. clean stale workspace-generated dirtiness from the source checkout only after the new workspace passes verification
 
-## 3. Current Machine Outcome
+## 3. Recorded Migration Outcome
 
-- workspace root: `/Users/jeking/AgenticOS-workspace`
-- source checkout: `/Users/jeking/dev/AgenticOS`
+- workspace root: `AGENTICOS_WORKSPACE_HOME`
+- source checkout: `AGENTICOS_SOURCE_ROOT`
 - Codex config migrated
 - Cursor config migrated
 - Claude settings required a manual env-path fallback because `claude` CLI was not present on PATH
@@ -46,9 +46,11 @@
 Use:
 
 ```bash
-/Users/jeking/dev/AgenticOS/projects/agenticos/tools/verify-workspace-separation.sh \
-  /Users/jeking/dev/AgenticOS \
-  /Users/jeking/AgenticOS-workspace \
+export AGENTICOS_SOURCE_ROOT="/absolute/path/to/current-agenticos-source-root"
+export AGENTICOS_WORKSPACE_HOME="/absolute/path/to/current-workspace-home"
+"$AGENTICOS_SOURCE_ROOT/projects/agenticos/tools/verify-workspace-separation.sh" \
+  "$AGENTICOS_SOURCE_ROOT" \
+  "$AGENTICOS_WORKSPACE_HOME" \
   agent-cli-api
 ```
 
@@ -68,3 +70,5 @@ If `agenticos-bootstrap` cannot update a supported local agent automatically:
 - re-run the verification script
 
 Do not treat the migration as complete until the verification script passes.
+
+This runbook documents a transitional separation step. The final target model is still `workspace home` plus `project source`, not a permanent requirement that users keep an external workspace path.

--- a/projects/agenticos/tasks/issue-205-root-path-semantics-cleanup.md
+++ b/projects/agenticos/tasks/issue-205-root-path-semantics-cleanup.md
@@ -1,0 +1,16 @@
+# Issue #205 — Root Path Semantics Cleanup
+
+## Goal
+
+Replace machine-local canonical root assumptions with `workspace home` and `source checkout` language in the targeted operator docs.
+
+## Scope
+
+- update root compatibility docs that still hard-code the old source root path
+- update standards docs so validation commands use variables instead of one machine-local path
+- keep this slice documentation-only
+
+## Validation
+
+- `rg -n "/Users/jeking/dev/AgenticOS" AGENTS.md CONTRIBUTING.md projects/agenticos/standards/knowledge/canonical-sync-contract-2026-03-25.md projects/agenticos/standards/knowledge/operator-checklist-v1-2026-03-23.md projects/agenticos/standards/knowledge/workspace-migration-runbook-2026-04-07.md`
+- `rg -n "AGENTICOS_SOURCE_ROOT|AGENTICOS_WORKSPACE_HOME|current AgenticOS source checkout|workspace home" AGENTS.md CONTRIBUTING.md projects/agenticos/standards/knowledge/canonical-sync-contract-2026-03-25.md projects/agenticos/standards/knowledge/operator-checklist-v1-2026-03-23.md projects/agenticos/standards/knowledge/workspace-migration-runbook-2026-04-07.md`


### PR DESCRIPTION
## Summary
- replace hard-coded root source-path assumptions with variable-driven workspace semantics
- clarify that the current source-root contract is transitional during root Git removal
- record the cleanup slice for issue #205

## Validation
- rg -n "/Users/jeking/dev/AgenticOS" AGENTS.md CONTRIBUTING.md projects/agenticos/standards/knowledge/canonical-sync-contract-2026-03-25.md projects/agenticos/standards/knowledge/operator-checklist-v1-2026-03-23.md projects/agenticos/standards/knowledge/workspace-migration-runbook-2026-04-07.md || true
- rg -n "AGENTICOS_SOURCE_ROOT|AGENTICOS_WORKSPACE_HOME|current AgenticOS source checkout|workspace home" AGENTS.md CONTRIBUTING.md projects/agenticos/standards/knowledge/canonical-sync-contract-2026-03-25.md projects/agenticos/standards/knowledge/operator-checklist-v1-2026-03-23.md projects/agenticos/standards/knowledge/workspace-migration-runbook-2026-04-07.md

Closes #205