### PR TITLE
feat(mcp-server): canonicalize issue bootstrap boundary (#233)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- agenticos-template: v8 -->
+<!-- agenticos-template: v9 -->
 # AGENTS.md — AgenticOS
 
 ## Adapter Role
@@ -25,9 +25,11 @@ It must expose the same canonical policy as other agent adapters rather than def
 
 Implementation work must use the executable guardrail flow:
 
-1. call `agenticos_preflight` before editing
-2. if preflight returns `REDIRECT`, call `agenticos_branch_bootstrap`
-3. do not submit a PR before running `agenticos_pr_scope_check`
+1. call `agenticos_preflight`; if it returns `REDIRECT`, call `agenticos_branch_bootstrap` and continue in the returned worktree
+2. after the issue worktree is active, perform the normal startup load and record `agenticos_issue_bootstrap`
+3. rerun `agenticos_preflight` in that worktree before editing
+4. use `agenticos_edit_guard` immediately before implementation edits
+5. do not submit a PR before running `agenticos_pr_scope_check`
 
 If any guardrail returns `BLOCK`, stop and resolve the blocking reason first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- agenticos-template: v7 -->
+<!-- agenticos-template: v9 -->
 # CLAUDE.md — AgenticOS
 
 ## Adapter Role
@@ -25,9 +25,11 @@ It must expose the same canonical policy as other agent adapters while allowing 
 
 For implementation-affecting work:
 
-1. call `agenticos_preflight` before editing
-2. if the result is `REDIRECT`, call `agenticos_branch_bootstrap` and continue in the returned worktree
-3. before PR creation or merge, call `agenticos_pr_scope_check`
+1. call `agenticos_preflight`; if the result is `REDIRECT`, call `agenticos_branch_bootstrap` and continue in the returned worktree
+2. after the issue worktree is active, perform the normal startup load and record `agenticos_issue_bootstrap`
+3. rerun `agenticos_preflight` in that worktree before editing
+4. call `agenticos_edit_guard` immediately before implementation edits
+5. before PR creation or merge, call `agenticos_pr_scope_check`
 
 If any guardrail command returns `BLOCK`, stop and resolve the blocking reason before continuing.
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -26,7 +26,7 @@ Use `agenticos-bootstrap --verify` to audit the selected agents and optional per
 After any local upgrade, reinstall, or source rebuild of `agenticos-mcp`, restart the current AI client before assuming its MCP tools reflect the new server behavior.
 MCP registration can be correct while the live client session is still holding an older server process.
 
-When the client supports a pre-edit hook or local command wrapper, point that layer at `agenticos-edit-guard` so implementation edits fail closed unless project alignment and matching PASS preflight evidence already exist.
+When the client supports a pre-edit hook or local command wrapper, point that layer at `agenticos-edit-guard` so implementation edits fail closed unless project alignment, matching issue bootstrap evidence, and matching PASS preflight evidence already exist.
 
 For stop-event reminders, prefer `agenticos-record-reminder`.
 The old root `tools/check-edit-boundary.sh` and `tools/record-reminder.sh` paths should now be treated as legacy compatibility shims.
@@ -171,6 +171,22 @@ AgenticOS does not treat every fallback as equal:
 
 ---
 
+## Guardrail Flow
+
+Implementation-affecting work uses one canonical issue-start chain:
+
+1. call `agenticos_preflight`
+2. if it returns `REDIRECT`, call `agenticos_branch_bootstrap` and continue in the returned worktree
+3. after entering that worktree, perform the normal startup context load and record `agenticos_issue_bootstrap`
+4. rerun `agenticos_preflight` in the active issue worktree
+5. call `agenticos_edit_guard` immediately before implementation edits
+6. call `agenticos_pr_scope_check` before PR creation or merge
+
+`agenticos_issue_bootstrap` is the canonical issue-intake boundary for implementation-affecting work.
+It proves the current issue packet, startup surfaces, and issue-bound repo/worktree before downstream guardrails continue.
+
+---
+
 ## 🛠️ Tools Reference
 
 ### agenticos_init
@@ -227,8 +243,22 @@ Show the status of the active project.
 
 **Returns**: Current task, pending items, and recent decisions
 
+### agenticos_issue_bootstrap
+Record canonical issue-start evidence for the current issue after the intended issue worktree is active and the normal startup load has completed.
+
+**Parameters**:
+- `issue_id` (required)
+- `issue_title` (required)
+- `repo_path` (required)
+- `context_reset_performed` (required)
+- `project_hot_load_performed` (required)
+- `issue_payload_attached` (required)
+- `project_path` (optional, but recommended when `repo_path` is a larger checkout or worktree)
+
+**Returns**: JSON with `RECORDED` or `BLOCK`
+
 ### agenticos_preflight
-Run machine-checkable guardrail preflight before implementation or PR creation.
+Run machine-checkable guardrail preflight after issue bootstrap and before implementation or PR creation.
 
 **Parameters**:
 - `task_type` (required)
@@ -240,7 +270,7 @@ Run machine-checkable guardrail preflight before implementation or PR creation.
 **Returns**: JSON with `PASS`, `BLOCK`, or `REDIRECT`
 
 ### agenticos_edit_guard
-Fail closed before implementation-affecting edits unless the active project and latest persisted preflight evidence already match the intended edit.
+Fail closed before implementation-affecting edits unless the active project, latest issue bootstrap evidence, and latest persisted PASS preflight evidence already match the intended edit.
 
 **Parameters**:
 - `repo_path` (required)

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -162,7 +162,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     },
     {
       name: 'agenticos_edit_guard',
-      description: 'Fail closed before implementation-affecting edits unless active-project alignment and matching PASS preflight evidence already exist.',
+      description: 'Fail closed before implementation-affecting edits unless active-project alignment, matching issue bootstrap evidence, and matching PASS preflight evidence already exist.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -185,7 +185,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     },
     {
       name: 'agenticos_issue_bootstrap',
-      description: 'Record explicit issue-start bootstrap evidence for the current issue after a clear-equivalent reset and normal project hot-load.',
+      description: 'Record canonical issue-start evidence for the current issue after entering the intended branch/worktree, performing a clear-equivalent reset, and loading normal startup context.',
       inputSchema: {
         type: 'object',
         properties: {

--- a/mcp-server/src/tools/__tests__/edit-guard.test.ts
+++ b/mcp-server/src/tools/__tests__/edit-guard.test.ts
@@ -66,11 +66,21 @@ describe('runEditGuard', () => {
       if (cmd.includes('rev-parse --git-common-dir')) {
         return { stdout: '.git\n', stderr: '' };
       }
+      if (cmd.includes('rev-parse --abbrev-ref HEAD')) {
+        return { stdout: 'feat/113-fail-closed-edit-boundaries\n', stderr: '' };
+      }
       throw new Error(`Unexpected command: ${cmd}`);
     });
     readFileMock.mockImplementation(async (path: string) => {
       if (path.endsWith('/.context/state.yaml')) {
         return JSON.stringify({
+          issue_bootstrap: {
+            latest: {
+              issue_id: '113',
+              repo_path: '/workspace/source',
+              current_branch: 'feat/113-fail-closed-edit-boundaries',
+            },
+          },
           guardrail_evidence: {
             preflight: {
               issue_id: '113',
@@ -133,7 +143,15 @@ describe('runEditGuard', () => {
   it('blocks when no preflight evidence is recorded', async () => {
     readFileMock.mockImplementation(async (path: string) => {
       if (path.endsWith('/.context/state.yaml')) {
-        return JSON.stringify({});
+        return JSON.stringify({
+          issue_bootstrap: {
+            latest: {
+              issue_id: '113',
+              repo_path: '/workspace/source',
+              current_branch: 'feat/113-fail-closed-edit-boundaries',
+            },
+          },
+        });
       }
 
       throw new Error(`Unexpected path: ${path}`);
@@ -151,6 +169,85 @@ describe('runEditGuard', () => {
 
     expect(result.status).toBe('BLOCK');
     expect(result.block_reasons.join(' ')).toContain('no preflight evidence');
+  });
+
+  it('blocks when no issue bootstrap evidence is recorded', async () => {
+    readFileMock.mockImplementation(async (path: string) => {
+      if (path.endsWith('/.context/state.yaml')) {
+        return JSON.stringify({
+          guardrail_evidence: {
+            preflight: {
+              issue_id: '113',
+              repo_path: '/workspace/source',
+              declared_target_files: [
+                'projects/agenticos/mcp-server/src/index.ts',
+              ],
+              result: {
+                status: 'PASS',
+              },
+            },
+          },
+        });
+      }
+
+      throw new Error(`Unexpected path: ${path}`);
+    });
+
+    const result = JSON.parse(await runEditGuard({
+      issue_id: '113',
+      task_type: 'implementation',
+      repo_path: '/workspace/source',
+      project_path: '/workspace/projects/agenticos/standards',
+      declared_target_files: [
+        'projects/agenticos/mcp-server/src/index.ts',
+      ],
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons.join(' ')).toContain('no issue bootstrap evidence');
+  });
+
+  it('blocks when the latest issue bootstrap does not match the requested issue', async () => {
+    readFileMock.mockImplementation(async (path: string) => {
+      if (path.endsWith('/.context/state.yaml')) {
+        return JSON.stringify({
+          issue_bootstrap: {
+            latest: {
+              issue_id: '179',
+              repo_path: '/workspace/source',
+              current_branch: 'feat/113-fail-closed-edit-boundaries',
+            },
+          },
+          guardrail_evidence: {
+            preflight: {
+              issue_id: '113',
+              repo_path: '/workspace/source',
+              declared_target_files: [
+                'projects/agenticos/mcp-server/src/index.ts',
+              ],
+              result: {
+                status: 'PASS',
+              },
+            },
+          },
+        });
+      }
+
+      throw new Error(`Unexpected path: ${path}`);
+    });
+
+    const result = JSON.parse(await runEditGuard({
+      issue_id: '113',
+      task_type: 'implementation',
+      repo_path: '/workspace/source',
+      project_path: '/workspace/projects/agenticos/standards',
+      declared_target_files: [
+        'projects/agenticos/mcp-server/src/index.ts',
+      ],
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons.join(' ')).toContain('latest issue bootstrap issue');
   });
 
   it('blocks when attempted targets exceed the preflight-declared scope', async () => {
@@ -176,6 +273,9 @@ describe('runEditGuard', () => {
       }
       if (cmd.includes('rev-parse --git-common-dir')) {
         return { stdout: '.git\n', stderr: '' };
+      }
+      if (cmd.includes('rev-parse --abbrev-ref HEAD')) {
+        return { stdout: 'fix/113-wrong-repo\n', stderr: '' };
       }
       throw new Error(`Unexpected command: ${cmd}`);
     });

--- a/mcp-server/src/tools/__tests__/standard-kit.test.ts
+++ b/mcp-server/src/tools/__tests__/standard-kit.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import yaml from 'yaml';
 import { runStandardKitAdopt, runStandardKitConformanceCheck, runStandardKitUpgradeCheck } from '../standard-kit.js';
-import { generateAgentsMd } from '../../utils/distill.js';
+import { CURRENT_TEMPLATE_VERSION, generateAgentsMd } from '../../utils/distill.js';
 
 async function writeRegistry(home: string, registry: unknown): Promise<void> {
   await mkdir(join(home, '.agent-workspace'), { recursive: true });
@@ -241,8 +241,8 @@ describe('standard kit commands', () => {
 
     const agentsMd = await readFile(join(projectRoot, 'AGENTS.md'), 'utf-8');
     const claudeMd = await readFile(join(projectRoot, 'CLAUDE.md'), 'utf-8');
-    expect(agentsMd).toContain('agenticos-template: v8');
-    expect(claudeMd).toContain('agenticos-template: v8');
+    expect(agentsMd).toContain(`agenticos-template: v${CURRENT_TEMPLATE_VERSION}`);
+    expect(claudeMd).toContain(`agenticos-template: v${CURRENT_TEMPLATE_VERSION}`);
     expect(agentsMd).toContain('## Task Intake Rule');
     expect(claudeMd).toContain('recover operator intent');
   });
@@ -314,7 +314,7 @@ describe('standard kit commands', () => {
     expect(result.created_files).toContain('.project.yaml');
 
     const claudeMd = await readFile(join(projectRoot, 'CLAUDE.md'), 'utf-8');
-    expect(claudeMd).toContain('agenticos-template: v8');
+    expect(claudeMd).toContain(`agenticos-template: v${CURRENT_TEMPLATE_VERSION}`);
     expect(claudeMd).toContain('custom dna');
     expect(claudeMd).toContain('## Current State');
   });
@@ -324,7 +324,7 @@ describe('standard kit commands', () => {
     process.env.AGENTICOS_HOME = home;
 
     await writeFile(join(projectRoot, 'AGENTS.md'), generateAgentsMd('Sample Project', ''), 'utf-8');
-    await writeFile(join(projectRoot, 'CLAUDE.md'), '<!-- agenticos-template: v8 -->\ncurrent claude\n', 'utf-8');
+    await writeFile(join(projectRoot, 'CLAUDE.md'), `<!-- agenticos-template: v${CURRENT_TEMPLATE_VERSION} -->\ncurrent claude\n`, 'utf-8');
 
     const result = JSON.parse(await runStandardKitUpgradeCheck({ project_path: projectRoot })) as {
       generated_files: Array<{ path: string; status: string; current_version: number | null }>;
@@ -332,11 +332,11 @@ describe('standard kit commands', () => {
 
     expect(result.generated_files.find((item) => item.path === 'AGENTS.md')).toMatchObject({
       status: 'current',
-      current_version: 8,
+      current_version: CURRENT_TEMPLATE_VERSION,
     });
     expect(result.generated_files.find((item) => item.path === 'CLAUDE.md')).toMatchObject({
       status: 'current',
-      current_version: 8,
+      current_version: CURRENT_TEMPLATE_VERSION,
     });
   });
 
@@ -499,7 +499,7 @@ describe('standard kit commands', () => {
 
     expect(result.upgraded_generated_files).toContain('AGENTS.md');
     const agentsMd = await readFile(join(projectRoot, 'AGENTS.md'), 'utf-8');
-    expect(agentsMd).toContain('agenticos-template: v8');
+    expect(agentsMd).toContain(`agenticos-template: v${CURRENT_TEMPLATE_VERSION}`);
     expect(agentsMd).toContain('Guardrail Protocol');
   });
 

--- a/mcp-server/src/tools/edit-guard.ts
+++ b/mcp-server/src/tools/edit-guard.ts
@@ -3,6 +3,7 @@ import { exec } from 'child_process';
 import { dirname, resolve } from 'path';
 import { promisify } from 'util';
 import yaml from 'yaml';
+import { extractLatestIssueBootstrap } from '../utils/guardrail-evidence.js';
 import {
   isImplementationAffectingTask,
   resolveGuardrailProjectTarget,
@@ -41,6 +42,10 @@ interface EditGuardResult {
     active_project: string | null;
     git_worktree_root: string | null;
     git_common_repo_root: string | null;
+    current_branch: string | null;
+    issue_bootstrap_issue_id: string | null;
+    issue_bootstrap_repo_path: string | null;
+    issue_bootstrap_branch: string | null;
     preflight_issue_id: string | null;
     preflight_repo_path: string | null;
     preflight_status: string | null;
@@ -83,6 +88,10 @@ export async function runEditGuard(args: EditGuardArgs): Promise<string> {
       active_project: null,
       git_worktree_root: null,
       git_common_repo_root: null,
+      current_branch: null,
+      issue_bootstrap_issue_id: null,
+      issue_bootstrap_repo_path: null,
+      issue_bootstrap_branch: null,
       preflight_issue_id: null,
       preflight_repo_path: null,
       preflight_status: null,
@@ -139,6 +148,7 @@ export async function runEditGuard(args: EditGuardArgs): Promise<string> {
       const gitWorktreeRoot = await runGit(repo_path, 'rev-parse --show-toplevel');
       const gitCommonDir = resolve(gitWorktreeRoot, await runGit(repo_path, 'rev-parse --git-common-dir'));
       const gitCommonRepoRoot = dirname(gitCommonDir);
+      result.evidence.current_branch = await runGit(repo_path, 'rev-parse --abbrev-ref HEAD');
       result.evidence.git_worktree_root = gitWorktreeRoot;
       result.evidence.git_common_repo_root = gitCommonRepoRoot;
 
@@ -174,10 +184,39 @@ export async function runEditGuard(args: EditGuardArgs): Promise<string> {
     }
   }
 
+  const latestBootstrap = extractLatestIssueBootstrap(state);
+  if (!latestBootstrap) {
+    result.block_reasons.push('no issue bootstrap evidence is recorded for the target project');
+    result.recovery_actions.push('record agenticos_issue_bootstrap for the current issue before rerunning preflight');
+  } else {
+    result.evidence.issue_bootstrap_issue_id = typeof latestBootstrap.issue_id === 'string' ? latestBootstrap.issue_id : null;
+    result.evidence.issue_bootstrap_repo_path = typeof latestBootstrap.repo_path === 'string' ? latestBootstrap.repo_path : null;
+    result.evidence.issue_bootstrap_branch = typeof latestBootstrap.current_branch === 'string' ? latestBootstrap.current_branch : null;
+
+    if (issue_id && latestBootstrap.issue_id !== issue_id) {
+      result.block_reasons.push(
+        `latest issue bootstrap issue "${latestBootstrap.issue_id || 'unknown'}" does not match requested issue "${issue_id}"`,
+      );
+      result.recovery_actions.push(`record agenticos_issue_bootstrap for issue #${issue_id} before rerunning preflight`);
+    }
+
+    if (repo_path && resolve(latestBootstrap.repo_path || '') !== resolve(repo_path)) {
+      result.block_reasons.push('latest issue bootstrap was recorded for a different repo_path');
+      result.recovery_actions.push('record agenticos_issue_bootstrap for the current repo_path before rerunning preflight');
+    }
+
+    if (result.evidence.current_branch && latestBootstrap.current_branch && latestBootstrap.current_branch !== result.evidence.current_branch) {
+      result.block_reasons.push(
+        `latest issue bootstrap branch "${latestBootstrap.current_branch}" does not match current branch "${result.evidence.current_branch}"`,
+      );
+      result.recovery_actions.push('record agenticos_issue_bootstrap again after entering the current issue branch/worktree');
+    }
+  }
+
   const preflight = state?.guardrail_evidence?.preflight;
   if (!preflight) {
     result.block_reasons.push('no preflight evidence is recorded for the target project');
-    result.recovery_actions.push('run agenticos_preflight and get PASS before implementation edits');
+    result.recovery_actions.push('run agenticos_preflight and get PASS after issue bootstrap before implementation edits');
   } else {
     result.evidence.preflight_issue_id = typeof preflight.issue_id === 'string' ? preflight.issue_id : null;
     result.evidence.preflight_repo_path = typeof preflight.repo_path === 'string' ? preflight.repo_path : null;
@@ -200,7 +239,7 @@ export async function runEditGuard(args: EditGuardArgs): Promise<string> {
 
     if (preflight?.result?.status !== 'PASS') {
       result.block_reasons.push(`latest preflight status is ${preflight?.result?.status || 'unknown'} instead of PASS`);
-      result.recovery_actions.push('resolve the latest preflight outcome and rerun until it returns PASS');
+      result.recovery_actions.push('resolve the latest preflight outcome and rerun it after issue bootstrap until it returns PASS');
     } else {
       result.preflight_ok = true;
     }

--- a/mcp-server/src/utils/__tests__/distill.test.ts
+++ b/mcp-server/src/utils/__tests__/distill.test.ts
@@ -19,8 +19,8 @@ describe('distill templates', () => {
   it('generates AGENTS.md with the current template marker, adapter role, and guardrail flow', () => {
     const content = generateAgentsMd('Demo Project', 'Guardrail test');
 
-    expect(CURRENT_TEMPLATE_VERSION).toBe(8);
-    expect(content).toContain('<!-- agenticos-template: v8 -->');
+    expect(CURRENT_TEMPLATE_VERSION).toBe(9);
+    expect(content).toContain('<!-- agenticos-template: v9 -->');
     expect(content).toContain('## Adapter Role');
     expect(content).toContain(AGENTS_ADAPTER_LINES[0]);
     expect(content).toContain(AGENTS_ADAPTER_LINES[1]);
@@ -38,6 +38,8 @@ describe('distill templates', () => {
     }
     expect(content).toContain('## Guardrail Protocol (MANDATORY)');
     expect(content).toContain('agenticos_preflight');
+    expect(content).toContain('agenticos_issue_bootstrap');
+    expect(content).toContain('agenticos_edit_guard');
     expect(content).toContain('agenticos_branch_bootstrap');
     expect(content).toContain('agenticos_pr_scope_check');
     expect(content).toContain('.context/quick-start.md');
@@ -65,6 +67,8 @@ describe('distill templates', () => {
     }
     expect(content).toContain('## Guardrail Protocol (MANDATORY)');
     expect(content).toContain('agenticos_preflight');
+    expect(content).toContain('agenticos_issue_bootstrap');
+    expect(content).toContain('agenticos_edit_guard');
     expect(content).toContain('agenticos_branch_bootstrap');
     expect(content).toContain('agenticos_pr_scope_check');
     expect(content).toContain('.context/quick-start.md');

--- a/mcp-server/src/utils/distill.ts
+++ b/mcp-server/src/utils/distill.ts
@@ -6,7 +6,7 @@ import { joinDisplayPath, type ManagedProjectContextDisplayPaths } from './agent
  * Current template version. Increment when templates change.
  * Used for auto-upgrade on project switch.
  */
-export const CURRENT_TEMPLATE_VERSION = 8;
+export const CURRENT_TEMPLATE_VERSION = 9;
 
 /** Version marker format in generated files */
 const VERSION_MARKER = `<!-- agenticos-template: v${CURRENT_TEMPLATE_VERSION} -->`;
@@ -125,9 +125,11 @@ ${renderSharedPolicySection()}${renderRuntimeGuidanceSection(AGENTS_RUNTIME_GUID
 
 Implementation work must use the executable guardrail flow:
 
-1. call \`agenticos_preflight\` before editing
-2. if preflight returns \`REDIRECT\`, call \`agenticos_branch_bootstrap\`
-3. do not submit a PR before running \`agenticos_pr_scope_check\`
+1. call \`agenticos_preflight\`; if it returns \`REDIRECT\`, call \`agenticos_branch_bootstrap\` and continue in the returned worktree
+2. after the issue worktree is active, perform the normal startup load and record \`agenticos_issue_bootstrap\`
+3. rerun \`agenticos_preflight\` in that worktree before editing
+4. use \`agenticos_edit_guard\` immediately before implementation edits
+5. do not submit a PR before running \`agenticos_pr_scope_check\`
 
 If any guardrail returns \`BLOCK\`, stop and resolve the blocking reason first.
 
@@ -275,9 +277,11 @@ ${renderSharedPolicySection()}${renderRuntimeGuidanceSection(CLAUDE_RUNTIME_GUID
 
 For implementation-affecting work:
 
-1. call \`agenticos_preflight\` before editing
-2. if the result is \`REDIRECT\`, call \`agenticos_branch_bootstrap\` and continue in the returned worktree
-3. before PR creation or merge, call \`agenticos_pr_scope_check\`
+1. call \`agenticos_preflight\`; if the result is \`REDIRECT\`, call \`agenticos_branch_bootstrap\` and continue in the returned worktree
+2. after the issue worktree is active, perform the normal startup load and record \`agenticos_issue_bootstrap\`
+3. rerun \`agenticos_preflight\` in that worktree before editing
+4. call \`agenticos_edit_guard\` immediately before implementation edits
+5. before PR creation or merge, call \`agenticos_pr_scope_check\`
 
 If any guardrail command returns \`BLOCK\`, stop and resolve the blocking reason before continuing.
 


### PR DESCRIPTION
## Summary
- make edit guard consume latest issue bootstrap evidence instead of trusting preflight alone
- align tool descriptions and generated adapter guidance around the canonical issue-start chain
- document `agenticos_issue_bootstrap` as the canonical issue-intake boundary for implementation work

## Testing
- cd mcp-server && npm test -- --run src/tools/__tests__/edit-guard.test.ts src/utils/__tests__/distill.test.ts src/tools/__tests__/preflight.test.ts
- cd mcp-server && npm run lint
