### PR TITLE
fix(workspace): normalize topology truth surfaces for #235

### DIFF
--- a/.context/conversations/2026-04-09.md
+++ b/.context/conversations/2026-04-09.md
@@ -19,3 +19,15 @@
 
 **Pending**:
 - Optionally repoint local AGENTICOS_HOME config surfaces to /opt/homebrew/var/agenticos when you want this machine to use the Homebrew workspace instead of the source checkout.
+
+### 03:17 — Correction Record
+
+**Summary**: Corrected the runtime-home interpretation from the earlier release-parity close-out. The previous note treated `/opt/homebrew/var/agenticos` as the expected home and implied that `/Users/jeking/dev/AgenticOS` was effectively a source-checkout target. The normalized model is instead: `/Users/jeking/dev/AgenticOS` is the valid workspace home on this machine, and `projects/agenticos` is the product source project.
+
+**Decisions**:
+- `AGENTICOS_HOME` names the workspace home, not the product source root.
+- `projects/<id>` is the project boundary; source-managed versus local-only is a per-project property.
+- `/opt/homebrew/var/agenticos` remains a valid Homebrew example workspace, but not the normative target for this self-hosting machine.
+
+**Pending**:
+- Complete the issue `#235` terminology, script, and metadata repair so the operator surfaces all reflect the normalized model.

--- a/.context/state.yaml
+++ b/.context/state.yaml
@@ -134,19 +134,22 @@ working_memory:
     - The Homebrew tap repository had to be updated in addition to the product
       repository because brew installs resolve from madlouse/homebrew-agenticos,
       not directly from AgenticOS/homebrew-tap.
-    - The remaining runtime recovery block under --expected-home
-      /opt/homebrew/var/agenticos is a local configuration choice pointing tools
-      at the source checkout, not an installed-runtime freshness failure.
+    - A runtime recovery block against /opt/homebrew/var/agenticos reflects a
+      mismatch against that specific example workspace path, not proof that
+      /Users/jeking/dev/AgenticOS is an invalid AGENTICOS_HOME on this machine.
   pending:
-    - Optionally repoint local AGENTICOS_HOME config surfaces to
-      /opt/homebrew/var/agenticos when you want this machine to use the Homebrew
-      workspace instead of the source checkout.
+    - Normalize workspace-home versus project-source terminology under issue
+      #235.
+    - Mark projects/agenticos as a github_versioned child project with truthful
+      source bindings.
+    - Re-run the focused audit and verification scripts against the corrected
+      model.
 session:
-  last_backup: 2026-04-09T02:48:03.586Z
+  last_backup: 2026-04-09T03:17:46Z
 current_task:
