### PR TITLE
feat(agenticos): add installed runtime hook commands

### DIFF
--- a/projects/agenticos/mcp-server/package-lock.json
+++ b/projects/agenticos/mcp-server/package-lock.json
@@ -13,7 +13,10 @@
         "yaml": "^2.3.4"
       },
       "bin": {
-        "agenticos-mcp": "build/index.js"
+        "agenticos-bootstrap": "build/bootstrap.js",
+        "agenticos-edit-guard": "build/edit-guard.js",
+        "agenticos-mcp": "build/index.js",
+        "agenticos-record-reminder": "build/record-reminder.js"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -1049,7 +1052,6 @@
       "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1736,7 +1738,6 @@
       "resolved": "https://registry.npmmirror.com/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2056,7 +2057,6 @@
       "resolved": "https://registry.npmmirror.com/hono/-/hono-4.12.8.tgz",
       "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2539,7 +2539,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3197,7 +3196,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3296,7 +3294,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -3505,7 +3502,6 @@
       "resolved": "https://registry.npmmirror.com/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -3521,7 +3517,6 @@
       "resolved": "https://registry.npmmirror.com/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/projects/agenticos/mcp-server/package.json
+++ b/projects/agenticos/mcp-server/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "bin": {
     "agenticos-mcp": "./build/index.js",
-    "agenticos-bootstrap": "./build/bootstrap.js"
+    "agenticos-bootstrap": "./build/bootstrap.js",
+    "agenticos-edit-guard": "./build/edit-guard.js",
+    "agenticos-record-reminder": "./build/record-reminder.js"
   },
   "scripts": {
     "build": "tsc",

--- a/projects/agenticos/mcp-server/src/edit-guard.ts
+++ b/projects/agenticos/mcp-server/src/edit-guard.ts
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+
+import { spawn } from 'child_process';
+import { runEditGuardCli, type EditGuardCliOptions } from './utils/edit-guard-cli.js';
+
+function callEditGuardViaMcp(options: EditGuardCliOptions, env: Record<string, string | undefined>): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const command = env.AGENTICOS_MCP_COMMAND || 'agenticos-mcp';
+    const extraArgs = env.AGENTICOS_MCP_ARGS_JSON ? JSON.parse(env.AGENTICOS_MCP_ARGS_JSON) : [];
+    const server = spawn(command, extraArgs, {
+      env: process.env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let buffer = '';
+    let settled = false;
+
+    const finish = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      server.kill();
+      fn();
+    };
+
+    server.stdout.on('data', (chunk) => {
+      buffer += chunk.toString();
+      let newlineIndex;
+      while ((newlineIndex = buffer.indexOf('\n')) >= 0) {
+        const line = buffer.slice(0, newlineIndex).trim();
+        buffer = buffer.slice(newlineIndex + 1);
+        if (!line) continue;
+
+        const msg = JSON.parse(line) as {
+          id?: number;
+          result?: { content?: Array<{ text?: string }> };
+          error?: { message?: string };
+        };
+        if (msg.id === 1) {
+          server.stdin.write(JSON.stringify({
+            jsonrpc: '2.0',
+            id: 2,
+            method: 'tools/call',
+            params: {
+              name: 'agenticos_edit_guard',
+              arguments: {
+                issue_id: options.issueId,
+                task_type: options.taskType,
+                repo_path: options.repoPath,
+                project_path: options.projectPath || undefined,
+                declared_target_files: options.declaredTargetFiles,
+              },
+            },
+          }) + '\n');
+          continue;
+        }
+        if (msg.id === 2) {
+          finish(() => resolve(msg.result?.content?.[0]?.text ?? JSON.stringify(msg)));
+        }
+      }
+    });
+
+    server.stderr.on('data', (chunk) => process.stderr.write(chunk));
+    server.on('error', (error) => finish(() => reject(error)));
+    server.on('exit', (code) => {
+      if (!settled) {
+        finish(() => reject(new Error(`agenticos-mcp exited with status ${code ?? 'unknown'}`)));
+      }
+    });
+
+    server.stdin.write(JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'agenticos-edit-guard', version: '1.0.0' },
+      },
+    }) + '\n');
+
+    setTimeout(() => {
+      finish(() => reject(new Error('timed out waiting for agenticos-mcp responses')));
+    }, 8000);
+  });
+}
+
+const exitCode = await runEditGuardCli(process.argv.slice(2), {
+  env: process.env,
+  stdout(line: string) {
+    console.log(line);
+  },
+  stderr(line: string) {
+    console.error(line);
+  },
+  callEditGuard(options) {
+    return callEditGuardViaMcp(options, process.env);
+  },
+});
+
+process.exit(exitCode);

