### PR TITLE
fix: require explicit workspace confirmation

### DIFF
--- a/projects/agenticos/mcp-server/src/utils/__tests__/bootstrap-cli.test.ts
+++ b/projects/agenticos/mcp-server/src/utils/__tests__/bootstrap-cli.test.ts
@@ -128,6 +128,7 @@ describe('bootstrap cli', () => {
 
   it('fails closed when no explicit or preconfirmed workspace exists', () => {
     const harness = createDeps();
+    harness.deps.env.AGENTICOS_SOURCE_ROOT = '/Users/tester/dev/AgenticOS';
 
     const exitCode = runBootstrapCli(
       ['--agent', 'codex'],
@@ -136,7 +137,8 @@ describe('bootstrap cli', () => {
 
     expect(exitCode).toBe(1);
     expect(harness.stderr.some((line) => line.includes('Workspace is required.'))).toBe(true);
-    expect(harness.stderr.some((line) => line.includes('/opt/homebrew/var/agenticos'))).toBe(true);
+    expect(harness.stderr.some((line) => line.includes('default: /Users/tester/dev/AgenticOS'))).toBe(true);
+    expect(harness.stderr.some((line) => line.includes('Confirm one explicitly with: agenticos-bootstrap --workspace "/Users/tester/dev/AgenticOS" ...'))).toBe(true);
     expect(harness.commands).toHaveLength(0);
   });
 

--- a/projects/agenticos/mcp-server/src/utils/__tests__/bootstrap-helper.test.ts
+++ b/projects/agenticos/mcp-server/src/utils/__tests__/bootstrap-helper.test.ts
@@ -38,8 +38,10 @@ describe('bootstrap helper', () => {
     const candidates = detectWorkspaceCandidates(
       (path) => path === '/opt/homebrew/var/agenticos',
       '/Users/tester',
+      '/Users/tester/dev/AgenticOS',
     );
     expect(candidates).toEqual([
+      '/Users/tester/dev/AgenticOS',
       '/opt/homebrew/var/agenticos',
       '/Users/tester/AgenticOS-workspace',
     ]);

--- a/projects/agenticos/mcp-server/src/utils/bootstrap-cli.ts
+++ b/projects/agenticos/mcp-server/src/utils/bootstrap-cli.ts
@@ -117,7 +117,11 @@ export function runBootstrapCli(argv: string[], deps: BootstrapCliDeps): number 
     const workspaceSelection = options.workspace
       ? { workspace: options.workspace, source: 'arg' as const }
       : detectDefaultWorkspace(deps.env.AGENTICOS_HOME, undefined, deps.homeDir);
-    const workspaceCandidates = detectWorkspaceCandidates(undefined, deps.homeDir);
+    const workspaceCandidates = detectWorkspaceCandidates(
+      undefined,
+      deps.homeDir,
+      deps.env.AGENTICOS_SOURCE_ROOT,
+    );
 
     if (!workspaceSelection) {
       deps.stderr('Workspace is required. Pass `--workspace <path>` or confirm AGENTICOS_HOME before bootstrap.');
@@ -232,10 +236,14 @@ export function buildHelpLines(): string[] {
 function buildWorkspaceConfirmationLines(candidates: string[]): string[] {
   const lines = [
     'User-confirmed workspace is required before bootstrap.',
-    'Candidate paths for confirmation:',
+    'Suggested workspace candidates for confirmation:',
   ];
-  for (const candidate of candidates) {
-    lines.push(`- ${candidate}`);
+  candidates.forEach((candidate, index) => {
+    const prefix = index === 0 ? '- default: ' : '- alternate: ';
+    lines.push(`${prefix}${candidate}`);
+  });
+  if (candidates.length > 0) {
+    lines.push(`Confirm one explicitly with: agenticos-bootstrap --workspace "${candidates[0]}" ...`);
   }
   return lines;
 }

--- a/projects/agenticos/mcp-server/src/utils/bootstrap-helper.ts
+++ b/projects/agenticos/mcp-server/src/utils/bootstrap-helper.ts
@@ -72,14 +72,26 @@ export function detectDefaultWorkspace(
 export function detectWorkspaceCandidates(
   fileExists: (path: string) => boolean = existsSync,
   userHome: string = homedir(),
+  preferredLocalRoot?: string,
 ): string[] {
   const candidates: string[] = [];
+  const seen = new Set<string>();
+
+  const pushCandidate = (value: string | undefined) => {
+    const trimmed = value?.trim();
+    if (!trimmed || seen.has(trimmed)) return;
+    seen.add(trimmed);
+    candidates.push(trimmed);
+  };
+
+  pushCandidate(preferredLocalRoot);
+
   for (const candidate of ['/opt/homebrew/var/agenticos', '/usr/local/var/agenticos']) {
     if (fileExists(candidate)) {
-      candidates.push(candidate);
+      pushCandidate(candidate);
     }
   }
-  candidates.push(join(userHome, 'AgenticOS-workspace'));
+  pushCandidate(join(userHome, 'AgenticOS-workspace'));
   return candidates;
 }
 

--- a/projects/agenticos/tasks/issue-218-explicit-workspace-confirmation.md
+++ b/projects/agenticos/tasks/issue-218-explicit-workspace-confirmation.md
@@ -17,6 +17,8 @@ path is always explicitly confirmed by the user.
 - bootstrap now accepts workspace from exactly two places:
   - `--workspace <path>`
   - preconfirmed `AGENTICOS_HOME`
+- when no confirmed workspace exists, bootstrap prints machine-local suggested
+  candidates and an explicit confirmation command, but does not auto-select
 - Homebrew and home-directory paths are now suggestions only, not implicit
   selections
 


### PR DESCRIPTION
## Summary
- remove silent workspace auto-selection from bootstrap flows
- accept workspace only from `--workspace` or preconfirmed `AGENTICOS_HOME`
- keep Homebrew and home-directory paths as suggestions instead of implicit defaults

## Verification
- `cd projects/agenticos/mcp-server && npx vitest run src/utils/__tests__/bootstrap-helper.test.ts src/utils/__tests__/bootstrap-cli.test.ts`
- `cd projects/agenticos/mcp-server && npm test`
