### PR TITLE
fix(agenticos): block runtime writes to canonical main

### DIFF
--- a/projects/agenticos/mcp-server/src/utils/__tests__/canonical-main-guard.test.ts
+++ b/projects/agenticos/mcp-server/src/utils/__tests__/canonical-main-guard.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const execAsyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock('child_process', () => ({
+  exec: vi.fn(),
+}));
+
+vi.mock('util', () => ({
+  promisify: vi.fn(() => execAsyncMock),
+}));
+
+import { detectCanonicalMainWriteProtection } from '../canonical-main-guard.js';
+
+describe('detectCanonicalMainWriteProtection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('blocks the main worktree on branch main', async () => {
+    execAsyncMock.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('rev-parse --show-toplevel')) return { stdout: '/workspace/root\n', stderr: '' };
+      if (cmd.includes('rev-parse --abbrev-ref HEAD')) return { stdout: 'main\n', stderr: '' };
+      if (cmd.includes('worktree list --porcelain')) return { stdout: 'worktree /workspace/root\nHEAD abc\nbranch refs/heads/main\n', stderr: '' };
+      throw new Error(`Unexpected command: ${cmd}`);
+    });
+
+    const result = await detectCanonicalMainWriteProtection('/workspace/root');
+    expect(result.blocked).toBe(true);
+    expect(result.workspace_type).toBe('main');
+  });
+
+  it('does not block isolated issue worktrees', async () => {
+    execAsyncMock.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('rev-parse --show-toplevel')) return { stdout: '/workspace/root-worktrees/issue-212\n', stderr: '' };
+      if (cmd.includes('rev-parse --abbrev-ref HEAD')) return { stdout: 'fix/212-canonical-main-write-guard\n', stderr: '' };
+      if (cmd.includes('worktree list --porcelain')) {
+        return {
+          stdout: 'worktree /workspace/root\nHEAD abc\nbranch refs/heads/main\n\nworktree /workspace/root-worktrees/issue-212\nHEAD def\nbranch refs/heads/fix/212-canonical-main-write-guard\n',
+          stderr: '',
+        };
+      }
+      throw new Error(`Unexpected command: ${cmd}`);
+    });
+
+    const result = await detectCanonicalMainWriteProtection('/workspace/root-worktrees/issue-212');
+    expect(result.blocked).toBe(false);
+    expect(result.workspace_type).toBe('isolated_worktree');
+  });
+});

--- a/projects/agenticos/mcp-server/src/utils/__tests__/guardrail-evidence.test.ts
+++ b/projects/agenticos/mcp-server/src/utils/__tests__/guardrail-evidence.test.ts
@@ -19,7 +19,12 @@ vi.mock('../registry.js', () => ({
   loadRegistry: vi.fn(),
 }));
 
+vi.mock('../canonical-main-guard.js', () => ({
+  detectCanonicalMainWriteProtection: vi.fn(async () => ({ blocked: false })),
+}));
+
 import { access, readFile, writeFile } from 'fs/promises';
+import { detectCanonicalMainWriteProtection } from '../canonical-main-guard.js';
 import { loadRegistry } from '../registry.js';
 import { persistGuardrailEvidence } from '../guardrail-evidence.js';
 
@@ -27,6 +32,7 @@ const accessMock = access as unknown as ReturnType<typeof vi.fn>;
 const readFileMock = readFile as unknown as ReturnType<typeof vi.fn>;
 const writeFileMock = writeFile as unknown as ReturnType<typeof vi.fn>;
 const loadRegistryMock = loadRegistry as unknown as ReturnType<typeof vi.fn>;
