### PR TITLE
chore(release): prepare v0.4.2 for #253

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No unreleased changes._
 
+## [0.4.2] — 2026-04-09
+
+### Fixed
+- Homebrew-installed runtime now includes the canonical context alignment
+  changes, so self-hosting AgenticOS surfaces honor configured
+  `agent_context` paths instead of rendering root `.context/*` as the primary
+  operational entry
+- generated `AGENTS.md` and `CLAUDE.md` adapter surfaces now ship with truthful
+  `standards/.context/*` navigation for the self-hosting product project
+
 ## [0.4.1] — 2026-04-07
 
 ### Fixed

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenticos-mcp",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenticos-mcp",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-mcp",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "MCP Server for AgenticOS - AI-native project management system",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- bump the packaged MCP runtime version from 0.4.1 to 0.4.2
- update package-lock metadata for the 0.4.2 release
- add changelog notes describing the installed-runtime relevance of canonical context alignment

## Verification
- `cd mcp-server && npm test`
- `cd mcp-server && npm pack`
