### PR TITLE
chore(release): update homebrew formula to 0.4.1

### DIFF
--- a/homebrew-tap/Formula/agenticos.rb
+++ b/homebrew-tap/Formula/agenticos.rb
@@ -3,10 +3,10 @@ require "language/node"
 class Agenticos < Formula
   desc "AI-native project management MCP server for Claude Code, Codex, Cursor, and Gemini CLI"
   homepage "https://github.com/madlouse/AgenticOS"
-  url "https://github.com/madlouse/AgenticOS/releases/download/v0.4.0/agenticos-mcp.tgz"
-  sha256 "5f049ba880f2de6d930d9ada07ae1ee549dba165e9bf2b30f6e6fe5a168096f7"
+  url "https://github.com/madlouse/AgenticOS/releases/download/v0.4.1/agenticos-mcp.tgz"
+  sha256 "8e60590011f384e7442c79ee448040c9a8dc630b5b0f7b875b205ec7b19312a6"
   license "MIT"
-  version "0.4.0"
+  version "0.4.1"
 
   depends_on "node"
 


### PR DESCRIPTION
## Summary

Updates the Homebrew formula from 0.4.0 to 0.4.1 so the repository-side release metadata matches the already-landed 0.4.1 source version and local package verification.

## What changed

- update `homebrew-tap/Formula/agenticos.rb` URL from `v0.4.0` to `v0.4.1`
- update formula `version` from `0.4.0` to `0.4.1`
- update formula `sha256` to the locally verified 0.4.1 tarball checksum

## Verification

- `npm install`
- `npm test`
- `npm pack`
- confirmed the generated tarball contains `build/utils/canonical-main-guard.js`
- confirmed local tarball sha256 is `8e60590011f384e7442c79ee448040c9a8dc630b5b0f7b875b205ec7b19312a6`

## Important follow-up

This PR only prepares repository-side parity.

`v0.4.1` is not yet published as a GitHub Release, so the formula will point at a real asset only after:
- this PR is merged
- the `v0.4.1` tag/release is created
- the release workflow uploads `agenticos-mcp.tgz`

Closes #236
