### PR TITLE
feat: define context publication policy contract (#246)

### DIFF
--- a/.meta/standard-kit/README.md
+++ b/.meta/standard-kit/README.md
@@ -14,6 +14,7 @@ This kit covers:
 - project-scoped agent instructions
 - execution templates
 - memory layer contracts
+- context publication policy
 - generated project files
 - versioning and upgrade rules
 
@@ -68,10 +69,20 @@ The contract distinguishes:
 - mutable vs append-only layers
 - operational state vs durable synthesis
 - project orientation vs raw session history
+- topology/source inclusion vs publication visibility
+
+`.project.yaml` also carries the canonical context publication policy field:
+
+- `local_private`
+- `private_continuity`
+- `public_distilled`
+
+That field determines whether raw session history is allowed in tracked source for the project class, rather than forcing later tools to guess from topology alone.
 
 The canonical rationale lives in:
 
 - `projects/agenticos/standards/knowledge/memory-layer-contract-spec-2026-03-25.md`
+- `projects/agenticos/standards/knowledge/context-publication-policy-2026-04-10.md`
 
 ## Sub-Agent Protocol
 

--- a/.meta/standard-kit/inheritance-rules.md
+++ b/.meta/standard-kit/inheritance-rules.md
@@ -18,6 +18,7 @@ Implication:
 - conversations stay append-only
 - knowledge stays synthesized
 - tasks stay future-facing
+- `.project.yaml` must also declare the context publication policy that governs whether raw conversation history is allowed in tracked source for the project class
 
 ## Rule 1: Generated Files vs Copied Templates
 

--- a/.meta/standard-kit/manifest.yaml
+++ b/.meta/standard-kit/manifest.yaml
@@ -122,6 +122,7 @@ adoption:
   required_behavior:
     - operator_intent_resolution
     - memory_layer_contracts
+    - context_publication_policy_contract
     - cross_agent_policy_contract
     - session_start_alignment
     - implementation_preflight

--- a/.meta/templates/.project.yaml
+++ b/.meta/templates/.project.yaml
@@ -7,6 +7,7 @@ meta:
 
 source_control:
   topology: "local_directory_only"  # local_directory_only for local work/knowledge; github_versioned for reusable capability surfaces
+  context_publication_policy: "local_private"  # local_private for local_directory_only; private_continuity or public_distilled for github_versioned
   # github_repo: "OWNER/REPO"       # Required when topology is github_versioned
   # branch_strategy: "github_flow"  # Required when topology is github_versioned
 

--- a/.project.yaml
+++ b/.project.yaml
@@ -7,6 +7,7 @@ meta:
 
 source_control:
   topology: github_versioned
+  context_publication_policy: public_distilled
   github_repo: madlouse/AgenticOS
   branch_strategy: github_flow
 

--- a/README.md
+++ b/README.md
@@ -133,3 +133,15 @@ codex mcp add --env AGENTICOS_HOME="$AGENTICOS_HOME" agenticos -- agenticos-mcp
 - `projects/agenticos/` is the only canonical AgenticOS product-source project under `projects/`
 - the enclosing `AgenticOS/` path is the workspace home; product source lives under `projects/agenticos/`
 - root-level `README.md`, `AGENTS.md`, and `CONTRIBUTING.md` currently remain as compatibility entrypoints during that migration
+
+## Managed Project Contract
+
+Managed projects now distinguish three separate questions:
+
+- workflow topology: `local_directory_only` vs `github_versioned`
+- canonical source inclusion: whether the project root is tracked in the canonical AgenticOS source tree
+- context publication policy: `local_private`, `private_continuity`, or `public_distilled`
+
+The canonical field location is `source_control.context_publication_policy` in `.project.yaml`.
+
+The canonical rationale for context publication policy lives in [standards/knowledge/context-publication-policy-2026-04-10.md](standards/knowledge/context-publication-policy-2026-04-10.md).

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -209,6 +209,7 @@ Create new project with standard structure.
 **Parameters**:
 - `name` (required) - Project name
 - `topology` (required) - `local_directory_only` or `github_versioned`
+- `context_publication_policy` (required for `github_versioned`, optional for `local_directory_only`) - `local_private`, `private_continuity`, or `public_distilled`
 - `description` (optional) - What this project is about
 - `path` (optional) - Custom location (otherwise uses $AGENTICOS_HOME/projects/{id})
 - `github_repo` (required when `topology=github_versioned`) - `OWNER/REPO`
@@ -221,9 +222,16 @@ Create new project with standard structure.
 - choose `github_versioned` for reusable capabilities that should evolve through issue/PR/release flow
 - if the boundary is unclear, require explicit confirmation instead of guessing
 
+**Context publication rubric**:
+- `local_directory_only` projects default to `context_publication_policy=local_private`
+- `github_versioned + private_continuity` means full AI continuity surfaces may live in the repo because the repo is private
+- `github_versioned + public_distilled` means distilled context may ship, but raw session history and other non-publishable runtime surfaces must be isolated from the public source tree
+
+Publication policy is not the same as workflow topology or canonical source inclusion. A project can be `github_versioned` and still require `public_distilled`.
+
 **Upgrade path**:
 - a project may start as `local_directory_only`
-- later, re-run `agenticos_init` with `normalize_existing=true`, `topology=github_versioned`, and `github_repo=OWNER/REPO`
+- later, re-run `agenticos_init` with `normalize_existing=true`, `topology=github_versioned`, `context_publication_policy=private_continuity|public_distilled`, and `github_repo=OWNER/REPO`
 - only do that when the project has clearly become a reusable capability surface
 
 ### agenticos_switch

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -63,6 +63,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
           description: { type: 'string', description: 'Project description' },
           path: { type: 'string', description: 'Optional custom path (otherwise uses $AGENTICOS_HOME/projects/{id})' },
           topology: { type: 'string', enum: ['local_directory_only', 'github_versioned'], description: 'Required source-control topology for the project.' },
+          context_publication_policy: { type: 'string', enum: ['local_private', 'private_continuity', 'public_distilled'], description: 'Context publication policy. local_directory_only projects use local_private; github_versioned projects must choose private_continuity or public_distilled.' },
           github_repo: { type: 'string', description: 'Required when topology is github_versioned. Use OWNER/REPO.' },
           normalize_existing: { type: 'boolean', description: 'When true, normalize an existing project directory/registry entry instead of failing closed.' },
         },