-  title: Runtime release parity for installed AgenticOS (#236)
-  status: completed
-  updated: 2026-04-09T02:47:56.955Z
+  title: Workspace registry and topology truth repair (#235)
+  status: in_progress
+  updated: 2026-04-09T03:17:46Z
 guardrail_evidence:
   updated_at: 2026-04-09T02:40:06.705Z
   last_command: agenticos_branch_bootstrap

--- a/.project.yaml
+++ b/.project.yaml
@@ -5,6 +5,11 @@ meta:
   created: 2026-03-23
   version: 1.0.0
 
+source_control:
+  topology: github_versioned
+  github_repo: madlouse/AgenticOS
+  branch_strategy: github_flow
+
 agent_context:
   quick_start: standards/.context/quick-start.md
   current_state: standards/.context/state.yaml
@@ -30,4 +35,4 @@ status:
 
 execution:
   source_repo_roots:
-    - ../..
+    - .

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,19 +91,21 @@ When you open this project in a new session, **immediately do the following**:
 ## Current State
 
 <!-- AGENT_CONTEXT_START -->
-**Last Updated**: 2026-04-09T02:48:03.586Z
+**Last Updated**: 2026-04-09T03:17:46Z
 
-**Current Task**: Runtime release parity for installed AgenticOS (#236) (status: completed)
+**Current Task**: Workspace registry and topology truth repair (#235) (status: in_progress)
 
 **Active Items**:
-- Optionally repoint local AGENTICOS_HOME config surfaces to /opt/homebrew/var/agenticos when you want this machine to use the Homebrew workspace instead of the source checkout.
+- Normalize `projects/agenticos` metadata so the product project is truthfully marked `github_versioned`.
+- Align audit and verification scripts with the `workspace home` vs `project source` model.
+- Refresh compatibility memory surfaces so `/Users/jeking/dev/AgenticOS` is treated as the valid workspace home on this machine.
 
 **Recent Decisions**:
-- When the published GitHub Release asset digest differed from the locally packed tarball used in PR #240, the correct recovery path was to reopen #236 and land a follow-up checksum fix instead of leaving the source formula incorrect.
-- The Homebrew tap repository had to be updated in addition to the product repository because brew installs resolve from madlouse/homebrew-agenticos, not directly from AgenticOS/homebrew-tap.
-- The remaining runtime recovery block under --expected-home /opt/homebrew/var/agenticos is a local configuration choice pointing tools at the source checkout, not an installed-runtime freshness failure.
+- `AGENTICOS_HOME` identifies the workspace home; source ownership is a project-level property under `projects/<id>`.
+- `/opt/homebrew/var/agenticos` is a Homebrew default example workspace path, not the normative target for this machine.
+- Historical migration docs should distinguish temporary external-workspace mitigation from the final self-hosting model.
 
-**Next Action**: Optionally repoint local AGENTICOS_HOME config surfaces to /opt/homebrew/var/agenticos when you want this machine to use the Homebrew workspace instead of the source checkout.
+**Next Action**: Finish the coordinated script, metadata, and state-surface corrections for issue `#235`, then rerun the focused audits.
 <!-- AGENT_CONTEXT_END -->
 
 ---

--- a/README.md
+++ b/README.md
@@ -31,12 +31,16 @@ exit:
 
 ## Quick Start
 
+Requires: node.js >= 20.0.0
+
 ```bash
 cd mcp-server
 npm install
 npm run build
 npm test
 ```
+
+Verify with `cd mcp-server && npm test` and confirm all tests pass.
 
 ## Supported Integration Modes
 
@@ -80,6 +84,8 @@ working.
 self-hosting AgenticOS workspace, as long as it is not the repo root of a
 project such as `projects/agenticos`.
 
+Requires: Node.js >= 20.0.0 for local build and packaged runtime workflows.
+
 ```bash
 export AGENTICOS_HOME=/absolute/path/to/your/workspace
 
@@ -89,6 +95,9 @@ claude mcp add --transport stdio --scope user -e AGENTICOS_HOME="$AGENTICOS_HOME
 codex mcp add --env AGENTICOS_HOME="$AGENTICOS_HOME" agenticos -- agenticos-mcp
 gemini mcp add -s user -e AGENTICOS_HOME="$AGENTICOS_HOME" agenticos agenticos-mcp
 ```
+
+Verify with `agenticos-mcp --version`, then restart the target MCP client and
+confirm `agenticos_list` succeeds.
 
 For Cursor, add `agenticos` with explicit `env.AGENTICOS_HOME` to
 `~/.cursor/mcp.json`, then restart Cursor and verify `agenticos_list`.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ agent manually or with `agenticos-bootstrap`, restart the current client, and
 explicitly verify `agenticos_list` before assuming project-intent routing is
 working.
 
+`AGENTICOS_HOME` may be any valid workspace home, including a long-term
+self-hosting AgenticOS workspace, as long as it is not the repo root of a
+project such as `projects/agenticos`.
+
 ```bash
 export AGENTICOS_HOME=/absolute/path/to/your/workspace
 
@@ -118,5 +122,5 @@ codex mcp add --env AGENTICOS_HOME="$AGENTICOS_HOME" agenticos -- agenticos-mcp
 ## Current Boundary Rule
 
 - `projects/agenticos/` is the only canonical AgenticOS product-source project under `projects/`
-- the workspace root is evolving toward `workspace home`, not permanent product-source Git root
+- the enclosing `AgenticOS/` path is the workspace home; product source lives under `projects/agenticos/`
 - root-level `README.md`, `AGENTS.md`, and `CONTRIBUTING.md` currently remain as compatibility entrypoints during that migration

--- a/homebrew-tap/README.md
+++ b/homebrew-tap/README.md
@@ -25,7 +25,7 @@ Homebrew does **not**:
 After installation, set `AGENTICOS_HOME` explicitly, bootstrap one officially supported agent, restart it, and verify `agenticos_list`:
 
 ```bash
-# Example workspace path
+# Example default workspace path for a Homebrew-only install
 mkdir -p "$(brew --prefix)/var/agenticos"
 export AGENTICOS_HOME="$(brew --prefix)/var/agenticos"
 
@@ -62,6 +62,10 @@ Then restart the AI tool and confirm `agenticos_list` works.
 If you prefer not to edit your shell profile, omit `--first-run` and use the explicit MCP commands below instead.
 On macOS, `--first-run` also enables `launchctl` persistence so GUI/session processes inherit `AGENTICOS_HOME`.
 Use `agenticos-bootstrap --verify` with the same flags to audit the current machine state without mutating it.
+
+`AGENTICOS_HOME` may also be a long-term self-hosting workspace home. The
+Homebrew example path above is a default example, not the only valid workspace
+layout.
 
 If you are developing AgenticOS from a source checkout, remember that `npm run build` in the repo does **not** replace the Homebrew-installed `agenticos-mcp` binary on your PATH.
 If your MCP client is registered to `agenticos-mcp`, it will keep launching the installed binary until you explicitly reinstall or upgrade that binary and restart the AI tool.

--- a/standards/.context/quick-start.md
+++ b/standards/.context/quick-start.md
@@ -35,8 +35,8 @@ Its job is to define and evolve:
 - `knowledge/switch-guardrail-evidence-implementation-report-2026-03-24.md` records the switch-surface implementation and verification
 - issue `#79` now reconciles the historical open backlog against landed self-hosting, standards, and guardrail changes
 - `knowledge/backlog-reconciliation-matrix-2026-03-24.md` records which old issues were closed, which remain open, and which required scope rewrite
-- issue `#78` now restores `/Users/jeking/dev/AgenticOS` as a clean canonical working copy aligned with `origin/main`
-- `knowledge/canonical-working-copy-cleanup-report-2026-03-24.md` records what was preserved, what was removed from the source checkout, and how the local main checkout was verified
+- issue `#78` now restores `/Users/jeking/dev/AgenticOS` as a clean canonical workspace home aligned with `origin/main`
+- `knowledge/canonical-working-copy-cleanup-report-2026-03-24.md` records what was preserved, what was removed from the product-source project, and how the local main workspace was verified
 - issue `#24` now fixes `agenticos_record` so JSON-stringified array arguments are normalized into real persisted list items instead of degrading into malformed state updates
 - `knowledge/record-array-parsing-fix-report-2026-03-24.md` records the fix, regression coverage, and verification for the restored `#24` work
 - issue `#23` now upgrades `agenticos_switch` so it returns inline actionable project context instead of only file paths
@@ -74,7 +74,7 @@ Its job is to define and evolve:
 - issue `#96` now adds one bounded first-class non-code evaluation command that validates completed rubric files and persists the latest structured evidence into project state
 - `knowledge/non-code-evaluation-command-design-2026-03-25.md` records why this issue should validate and persist rubric results rather than inventing a second scoring system
 - `knowledge/non-code-evaluation-command-implementation-report-2026-03-25.md` records the landed command, persistence contract, and full targeted coverage result
-- issue `#104` now corrects the overreaching migration interpretation and restores the preserved visible project layout in the source checkout
+- issue `#104` now corrects the overreaching migration interpretation and restores the preserved visible project layout in the workspace home
 - `knowledge/project-layout-restoration-report-2026-03-25.md` records the root cause, verified restored paths, and the corrected repository boundary rule
 - issue `#106` now audits whether `t5t` and `okr-management` can be honestly restored from verified local evidence
 - `knowledge/missing-project-source-audit-2026-03-25.md` records that `t5t` is reconstructable from verified local sources, while `okr-management` currently only supports an external-source or archive recovery model

--- a/standards/.context/state.yaml
+++ b/standards/.context/state.yaml
@@ -2,11 +2,11 @@ session:
   id: standards-main-2026-03-23-001
   started: 2026-03-23T09:30:00.000Z
   agent: codex
-  last_backup: 2026-03-23T10:35:00.000Z
+  last_backup: 2026-04-09T03:17:46Z
 current_task:
-  title: restore projects/okr-management as an external-source wrapper project
-  status: completed
-  updated: 2026-03-25T20:10:00.000Z
+  title: normalize workspace-home and project-source truth surfaces
+  status: in_progress
+  updated: 2026-04-09T03:17:46Z
 working_memory:
   facts:
     - projects/agenticos/standards is now the only canonical location for
@@ -60,7 +60,7 @@ working_memory:
       /Users/jeking/worktrees/agenticos-working-copy-78-backup/2026-03-24/
     - the previous local-only main commits for
     - retired standalone standards residue and runtime-project leftovers were
-      removed from the source checkout after backup
+      removed from the product-source project after backup
     - issue
     - agenticos_record now accepts JSON-stringified arrays for decisions,
       outcomes, and pending in addition to native arrays
@@ -123,9 +123,9 @@ working_memory:
     - issue
     - targeted coverage for the
     - issue
-    - the canonical source checkout at /Users/jeking/dev/AgenticOS now again
+    - the canonical workspace home at /Users/jeking/dev/AgenticOS now again
       contains preserved sibling projects 2026okr, 360teams, agentic-devops,
-      agentic-os-development, and ghostty-optimization
+      agentic-os-development, and ghostty-optimization under projects/
     - the legacy top-level compatibility hook path tools/record-reminder.sh has
       been restored because existing Claude Code hooks still call it directly
     - preserved history only contains orphaned gitlinks for projects/t5t and
@@ -146,12 +146,12 @@ working_memory:
       corpus under /Users/jeking/work/02.目标绩效/00.OKR管理/, not a preserved
       project-local AgenticOS directory
     - issue
-    - projects/t5t is now present again in the canonical source checkout under
+    - projects/t5t is now present again in the canonical workspace home under
       /Users/jeking/dev/AgenticOS/projects/t5t
     - issue
-    - projects/okr-management is now present again in the canonical source
-      checkout with project metadata, entry surfaces, provenance docs, and
-      verified 2026 OKR snapshots
+    - projects/okr-management is now present again in the canonical workspace
+      home with project metadata, entry surfaces, provenance docs, and verified
+      2026 OKR snapshots
     - the canonical external content source for okr-management currently points
       to /Users/jeking/work/02.目标绩效/00.OKR管理/
   decisions:
@@ -215,9 +215,15 @@ working_memory:
     - when the strongest verified content source is external to the repo, prefer
       an external-source wrapper project over a false claim of full in-repo
       restoration
+    - `AGENTICOS_HOME` should be described as the workspace home, while
+      `projects/<id>` remains the project-source boundary for source-managed
+      projects
+    - `/opt/homebrew/var/agenticos` is a valid Homebrew example workspace path,
+      not the normative target when a self-hosting machine already uses
+      /Users/jeking/dev/AgenticOS as its workspace home
   pending:
-    - execute issue
-    - revisit issue
+    - land the issue #235 terminology and audit-surface corrections
+    - verify that projects/agenticos now carries truthful topology metadata
 loaded_context:
   - .project.yaml
   - .context/quick-start.md

--- a/standards/knowledge/runtime-project-extraction-plan-2026-03-23.md
+++ b/standards/knowledge/runtime-project-extraction-plan-2026-03-23.md
@@ -39,7 +39,7 @@ The AgenticOS product source repository should no longer need to carry real runt
 
 Goal state:
 - source repo keeps `projects/agenticos`
-- runtime projects live in the separate live workspace rooted at `AGENTICOS_HOME`
+- runtime projects live in the workspace home rooted at `AGENTICOS_HOME`
 - fixture content is either regenerated on demand or kept as explicit fixture content with that role documented
 
 ## Extraction Sequence
@@ -53,8 +53,13 @@ Done by this plan:
 
 ### Phase 2: Prepare destination workspace
 
-Create or confirm a clean live workspace outside the product source checkout, for example:
+As a migration step, create or confirm a clean workspace home outside the
+product source project root, for example:
 - `~/AgenticOS-workspace`
+
+This external workspace example is phase-specific migration guidance, not the
+final storage model. The final target remains one workspace home with child
+projects under `projects/*`.
 
 The destination should contain:
 - `.agent-workspace/`
@@ -109,7 +114,7 @@ Recommended sequence:
 After extraction:
 - root README should describe `projects/agenticos` as the only product-source project under `projects/`
 - root AGENTS/CLAUDE guidance should stop treating remaining `projects/*` entries as part of the source tree
-- bootstrap docs should point live projects to `AGENTICOS_HOME`, not to the source checkout
+- bootstrap docs should point live projects to `AGENTICOS_HOME`, not to the product source project root
 
 ## Acceptance Judgment
 
@@ -120,4 +125,5 @@ This plan satisfies the current planning milestone for issue `#38` because it no
 - a de-tracking strategy
 - a clear target boundary between source repo and live workspace
 
-Actual filesystem extraction remains an execution step and should follow this plan rather than improvising on the live source checkout.
+Actual filesystem extraction remains an execution step and should follow this
+plan rather than improvising on the live product source project root.

--- a/standards/knowledge/workspace-migration-runbook-2026-04-07.md
+++ b/standards/knowledge/workspace-migration-runbook-2026-04-07.md
@@ -2,36 +2,43 @@
 
 > Date: 2026-04-07
 > Issue: #195
-> Purpose: move the live AgenticOS workspace off the current source checkout and verify that workspace operations no longer pollute product source
+> Purpose: document the temporary external-workspace mitigation that moved live
+> workspace activity off the product-source repo root before the final
+> workspace-home model was fully restored
 
-## 1. Rules
+> Historical note: this runbook records a transitional mitigation, not the final
+> steady-state storage model. The final terminology is frozen in
+> `workspace-home-vs-project-source-model-2026-04-07.md`.
 
-- the live `AGENTICOS_HOME` must not point inside the AgenticOS product source checkout
+## 1. Transitional Rules
+
+- the live `AGENTICOS_HOME` must not point at the AgenticOS product-source repo root
+- during this mitigation phase, the live workspace was moved to a temporary external workspace home
 - the live workspace must contain portable workspace data:
   - `.agent-workspace/`
   - `projects/`
-- supported local agent configs must point to the dedicated workspace root
+- supported local agent configs must point to the chosen workspace home for the mitigation
 - verification must include one real MCP workspace flow:
   - `list`
   - `switch`
   - `status`
-- the product source checkout must remain unchanged before and after that flow
+- the product source repo root must remain unchanged before and after that flow
 
 ## 2. Execution Outline
 
 1. back up the current agent config files and workspace registry
-2. copy the portable workspace data into the new workspace root
+2. copy the portable workspace data into the temporary workspace home
    - preserve nested child `.git/` directories for standalone child repos
 3. update agent configs with `agenticos-bootstrap`
 4. apply manual fallback edits if a supported agent cannot be auto-updated
 5. run the verification script
 6. run a topology audit over `projects/*` in the new workspace
-7. clean stale workspace-generated dirtiness from the source checkout only after the new workspace passes verification
+7. clean stale workspace-generated dirtiness from the product source root only after the new workspace passes verification
 
 ## 3. Recorded Migration Outcome
 
-- workspace root: `AGENTICOS_WORKSPACE_HOME`
-- source checkout: `AGENTICOS_SOURCE_ROOT`
+- mitigation workspace home: `AGENTICOS_WORKSPACE_HOME`
+- product source root: `AGENTICOS_SOURCE_ROOT`
 - Codex config migrated
 - Cursor config migrated
 - Claude settings required a manual env-path fallback because `claude` CLI was not present on PATH
@@ -39,14 +46,14 @@
 - the installed local `agenticos_init` path did not fully backfill `source_control.topology` during one normalization step, so topology audit remained necessary after migration
 - shell profile updated
 - `launchctl` session env updated
-- product source checkout was cleaned after the new workspace verification passed
+- product source root was cleaned after the new workspace verification passed
 
 ## 4. Repeatable Verification
 
 Use:
 
 ```bash
-export AGENTICOS_SOURCE_ROOT="/absolute/path/to/current-agenticos-source-root"
+export AGENTICOS_SOURCE_ROOT="/absolute/path/to/current-agenticos-product-source-root"
 export AGENTICOS_WORKSPACE_HOME="/absolute/path/to/current-workspace-home"
 "$AGENTICOS_SOURCE_ROOT/projects/agenticos/tools/verify-workspace-separation.sh" \
   "$AGENTICOS_SOURCE_ROOT" \
@@ -57,9 +64,9 @@ export AGENTICOS_WORKSPACE_HOME="/absolute/path/to/current-workspace-home"
 Expected result:
 
 - the script exits `0`
-- the script proves config separation
+- the script proves config separation for the chosen workspace home
 - the script proves workspace MCP flow succeeds
-- the script proves the product source checkout does not gain new dirtiness
+- the script proves the product source root does not gain new dirtiness
 
 ## 5. Manual Fallback Rule
 
@@ -71,4 +78,8 @@ If `agenticos-bootstrap` cannot update a supported local agent automatically:
 
 Do not treat the migration as complete until the verification script passes.
 
-This runbook documents a transitional separation step. The final target model is still `workspace home` plus `project source`, not a permanent requirement that users keep an external workspace path.
+This runbook documents a transitional separation step. The final target model is
+still `workspace home` plus `project source`, not a permanent requirement that
+users keep an external workspace path. In the steady state, the enclosing
+`AgenticOS/` path may itself be the valid `AGENTICOS_HOME` as long as the
+product source remains the child project at `projects/agenticos`.

--- a/tools/audit-runtime-recovery.sh
+++ b/tools/audit-runtime-recovery.sh
@@ -4,11 +4,13 @@ set -euo pipefail
 usage() {
   cat <<'EOF'
 Usage:
-  audit-runtime-recovery.sh --source-root /abs/path [--expected-home /abs/path]
+  audit-runtime-recovery.sh --product-source-root /abs/path [--workspace-home /abs/path]
 
 Options:
-  --source-root    AgenticOS source checkout or intended workspace root.
-  --expected-home  Optional path that local configs are expected to target.
+  --product-source-root  Product source root to audit, for example `projects/agenticos`.
+  --workspace-home       Optional workspace home that local configs are expected to target.
+  --source-root          Deprecated alias for --product-source-root.
+  --expected-home        Deprecated alias for --workspace-home.
 
 Behavior:
   - read-only audit
@@ -18,17 +20,17 @@ Behavior:
 EOF
 }
 
-SOURCE_ROOT=""
-EXPECTED_HOME=""
+PRODUCT_SOURCE_ROOT=""
+WORKSPACE_HOME=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --source-root)
-      SOURCE_ROOT="${2:-}"
+    --product-source-root|--source-root)
+      PRODUCT_SOURCE_ROOT="${2:-}"
       shift 2
       ;;
-    --expected-home)
-      EXPECTED_HOME="${2:-}"
+    --workspace-home|--expected-home)
+      WORKSPACE_HOME="${2:-}"
       shift 2
       ;;
     -h|--help)
@@ -43,23 +45,23 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ -z "$SOURCE_ROOT" ]]; then
+if [[ -z "$PRODUCT_SOURCE_ROOT" ]]; then
   usage >&2
   exit 64
 fi
 
-SOURCE_ROOT="$(cd "$SOURCE_ROOT" && pwd)"
-if [[ -n "$EXPECTED_HOME" ]]; then
-  EXPECTED_HOME="$(cd "$EXPECTED_HOME" && pwd)"
+PRODUCT_SOURCE_ROOT="$(cd "$PRODUCT_SOURCE_ROOT" && pwd)"
+if [[ -n "$WORKSPACE_HOME" ]]; then
+  WORKSPACE_HOME="$(cd "$WORKSPACE_HOME" && pwd)"
 fi
 
-SOURCE_ROOT="$SOURCE_ROOT" EXPECTED_HOME="$EXPECTED_HOME" node --input-type=module <<'NODE'
+PRODUCT_SOURCE_ROOT="$PRODUCT_SOURCE_ROOT" WORKSPACE_HOME="$WORKSPACE_HOME" node --input-type=module <<'NODE'
 import { execFileSync } from 'child_process';
 import { existsSync, readFileSync } from 'fs';
 import { resolve } from 'path';
 
-const sourceRoot = resolve(process.env.SOURCE_ROOT);
-const expectedHome = process.env.EXPECTED_HOME ? resolve(process.env.EXPECTED_HOME) : null;
+const productSourceRoot = resolve(process.env.PRODUCT_SOURCE_ROOT);
+const workspaceHome = process.env.WORKSPACE_HOME ? resolve(process.env.WORKSPACE_HOME) : null;
 
 const checks = [];
 
@@ -142,14 +144,14 @@ if (configuredHomes.size === 0) {
   );
 } else {
   const configuredHome = Array.from(configuredHomes)[0];
-  const status = expectedHome && configuredHome !== expectedHome ? 'BLOCK' : 'PASS';
+  const status = workspaceHome && configuredHome !== workspaceHome ? 'BLOCK' : 'PASS';
   addCheck(
     'config-agenticos-home',
     status,
     status === 'PASS'
       ? 'all audited local config surfaces agree on one AGENTICOS_HOME value'
-      : 'audited local config surfaces point at a different AGENTICOS_HOME than the expected target',
-    { files: configResults, configured_home: configuredHome, expected_home: expectedHome },
+      : 'audited local config surfaces point at a different AGENTICOS_HOME than the expected workspace home',
+    { files: configResults, configured_home: configuredHome, workspace_home: workspaceHome },
   );
 }
 
@@ -160,47 +162,58 @@ if (!launchctl.ok || !launchctl.stdout) {
   });
 } else {
   const launchctlHome = resolve(launchctl.stdout);
-  const status = expectedHome && launchctlHome !== expectedHome ? 'BLOCK' : 'PASS';
+  const status = workspaceHome && launchctlHome !== workspaceHome ? 'BLOCK' : 'PASS';
   addCheck(
     'launchctl-agenticos-home',
     status,
     status === 'PASS'
-      ? 'launchctl AGENTICOS_HOME matches the expected target'
-      : 'launchctl AGENTICOS_HOME does not match the expected target',
-    { launchctl_home: launchctlHome, expected_home: expectedHome },
+      ? 'launchctl AGENTICOS_HOME matches the workspace home'
+      : 'launchctl AGENTICOS_HOME does not match the workspace home',
+    { launchctl_home: launchctlHome, workspace_home: workspaceHome },
   );
 }
 
-const gitRoot = run('git', ['-C', sourceRoot, 'rev-parse', '--show-toplevel']);
-if (gitRoot.ok && gitRoot.stdout === sourceRoot) {
-  if (expectedHome && expectedHome === sourceRoot) {
+const workspaceHomeCollidesWithProductSource = workspaceHome
+  ? workspaceHome === productSourceRoot || workspaceHome.startsWith(`${productSourceRoot}/`)
+  : false;
+
+const gitRoot = run('git', ['-C', productSourceRoot, 'rev-parse', '--show-toplevel']);
+if (workspaceHomeCollidesWithProductSource) {
+  addCheck(
+    'product-source-git-role',
+    'BLOCK',
+    'the workspace home is the same path as, or nested inside, the product source root',
+    { product_source_root: productSourceRoot, workspace_home: workspaceHome, git_root: gitRoot.ok ? gitRoot.stdout : null },
+  );
+} else if (gitRoot.ok && gitRoot.stdout === productSourceRoot) {
+  if (workspaceHome) {
     addCheck(
-      'source-root-git-role',
-      'BLOCK',
-      'the expected workspace home is the same path as a Git repository root, so it is not yet a safe final workspace home',
-      { source_root: sourceRoot, expected_home: expectedHome },
+      'product-source-git-role',
+      'PASS',
+      'the product source root is a Git repository root and the workspace home is separate, so project source and workspace home are distinguishable',
+      { product_source_root: productSourceRoot, workspace_home: workspaceHome },
     );
   } else {
     addCheck(
-      'source-root-git-role',
+      'product-source-git-role',
       'PASS',
-      'the source root is a Git repository root, but the expected workspace home is separate so source pollution is avoidable',
-      { source_root: sourceRoot, expected_home: expectedHome },
+      'the product source root is a Git repository root',
+      { product_source_root: productSourceRoot },
     );
   }
 } else if (gitRoot.ok) {
   addCheck(
-    'source-root-git-role',
+    'product-source-git-role',
     'WARN',
-    'the target path is inside a Git repository but is not itself the repository root',
-    { source_root: sourceRoot, git_root: gitRoot.stdout },
+    'the product source root is inside a Git repository but is not itself the repository root',
+    { product_source_root: productSourceRoot, git_root: gitRoot.stdout, workspace_home: workspaceHome },
   );
 } else {
   addCheck(
-    'source-root-git-role',
+    'product-source-git-role',
     'PASS',
-    'the target path is not currently acting as a Git repository root',
-    { source_root: sourceRoot },
+    'the product source root is not currently acting as a Git repository root',
+    { product_source_root: productSourceRoot, workspace_home: workspaceHome },
   );
 }
 
@@ -257,8 +270,10 @@ const overall = checks.some((check) => check.status === 'BLOCK')
 
 const result = {
   overall,
-  source_root: sourceRoot,
-  expected_home: expectedHome,
+  product_source_root: productSourceRoot,
+  workspace_home: workspaceHome,
+  source_root: productSourceRoot,
+  expected_home: workspaceHome,
   checks,
 };
 

--- a/tools/verify-workspace-separation.sh
+++ b/tools/verify-workspace-separation.sh
@@ -2,38 +2,38 @@
 set -euo pipefail
 
 if [[ $# -lt 2 || $# -gt 3 ]]; then
-  echo "usage: $0 <source_root> <workspace_root> [project_id]" >&2
+  echo "usage: $0 <product_source_root> <workspace_home> [project_id]" >&2
   exit 2
 fi
 
-SOURCE_ROOT="$(cd "$1" && pwd)"
-WORKSPACE_ROOT="$(cd "$2" && pwd)"
+PRODUCT_SOURCE_ROOT="$(cd "$1" && pwd)"
+WORKSPACE_HOME="$(cd "$2" && pwd)"
 PROJECT_ID="${3:-agent-cli-api}"
 
-if [[ "$WORKSPACE_ROOT" == "$SOURCE_ROOT" || "$WORKSPACE_ROOT" == "$SOURCE_ROOT"/* ]]; then
-  echo "FAIL workspace root is inside source checkout" >&2
+if [[ "$WORKSPACE_HOME" == "$PRODUCT_SOURCE_ROOT" || "$WORKSPACE_HOME" == "$PRODUCT_SOURCE_ROOT"/* ]]; then
+  echo "FAIL workspace home is inside the product source root" >&2
   exit 1
 fi
 
-if [[ ! -f "$WORKSPACE_ROOT/.agent-workspace/registry.yaml" ]]; then
-  echo "FAIL missing workspace registry at $WORKSPACE_ROOT/.agent-workspace/registry.yaml" >&2
+if [[ ! -f "$WORKSPACE_HOME/.agent-workspace/registry.yaml" ]]; then
+  echo "FAIL missing workspace registry at $WORKSPACE_HOME/.agent-workspace/registry.yaml" >&2
   exit 1
 fi
 
-if [[ ! -d "$WORKSPACE_ROOT/projects" ]]; then
-  echo "FAIL missing workspace projects directory at $WORKSPACE_ROOT/projects" >&2
+if [[ ! -d "$WORKSPACE_HOME/projects" ]]; then
+  echo "FAIL missing workspace projects directory at $WORKSPACE_HOME/projects" >&2
   exit 1
 fi
 
 check_config_path() {
   local file="$1"
   if [[ -f "$file" ]]; then
-    if grep -Eq "AGENTICOS_HOME[\"[:space:]=:]*${SOURCE_ROOT//\//\\/}" "$file"; then
-      echo "FAIL AGENTICOS_HOME still points at source checkout: $file" >&2
+    if grep -Eq "AGENTICOS_HOME[\"[:space:]=:]*${PRODUCT_SOURCE_ROOT//\//\\/}" "$file"; then
+      echo "FAIL AGENTICOS_HOME still points at the product source root: $file" >&2
       exit 1
     fi
-    if ! grep -Eq "AGENTICOS_HOME[\"[:space:]=:]*${WORKSPACE_ROOT//\//\\/}" "$file"; then
-      echo "FAIL AGENTICOS_HOME does not point at workspace root: $file" >&2
+    if ! grep -Eq "AGENTICOS_HOME[\"[:space:]=:]*${WORKSPACE_HOME//\//\\/}" "$file"; then
+      echo "FAIL AGENTICOS_HOME does not point at the workspace home: $file" >&2
       exit 1
     fi
   fi
@@ -43,21 +43,21 @@ check_config_path "$HOME/.codex/config.toml"
 check_config_path "$HOME/.cursor/mcp.json"
 check_config_path "$HOME/.claude/settings.json"
 
-STATUS_BEFORE="$(git -C "$SOURCE_ROOT" status --short)"
+STATUS_BEFORE="$(git -C "$PRODUCT_SOURCE_ROOT" status --short)"
 
-WORKSPACE_ROOT="$WORKSPACE_ROOT" PROJECT_ID="$PROJECT_ID" node --input-type=module <<'NODE'
+WORKSPACE_HOME="$WORKSPACE_HOME" PROJECT_ID="$PROJECT_ID" node --input-type=module <<'NODE'
 import { spawn } from 'child_process';
 
-const workspaceRoot = process.env.WORKSPACE_ROOT;
+const workspaceHome = process.env.WORKSPACE_HOME;
 const projectId = process.env.PROJECT_ID;
 
-if (!workspaceRoot || !projectId) {
-  console.error('missing WORKSPACE_ROOT or PROJECT_ID');
+if (!workspaceHome || !projectId) {
+  console.error('missing WORKSPACE_HOME or PROJECT_ID');
   process.exit(1);
 }
 
 const server = spawn('agenticos-mcp', [], {
-  env: { ...process.env, AGENTICOS_HOME: workspaceRoot },
+  env: { ...process.env, AGENTICOS_HOME: workspaceHome },
   stdio: ['pipe', 'pipe', 'pipe'],
 });
 
@@ -110,6 +110,9 @@ server.stdout.on('data', (chunk) => {
     if (msg.id === 3) {
       const text = msg?.result?.content?.[0]?.text ?? '';
       if (!text.includes('Switched to project')) {
+        if (text.includes('source-control topology initialization')) {
+          fail(`FAIL project metadata incomplete for ${projectId}: ${text}`);
+        }
         fail(`agenticos_switch failed: ${text}`);
       }
       sendTool(4, 'agenticos_status');
@@ -148,10 +151,10 @@ server.stdin.write(JSON.stringify({
 setTimeout(() => fail('timed out waiting for agenticos-mcp responses'), 15000);
 NODE
 
-STATUS_AFTER="$(git -C "$SOURCE_ROOT" status --short)"
+STATUS_AFTER="$(git -C "$PRODUCT_SOURCE_ROOT" status --short)"
 
 if [[ "$STATUS_BEFORE" != "$STATUS_AFTER" ]]; then
-  echo "FAIL source checkout dirtiness changed during workspace verification" >&2
+  echo "FAIL product source dirtiness changed during workspace verification" >&2
   echo "--- before" >&2
   printf '%s\n' "$STATUS_BEFORE" >&2
   echo "--- after" >&2
@@ -159,4 +162,4 @@ if [[ "$STATUS_BEFORE" != "$STATUS_AFTER" ]]; then
   exit 1
 fi
 
-echo "OK workspace separation verified"
+echo "OK workspace home and project source separation verified"


### PR DESCRIPTION
## Summary

Normalizes the self-hosting workspace model across project metadata, operator docs, audit scripts, and current memory surfaces.

The corrected model is:
- `AGENTICOS_HOME` identifies the workspace home
- `projects/<id>` is the project root
- source-managed versus local-only is a per-project property
- `projects/agenticos` is the AgenticOS product source project
- `/opt/homebrew/var/agenticos` is a valid Homebrew example workspace path, not the normative target for this self-hosting machine

## What changed

- normalize `projects/agenticos/.project.yaml` with `source_control.topology=github_versioned`, `github_repo=madlouse/AgenticOS`, `branch_strategy=github_flow`, and truthful `execution.source_repo_roots`
- clarify `README.md` and `homebrew-tap/README.md` so `AGENTICOS_HOME` is described as any valid workspace home instead of implying one fixed path
- reframe the historical workspace-migration and runtime-extraction docs so external-workspace guidance is explicitly transitional, not the final model
- update `tools/audit-runtime-recovery.sh` to expose `--product-source-root` / `--workspace-home` terminology while preserving the old aliases
- update `tools/verify-workspace-separation.sh` to distinguish workspace-topology failures from incomplete project metadata
- refresh current compatibility state surfaces and append a correction record instead of rewriting old session history

## Verification

- `bash -n tools/audit-runtime-recovery.sh`
- `bash -n tools/verify-workspace-separation.sh`
- `tools/audit-runtime-recovery.sh --product-source-root /Users/jeking/dev/AgenticOS/projects/agenticos --workspace-home /Users/jeking/dev/AgenticOS`
- `tools/audit-runtime-recovery.sh --source-root /Users/jeking/dev/AgenticOS/projects/agenticos --expected-home /Users/jeking/dev/AgenticOS`
- `tools/verify-workspace-separation.sh /Users/jeking/dev/AgenticOS/worktrees/agenticos-235-workspace-topology-truth-repair /Users/jeking/dev/AgenticOS agent-cli-api`
- `tools/verify-workspace-separation.sh /Users/jeking/dev/AgenticOS/worktrees/agenticos-235-workspace-topology-truth-repair /Users/jeking/dev/AgenticOS agenticos`
  - now fails with the explicit class `FAIL project metadata incomplete for agenticos: ...` rather than a misleading workspace-topology error
- `agenticos_pr_scope_check` for issue `#235`

Closes #235