+const detectCanonicalMainWriteProtectionMock = detectCanonicalMainWriteProtection as unknown as ReturnType<typeof vi.fn>;
 
 describe('persistGuardrailEvidence', () => {
   beforeEach(() => {
@@ -55,6 +61,7 @@ describe('persistGuardrailEvidence', () => {
     accessMock.mockResolvedValue(undefined);
     readFileMock.mockResolvedValue(JSON.stringify({ session: {}, working_memory: { facts: [], decisions: [], pending: [] } }));
     writeFileMock.mockResolvedValue(undefined);
+    detectCanonicalMainWriteProtectionMock.mockResolvedValue({ blocked: false });
   });
 
   it('persists latest preflight evidence into the matching managed project state', async () => {
@@ -233,6 +240,35 @@ describe('persistGuardrailEvidence', () => {
 
     expect(result.persisted).toBe(false);
     expect(result.reason).toContain('not within a resolvable AgenticOS project');
+    expect(writeFileMock).not.toHaveBeenCalled();
+  });
+
+  it('does not persist guardrail evidence into canonical main checkouts', async () => {
+    readFileMock.mockImplementation(async (path: string) => {
+      if (path.endsWith('/.project.yaml')) {
+        return JSON.stringify({
+          meta: { id: 'agenticos', name: 'AgenticOS' },
+          agent_context: { current_state: 'standards/.context/state.yaml' },
+        });
+      }
+      return JSON.stringify({ session: {}, working_memory: { facts: [], decisions: [], pending: [] } });
+    });
+    detectCanonicalMainWriteProtectionMock.mockResolvedValue({
+      blocked: true,
+      reason: 'canonical main checkout is write-protected for runtime persistence: /workspace/root',
+    });
+
+    const result = await persistGuardrailEvidence({
+      command: 'agenticos_preflight',
+      repo_path: '/workspace/root/projects/agenticos/mcp-server',
+      payload: {
+        issue_id: '212',
+        result: { status: 'REDIRECT' },
+      },
+    });
+
+    expect(result.persisted).toBe(false);
+    expect(result.reason).toContain('write-protected');
     expect(writeFileMock).not.toHaveBeenCalled();
   });
 });

--- a/projects/agenticos/mcp-server/src/utils/__tests__/registry.test.ts
+++ b/projects/agenticos/mcp-server/src/utils/__tests__/registry.test.ts
@@ -45,6 +45,10 @@ vi.mock('yaml', () => ({
   default: yamlMock,
 }));
 
+vi.mock('../canonical-main-guard.js', () => ({
+  detectCanonicalMainWriteProtection: vi.fn(async () => ({ blocked: false })),
+}));
+
 // Must import after mocks are set up
 import {
   loadRegistry,
@@ -52,6 +56,7 @@ import {
   getAgenticOSHome,
   MISSING_AGENTICOS_HOME_MESSAGE,
 } from '../registry.js';
+import { detectCanonicalMainWriteProtection } from '../canonical-main-guard.js';
 import * as fsPromises from 'fs/promises';
 
 const fsPromisesMock = fsPromises as typeof fsPromises & {
@@ -60,11 +65,13 @@ const fsPromisesMock = fsPromises as typeof fsPromises & {
   mkdir: ReturnType<typeof vi.fn>;
   access: ReturnType<typeof vi.fn>;
 };
+const detectCanonicalMainWriteProtectionMock = detectCanonicalMainWriteProtection as unknown as ReturnType<typeof vi.fn>;
 
 describe('registry utilities', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     process.env.AGENTICOS_HOME = '/home/testuser/AgenticOS';
+    detectCanonicalMainWriteProtectionMock.mockResolvedValue({ blocked: false });
   });
 
   afterEach(() => {
@@ -209,6 +216,23 @@ describe('registry utilities', () => {
       const writeCall = fsPromisesMock.writeFile.mock.calls[0];
       const writtenContent = writeCall[1] as string;
       expect(writtenContent).toContain('/external/path');
+    });
+
+    it('blocks writes when AGENTICOS_HOME is the canonical main checkout', async () => {
+      detectCanonicalMainWriteProtectionMock.mockResolvedValue({
+        blocked: true,
+        reason: 'canonical main checkout is write-protected for runtime persistence: /home/testuser/AgenticOS',
+      });
+
+      const registry = {
+        version: '1.0.0',
+        last_updated: '2025-01-01T00:00:00.000Z',
+        active_project: 'my-project',
+        projects: [],
+      };
+
+      await expect(saveRegistry(registry)).rejects.toThrow('write-protected');
+      expect(fsPromisesMock.writeFile).not.toHaveBeenCalled();
     });
   });
 });

--- a/projects/agenticos/mcp-server/src/utils/canonical-main-guard.ts
+++ b/projects/agenticos/mcp-server/src/utils/canonical-main-guard.ts
@@ -1,0 +1,58 @@
+import { exec } from 'child_process';
+import { resolve } from 'path';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+export interface CanonicalMainGuardResult {
+  blocked: boolean;
+  reason?: string;
+  git_worktree_root?: string;
+  current_branch?: string;
+  workspace_type?: 'main' | 'isolated_worktree';
+}
+
+async function runGit(repoPath: string, args: string): Promise<string> {
+  const { stdout } = await execAsync(`git -C "${repoPath}" ${args}`);
+  return stdout.trim();
+}
+
+function detectWorkspaceTypeFromPorcelain(output: string, gitWorktreeRoot: string): 'main' | 'isolated_worktree' {
+  const worktreeLines = output
+    .split('\n')
+    .filter((line) => line.startsWith('worktree '))
+    .map((line) => line.replace(/^worktree\s+/, '').trim());
+
+  if (worktreeLines.length > 0 && resolve(worktreeLines[0]) === resolve(gitWorktreeRoot)) {
+    return 'main';
+  }
+  return 'isolated_worktree';
+}
+
+export async function detectCanonicalMainWriteProtection(repoPath: string): Promise<CanonicalMainGuardResult> {
+  try {
+    const gitWorktreeRoot = await runGit(repoPath, 'rev-parse --show-toplevel');
+    const currentBranch = await runGit(repoPath, 'rev-parse --abbrev-ref HEAD');
+    const worktreeList = await runGit(repoPath, 'worktree list --porcelain');
+    const workspaceType = detectWorkspaceTypeFromPorcelain(worktreeList, gitWorktreeRoot);
+
+    if (currentBranch === 'main' && workspaceType === 'main') {
+      return {
+        blocked: true,
+        reason: `canonical main checkout is write-protected for runtime persistence: ${gitWorktreeRoot}`,
+        git_worktree_root: gitWorktreeRoot,
+        current_branch: currentBranch,
+        workspace_type: workspaceType,
+      };
+    }
+
+    return {
+      blocked: false,
+      git_worktree_root: gitWorktreeRoot,
+      current_branch: currentBranch,
+      workspace_type: workspaceType,
+    };
+  } catch {
+    return { blocked: false };
+  }
+}

--- a/projects/agenticos/mcp-server/src/utils/guardrail-evidence.ts
+++ b/projects/agenticos/mcp-server/src/utils/guardrail-evidence.ts
@@ -2,6 +2,7 @@ import { access, readFile, writeFile } from 'fs/promises';
 import { basename, dirname, join, resolve, sep } from 'path';
 import yaml from 'yaml';
 import { loadRegistry } from './registry.js';
+import { detectCanonicalMainWriteProtection } from './canonical-main-guard.js';
 
 type GuardrailCommand =
   | 'agenticos_preflight'
@@ -255,6 +256,17 @@ export async function persistGuardrailEvidence(
       reason: project_path
         ? `project_path is not a resolvable AgenticOS project: ${project_path}`
         : `repo_path is not within a resolvable AgenticOS project: ${repo_path}`,
+    };
+  }
+
+  const writeProtection = await detectCanonicalMainWriteProtection(repo_path);
+  if (writeProtection.blocked) {
+    return {
+      attempted: true,
+      persisted: false,
+      project_id: project.id,
+      state_path: project.statePath,
+      reason: writeProtection.reason,
     };
   }
 

--- a/projects/agenticos/mcp-server/src/utils/registry.ts
+++ b/projects/agenticos/mcp-server/src/utils/registry.ts
@@ -1,6 +1,7 @@
 import { readFile, writeFile, mkdir } from 'fs/promises';
 import { join, isAbsolute, relative } from 'path';
 import yaml from 'yaml';
+import { detectCanonicalMainWriteProtection } from './canonical-main-guard.js';
 
 export const MISSING_AGENTICOS_HOME_MESSAGE =
   'AGENTICOS_HOME is not set. AgenticOS requires an explicit workspace root. Set AGENTICOS_HOME before starting agenticos-mcp.';
@@ -73,6 +74,11 @@ export async function loadRegistry(): Promise<Registry> {
 }
 
 export async function saveRegistry(registry: Registry): Promise<void> {
+  const writeProtection = await detectCanonicalMainWriteProtection(getAgenticOSHome());
+  if (writeProtection.blocked) {
+    throw new Error(writeProtection.reason);
+  }
+
   registry.last_updated = new Date().toISOString();
   // Convert absolute paths to relative before storing
   const toStore: Registry = {

--- a/projects/agenticos/tasks/issue-212-canonical-main-write-guard.md
+++ b/projects/agenticos/tasks/issue-212-canonical-main-write-guard.md
@@ -1,0 +1,16 @@
+# Issue #212 — Canonical Main Write Guard
+
+## Goal
+
+Prevent canonical `main` checkouts from receiving runtime persistence writes.
+
+## Scope
+
+- add a shared canonical-main write-protection helper
+- block guardrail evidence persistence into canonical `main`
+- block registry writes when `AGENTICOS_HOME` resolves to canonical `main`
+
+## Validation
+
+- `cd projects/agenticos/mcp-server && npm run lint`
+- `cd projects/agenticos/mcp-server && npx vitest run src/utils/__tests__/canonical-main-guard.test.ts src/utils/__tests__/guardrail-evidence.test.ts src/utils/__tests__/registry.test.ts`


### PR DESCRIPTION
## Summary
- add a shared guard that detects canonical main checkouts
- block guardrail evidence persistence into canonical main
- block registry writes when `AGENTICOS_HOME` resolves to canonical main

## Validation
- cd projects/agenticos/mcp-server && npm install
- cd projects/agenticos/mcp-server && npm run lint
- cd projects/agenticos/mcp-server && npm test

Closes #212