### PR TITLE
fix: harden guardrail project resolution and main write protection

### DIFF
--- a/mcp-server/src/utils/__tests__/guardrail-evidence.test.ts
+++ b/mcp-server/src/utils/__tests__/guardrail-evidence.test.ts
@@ -26,7 +26,7 @@ vi.mock('../canonical-main-guard.js', () => ({
 import { access, readFile, writeFile } from 'fs/promises';
 import { detectCanonicalMainWriteProtection } from '../canonical-main-guard.js';
 import { loadRegistry } from '../registry.js';
-import { persistGuardrailEvidence } from '../guardrail-evidence.js';
+import { persistGuardrailEvidence, persistIssueBootstrapEvidence } from '../guardrail-evidence.js';
 
 const accessMock = access as unknown as ReturnType<typeof vi.fn>;
 const readFileMock = readFile as unknown as ReturnType<typeof vi.fn>;
@@ -264,6 +264,86 @@ describe('persistGuardrailEvidence', () => {
       payload: {
         issue_id: '212',
         result: { status: 'REDIRECT' },
+      },
+    });
+
+    expect(result.persisted).toBe(false);
+    expect(result.reason).toContain('write-protected');
+    expect(writeFileMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('persistIssueBootstrapEvidence', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    yamlMock.parse.mockImplementation((content: string) => {
+      try {
+        return JSON.parse(content);
+      } catch {
+        return undefined;
+      }
+    });
+    yamlMock.stringify.mockImplementation((obj: unknown) => JSON.stringify(obj));
+    loadRegistryMock.mockResolvedValue({
+      active_project: 'agenticos',
+      projects: [
+        {
+          id: 'agenticos',
+          name: 'AgenticOS',
+          path: '/workspace/projects/agenticos',
+          status: 'active',
+          created: '2026-03-23',
+          last_accessed: '2026-03-23T00:00:00.000Z',
+        },
+      ],
+    });
+    accessMock.mockResolvedValue(undefined);
+    readFileMock.mockImplementation(async (path: string) => {
+      if (path.endsWith('/.project.yaml')) {
+        return JSON.stringify({
+          meta: { id: 'agenticos', name: 'AgenticOS' },
+          agent_context: { current_state: 'standards/.context/state.yaml' },
+        });
+      }
+      return JSON.stringify({ session: {}, working_memory: { facts: [], decisions: [], pending: [] } });
+    });
+    writeFileMock.mockResolvedValue(undefined);
+    detectCanonicalMainWriteProtectionMock.mockResolvedValue({ blocked: false });
+  });
+
+  it('persists the latest issue bootstrap record into the matching managed project state', async () => {
+    const result = await persistIssueBootstrapEvidence({
+      repo_path: '/workspace/projects/agenticos/mcp-server',
+      payload: {
+        issue_id: '260',
+        issue_title: 'Stop runtime persistence pollution',
+        repo_path: '/workspace/projects/agenticos/mcp-server',
+      },
+    });
+
+    expect(result.persisted).toBe(true);
+    expect(result.project_id).toBe('agenticos');
+    expect(writeFileMock).toHaveBeenCalledTimes(1);
+    expect(writeFileMock.mock.calls[0]?.[0]).toBe('/workspace/projects/agenticos/standards/.context/state.yaml');
+
+    const [, content] = writeFileMock.mock.calls[0];
+    const writtenState = JSON.parse(content as string);
+    expect(writtenState.issue_bootstrap.latest.issue_id).toBe('260');
+    expect(writtenState.issue_bootstrap.latest.issue_title).toBe('Stop runtime persistence pollution');
+    expect(writtenState.issue_bootstrap.latest.repo_path).toBe('/workspace/projects/agenticos/mcp-server');
+  });
+
+  it('does not persist issue bootstrap evidence into canonical main checkouts', async () => {
+    detectCanonicalMainWriteProtectionMock.mockResolvedValue({
+      blocked: true,
+      reason: 'canonical main checkout is write-protected for runtime persistence: /workspace/root',
+    });
+
+    const result = await persistIssueBootstrapEvidence({
+      repo_path: '/workspace/root/projects/agenticos/mcp-server',
+      payload: {
+        issue_id: '260',
+        issue_title: 'Stop runtime persistence pollution',
       },
     });
 

--- a/mcp-server/src/utils/__tests__/repo-boundary.test.ts
+++ b/mcp-server/src/utils/__tests__/repo-boundary.test.ts
@@ -101,6 +101,43 @@ describe('resolveGuardrailProjectTarget', () => {
     expect(result.resolutionSource).toBe('repo_path_match');
   });
 
+  it('resolves an explicit project_path even when active_project has drifted elsewhere', async () => {
+    loadRegistryMock.mockResolvedValue({
+      active_project: 'beta',
+      projects: [
+        {
+          id: 'alpha',
+          name: 'Alpha Project',
+          path: '/workspace/projects/alpha',
+          status: 'active',
+          created: '2026-04-06',
+          last_accessed: '2026-04-06T00:00:00.000Z',
+        },
+        {
+          id: 'beta',
+          name: 'Beta Project',
+          path: '/workspace/projects/beta',
+          status: 'active',
+          created: '2026-04-06',
+          last_accessed: '2026-04-06T00:00:00.000Z',
+        },
+      ],
+    });
+
+    const result = await resolveGuardrailProjectTarget({
+      commandName: 'agenticos_preflight',
+      repoPath: '/workspace/source',
+      projectPath: '/workspace/projects/alpha',
+    });
+
+    expect(result.activeProjectId).toBe('beta');
+    expect(result.targetProject?.id).toBe('alpha');
+    expect(result.targetProject?.path).toBe('/workspace/projects/alpha');
+    expect(result.resolutionSource).toBe('explicit_project_path');
+    expect(result.resolutionErrors).toEqual([]);
+    expect(resolveManagedProjectTargetMock).not.toHaveBeenCalled();
+  });
+
   it('returns a fail-closed resolution error when project metadata cannot be proven', async () => {
     loadRegistryMock.mockResolvedValue({
       active_project: 'alpha',

--- a/mcp-server/src/utils/guardrail-evidence.ts
+++ b/mcp-server/src/utils/guardrail-evidence.ts
@@ -337,6 +337,17 @@ export async function persistIssueBootstrapEvidence(
     };
   }
 
+  const writeProtection = await detectCanonicalMainWriteProtection(repo_path);
+  if (writeProtection.blocked) {
+    return {
+      attempted: true,
+      persisted: false,
+      project_id: project.id,
+      state_path: project.statePath,
+      reason: writeProtection.reason,
+    };
+  }
+
   const statePath = project.statePath;
   let state: StateYaml = {};
 

--- a/mcp-server/src/utils/repo-boundary.ts
+++ b/mcp-server/src/utils/repo-boundary.ts
@@ -118,18 +118,10 @@ export async function resolveGuardrailProjectTarget(args: {
 
   if (projectPath) {
     try {
-      const resolved = await resolveManagedProjectTarget({
-        commandName,
-        project: projectPath,
-      });
-      const targetProject = await buildTargetFromProjectPath(
-        resolved.projectPath,
-        resolved.projectId,
-        resolved.projectName,
-      );
+      const targetProject = await buildTargetFromProjectPath(projectPath);
       return {
         activeProjectId,
-        resolutionSource: 'explicit_project_path',
+        resolutionSource: targetProject ? 'explicit_project_path' : null,
         targetProject,
         resolutionErrors: targetProject ? [] : [`project_path is not a resolvable managed project: ${projectPath}`],
       };


### PR DESCRIPTION
## Summary
- allow guardrail tools to honor an explicit `project_path` without failing on unrelated active-project drift
- prevent `agenticos_issue_bootstrap` persistence from writing into canonical `main` state surfaces
- add regression tests for explicit-project resolution and issue bootstrap write protection

## Testing
- npm test -- --run src/utils/__tests__/repo-boundary.test.ts src/utils/__tests__/guardrail-evidence.test.ts src/tools/__tests__/issue-bootstrap.test.ts
- npm test
- npm run lint

Closes #260