### PR TITLE
chore: prepare AgenticOS v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No unreleased changes._
 
+## [0.4.1] — 2026-04-07
+
+### Fixed
+- canonical `main` checkout now refuses runtime guardrail/state writes in the
+  merged source implementation, which unblocks recovery toward a clean standard
+  install/runtime model
+- runtime recovery now has an executable audit surface for detecting temporary
+  workspace bindings, install-time drift, and Homebrew formula ambiguity before
+  any cutover attempt
+
 ## [0.3.1] — 2026-04-01
 
 ### Added

--- a/projects/agenticos/mcp-server/package-lock.json
+++ b/projects/agenticos/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenticos-mcp",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenticos-mcp",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/projects/agenticos/mcp-server/package.json
+++ b/projects/agenticos/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-mcp",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "MCP Server for AgenticOS - AI-native project management system",
   "type": "module",
   "bin": {

--- a/projects/agenticos/tasks/issue-215-runtime-guard-patch-release.md
+++ b/projects/agenticos/tasks/issue-215-runtime-guard-patch-release.md
@@ -1,0 +1,48 @@
+---
+issue: 215
+title: patch release for canonical-main runtime write protection
+status: in_progress
+owners:
+  - codex
+created: 2026-04-07
+---
+
+## Goal
+
+Prepare the next patch release so the standard Homebrew-installed runtime can
+pick up the canonical-main write-protection changes already merged to `main`.
+
+## Why
+
+The recovery audit now shows that the source tree contains the protection, but
+the installed `agenticos-mcp` runtime still does not. Recovery should not rely
+on local source-only fixes; it needs a standard install-time binary.
+
+## Deliverables
+
+- bump `projects/agenticos/mcp-server/package.json` to the next patch version
+- update `package-lock.json` version metadata
+- add release notes to `CHANGELOG.md`
+- record this release-prep work in the issue task file
+
+## Follow-up
+
+- merge this preparation PR
+- create and push the release tag
+- wait for `agenticos-mcp.tgz` to publish
+- update `projects/agenticos/homebrew-tap/Formula/agenticos.rb` with the new
+  version, URL, and sha256
+- reinstall and verify the Homebrew runtime on this machine
+
+## Self-check
+
+### Rule-based
+
+- patch bump only
+- no product behavior changes in this issue
+- changelog entries must describe the real runtime recovery relevance
+
+### Executable
+
+- `npm test` still passes after the version bump
+- `agenticos-mcp --version` from the build output reports the new patch version


### PR DESCRIPTION
## Summary
- prepare patch release `0.4.1` for runtime recovery fixes already merged to main
- update package version and lock metadata
- add changelog notes describing canonical-main write protection and recovery audit relevance
- record the release-prep work in the issue task file

## Verification
- `cd projects/agenticos/mcp-server && npm test`
- `cd projects/agenticos/mcp-server && npm run build && node build/index.js --version`