--- a/projects/agenticos/mcp-server/src/record-reminder.ts
+++ b/projects/agenticos/mcp-server/src/record-reminder.ts
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+import { existsSync, statSync } from 'fs';
+import { basename, dirname, join } from 'path';
+import { runRecordReminderCli } from './utils/record-reminder-cli.js';
+
+const exitCode = runRecordReminderCli(process.argv.slice(2), {
+  cwd() {
+    return process.cwd();
+  },
+  nowSeconds() {
+    return Math.floor(Date.now() / 1000);
+  },
+  fileExists(path: string) {
+    return existsSync(path);
+  },
+  fileMtimeSeconds(path: string) {
+    return Math.floor(statSync(path).mtimeMs / 1000);
+  },
+  dirname,
+  basename,
+  join,
+  stdout(line: string) {
+    console.log(line);
+  },
+  stderr(line: string) {
+    console.error(line);
+  },
+});
+
+process.exit(exitCode);

--- a/projects/agenticos/mcp-server/src/utils/__tests__/edit-guard-cli.test.ts
+++ b/projects/agenticos/mcp-server/src/utils/__tests__/edit-guard-cli.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+import { runEditGuardCli } from '../edit-guard-cli.js';
+
+describe('edit guard cli', () => {
+  it('prints help', async () => {
+    const stdout: string[] = [];
+    const exitCode = await runEditGuardCli(['--help'], {
+      env: {},
+      stdout: (line) => stdout.push(line),
+      stderr: vi.fn(),
+      callEditGuard: vi.fn(),
+    });
+
+    expect(exitCode).toBe(0);
+    expect(stdout.join('\n')).toContain('agenticos-edit-guard');
+  });
+
+  it('requires AGENTICOS_HOME', async () => {
+    const stderr: string[] = [];
+    const exitCode = await runEditGuardCli(
+      ['--repo-path', '/repo', '--issue-id', '113', '--declared-target-file', 'README.md'],
+      {
+        env: {},
+        stdout: vi.fn(),
+        stderr: (line) => stderr.push(line),
+        callEditGuard: vi.fn(),
+      },
+    );
+
+    expect(exitCode).toBe(64);
+    expect(stderr.join('\n')).toContain('AGENTICOS_HOME is required');
+  });
+
+  it('returns 0 when edit guard passes', async () => {
+    const stdout: string[] = [];
+    const exitCode = await runEditGuardCli(
+      ['--repo-path', '/repo', '--issue-id', '113', '--declared-target-file', 'README.md'],
+      {
+        env: { AGENTICOS_HOME: '/workspace' },
+        stdout: (line) => stdout.push(line),
+        stderr: vi.fn(),
+        callEditGuard: vi.fn(async () => JSON.stringify({ status: 'PASS' })),
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout.join('\n')).toContain('"PASS"');
+  });
+
+  it('returns 2 when edit guard blocks', async () => {
+    const exitCode = await runEditGuardCli(
+      ['--repo-path', '/repo', '--issue-id', '113', '--declared-target-file', 'README.md'],
+      {
+        env: { AGENTICOS_HOME: '/workspace' },
+        stdout: vi.fn(),
+        stderr: vi.fn(),
+        callEditGuard: vi.fn(async () => JSON.stringify({ status: 'BLOCK' })),
+      },
+    );
+
+    expect(exitCode).toBe(2);
+  });
+});

--- a/projects/agenticos/mcp-server/src/utils/__tests__/record-reminder-cli.test.ts
+++ b/projects/agenticos/mcp-server/src/utils/__tests__/record-reminder-cli.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest';
+import { findProjectDir, runRecordReminderCli } from '../record-reminder-cli.js';
+
+function createDeps(existingPaths: string[] = [], mtimes: Record<string, number> = {}) {
+  const pathSet = new Set(existingPaths);
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+
+  return {
+    stdout,
+    stderr,
+    deps: {
+      cwd: () => '/workspace/projects/demo/tasks',
+      nowSeconds: () => 1000,
+      fileExists: (path: string) => pathSet.has(path),
+      fileMtimeSeconds: (path: string) => mtimes[path] ?? 0,
+      dirname: (path: string) => path.replace(/\/[^/]+$/, '') || '/',
+      basename: (path: string) => path.split('/').filter(Boolean).at(-1) || '',
+      join: (...parts: string[]) => parts.join('/').replace(/\/+/g, '/'),
+      stdout: (line: string) => stdout.push(line),
+      stderr: (line: string) => stderr.push(line),
+    },
+  };
+}
+
+describe('record reminder cli', () => {
+  it('finds the nearest project directory', () => {
+    const harness = createDeps(['/workspace/projects/demo/.project.yaml']);
+    expect(findProjectDir('/workspace/projects/demo/tasks', harness.deps)).toBe('/workspace/projects/demo');
+  });
+
+  it('does nothing when no project is found', () => {
+    const harness = createDeps();
+    const exitCode = runRecordReminderCli([], harness.deps);
+
+    expect(exitCode).toBe(0);
+    expect(harness.stdout).toEqual([]);
+  });
+
+  it('does nothing when the last record marker is recent', () => {
+    const marker = '/workspace/projects/demo/.context/.last_record';
+    const harness = createDeps(
+      ['/workspace/projects/demo/.project.yaml', marker],
+      { [marker]: 950 },
+    );
+
+    const exitCode = runRecordReminderCli([], harness.deps);
+
+    expect(exitCode).toBe(0);
+    expect(harness.stdout).toEqual([]);
+  });
+
+  it('prints a reminder when the marker is missing or stale', () => {
+    const harness = createDeps(['/workspace/projects/demo/.project.yaml']);
+    const exitCode = runRecordReminderCli([], harness.deps);
+
+    expect(exitCode).toBe(0);
+    expect(harness.stdout.join('\n')).toContain('agenticos_record');
+    expect(harness.stdout.join('\n')).toContain('demo');
+  });
+});

--- a/projects/agenticos/mcp-server/src/utils/edit-guard-cli.ts
+++ b/projects/agenticos/mcp-server/src/utils/edit-guard-cli.ts
@@ -1,0 +1,103 @@
+export interface EditGuardCliOptions {
+  repoPath: string;
+  projectPath?: string;
+  issueId: string;
+  taskType: string;
+  declaredTargetFiles: string[];
+}
+
+export interface EditGuardCliDeps {
+  env: Record<string, string | undefined>;
+  stdout(line: string): void;
+  stderr(line: string): void;
+  callEditGuard(options: EditGuardCliOptions): Promise<string>;
+}
+
+export function parseEditGuardCliArgs(argv: string[]): EditGuardCliOptions | { help: true } {
+  const options: EditGuardCliOptions = {
+    repoPath: '',
+    issueId: '',
+    taskType: 'implementation',
+    declaredTargetFiles: [],
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    switch (arg) {
+      case '--repo-path':
+        options.repoPath = argv[index + 1] || '';
+        index += 1;
+        break;
+      case '--project-path':
+        options.projectPath = argv[index + 1] || '';
+        index += 1;
+        break;
+      case '--issue-id':
+        options.issueId = argv[index + 1] || '';
+        index += 1;
+        break;
+      case '--task-type':
+        options.taskType = argv[index + 1] || '';
+        index += 1;
+        break;
+      case '--declared-target-file':
+        options.declaredTargetFiles.push(argv[index + 1] || '');
+        index += 1;
+        break;
+      case '--help':
+      case '-h':
+        return { help: true };
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+export function buildEditGuardHelpLines(): string[] {
+  return [
+    'agenticos-edit-guard — installed runtime wrapper for agenticos_edit_guard',
+    '',
+    'Usage:',
+    '  agenticos-edit-guard \\',
+    '    --repo-path /abs/repo \\',
+    '    --issue-id 113 \\',
+    '    --declared-target-file path/to/file \\',
+    '    [--declared-target-file other/file] \\',
+    '    [--project-path /abs/project/root] \\',
+    '    [--task-type implementation]',
+    '',
+    'Environment:',
+    '  AGENTICOS_HOME             Required AgenticOS workspace root.',
+  ];
+}
+
+export async function runEditGuardCli(argv: string[], deps: EditGuardCliDeps): Promise<number> {
+  try {
+    const parsed = parseEditGuardCliArgs(argv);
+    if ('help' in parsed) {
+      for (const line of buildEditGuardHelpLines()) deps.stdout(line);
+      return 0;
+    }
+
+    if (!deps.env.AGENTICOS_HOME) {
+      deps.stderr('AGENTICOS_HOME is required.');
+      return 64;
+    }
+
+    if (!parsed.repoPath || !parsed.issueId || parsed.declaredTargetFiles.length === 0) {
+      for (const line of buildEditGuardHelpLines()) deps.stderr(line);
+      return 64;
+    }
+
+    const resultJson = await deps.callEditGuard(parsed);
+    deps.stdout(resultJson);
+
+    const result = JSON.parse(resultJson) as { status?: string };
+    return result.status === 'PASS' ? 0 : 2;
+  } catch (error) {
+    deps.stderr(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+}

--- a/projects/agenticos/mcp-server/src/utils/record-reminder-cli.ts
+++ b/projects/agenticos/mcp-server/src/utils/record-reminder-cli.ts
@@ -1,0 +1,100 @@
+export interface RecordReminderCliOptions {
+  cwd?: string;
+  thresholdSeconds: number;
+}
+
+export interface RecordReminderCliDeps {
+  cwd(): string;
+  nowSeconds(): number;
+  fileExists(path: string): boolean;
+  fileMtimeSeconds(path: string): number;
+  dirname(path: string): string;
+  basename(path: string): string;
+  join(...parts: string[]): string;
+  stdout(line: string): void;
+  stderr(line: string): void;
+}
+
+export function parseRecordReminderCliArgs(argv: string[]): RecordReminderCliOptions | { help: true } {
+  const options: RecordReminderCliOptions = {
+    thresholdSeconds: 900,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    switch (arg) {
+      case '--cwd':
+        options.cwd = argv[index + 1] || '';
+        index += 1;
+        break;
+      case '--threshold-seconds':
+        options.thresholdSeconds = Number(argv[index + 1] || '');
+        index += 1;
+        break;
+      case '--help':
+      case '-h':
+        return { help: true };
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!Number.isFinite(options.thresholdSeconds) || options.thresholdSeconds < 0) {
+    throw new Error('--threshold-seconds must be a non-negative number.');
+  }
+
+  return options;
+}
+
+export function buildRecordReminderHelpLines(): string[] {
+  return [
+    'agenticos-record-reminder — installed runtime reminder for missing agenticos_record',
+    '',
+    'Usage:',
+    '  agenticos-record-reminder [--cwd /path] [--threshold-seconds 900]',
+  ];
+}
+
+export function findProjectDir(startDir: string, deps: RecordReminderCliDeps): string | null {
+  let current = startDir;
+  while (true) {
+    if (deps.fileExists(deps.join(current, '.project.yaml'))) {
+      return current;
+    }
+    const parent = deps.dirname(current);
+    if (parent === current) {
+      return null;
+    }
+    current = parent;
+  }
+}
+
+export function runRecordReminderCli(argv: string[], deps: RecordReminderCliDeps): number {
+  try {
+    const parsed = parseRecordReminderCliArgs(argv);
+    if ('help' in parsed) {
+      for (const line of buildRecordReminderHelpLines()) deps.stdout(line);
+      return 0;
+    }
+
+    const projectDir = findProjectDir(parsed.cwd || deps.cwd(), deps);
+    if (!projectDir) {
+      return 0;
+    }
+
+    const marker = deps.join(projectDir, '.context', '.last_record');
+    if (deps.fileExists(marker)) {
+      const age = deps.nowSeconds() - deps.fileMtimeSeconds(marker);
+      if (age < parsed.thresholdSeconds) {
+        return 0;
+      }
+    }
+
+    const projectName = deps.basename(projectDir);
+    deps.stdout(`🔔 AgenticOS: 当前在项目「${projectName}」中工作，还未记录会话。请在合适时机调用 agenticos_record 保存进展。`);
+    return 0;
+  } catch (error) {
+    deps.stderr(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+}

--- a/projects/agenticos/tasks/issue-207-installed-runtime-hook-commands.md
+++ b/projects/agenticos/tasks/issue-207-installed-runtime-hook-commands.md
@@ -1,0 +1,16 @@
+# Issue #207 — Installed Runtime Hook Commands
+
+## Goal
+
+Add installed-runtime hook commands so root-level compatibility scripts are no longer the only callable surfaces.
+
+## Scope
+
+- expose `agenticos-edit-guard`
+- expose `agenticos-record-reminder`
+- add unit coverage for both command behaviors
+
+## Validation
+
+- `cd projects/agenticos/mcp-server && npm run lint`
+- `cd projects/agenticos/mcp-server && npm test`


### PR DESCRIPTION
## Summary
- add installed-runtime `agenticos-edit-guard` and `agenticos-record-reminder` commands
- expose testable CLI helpers for both hook behaviors
- add unit coverage and keep package metadata aligned

## Validation
- cd projects/agenticos/mcp-server && npm install
- cd projects/agenticos/mcp-server && npm run lint
- cd projects/agenticos/mcp-server && npm test

Closes #207