### PR TITLE
fix(homebrew-tap): sync formula to v0.4.2 asset (#253)

### DIFF
--- a/homebrew-tap/Formula/agenticos.rb
+++ b/homebrew-tap/Formula/agenticos.rb
@@ -3,10 +3,10 @@ require "language/node"
 class Agenticos < Formula
   desc "AI-native project management MCP server for Claude Code, Codex, Cursor, and Gemini CLI"
   homepage "https://github.com/madlouse/AgenticOS"
-  url "https://github.com/madlouse/AgenticOS/releases/download/v0.4.1/agenticos-mcp.tgz"
-  sha256 "70c1edf028bef71117ad841d87724806e147dad45926bdc65e917de9bec8bed6"
+  url "https://github.com/madlouse/AgenticOS/releases/download/v0.4.2/agenticos-mcp.tgz"
+  sha256 "9ccc0051cbf11ec4731d57c3765cb548e092a344520bc733e89d149a7ad27cc8"
   license "MIT"
-  version "0.4.1"
+  version "0.4.2"
 
   depends_on "node"
 


### PR DESCRIPTION
## Summary
- sync the product mirror Homebrew formula to the published v0.4.2 release asset
- use the GitHub release tarball SHA256 instead of the stale v0.4.1 checksum
- keep the mirror formula aligned with the live tap after the runtime reinstall verification

## Testing
- brew reinstall madlouse/agenticos/agenticos
- /opt/homebrew/bin/agenticos-mcp --version
- node -p "require('/opt/homebrew/opt/agenticos/libexec/lib/node_modules/agenticos-mcp/package.json').version"
- direct runtime verification that refreshEntrySurfaces writes to standards/.context/*