### PR TITLE
feat: harden bootstrap and session-start guardrails (#232)

### DIFF
--- a/.meta/bootstrap/agent-adapter-matrix.yaml
+++ b/.meta/bootstrap/agent-adapter-matrix.yaml
@@ -10,6 +10,9 @@ adapters:
       - '## Claude Runtime Notes'
       - 'Claude CLI-managed user MCP config'
       - 'optional local stop-hook reminders'
+      - '`agenticos_status`'
+      - '`agenticos_switch`'
+      - '`agenticos_issue_bootstrap`'
   - agent_id: codex
     support_tier: official
     adapter_file: AGENTS.md
@@ -19,6 +22,9 @@ adapters:
       - '## Codex / Generic Runtime Notes'
       - 'use explicit `agenticos_*` tool calls'
       - 'Bootstrap differences are runtime concerns'
+      - '`agenticos_status`'
+      - '`agenticos_switch`'
+      - '`agenticos_issue_bootstrap`'
   - agent_id: cursor
     support_tier: official
     adapter_file: AGENTS.md
@@ -28,6 +34,9 @@ adapters:
       - '## Codex / Generic Runtime Notes'
       - 'use explicit `agenticos_*` tool calls'
       - 'Bootstrap differences are runtime concerns'
+      - '`agenticos_status`'
+      - '`agenticos_switch`'
+      - '`agenticos_issue_bootstrap`'
   - agent_id: gemini-cli
     support_tier: official
     adapter_file: AGENTS.md
@@ -37,3 +46,6 @@ adapters:
       - '## Codex / Generic Runtime Notes'
       - 'use explicit `agenticos_*` tool calls'
       - 'Bootstrap differences are runtime concerns'
+      - '`agenticos_status`'
+      - '`agenticos_switch`'
+      - '`agenticos_issue_bootstrap`'

--- a/.meta/bootstrap/agent-bootstrap-matrix.yaml
+++ b/.meta/bootstrap/agent-bootstrap-matrix.yaml
@@ -7,6 +7,12 @@ verification_contract:
   automation_rationale:
     - official MCP registrations live in agent-owned user config outside AGENTICOS_HOME
     - agenticos_health remains repo/project scoped and does not rewrite per-agent MCP settings
+  session_start_sequence:
+    - call `agenticos_status` before meaningful work
+    - if the active project is missing or wrong, call `agenticos_switch`
+    - load the project's startup surfaces
+    - review the latest guardrail evidence and latest `agenticos_issue_bootstrap` record before implementation-affecting work
+    - if implementation work is requested, enter the canonical issue-start chain
 supported_agents:
   - id: claude-code
     label: Claude Code

--- a/.meta/bootstrap/cross-agent-execution-contract.yaml
+++ b/.meta/bootstrap/cross-agent-execution-contract.yaml
@@ -9,8 +9,12 @@ summary: >
 policy_invariants:
   - id: active_project_alignment
     summary: Implementation work must align to the intended active project before edits begin.
+  - id: session_start_alignment
+    summary: Session start must verify active-project alignment and current status before meaningful work begins.
   - id: issue_first_execution
     summary: Implementation work must start from an issue-scoped task rather than ad hoc mutation.
+  - id: issue_bootstrap_entry
+    summary: Implementation work must record canonical issue bootstrap evidence after issue worktree startup load and before further guardrails continue.
   - id: implementation_preflight
     summary: Implementation-affecting work must pass executable preflight before editing.
   - id: isolated_worktree_execution

--- a/.meta/standard-kit/manifest.yaml
+++ b/.meta/standard-kit/manifest.yaml
@@ -100,8 +100,8 @@ layers:
 
 upgrade_rules:
   template_marker_version:
-    AGENTS.md: 7
-    CLAUDE.md: 7
+    AGENTS.md: 10
+    CLAUDE.md: 10
   compatibility_rule: >
     Generated files may be upgraded in place by distill when the template marker version changes.
   copied_template_rule: >
@@ -123,6 +123,7 @@ adoption:
     - operator_intent_resolution
     - memory_layer_contracts
     - cross_agent_policy_contract
+    - session_start_alignment
     - implementation_preflight
     - issue_first_branching
     - isolated_worktree_execution

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- agenticos-template: v9 -->
+<!-- agenticos-template: v10 -->
 # AGENTS.md — AgenticOS
 
 ## Adapter Role
@@ -22,6 +22,8 @@ It must expose the same canonical policy as other agent adapters rather than def
 - Separate goals, hard constraints, useful signals, and candidate methods before choosing an execution path.
 - Once intent is resolved, collapse it into a clean execution objective instead of carrying the full intake rubric through every later step.
 ## Guardrail Protocol (MANDATORY)
+
+Before implementation edits, confirm project alignment with `agenticos_status`; if the active project is missing or wrong, call `agenticos_switch`.
 
 Implementation work must use the executable guardrail flow:
 
@@ -56,11 +58,12 @@ After recording, call `agenticos_save` to commit to Git.
 
 ### Session Start
 
-On session start, read these files for context:
-1. `.project.yaml` — Project metadata
-2. `standards/.context/quick-start.md` — human-readable project summary
-3. `standards/.context/state.yaml` — Current state and working memory
-4. `standards/.context/conversations/` — Previous session records
+On session start, align the runtime before meaningful work:
+1. call `agenticos_status` to confirm the active project, current task, pending work, and latest recorded state
+2. if the active project is missing or not `AgenticOS`, call `agenticos_switch`
+3. read `.project.yaml`, `standards/.context/quick-start.md`, `standards/.context/state.yaml`, and `standards/.context/conversations/`
+4. review the latest guardrail evidence and latest `agenticos_issue_bootstrap` record before implementation-affecting work
+5. if implementation work is requested, follow the Guardrail Protocol above exactly before editing
 
 Then greet the user with: project name, last progress, current pending items, suggested next step.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- agenticos-template: v9 -->
+<!-- agenticos-template: v10 -->
 # CLAUDE.md — AgenticOS
 
 ## Adapter Role
@@ -22,6 +22,8 @@ It must expose the same canonical policy as other agent adapters while allowing 
 - Separate goals, hard constraints, useful signals, and candidate methods before choosing an execution path.
 - Once intent is resolved, collapse it into a clean execution objective instead of carrying the full intake rubric through every later step.
 ## Guardrail Protocol (MANDATORY)
+
+Before implementation edits, confirm project alignment with `agenticos_status`; if the active project is missing or wrong, call `agenticos_switch`.
 
 For implementation-affecting work:
 
@@ -67,8 +69,11 @@ When the user signals session end (says goodbye, thanks, done, or stops respondi
 
 When you open this project in a new session, **immediately do the following**:
 
-1. Read the "Current State" section below
-2. Greet the user with a brief status report:
+1. Call `agenticos_status` to confirm the active project, current task, pending work, and latest recorded state
+2. If the active project is missing or not `AgenticOS`, call `agenticos_switch`
+3. Read `.project.yaml`, the "Current State" section below, `standards/.context/quick-start.md`, and `standards/.context/conversations/`
+4. Review the latest guardrail evidence and latest `agenticos_issue_bootstrap` record before implementation-affecting work
+5. Greet the user with a brief status report:
 
 ```
 📍 项目：AgenticOS
@@ -79,7 +84,8 @@ When you open this project in a new session, **immediately do the following**:
 继续上次的工作，还是有新的方向？
 ```
 
-3. Wait for the user's direction before proceeding
+6. If implementation work is requested, enter the Guardrail Protocol above before editing
+7. Wait for the user's direction before proceeding
 
 ---
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -171,6 +171,20 @@ AgenticOS does not treat every fallback as equal:
 
 ---
 
+## Session-Start Contract
+
+Every officially supported adapter must align the runtime before meaningful work begins:
+
+1. call `agenticos_status` to confirm the active project, current task, pending work, and latest recorded state
+2. if the active project is missing or wrong, call `agenticos_switch`
+3. load the project's startup surfaces (`.project.yaml`, quick-start, state, and session history)
+4. review the latest guardrail evidence and latest `agenticos_issue_bootstrap` record before implementation-affecting work
+5. if implementation work is requested, enter the canonical guardrail flow below
+
+This is canonical policy. Adapter-specific bootstrap notes must not replace it.
+
+---
+
 ## Guardrail Flow
 
 Implementation-affecting work uses one canonical issue-start chain:
@@ -220,6 +234,8 @@ Switch to existing project and load context.
 
 **Returns**: Loaded context (project config, quick-start, state)
 
+Use this when `agenticos_status` shows the active project is missing or not the intended project.
+
 The quick-start/state split is intentional:
 - `quick-start.md` is a concise entry surface
 - `state.yaml` is mutable operational state
@@ -242,6 +258,8 @@ Save state and backup to Git.
 Show the status of the active project.
 
 **Returns**: Current task, pending items, and recent decisions
+
+Call this first at session start to verify project alignment before meaningful work.
 
 ### agenticos_issue_bootstrap
 Record canonical issue-start evidence for the current issue after the intended issue worktree is active and the normal startup load has completed.

--- a/mcp-server/src/tools/__tests__/standard-kit.test.ts
+++ b/mcp-server/src/tools/__tests__/standard-kit.test.ts
@@ -74,6 +74,7 @@ async function setupKitHome(): Promise<{ home: string; projectRoot: string }> {
         'operator_intent_resolution',
         'memory_layer_contracts',
         'cross_agent_policy_contract',
+        'session_start_alignment',
         'implementation_preflight',
         'issue_first_branching',
         'isolated_worktree_execution',
@@ -100,6 +101,17 @@ async function setupKitHome(): Promise<{ home: string; projectRoot: string }> {
     yaml.stringify({
       version: 1,
       primary_integration_mode: 'mcp-native',
+      verification_contract: {
+        canonical_runtime_entrypoint: 'agenticos-mcp',
+        legacy_source_checkout_paths_unsupported: true,
+        automation_boundary: 'manual_agent_cli',
+        automation_rationale: ['agent-owned config'],
+        session_start_sequence: [
+          'call `agenticos_status` before meaningful work',
+          'if the active project is missing or wrong, call `agenticos_switch`',
+          'review the latest `agenticos_issue_bootstrap` record',
+        ],
+      },
       supported_agents: [
         {
           id: 'claude-code',
@@ -132,7 +144,11 @@ async function setupKitHome(): Promise<{ home: string; projectRoot: string }> {
     yaml.stringify({
       version: 1,
       contract_id: 'cross-agent-execution-contract',
-      policy_invariants: [{ id: 'issue_first_execution' }],
+      policy_invariants: [
+        { id: 'session_start_alignment' },
+        { id: 'issue_first_execution' },
+        { id: 'issue_bootstrap_entry' },
+      ],
       adapter_surfaces: [
         { id: 'codex-generic', generated_file: 'AGENTS.md' },
         { id: 'claude-code', generated_file: 'CLAUDE.md' },
@@ -156,6 +172,9 @@ async function setupKitHome(): Promise<{ home: string; projectRoot: string }> {
             '## Claude Runtime Notes',
             'Claude CLI-managed user MCP config',
             'optional local stop-hook reminders',
+            '`agenticos_status`',
+            '`agenticos_switch`',
+            '`agenticos_issue_bootstrap`',
           ],
         },
         {
@@ -168,6 +187,9 @@ async function setupKitHome(): Promise<{ home: string; projectRoot: string }> {
             '## Codex / Generic Runtime Notes',
             'use explicit `agenticos_*` tool calls',
             'Bootstrap differences are runtime concerns',
+            '`agenticos_status`',
+            '`agenticos_switch`',
+            '`agenticos_issue_bootstrap`',
           ],
         },
       ],

--- a/mcp-server/src/utils/__tests__/bootstrap-matrix.test.ts
+++ b/mcp-server/src/utils/__tests__/bootstrap-matrix.test.ts
@@ -23,6 +23,7 @@ async function setupBootstrapHome(): Promise<string> {
         legacy_source_checkout_paths_unsupported: true,
         automation_boundary: 'manual_agent_cli',
         automation_rationale: ['agent-owned config'],
+        session_start_sequence: ['call agenticos_status'],
       },
       supported_agents: [
         {
@@ -72,6 +73,7 @@ async function setupBootstrapHomeWithoutExperimental(): Promise<string> {
         legacy_source_checkout_paths_unsupported: true,
         automation_boundary: 'manual_agent_cli',
         automation_rationale: ['agent-owned config'],
+        session_start_sequence: ['call agenticos_status'],
       },
       supported_agents: [
         {
@@ -107,6 +109,7 @@ describe('bootstrap matrix', () => {
     expect(matrix.version).toBe(1);
     expect(matrix.primary_integration_mode).toBe('mcp-native');
     expect(matrix.verification_contract.canonical_runtime_entrypoint).toBe('agenticos-mcp');
+    expect(matrix.verification_contract.session_start_sequence).toContain('call agenticos_status');
     expect(matrix.supported_agents.map((agent) => agent.id)).toEqual(['claude-code']);
   });
 

--- a/mcp-server/src/utils/__tests__/distill.test.ts
+++ b/mcp-server/src/utils/__tests__/distill.test.ts
@@ -19,8 +19,8 @@ describe('distill templates', () => {
   it('generates AGENTS.md with the current template marker, adapter role, and guardrail flow', () => {
     const content = generateAgentsMd('Demo Project', 'Guardrail test');
 
-    expect(CURRENT_TEMPLATE_VERSION).toBe(9);
-    expect(content).toContain('<!-- agenticos-template: v9 -->');
+    expect(CURRENT_TEMPLATE_VERSION).toBe(10);
+    expect(content).toContain('<!-- agenticos-template: v10 -->');
     expect(content).toContain('## Adapter Role');
     expect(content).toContain(AGENTS_ADAPTER_LINES[0]);
     expect(content).toContain(AGENTS_ADAPTER_LINES[1]);
@@ -38,6 +38,8 @@ describe('distill templates', () => {
     }
     expect(content).toContain('## Guardrail Protocol (MANDATORY)');
     expect(content).toContain('agenticos_preflight');
+    expect(content).toContain('agenticos_status');
+    expect(content).toContain('agenticos_switch');
     expect(content).toContain('agenticos_issue_bootstrap');
     expect(content).toContain('agenticos_edit_guard');
     expect(content).toContain('agenticos_branch_bootstrap');
@@ -67,6 +69,8 @@ describe('distill templates', () => {
     }
     expect(content).toContain('## Guardrail Protocol (MANDATORY)');
     expect(content).toContain('agenticos_preflight');
+    expect(content).toContain('agenticos_status');
+    expect(content).toContain('agenticos_switch');
     expect(content).toContain('agenticos_issue_bootstrap');
     expect(content).toContain('agenticos_edit_guard');
     expect(content).toContain('agenticos_branch_bootstrap');

--- a/mcp-server/src/utils/bootstrap-matrix.ts
+++ b/mcp-server/src/utils/bootstrap-matrix.ts
@@ -23,6 +23,7 @@ export interface BootstrapVerificationContract {
   legacy_source_checkout_paths_unsupported: boolean;
   automation_boundary: string;
   automation_rationale: string[];
+  session_start_sequence?: string[];
 }
 
 export interface AgentBootstrapMatrix {

--- a/mcp-server/src/utils/distill.ts
+++ b/mcp-server/src/utils/distill.ts
@@ -6,7 +6,7 @@ import { joinDisplayPath, type ManagedProjectContextDisplayPaths } from './agent
  * Current template version. Increment when templates change.
  * Used for auto-upgrade on project switch.
  */
-export const CURRENT_TEMPLATE_VERSION = 9;
+export const CURRENT_TEMPLATE_VERSION = 10;
 
 /** Version marker format in generated files */
 const VERSION_MARKER = `<!-- agenticos-template: v${CURRENT_TEMPLATE_VERSION} -->`;
@@ -123,6 +123,8 @@ ${AGENTS_ADAPTER_LINES[1]}
 
 ${renderSharedPolicySection()}${renderRuntimeGuidanceSection(AGENTS_RUNTIME_GUIDANCE_TITLE, AGENTS_RUNTIME_GUIDANCE_BULLETS)}${renderRuntimeGuidanceSection(TASK_INTAKE_RULE_TITLE, TASK_INTAKE_RULE_BULLETS)}## Guardrail Protocol (MANDATORY)
 
+Before implementation edits, confirm project alignment with \`agenticos_status\`; if the active project is missing or wrong, call \`agenticos_switch\`.
+
 Implementation work must use the executable guardrail flow:
 
 1. call \`agenticos_preflight\`; if it returns \`REDIRECT\`, call \`agenticos_branch_bootstrap\` and continue in the returned worktree
@@ -156,11 +158,12 @@ After recording, call \`agenticos_save\` to commit to Git.
 
 ### Session Start
 
-On session start, read these files for context:
-1. \`.project.yaml\` — Project metadata
-2. \`${contextPaths.quickStartPath}\` — human-readable project summary
-3. \`${contextPaths.statePath}\` — Current state and working memory
-4. \`${contextPaths.conversationsDir}\` — Previous session records
+On session start, align the runtime before meaningful work:
+1. call \`agenticos_status\` to confirm the active project, current task, pending work, and latest recorded state
+2. if the active project is missing or not \`${name}\`, call \`agenticos_switch\`
+3. read \`.project.yaml\`, \`${contextPaths.quickStartPath}\`, \`${contextPaths.statePath}\`, and \`${contextPaths.conversationsDir}\`
+4. review the latest guardrail evidence and latest \`agenticos_issue_bootstrap\` record before implementation-affecting work
+5. if implementation work is requested, follow the Guardrail Protocol above exactly before editing
 
 Then greet the user with: project name, last progress, current pending items, suggested next step.
 
@@ -275,6 +278,8 @@ ${CLAUDE_ADAPTER_LINES[1]}
 
 ${renderSharedPolicySection()}${renderRuntimeGuidanceSection(CLAUDE_RUNTIME_GUIDANCE_TITLE, CLAUDE_RUNTIME_GUIDANCE_BULLETS)}${renderRuntimeGuidanceSection(TASK_INTAKE_RULE_TITLE, TASK_INTAKE_RULE_BULLETS)}## Guardrail Protocol (MANDATORY)
 
+Before implementation edits, confirm project alignment with \`agenticos_status\`; if the active project is missing or wrong, call \`agenticos_switch\`.
+
 For implementation-affecting work:
 
 1. call \`agenticos_preflight\`; if the result is \`REDIRECT\`, call \`agenticos_branch_bootstrap\` and continue in the returned worktree
@@ -319,8 +324,11 @@ When the user signals session end (says goodbye, thanks, done, or stops respondi
 
 When you open this project in a new session, **immediately do the following**:
 
-1. Read the "Current State" section below
-2. Greet the user with a brief status report:
+1. Call \`agenticos_status\` to confirm the active project, current task, pending work, and latest recorded state
+2. If the active project is missing or not \`${name}\`, call \`agenticos_switch\`
+3. Read \`.project.yaml\`, the "Current State" section below, \`${contextPaths.quickStartPath}\`, and \`${contextPaths.conversationsDir}\`
+4. Review the latest guardrail evidence and latest \`agenticos_issue_bootstrap\` record before implementation-affecting work
+5. Greet the user with a brief status report:
 
 \`\`\`
 📍 项目：${name}
@@ -331,7 +339,8 @@ When you open this project in a new session, **immediately do the following**:
 继续上次的工作，还是有新的方向？
 \`\`\`
 
-3. Wait for the user's direction before proceeding
+6. If implementation work is requested, enter the Guardrail Protocol above before editing
+7. Wait for the user's direction before proceeding
 
 ---
 

--- a/mcp-server/src/utils/standard-kit.ts
+++ b/mcp-server/src/utils/standard-kit.ts
@@ -451,6 +451,9 @@ export async function checkStandardKitConformance(args: { project_path?: string;
   const agentsMd = await readProjectFile(upgrade.project_path, 'AGENTS.md');
   const claudeMd = await readProjectFile(upgrade.project_path, 'CLAUDE.md');
   const designBrief = await readProjectFile(upgrade.project_path, 'tasks/templates/issue-design-brief.md');
+  const bootstrapMatrixSource = readFileSync(resolveAgenticOSProductPath('.meta', 'bootstrap', 'agent-bootstrap-matrix.yaml'), 'utf-8');
+  const adapterMatrixSource = readFileSync(resolveAgenticOSProductPath('.meta', 'bootstrap', 'agent-adapter-matrix.yaml'), 'utf-8');
+  const crossAgentContractSource = readFileSync(resolveAgenticOSProductPath('.meta', 'bootstrap', 'cross-agent-execution-contract.yaml'), 'utf-8');
   const officialAdapters = getOfficialAgentAdapters(await loadAgentAdapterMatrix());
 
   const behaviorChecks: ConformanceBehaviorStatus[] = [];
@@ -514,6 +517,28 @@ export async function checkStandardKitConformance(args: { project_path?: string;
             ? 'Generated adapter docs expose the shared cross-agent policy block.'
             : 'Generated adapter docs are missing the shared cross-agent policy block.',
           evidence_paths: ['AGENTS.md', 'CLAUDE.md'],
+        });
+        break;
+      }
+      case 'session_start_alignment': {
+        const pass = fileContainsAll(agentsMd, ['agenticos_status', 'agenticos_switch', 'agenticos_issue_bootstrap'])
+          && fileContainsAll(claudeMd, ['agenticos_status', 'agenticos_switch', 'agenticos_issue_bootstrap'])
+          && fileContainsAll(bootstrapMatrixSource, ['session_start_sequence', 'agenticos_status', 'agenticos_switch', 'agenticos_issue_bootstrap'])
+          && fileContainsAll(adapterMatrixSource, ['agenticos_status', 'agenticos_switch', 'agenticos_issue_bootstrap'])
+          && fileContainsAll(crossAgentContractSource, ['session_start_alignment', 'issue_bootstrap_entry']);
+        behaviorChecks.push({
+          behavior,
+          status: pass ? 'PASS' : 'FAIL',
+          summary: pass
+            ? 'Adapter surfaces and canonical bootstrap metadata preserve the session-start alignment and issue-bootstrap entry contract.'
+            : 'Session-start alignment or issue-bootstrap entry guidance is missing from adapter surfaces or canonical bootstrap metadata.',
+          evidence_paths: [
+            'AGENTS.md',
+            'CLAUDE.md',
+            join(toCanonicalProductRelativePath('projects/agenticos/.meta/bootstrap/agent-bootstrap-matrix.yaml')),
+            join(toCanonicalProductRelativePath('projects/agenticos/.meta/bootstrap/agent-adapter-matrix.yaml')),
+            join(toCanonicalProductRelativePath('projects/agenticos/.meta/bootstrap/cross-agent-execution-contract.yaml')),
+          ],
         });
         break;
       }


### PR DESCRIPTION
## Summary
- add a canonical session-start contract across generated adapters, bootstrap metadata, and README guidance
- require standard-kit conformance to verify session-start alignment and issue-bootstrap entry metadata
- bump generated template markers to v10 and extend tests for the new contract

## Testing
- npm test -- --run src/utils/__tests__/distill.test.ts src/utils/__tests__/bootstrap-matrix.test.ts src/tools/__tests__/standard-kit.test.ts
- npm test
- npm run lint

Closes #232