### PR TITLE
docs(agenticos): migrate hook docs to installed commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,8 @@ npm run build
 Repository boundary rule:
 - `projects/agenticos/` is the only canonical AgenticOS product-source project under `projects/`
 - preserved sibling `projects/*` directories are still part of the operator-visible workspace layout and must not be removed just because AgenticOS itself was reorganized
-- top-level `tools/record-reminder.sh` must remain available as a legacy-compatible hook path until hook callers are migrated
+- installed-runtime hook commands are preferred: `agenticos-edit-guard` and `agenticos-record-reminder`
+- top-level `tools/record-reminder.sh` remains only as a legacy-compatible hook path until hook callers are migrated
 - orphaned gitlink residues `okr-management` and `t5t` are not verified full projects and must be handled only with explicit recovery evidence, not assumed deletion safety
 
 ## Development Rules

--- a/README.md
+++ b/README.md
@@ -35,12 +35,14 @@ On macOS, `--first-run` also enables `launchctl` persistence so GUI-launched too
 Use `agenticos-bootstrap --verify` to audit the current bootstrap state without mutating configs.
 Successful apply/first-run runs also record bootstrap metadata under `$AGENTICOS_HOME/.agent-workspace/bootstrap-state.yaml`.
 
-For implementation-affecting work, AgenticOS also ships a hook-friendly guard wrapper at `tools/check-edit-boundary.sh`.
+For implementation-affecting work, AgenticOS now ships an installed-runtime hook command: `agenticos-edit-guard`.
 Use it from local automation or any client-side pre-edit hook layer to fail closed unless:
 
 - the active project matches the intended managed project
 - the intended issue is explicit
 - the latest persisted `agenticos_preflight` for that issue and repo is `PASS`
+
+The root-level `tools/check-edit-boundary.sh` path is now legacy compatibility only.
 
 ### Option B — Manual install (from GitHub Releases)
 
@@ -246,7 +248,8 @@ For downstream project inheritance, the executable workflow standard kit lives i
 
 Within this repository, only `projects/agenticos/` should be treated as the canonical **AgenticOS product-source** project.
 Sibling entries under `projects/` may still exist as preserved managed-project content and should not be rewritten or removed just because AgenticOS itself adopted a self-hosting layout.
-The source checkout also keeps a legacy-compatible top-level `tools/record-reminder.sh` path because existing Claude Code hooks still call that location directly.
+The installed-runtime command `agenticos-record-reminder` is now the preferred reminder hook entrypoint.
+The source checkout keeps a legacy-compatible top-level `tools/record-reminder.sh` path only for older hook callers that have not been migrated yet.
 The orphaned gitlink residues `okr-management` and `t5t` were not recoverable as full tracked projects and therefore should not be treated as canonical managed-project content without a separate verified source.
 
 ---

--- a/projects/agenticos/mcp-server/README.md
+++ b/projects/agenticos/mcp-server/README.md
@@ -26,7 +26,10 @@ Use `agenticos-bootstrap --verify` to audit the selected agents and optional per
 After any local upgrade, reinstall, or source rebuild of `agenticos-mcp`, restart the current AI client before assuming its MCP tools reflect the new server behavior.
 MCP registration can be correct while the live client session is still holding an older server process.
 
-When the client supports a pre-edit hook or local command wrapper, point that layer at `tools/check-edit-boundary.sh` so implementation edits fail closed unless project alignment and matching PASS preflight evidence already exist.
+When the client supports a pre-edit hook or local command wrapper, point that layer at `agenticos-edit-guard` so implementation edits fail closed unless project alignment and matching PASS preflight evidence already exist.
+
+For stop-event reminders, prefer `agenticos-record-reminder`.
+The old root `tools/check-edit-boundary.sh` and `tools/record-reminder.sh` paths should now be treated as legacy compatibility shims.
 
 ### Homebrew Post-Install Contract
 

--- a/projects/agenticos/tasks/issue-209-hook-doc-migration.md
+++ b/projects/agenticos/tasks/issue-209-hook-doc-migration.md
@@ -1,0 +1,15 @@
+# Issue #209 — Hook Doc Migration
+
+## Goal
+
+Make installed-runtime hook commands the recommended entrypoints in docs.
+
+## Scope
+
+- update root README
+- update root AGENTS
+- update `projects/agenticos/mcp-server/README.md`
+
+## Validation
+
+- `rg -n "agenticos-edit-guard|agenticos-record-reminder|legacy compatibility" README.md AGENTS.md projects/agenticos/mcp-server/README.md`


### PR DESCRIPTION
## Summary
- make installed hook commands the recommended entrypoints in docs
- keep root `tools/*` paths documented only as legacy compatibility
- record the migration slice for issue #209

## Validation
- rg -n "agenticos-edit-guard|agenticos-record-reminder|legacy compatibility|legacy-compatible" README.md AGENTS.md projects/agenticos/mcp-server/README.md

Closes #209