### PR TITLE
fix(release): correct v0.4.1 formula sha for #236

### DIFF
--- a/homebrew-tap/Formula/agenticos.rb
+++ b/homebrew-tap/Formula/agenticos.rb
@@ -4,7 +4,7 @@ class Agenticos < Formula
   desc "AI-native project management MCP server for Claude Code, Codex, Cursor, and Gemini CLI"
   homepage "https://github.com/madlouse/AgenticOS"
   url "https://github.com/madlouse/AgenticOS/releases/download/v0.4.1/agenticos-mcp.tgz"
-  sha256 "8e60590011f384e7442c79ee448040c9a8dc630b5b0f7b875b205ec7b19312a6"
+  sha256 "70c1edf028bef71117ad841d87724806e147dad45926bdc65e917de9bec8bed6"
   license "MIT"
   version "0.4.1"
 


### PR DESCRIPTION
## Summary

Corrects the `homebrew-tap/Formula/agenticos.rb` checksum for `v0.4.1` after the GitHub Release asset was published with a different digest than the locally packed tarball used in PR #240.

## What changed

- update the formula `sha256` to match the uploaded `v0.4.1` release asset

## Verification

- `gh release view v0.4.1 --json assets`
- `gh release download v0.4.1 -p agenticos-mcp.tgz -D /tmp/agenticos-release-041 --clobber`
- `shasum -a 256 /tmp/agenticos-release-041/agenticos-mcp.tgz`
- `agenticos_pr_scope_check` for issue `#236`
- `brew upgrade agenticos`
- `brew link --overwrite agenticos`
- `tools/audit-runtime-recovery.sh --source-root /Users/jeking/dev/AgenticOS/projects/agenticos`

## Runtime recovery result

The installed runtime now resolves `agenticos-mcp` from Homebrew `0.4.1`, and the audit reports `installed-runtime: PASS`. The remaining `--expected-home /opt/homebrew/var/agenticos` block is only the local config still pointing at the source checkout during active development.

Closes #236