--- a/mcp-server/src/tools/__tests__/init.test.ts
+++ b/mcp-server/src/tools/__tests__/init.test.ts
@@ -80,8 +80,14 @@ describe('initProject', () => {
 
   it('fails when github_versioned is missing github_repo', async () => {
     await expect(
-      initProject({ name: 'Test Project', description: 'A test project', topology: 'github_versioned' }),
+      initProject({ name: 'Test Project', description: 'A test project', topology: 'github_versioned', context_publication_policy: 'private_continuity' }),
     ).rejects.toThrow('github_repo is required');
+  });
+
+  it('fails when github_versioned is missing context_publication_policy', async () => {
+    await expect(
+      initProject({ name: 'Test Project', description: 'A test project', topology: 'github_versioned', github_repo: 'madlouse/test-project' }),
+    ).rejects.toThrow('context_publication_policy is required');
   });
 
   it('creates directories with correct structure', async () => {
@@ -127,6 +133,7 @@ describe('initProject', () => {
     expect(parsed.meta.description).toBe('A test project');
     expect(parsed.meta.version).toBe('1.0.0');
     expect(parsed.source_control.topology).toBe('local_directory_only');
+    expect(parsed.source_control.context_publication_policy).toBe('local_private');
     expect(parsed.agent_context.quick_start).toBe('.context/quick-start.md');
     expect(parsed.agent_context.current_state).toBe('.context/state.yaml');
   });
@@ -136,6 +143,7 @@ describe('initProject', () => {
       name: 'Test Project',
       description: 'A test project',
       topology: 'github_versioned',
+      context_publication_policy: 'private_continuity',
       github_repo: 'madlouse/test-project',
     });
 
@@ -145,6 +153,7 @@ describe('initProject', () => {
 
     const parsed = JSON.parse(projectYamlCall![1] as string);
     expect(parsed.source_control.topology).toBe('github_versioned');
+    expect(parsed.source_control.context_publication_policy).toBe('private_continuity');
     expect(parsed.source_control.github_repo).toBe('madlouse/test-project');
     expect(parsed.source_control.branch_strategy).toBe('github_flow');
     expect(parsed.execution.source_repo_roots).toEqual(['.']);
@@ -231,6 +240,63 @@ describe('initProject', () => {
     expect(testProject.name).toBe('Test Project');
     expect(testProject.status).toBe('active');
     expect(writtenRegistry.active_project).toBe('test-project');
+  });
+
+  it('normalizes an existing github_versioned project when context_publication_policy is provided explicitly', async () => {
+    fsMock.existsSync.mockReturnValue(true);
+    fsPromisesMock.access.mockResolvedValue(undefined);
+    fsPromisesMock.readFile.mockImplementation(async (path: any) => {
+      const normalizedPath = String(path);
+      if (normalizedPath.endsWith('registry.yaml')) {
+        return JSON.stringify({
+          version: '1.0.0',
+          last_updated: '2025-01-01T00:00:00.000Z',
+          active_project: 'test-project',
+          projects: [
+            {
+              id: 'test-project',
+              name: 'Test Project',
+              path: '/home/testuser/AgenticOS/projects/test-project',
+              status: 'active',
+              created: '2025-01-01',
+              last_accessed: '2025-01-01T00:00:00.000Z',
+            },
+          ],
+        });
+      }
+
+      if (normalizedPath.endsWith('.project.yaml')) {
+        return JSON.stringify({
+          meta: { name: 'Test Project', id: 'test-project' },
+          source_control: {
+            topology: 'github_versioned',
+            context_publication_policy: 'public_distilled',
+            github_repo: 'madlouse/test-project',
+            branch_strategy: 'github_flow',
+          },
+          execution: {
+            source_repo_roots: ['.'],
+          },
+        });
+      }
+
+      throw new Error(`Unexpected readFile path: ${normalizedPath}`);
+    });
+
+    await initProject({
+      name: 'Test Project',
+      topology: 'github_versioned',
+      github_repo: 'madlouse/test-project',
+      context_publication_policy: 'public_distilled',
+      normalize_existing: true,
+    });
+
+    const writeCalls = fsPromisesMock.writeFile.mock.calls;
+    const projectYamlCall = writeCalls.find((c) => c[0].endsWith('.project.yaml'));
+    expect(projectYamlCall).toBeDefined();
+
+    const parsed = JSON.parse(projectYamlCall![1] as string);
+    expect(parsed.source_control.context_publication_policy).toBe('public_distilled');
   });
 
   it('returns success message with project path and ID', async () => {

--- a/mcp-server/src/tools/__tests__/standard-kit.test.ts
+++ b/mcp-server/src/tools/__tests__/standard-kit.test.ts
@@ -73,6 +73,7 @@ async function setupKitHome(): Promise<{ home: string; projectRoot: string }> {
       required_behavior: [
         'operator_intent_resolution',
         'memory_layer_contracts',
+        'context_publication_policy_contract',
         'cross_agent_policy_contract',
         'session_start_alignment',
         'implementation_preflight',
@@ -87,7 +88,7 @@ async function setupKitHome(): Promise<{ home: string; projectRoot: string }> {
   };
 
   await writeFile(join(kitRoot, 'manifest.yaml'), yaml.stringify(manifest), 'utf-8');
-  await writeFile(join(templateRoot, '.project.yaml'), `meta:\n  name: "Project Name"\n  id: "project-id"\n  version: "1.0.0"\n  created: "YYYY-MM-DD"\n  description: "Project description"\nagent_context:\n  quick_start: ".context/quick-start.md"\n  current_state: ".context/state.yaml"\n  conversations: ".context/conversations/"\n  knowledge: "knowledge/"\n  tasks: "tasks/"\n  artifacts: "artifacts/"\nmemory_contract:\n  version: 1\n  quick_start_role: "project_orientation"\n  state_role: "operational_working_state"\n  conversations_role: "append_only_session_history"\n  knowledge_role: "durable_synthesis"\n  tasks_role: "execution_artifacts"\n  artifacts_role: "deliverables"\nstatus:\n  phase: "planning"\n  last_updated: "YYYY-MM-DD"\n`, 'utf-8');
+  await writeFile(join(templateRoot, '.project.yaml'), `meta:\n  name: "Project Name"\n  id: "project-id"\n  version: "1.0.0"\n  created: "YYYY-MM-DD"\n  description: "Project description"\nsource_control:\n  topology: "local_directory_only"\n  context_publication_policy: "local_private"\nagent_context:\n  quick_start: ".context/quick-start.md"\n  current_state: ".context/state.yaml"\n  conversations: ".context/conversations/"\n  knowledge: "knowledge/"\n  tasks: "tasks/"\n  artifacts: "artifacts/"\nmemory_contract:\n  version: 1\n  quick_start_role: "project_orientation"\n  state_role: "operational_working_state"\n  conversations_role: "append_only_session_history"\n  knowledge_role: "durable_synthesis"\n  tasks_role: "execution_artifacts"\n  artifacts_role: "deliverables"\nstatus:\n  phase: "planning"\n  last_updated: "YYYY-MM-DD"\n`, 'utf-8');
   await writeFile(join(templateRoot, 'quick-start.md'), '# Quick Start\n\n> Contract: concise project-level orientation for fast resume.\n> Do not store full session history, exhaustive decision logs, or issue-by-issue execution details here.\n\n## Project Snapshot\n- **Project**: [Project Name]\n- **Goal**: [Main objective]\n- **Status**: [Current phase]\n- **Last Action**: [What was done last]\n- **Current Focus**: [What to do next]\n- **Resume Here**: [What to do next]\n\n## Key Facts\n- [Important fact 1]\n- [Important fact 2]\n\n## Canonical Layers\n- Operational state: `.context/state.yaml`\n- Session history: `.context/conversations/`\n- Durable knowledge: `knowledge/`\n- Execution plans: `tasks/`\n- Deliverables: `artifacts/`\n', 'utf-8');
   await writeFile(join(templateRoot, 'state.yaml'), '# Contract:\n# - Mutable operational working state only\n# - Keep current task, working memory, and latest guardrail evidence here\n# - Do not append raw conversation transcripts here\n# - Durable synthesis belongs in knowledge/\nsession:\n  id: "session-001"\n  started: "YYYY-MM-DDTHH:MM:SSZ"\n  agent: "claude-sonnet-4.6"\ncurrent_task:\n  id: null\n  title: null\n  status: "pending"\n  next_step: null\nworking_memory:\n  facts: []\n  decisions: []\n  pending: []\nmemory_contract:\n  version: 1\n  quick_start_role: "project_orientation"\n  state_role: "operational_working_state"\n  conversations_role: "append_only_session_history"\n  knowledge_role: "durable_synthesis"\n  tasks_role: "execution_artifacts"\nloaded_context:\n  - ".project.yaml"\n', 'utf-8');
   await writeFile(join(templateRoot, 'agent-preflight-checklist.yaml'), 'version: 0.2\n', 'utf-8');
@@ -252,6 +253,7 @@ describe('standard kit commands', () => {
     expect(projectYaml.meta.name).toBe('Sample Project');
     expect(projectYaml.meta.id).toBe('sample-project');
     expect(projectYaml.memory_contract.version).toBe(1);
+    expect(projectYaml.source_control.context_publication_policy).toBe('local_private');
     expect(projectYaml.agent_context.conversations).toBe('.context/conversations/');
 
     const quickStart = await readFile(join(projectRoot, '.context', 'quick-start.md'), 'utf-8');
@@ -493,7 +495,7 @@ describe('standard kit commands', () => {
 
     await writeFile(
       join(projectRoot, '.project.yaml'),
-      'meta:\n  name: "Yaml Project"\n  id: "yaml-project"\n  description: "yaml description"\n',
+      'meta:\n  name: "Yaml Project"\n  id: "yaml-project"\n  description: "yaml description"\nsource_control:\n  topology: "local_directory_only"\n  context_publication_policy: "local_private"\n',
       'utf-8',
     );
 
@@ -616,7 +618,7 @@ describe('standard kit commands', () => {
     });
     await writeFile(
       join(home, 'projects', 'agenticos', '.meta', 'templates', '.project.yaml'),
-      'meta:\n  name: "Template Name"\nstatus:\n  phase: "discovery"\n',
+      'meta:\n  name: "Template Name"\nsource_control:\n  topology: "local_directory_only"\n  context_publication_policy: "local_private"\nstatus:\n  phase: "discovery"\n',
       'utf-8',
     );
     await writeFile(
@@ -657,7 +659,7 @@ describe('standard kit commands', () => {
     });
     await writeFile(
       join(home, 'projects', 'agenticos', '.meta', 'templates', '.project.yaml'),
-      '{}\n',
+      'source_control:\n  topology: "local_directory_only"\n  context_publication_policy: "local_private"\n',
       'utf-8',
     );
 

--- a/mcp-server/src/tools/init.ts
+++ b/mcp-server/src/tools/init.ts
@@ -3,17 +3,46 @@ import { join } from 'path';
 import yaml from 'yaml';
 import { loadRegistry, saveRegistry, getAgenticOSHome } from '../utils/registry.js';
 import { generateClaudeMd, generateAgentsMd } from '../utils/distill.js';
-import { buildProjectTopologyInitializationMessage, type ProjectTopology } from '../utils/project-contract.js';
+import { buildProjectTopologyInitializationMessage, validateContextPublicationPolicy, type ContextPublicationPolicy, type ProjectTopology } from '../utils/project-contract.js';
 import { resolveManagedProjectContextDisplayPaths, resolveManagedProjectContextPaths } from '../utils/agent-context-paths.js';
 
 function isValidGithubRepo(value: string): boolean {
   return /^[^/\s]+\/[^/\s]+$/.test(value);
 }
 
-function resolveTopologyArgs(args: any): { topology: ProjectTopology; githubRepo?: string; normalizeExisting: boolean } {
+function resolveContextPublicationPolicy(
+  topology: ProjectTopology,
+  rawPolicy: unknown,
+  existingProjectYaml?: any,
+): ContextPublicationPolicy {
+  const policy = typeof rawPolicy === 'string' ? rawPolicy.trim() : '';
+  const existingPolicy = typeof existingProjectYaml?.source_control?.context_publication_policy === 'string'
+    ? existingProjectYaml.source_control.context_publication_policy.trim()
+    : '';
+  const resolvedPolicy = policy || existingPolicy;
+
+  if (topology === 'local_directory_only') {
+    if (!resolvedPolicy) return 'local_private';
+    if (resolvedPolicy !== 'local_private') {
+      throw new Error('context_publication_policy must be "local_private" when topology is "local_directory_only".');
+    }
+    return 'local_private';
+  }
+
+  if (resolvedPolicy !== 'private_continuity' && resolvedPolicy !== 'public_distilled') {
+    throw new Error('context_publication_policy is required when topology is "github_versioned" and must be "private_continuity" or "public_distilled".');
+  }
+
+  return resolvedPolicy;
+}
+
+function resolveTopologyArgs(args: any): { topology: ProjectTopology; rawContextPublicationPolicy?: string; githubRepo?: string; normalizeExisting: boolean } {
   const topology = typeof args.topology === 'string' ? args.topology.trim() : '';
   const githubRepo = typeof args.github_repo === 'string' ? args.github_repo.trim() : '';
   const normalizeExisting = args.normalize_existing === true;
+  const rawContextPublicationPolicy = typeof args.context_publication_policy === 'string'
+    ? args.context_publication_policy
+    : undefined;
 
   if (topology !== 'local_directory_only' && topology !== 'github_versioned') {
     throw new Error('topology is required and must be "local_directory_only" or "github_versioned".');
@@ -26,10 +55,14 @@ function resolveTopologyArgs(args: any): { topology: ProjectTopology; githubRepo
     if (!isValidGithubRepo(githubRepo)) {
       throw new Error('github_repo must use the form "OWNER/REPO".');
     }
-    return { topology, githubRepo, normalizeExisting };
+    return { topology, rawContextPublicationPolicy, githubRepo, normalizeExisting };
   }
 
-  return { topology, normalizeExisting };
+  return {
+    topology,
+    rawContextPublicationPolicy,
+    normalizeExisting,
+  };
 }
 
 async function loadExistingProjectYaml(projectPath: string): Promise<any> {
@@ -46,9 +79,10 @@ function buildProjectYaml(args: {
   description?: string;
   existingProjectYaml?: any;
   topology: ProjectTopology;
+  contextPublicationPolicy: ContextPublicationPolicy;
   githubRepo?: string;
 }): any {
-  const { name, id, description, existingProjectYaml = {}, topology, githubRepo } = args;
+  const { name, id, description, existingProjectYaml = {}, topology, contextPublicationPolicy, githubRepo } = args;
   const today = new Date().toISOString().split('T')[0];
   const meta = existingProjectYaml?.meta || {};
   const merged: any = {
@@ -63,6 +97,7 @@ function buildProjectYaml(args: {
     },
     source_control: {
       topology,
+      context_publication_policy: contextPublicationPolicy,
       ...(topology === 'github_versioned'
         ? {
             github_repo: githubRepo,
@@ -96,7 +131,7 @@ function buildProjectYaml(args: {
 export async function initProject(args: any): Promise<string> {
   const { name, path: customPath } = args;
   const description = typeof args.description === 'string' ? args.description : undefined;
-  const { topology, githubRepo, normalizeExisting } = resolveTopologyArgs(args);
+  const { topology, rawContextPublicationPolicy, githubRepo, normalizeExisting } = resolveTopologyArgs(args);
   const id = name.toLowerCase().replace(/\s+/g, '-');
 
   const projectPath = customPath || join(getAgenticOSHome(), 'projects', id);
@@ -118,6 +153,10 @@ export async function initProject(args: any): Promise<string> {
     if (!existingProjectYaml?.source_control?.topology) {
       return buildProjectTopologyInitializationMessage(name);
     }
+    const publicationValidation = validateContextPublicationPolicy(name, existingProjectYaml);
+    if (!publicationValidation.ok) {
+      return `${publicationValidation.message} Re-run agenticos_init with normalize_existing=true and the intended topology/publication contract.`;
+    }
     registry.active_project = id;
     await saveRegistry(registry);
     return `Project '${name}' already exists at ${projectPath}. Use \`agenticos_switch\` to activate it.`;
@@ -133,6 +172,11 @@ export async function initProject(args: any): Promise<string> {
   }
 
   const existingProjectYaml = pathExists ? await loadExistingProjectYaml(projectPath) : {};
+  const contextPublicationPolicy = resolveContextPublicationPolicy(
+    topology,
+    rawContextPublicationPolicy,
+    existingProjectYaml,
+  );
   const today = new Date().toISOString().split('T')[0];
   const projectYaml = buildProjectYaml({
     name,
@@ -140,6 +184,7 @@ export async function initProject(args: any): Promise<string> {
     description,
     existingProjectYaml,
     topology,
+    contextPublicationPolicy,
     githubRepo,
   });
   await writeFile(join(projectPath, '.project.yaml'), yaml.stringify(projectYaml), 'utf-8');
@@ -208,6 +253,7 @@ ${description ?? existingProjectYaml?.meta?.description ?? ''}
   const topologyLine = topology === 'github_versioned'
     ? `Topology: github_versioned (${githubRepo}, github_flow)`
     : 'Topology: local_directory_only';
+  const publicationLine = `Context Publication: ${contextPublicationPolicy}`;
   const prefix = pathExists ? 'Normalized' : 'Created';
-  return `✅ ${prefix} project "${name}" at ${projectPath}\n\nProject ID: ${id}\nStatus: Active\n${topologyLine}\n\nUse agenticos_switch to load this project context.`;
+  return `✅ ${prefix} project "${name}" at ${projectPath}\n\nProject ID: ${id}\nStatus: Active\n${topologyLine}\n${publicationLine}\n\nUse agenticos_switch to load this project context.`;
 }

--- a/mcp-server/src/utils/__tests__/project-contract.test.ts
+++ b/mcp-server/src/utils/__tests__/project-contract.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { validateContextPublicationPolicy } from '../project-contract.js';
+
+describe('validateContextPublicationPolicy', () => {
+  it('accepts local_private for local_directory_only projects', () => {
+    expect(validateContextPublicationPolicy('Local Project', {
+      source_control: {
+        topology: 'local_directory_only',
+        context_publication_policy: 'local_private',
+      },
+    })).toEqual({ ok: true, policy: 'local_private' });
+  });
+
+  it('accepts private_continuity for github_versioned projects', () => {
+    expect(validateContextPublicationPolicy('Private Repo', {
+      source_control: {
+        topology: 'github_versioned',
+        context_publication_policy: 'private_continuity',
+      },
+    })).toEqual({ ok: true, policy: 'private_continuity' });
+  });
+
+  it('rejects local_private for github_versioned projects', () => {
+    const result = validateContextPublicationPolicy('Public Repo', {
+      source_control: {
+        topology: 'github_versioned',
+        context_publication_policy: 'local_private',
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain('github_versioned');
+      expect(result.message).toContain('private_continuity');
+    }
+  });
+
+  it('rejects missing publication policy', () => {
+    const result = validateContextPublicationPolicy('Missing Policy', {
+      source_control: {
+        topology: 'github_versioned',
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain('context_publication_policy');
+    }
+  });
+});

--- a/mcp-server/src/utils/project-contract.ts
+++ b/mcp-server/src/utils/project-contract.ts
@@ -7,11 +7,53 @@ interface ArchiveContract {
 }
 
 export type ProjectTopology = 'local_directory_only' | 'github_versioned';
+export type ContextPublicationPolicy = 'local_private' | 'private_continuity' | 'public_distilled';
 
 interface SourceControlContract {
   topology?: ProjectTopology;
+  context_publication_policy?: ContextPublicationPolicy;
   github_repo?: string;
   branch_strategy?: string;
+}
+
+export function isValidContextPublicationPolicy(value: unknown): value is ContextPublicationPolicy {
+  return value === 'local_private' || value === 'private_continuity' || value === 'public_distilled';
+}
+
+export function validateContextPublicationPolicy(projectName: string, projectYaml: any): { ok: true; policy: ContextPublicationPolicy } | { ok: false; message: string } {
+  const contract = getSourceControlContract(projectYaml);
+  const topology = contract?.topology;
+  const policy = contract?.context_publication_policy;
+
+  if (topology !== 'local_directory_only' && topology !== 'github_versioned') {
+    return {
+      ok: false,
+      message: `Project "${projectName}" must declare source_control.topology before validating source_control.context_publication_policy.`,
+    };
+  }
+
+  if (!isValidContextPublicationPolicy(policy)) {
+    return {
+      ok: false,
+      message: `Project "${projectName}" is missing source_control.context_publication_policy. Use "local_private", "private_continuity", or "public_distilled".`,
+    };
+  }
+
+  if (topology === 'local_directory_only' && policy !== 'local_private') {
+    return {
+      ok: false,
+      message: `Project "${projectName}" uses topology="local_directory_only" and must use source_control.context_publication_policy="local_private".`,
+    };
+  }
+
+  if (topology === 'github_versioned' && policy === 'local_private') {
+    return {
+      ok: false,
+      message: `Project "${projectName}" uses topology="github_versioned" and must use source_control.context_publication_policy="private_continuity" or "public_distilled".`,
+    };
+  }
+
+  return { ok: true, policy };
 }
 
 export function getArchiveContract(projectYaml: any): ArchiveContract | null {

--- a/mcp-server/src/utils/standard-kit.ts
+++ b/mcp-server/src/utils/standard-kit.ts
@@ -6,6 +6,7 @@ import { getAgenticOSHome, loadRegistry } from './registry.js';
 import { getOfficialAgentAdapters, loadAgentAdapterMatrix } from './agent-adapter-matrix.js';
 import { CURRENT_TEMPLATE_VERSION, extractTemplateVersion, generateAgentsMd, generateClaudeMd, upgradeClaudeMd } from './distill.js';
 import { buildArchivedReferenceMessage, isArchivedReferenceProject } from './project-contract.js';
+import { validateContextPublicationPolicy } from './project-contract.js';
 import { resolveAgenticOSProductPath, resolveAgenticOSProductRoot, toCanonicalProductRelativePath } from './product-source-root.js';
 import { resolveManagedProjectContextDisplayPaths, resolveManagedProjectContextPaths, type ManagedProjectContextDisplayPaths } from './agent-context-paths.js';
 
@@ -499,6 +500,22 @@ export async function checkStandardKitConformance(args: { project_path?: string;
             ? 'Project metadata and state preserve the memory-layer contract.'
             : 'Project metadata or state is missing required memory-layer contract fields.',
           evidence_paths: ['.project.yaml', '.context/state.yaml'],
+        });
+        break;
+      }
+      case 'context_publication_policy_contract': {
+        const publicationValidation = validateContextPublicationPolicy(project.projectName, projectYaml);
+        const pass = publicationValidation.ok
+          && fileContainsAll(JSON.stringify(projectYaml?.source_control || {}), ['context_publication_policy']);
+        behaviorChecks.push({
+          behavior,
+          status: pass ? 'PASS' : 'FAIL',
+          summary: pass
+            ? 'The managed project declares a valid context publication policy in .project.yaml.'
+            : publicationValidation.ok
+              ? 'The managed project is missing source_control.context_publication_policy in .project.yaml.'
+              : publicationValidation.message,
+          evidence_paths: ['.project.yaml'],
         });
         break;
       }

--- a/standards/knowledge/context-publication-policy-2026-04-10.md
+++ b/standards/knowledge/context-publication-policy-2026-04-10.md
@@ -1,0 +1,88 @@
+# Context Publication Policy - 2026-04-10
+
+## Problem
+
+Workflow topology and canonical source inclusion do not answer a third question:
+
+- which context surfaces are allowed to live in tracked Git source for this project class?
+
+Without that contract, later runtime behavior has to guess from topology and local convention. That is not precise enough for `github_versioned` projects.
+
+## Canonical Field
+
+The canonical field location is:
+
+- `.project.yaml`
+- `source_control.context_publication_policy`
+
+## Allowed Values
+
+### `local_private`
+
+Use for:
+
+- `local_directory_only` projects
+
+Meaning:
+
+- the project remains local/private by default
+- AgenticOS should not assume raw or distilled continuity surfaces belong in a public or shared tracked source tree
+
+### `private_continuity`
+
+Use for:
+
+- `github_versioned` projects whose repository is private and where cross-machine AI continuity matters more than transcript secrecy
+
+Meaning:
+
+- full continuity surfaces may be tracked in the repo
+- `.context/conversations/` may remain a tracked project surface
+
+### `public_distilled`
+
+Use for:
+
+- `github_versioned` projects whose repository is public or otherwise should not publish raw session history
+
+Meaning:
+
+- distilled context may be tracked in source
+- raw session history and other non-publishable runtime surfaces must be isolated from the public source tree
+- `.context/conversations/` must not remain a tracked public-tree path once enforcement work lands
+
+## Interaction With Other Contracts
+
+These are separate axes:
+
+1. workflow topology
+2. canonical source inclusion
+3. context publication policy
+
+Examples:
+
+- `github_versioned` + `included_in_canonical_source` + `public_distilled`
+  - tracked capability surface inside the main AgenticOS repo
+  - public repo
+  - raw conversations must be isolated
+- `github_versioned` + standalone repo + `private_continuity`
+  - separate GitHub repo
+  - private continuity surfaces may remain tracked there
+- `local_directory_only` + `excluded_local_root` + `local_private`
+  - long-lived local project
+  - not intended for tracked Git publication
+
+## Current Enforcement Boundary
+
+This issue defines the contract and pushes it into templates, initialization flow, and conformance checks.
+
+It does not yet implement all publication-aware routing behavior.
+
+Follow-up work:
+
+- `#244` private continuity persistence behavior
+- `#245` raw conversation isolation for public `github_versioned` projects
+
+## Outcome
+
+After this policy lands, later implementation issues can route `save`, `record`, and runtime sidecars against one explicit contract instead of inventing topology-based heuristics.

--- a/standards/knowledge/local-project-source-inclusion-policy-2026-04-07.md
+++ b/standards/knowledge/local-project-source-inclusion-policy-2026-04-07.md
@@ -4,10 +4,13 @@
 
 `AgenticOS` must distinguish project workflow topology from canonical source-control inclusion.
 
+That still is not enough by itself. Context publication policy is a third question.
+
 These are different questions:
 
 1. how should the project iterate?
 2. should the project remain tracked inside the GitHub-backed canonical source tree?
+3. if the project is Git-backed, which context surfaces are publishable into tracked source?
 
 ## Workflow Topology
 
@@ -31,6 +34,19 @@ Two source-inclusion modes matter in practice:
 - `excluded_local_root`
   - the project root lives under `AGENTICOS_HOME/projects/`, but is intentionally ignored by the canonical repository
 
+## Context Publication Policy
+
+Context publication policy answers whether AI continuity surfaces are allowed in tracked source for the project class.
+
+- `local_private`
+  - local/private by definition
+  - used with `local_directory_only`
+- `private_continuity`
+  - full continuity surfaces may be tracked because the repo is private
+- `public_distilled`
+  - distilled context may be tracked
+  - raw session history and other non-publishable runtime surfaces must be isolated from the public tree
+
 ## Policy Matrix
 
 ### `github_versioned` + included in canonical source
@@ -49,6 +65,8 @@ Use this for downstream projects that are GitHub-managed but own their own repos
 Examples:
 
 - `projects/agent-cli-api`
+
+For those projects, context publication policy still must be declared separately as `private_continuity` or `public_distilled`.
 
 ### `local_directory_only` + excluded local root
 

--- a/standards/knowledge/memory-layer-contract-spec-2026-03-25.md
+++ b/standards/knowledge/memory-layer-contract-spec-2026-03-25.md
@@ -37,6 +37,11 @@ The goal here is to define the contract first and encode it into the default pro
 
 Later validation and linting can build on it.
 
+This memory-layer contract defines what each surface is for.
+
+It does not decide whether those surfaces belong in tracked Git source for a given project.
+That question is handled separately by the context publication policy contract.
+
 ## Canonical Layer Matrix
 
 | Layer | Purpose | Source of Truth | Mutability | What Belongs Here | What Must Not Be Written Here |
@@ -154,3 +159,8 @@ It does three concrete things:
 ## Outcome
 
 After this issue, later work can reference one canonical memory contract instead of restating the same distinctions from scratch.
+
+Context publication remains a separate contract:
+
+- the memory-layer contract says what belongs in `conversations/`, `state.yaml`, `knowledge/`, and related surfaces
+- the context publication policy says whether those surfaces may remain tracked for that project class

--- a/standards/knowledge/project-topology-decision-rubric-2026-04-07.md
+++ b/standards/knowledge/project-topology-decision-rubric-2026-04-07.md
@@ -9,6 +9,11 @@
 
 This rubric defines when to choose each one, when to stop and confirm, and how a local project can later upgrade into GitHub Flow.
 
+Topology answers workflow mode only.
+
+It does not answer whether raw or distilled continuity surfaces should live in tracked Git source.
+That is governed separately by `source_control.context_publication_policy`.
+
 ## Direct Rules
 
 Choose `local_directory_only` when the project is primarily:
@@ -80,4 +85,9 @@ GitHub Flow is for capability growth.
 A local project that only evolves private knowledge, writing, or working material should remain `local_directory_only` even if it changes frequently.
 
 Only the capability-like subset should move into GitHub Flow.
+
+After topology is chosen, context publication policy still must be set independently:
+
+- `local_directory_only` -> `local_private`
+- `github_versioned` -> `private_continuity` or `public_distilled`
 When necessary, split that subset into its own project rather than forcing the whole local project into a versioned workflow.


### PR DESCRIPTION
## Summary
- define a canonical context publication policy contract in `.project.yaml`
- wire the contract into `agenticos_init`, standard-kit docs, and conformance checks
- document how publication policy differs from topology and source inclusion

## Policy
- `local_private` for `local_directory_only`
- `private_continuity` for private `github_versioned` repos
- `public_distilled` for public `github_versioned` repos that must isolate raw session history

## Non-goals
- no `agenticos_save` or `agenticos_record` routing change yet
- no sidecar isolation implementation yet; follow-up issues keep that work separate

Closes #246