### PR TITLE
redesign: make project resolution session-local and remove runtime fallback to global active_project

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- agenticos-template: v10 -->
+<!-- agenticos-template: v11 -->
 # AGENTS.md — AgenticOS
 
 ## Adapter Role
@@ -23,7 +23,7 @@ It must expose the same canonical policy as other agent adapters rather than def
 - Once intent is resolved, collapse it into a clean execution objective instead of carrying the full intake rubric through every later step.
 ## Guardrail Protocol (MANDATORY)
 
-Before implementation edits, confirm project alignment with `agenticos_status`; if the active project is missing or wrong, call `agenticos_switch`.
+Before implementation edits, confirm session/project alignment with `agenticos_status`; if no session project is bound or the bound project is not the intended one, call `agenticos_switch`.
 
 Implementation work must use the executable guardrail flow:
 
@@ -59,8 +59,8 @@ After recording, call `agenticos_save` to commit to Git.
 ### Session Start
 
 On session start, align the runtime before meaningful work:
-1. call `agenticos_status` to confirm the active project, current task, pending work, and latest recorded state
-2. if the active project is missing or not `AgenticOS`, call `agenticos_switch`
+1. call `agenticos_status` to confirm the current session project, current task, pending work, and latest recorded state
+2. if no session project is bound or the bound project is not `AgenticOS`, call `agenticos_switch`
 3. read `.project.yaml`, `standards/.context/quick-start.md`, `standards/.context/state.yaml`, and `standards/.context/conversations/`
 4. review the latest guardrail evidence and latest `agenticos_issue_bootstrap` record before implementation-affecting work
 5. if implementation work is requested, follow the Guardrail Protocol above exactly before editing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- agenticos-template: v8 -->
+<!-- agenticos-template: v11 -->
 # CLAUDE.md — AgenticOS
 
 ## Adapter Role
@@ -23,7 +23,7 @@ It must expose the same canonical policy as other agent adapters while allowing 
 - Once intent is resolved, collapse it into a clean execution objective instead of carrying the full intake rubric through every later step.
 ## Guardrail Protocol (MANDATORY)
 
-Before implementation edits, confirm project alignment with `agenticos_status`; if the active project is missing or wrong, call `agenticos_switch`.
+Before implementation edits, confirm session/project alignment with `agenticos_status`; if no session project is bound or the bound project is not the intended one, call `agenticos_switch`.
 
 For implementation-affecting work:
 
@@ -69,8 +69,8 @@ When the user signals session end (says goodbye, thanks, done, or stops respondi
 
 When you open this project in a new session, **immediately do the following**:
 
-1. Call `agenticos_status` to confirm the active project, current task, pending work, and latest recorded state
-2. If the active project is missing or not `AgenticOS`, call `agenticos_switch`
+1. Call `agenticos_status` to confirm the current session project, current task, pending work, and latest recorded state
+2. If no session project is bound or the bound project is not `AgenticOS`, call `agenticos_switch`
 3. Read `.project.yaml`, the "Current State" section below, `standards/.context/quick-start.md`, and `standards/.context/conversations/`
 4. Review the latest guardrail evidence and latest `agenticos_issue_bootstrap` record before implementation-affecting work
 5. Greet the user with a brief status report:
@@ -101,18 +101,18 @@ When you open this project in a new session, **immediately do the following**:
 <!-- AGENT_CONTEXT_START -->
 **Last Updated**: 2026-04-10T08:55:55.177Z
 
-**Current Task**: fix: stop active-project drift and canonical-main runtime persistence pollution (status: completed)
+**Current Task**: design/implement #262 concurrent runtime project resolution and legacy fallback downgrade (status: in_progress)
 
 **Active Items**:
-- Review and merge PR #261.
-- After #260 lands, continue remaining backlog in priority order: #245 public github_versioned raw conversation isolation, then #244 private github_versioned full continuity persistence.
+- Finish #262 runtime semantic unification across MCP tools, templates, and docs.
+- Verify remaining normative references versus historical records, then split any migration-only work into #263.
 
 **Recent Decisions**:
-- Guardrail commands should honor an explicit `project_path` even when global `active_project` has drifted to another managed project.
-- Canonical `main` write protection must apply to `agenticos_issue_bootstrap` persistence exactly as it already applies to other guardrail evidence writes.
-- Keep strict active-project matching in general managed-project resolution; loosen only the guardrail-side explicit-project path.
+- Treat session-local project binding, explicit project selection, and repo-path proof as authoritative; runtime target resolution no longer falls back through legacy registry state.
+- Keep `registry.active_project` as compatibility-only state rather than a home-global enforcement primitive.
+- Handle legacy project migration separately in #263 with compatibility-on-read and targeted repair, not a one-shot mutate-first rewrite.
 
-**Next Action**: Review and merge PR #261.
+**Next Action**: Complete #262 residual runtime/doc cleanup, rerun verification, then record and save the landed design state.
 <!-- AGENT_CONTEXT_END -->
 
 ---

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -175,8 +175,8 @@ AgenticOS does not treat every fallback as equal:
 
 Every officially supported adapter must align the runtime before meaningful work begins:
 
-1. call `agenticos_status` to confirm the active project, current task, pending work, and latest recorded state
-2. if the active project is missing or wrong, call `agenticos_switch`
+1. call `agenticos_status` to confirm the current session project, current task, pending work, and latest recorded state
+2. if no session project is bound or the bound project is wrong, call `agenticos_switch`
 3. load the project's startup surfaces (`.project.yaml`, quick-start, state, and session history)
 4. review the latest guardrail evidence and latest `agenticos_issue_bootstrap` record before implementation-affecting work
 5. if implementation work is requested, enter the canonical guardrail flow below
@@ -242,7 +242,7 @@ Switch to existing project and load context.
 
 **Returns**: Loaded context (project config, quick-start, state)
 
-Use this when `agenticos_status` shows the active project is missing or not the intended project.
+Use this when `agenticos_status` shows that no session project is bound or the bound project is not the intended one.
 
 The quick-start/state split is intentional:
 - `quick-start.md` is a concise entry surface
@@ -252,7 +252,7 @@ The quick-start/state split is intentional:
 ### agenticos_list
 List all projects with status.
 
-**Returns**: Formatted list with active project highlighted
+**Returns**: Formatted list with the current session project highlighted when one is bound
 
 ### agenticos_save
 Save state and backup to Git.
@@ -263,7 +263,7 @@ Save state and backup to Git.
 **Returns**: Backup confirmation with timestamp
 
 ### agenticos_status
-Show the status of the active project.
+Show the status of the current session project, or an explicit project when provided.
 
 **Returns**: Current task, pending items, and recent decisions
 
@@ -296,7 +296,7 @@ Run machine-checkable guardrail preflight after issue bootstrap and before imple
 **Returns**: JSON with `PASS`, `BLOCK`, or `REDIRECT`
 
 ### agenticos_edit_guard
-Fail closed before implementation-affecting edits unless the active project, latest issue bootstrap evidence, and latest persisted PASS preflight evidence already match the intended edit.
+Fail closed before implementation-affecting edits unless the resolved managed project identity, latest issue bootstrap evidence, and latest persisted PASS preflight evidence already match the intended edit.
 
 **Parameters**:
 - `repo_path` (required)
@@ -373,7 +373,7 @@ Validate a completed non-code evaluation rubric against the canonical contract a
 ## 📦 Resources Reference
 
 ### agenticos://context/current
-Get complete context for active project.
+Get complete context for the current session project.
 
 **Returns**:
 - Project configuration (.project.yaml)

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -72,7 +72,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     },
     {
       name: 'agenticos_switch',
-      description: 'Switch to an existing AgenticOS project',
+      description: 'Bind the current MCP session to an existing AgenticOS project',
       inputSchema: {
         type: 'object',
         properties: {
@@ -92,7 +92,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
       inputSchema: {
         type: 'object',
         properties: {
-          project: { type: 'string', description: 'Optional project ID, name, or path. If provided, it must match the active project or the call fails closed.' },
+          project: { type: 'string', description: 'Optional project ID, name, or path. If omitted, uses the current session project.' },
           summary: { type: 'string', description: 'What happened in this session (required)' },
           decisions: { type: 'array', items: { type: 'string' }, description: 'Key decisions made during this session' },
           outcomes: { type: 'array', items: { type: 'string' }, description: 'What was accomplished' },
@@ -115,19 +115,24 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
       inputSchema: {
         type: 'object',
         properties: {
-          project: { type: 'string', description: 'Optional project ID, name, or path. If provided, it must match the active project or the call fails closed.' },
+          project: { type: 'string', description: 'Optional project ID, name, or path. If omitted, uses the current session project.' },
           message: { type: 'string', description: 'Optional commit message' },
         },
       },
     },
     {
       name: 'agenticos_status',
-      description: 'Show status of the active project: last recorded time, current task, pending items, recent decisions.',
-      inputSchema: { type: 'object', properties: {} },
+      description: 'Show status of the current session project, or an explicit project when provided.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          project: { type: 'string', description: 'Optional project ID, name, or path. If omitted, uses the current session project.' },
+        },
+      },
     },
     {
       name: 'agenticos_preflight',
-      description: 'Run machine-checkable guardrail preflight before implementation or PR creation. Returns JSON with PASS, BLOCK, or REDIRECT.',
+      description: 'Run machine-checkable guardrail preflight before implementation or PR creation. Target resolution prefers explicit project_path, then provable repo_path, then session-local binding, otherwise fails closed. Returns JSON with PASS, BLOCK, or REDIRECT.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -163,7 +168,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     },
     {
       name: 'agenticos_edit_guard',
-      description: 'Fail closed before implementation-affecting edits unless active-project alignment, matching issue bootstrap evidence, and matching PASS preflight evidence already exist.',
+      description: 'Fail closed before implementation-affecting edits unless the resolved managed project identity, matching issue bootstrap evidence, and matching PASS preflight evidence already exist.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -186,7 +191,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     },
     {
       name: 'agenticos_issue_bootstrap',
-      description: 'Record canonical issue-start evidence for the current issue after entering the intended branch/worktree, performing a clear-equivalent reset, and loading normal startup context.',
+      description: 'Record canonical issue-start evidence for the current issue after entering the intended branch/worktree, performing a clear-equivalent reset, and loading normal startup context. Guardrail target resolution prefers explicit project_path, then provable repo_path, then session-local binding.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -218,7 +223,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     },
     {
       name: 'agenticos_branch_bootstrap',
-      description: 'Create an issue branch and isolated worktree from the intended remote base. Returns JSON with CREATED or BLOCK.',
+      description: 'Create an issue branch and isolated worktree from the intended remote base. Guardrail target resolution prefers explicit project_path, then provable repo_path, then session-local binding. Returns JSON with CREATED or BLOCK.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -235,7 +240,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     },
     {
       name: 'agenticos_pr_scope_check',
-      description: 'Validate that the current branch diff is scoped to the intended issue relative to the intended remote base.',
+      description: 'Validate that the current branch diff is scoped to the intended issue relative to the intended remote base. Guardrail target resolution prefers explicit project_path, then provable repo_path, then session-local binding.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -298,7 +303,8 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
       inputSchema: {
         type: 'object',
         properties: {
-          project_path: { type: 'string', description: 'Absolute target project path. If omitted, uses the active project from the registry.' },
+          project_path: { type: 'string', description: 'Absolute target project path. If omitted, uses explicit project, then the session-local current project.' },
+          project: { type: 'string', description: 'Optional managed project id, name, or path when project_path is not provided.' },
           project_name: { type: 'string', description: 'Project name to use when creating missing .project.yaml or generated guidance.' },
           project_description: { type: 'string', description: 'Optional project description used for generated guidance.' },
         },
@@ -310,7 +316,8 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
       inputSchema: {
         type: 'object',
         properties: {
-          project_path: { type: 'string', description: 'Absolute target project path. If omitted, uses the active project from the registry.' },
+          project_path: { type: 'string', description: 'Absolute target project path. If omitted, uses explicit project, then the session-local current project.' },
+          project: { type: 'string', description: 'Optional managed project id, name, or path when project_path is not provided.' },
           project_name: { type: 'string', description: 'Optional project name override used for reporting when .project.yaml is missing.' },
           project_description: { type: 'string', description: 'Optional project description override used for reporting.' },
         },
@@ -322,7 +329,8 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
       inputSchema: {
         type: 'object',
         properties: {
-          project_path: { type: 'string', description: 'Absolute target project path. If omitted, uses the active project from the registry.' },
+          project_path: { type: 'string', description: 'Absolute target project path. If omitted, uses explicit project, then the session-local current project.' },
+          project: { type: 'string', description: 'Optional managed project id, name, or path when project_path is not provided.' },
           project_name: { type: 'string', description: 'Optional project name override used for reporting when .project.yaml is missing.' },
           project_description: { type: 'string', description: 'Optional project description override used for reporting.' },
         },
@@ -375,7 +383,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     case 'agenticos_save':
       return { content: [{ type: 'text', text: await saveState(args) }] };
     case 'agenticos_status':
-      return { content: [{ type: 'text', text: await getStatus() }] };
+      return { content: [{ type: 'text', text: await getStatus(args ?? {}) }] };
     case 'agenticos_preflight':
       return { content: [{ type: 'text', text: await runPreflight(args ?? {}) }] };
     case 'agenticos_issue_bootstrap':
@@ -411,7 +419,7 @@ server.setRequestHandler(ListResourcesRequestSchema, async () => ({
     {
       uri: 'agenticos://context/current',
       name: 'Current Project Context',
-      description: 'Get context for the currently active project',
+      description: 'Get context for the current session project',
       mimeType: 'text/markdown',
     },
   ],

--- a/mcp-server/src/tools/__tests__/branch-bootstrap.test.ts
+++ b/mcp-server/src/tools/__tests__/branch-bootstrap.test.ts
@@ -48,7 +48,7 @@ describe('runBranchBootstrap', () => {
     });
     resolveGuardrailProjectTargetMock.mockResolvedValue({
       activeProjectId: 'agenticos',
-      resolutionSource: 'active_project',
+      resolutionSource: 'repo_path_match',
       resolutionErrors: [],
       targetProject: {
         id: 'agenticos',

--- a/mcp-server/src/tools/__tests__/edit-guard.test.ts
+++ b/mcp-server/src/tools/__tests__/edit-guard.test.ts
@@ -47,7 +47,7 @@ describe('runEditGuard', () => {
     });
     resolveGuardrailProjectTargetMock.mockResolvedValue({
       activeProjectId: 'agenticos-standards',
-      resolutionSource: 'active_project',
+      resolutionSource: 'repo_path_match',
       resolutionErrors: [],
       targetProject: {
         id: 'agenticos-standards',
@@ -118,11 +118,11 @@ describe('runEditGuard', () => {
     expect(result.scope_ok).toBe(true);
   });
 
-  it('blocks when active project does not match the intended target project', async () => {
+  it('blocks when the target project cannot be resolved and asks for an explicit managed project path', async () => {
     resolveGuardrailProjectTargetMock.mockResolvedValue({
       activeProjectId: 'cc-switch',
       resolutionSource: null,
-      resolutionErrors: ['Requested project "beta" does not match active project "cc-switch".'],
+      resolutionErrors: ['target project could not be resolved from repo_path or session binding; pass project_path explicitly'],
       targetProject: null,
     });
 
@@ -130,14 +130,14 @@ describe('runEditGuard', () => {
       issue_id: '113',
       task_type: 'implementation',
       repo_path: '/workspace/source',
-      project_path: '/workspace/projects/agenticos/standards',
       declared_target_files: [
         'projects/agenticos/mcp-server/src/index.ts',
       ],
-    })) as { status: string; block_reasons: string[] };
+    })) as { status: string; block_reasons: string[]; recovery_actions: string[] };
 
     expect(result.status).toBe('BLOCK');
-    expect(result.block_reasons.join(' ')).toContain('does not match active project');
+    expect(result.block_reasons.join(' ')).toContain('pass project_path explicitly');
+    expect(result.recovery_actions.join(' ')).toContain('pass project_path');
   });
 
   it('blocks when no preflight evidence is recorded', async () => {

--- a/mcp-server/src/tools/__tests__/init.test.ts
+++ b/mcp-server/src/tools/__tests__/init.test.ts
@@ -12,6 +12,8 @@ vi.mock('fs/promises', () => ({
   writeFile: vi.fn(),
   mkdir: vi.fn(),
   access: vi.fn(),
+  rename: vi.fn(),
+  rm: vi.fn(),
 }));
 
 vi.mock('fs', () => ({
@@ -45,6 +47,8 @@ const fsPromisesMock = fsPromises as typeof fsPromises & {
   writeFile: ReturnType<typeof vi.fn>;
   mkdir: ReturnType<typeof vi.fn>;
   access: ReturnType<typeof vi.fn>;
+  rename: ReturnType<typeof vi.fn>;
+  rm: ReturnType<typeof vi.fn>;
 };
 const fsMock = fs as typeof fs & { existsSync: ReturnType<typeof vi.fn> };
 const osMock = os as typeof os & { homedir: ReturnType<typeof vi.fn> };
@@ -58,6 +62,8 @@ describe('initProject', () => {
     fsPromisesMock.readFile.mockRejectedValue(new Error('ENOENT'));
     // access() throws → path doesn't exist → normal creation path
     fsPromisesMock.access.mockRejectedValue(new Error('ENOENT'));
+    fsPromisesMock.rename.mockResolvedValue(undefined);
+    fsPromisesMock.rm.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -112,8 +118,8 @@ describe('initProject', () => {
     for (const dir of expectedDirs) {
       expect(mkdirCalls).toContain(dir);
     }
-    // 5 calls: .context/conversations (implicitly creates .context), knowledge, tasks, artifacts
-    expect(mkdirCalls.length).toBe(5);
+    // Registry locking adds extra mkdir calls beyond the core project directories.
+    expect(mkdirCalls.length).toBeGreaterThanOrEqual(5);
   });
 
   it('writes .project.yaml with correct content', async () => {
@@ -239,7 +245,7 @@ describe('initProject', () => {
     expect(testProject).toBeDefined();
     expect(testProject.name).toBe('Test Project');
     expect(testProject.status).toBe('active');
-    expect(writtenRegistry.active_project).toBe('test-project');
+    expect(writtenRegistry.active_project).toBeNull();
   });
 
   it('normalizes an existing github_versioned project when context_publication_policy is provided explicitly', async () => {

--- a/mcp-server/src/tools/__tests__/issue-bootstrap.test.ts
+++ b/mcp-server/src/tools/__tests__/issue-bootstrap.test.ts
@@ -60,7 +60,7 @@ describe('runIssueBootstrap', () => {
     vi.clearAllMocks();
     resolveGuardrailProjectTargetMock.mockResolvedValue({
       activeProjectId: 'agenticos',
-      resolutionSource: 'active_project',
+      resolutionSource: 'repo_path_match',
       resolutionErrors: [],
       targetProject: {
         id: 'agenticos',

--- a/mcp-server/src/tools/__tests__/pr-scope-check.test.ts
+++ b/mcp-server/src/tools/__tests__/pr-scope-check.test.ts
@@ -66,7 +66,7 @@ describe('runPrScopeCheck', () => {
     });
     resolveGuardrailProjectTargetMock.mockResolvedValue({
       activeProjectId: 'agenticos',
-      resolutionSource: 'active_project',
+      resolutionSource: 'repo_path_match',
       resolutionErrors: [],
       targetProject: {
         id: 'agenticos',

--- a/mcp-server/src/tools/__tests__/preflight.test.ts
+++ b/mcp-server/src/tools/__tests__/preflight.test.ts
@@ -65,7 +65,7 @@ describe('runPreflight', () => {
     });
     resolveGuardrailProjectTargetMock.mockResolvedValue({
       activeProjectId: 'agenticos',
-      resolutionSource: 'active_project',
+      resolutionSource: 'repo_path_match',
       resolutionErrors: [],
       targetProject: {
         id: 'agenticos',
@@ -195,7 +195,7 @@ describe('runPreflight', () => {
     }));
   });
 
-  it('persists the resolved active project path even when repo_path is a larger checkout root', async () => {
+  it('persists the resolved target project path even when repo_path is a larger checkout root', async () => {
     mockGitResponses({
       'rev-parse --show-toplevel': '/repo\n',
       'rev-parse --git-common-dir': '.git\n',
@@ -209,7 +209,7 @@ describe('runPreflight', () => {
     });
     resolveGuardrailProjectTargetMock.mockResolvedValue({
       activeProjectId: 'agenticos-standards',
-      resolutionSource: 'active_project',
+      resolutionSource: 'repo_path_match',
       resolutionErrors: [],
       targetProject: {
         id: 'agenticos-standards',

--- a/mcp-server/src/tools/__tests__/project.test.ts
+++ b/mcp-server/src/tools/__tests__/project.test.ts
@@ -30,7 +30,7 @@ vi.mock('yaml', () => ({
 
 vi.mock('../../utils/registry.js', () => ({
   loadRegistry: vi.fn(),
-  saveRegistry: vi.fn(),
+  patchProjectMetadata: vi.fn(),
   getAgenticOSHome: vi.fn(() => '/home/testuser/AgenticOS'),
   resolvePath: vi.fn((p: string) => p),
 }));
@@ -48,6 +48,7 @@ import { switchProject, listProjects, getStatus } from '../project.js';
 import * as fsPromises from 'fs/promises';
 import * as registry from '../../utils/registry.js';
 import * as fs from 'fs';
+import { bindSessionProject, clearSessionProjectBinding } from '../../utils/session-context.js';
 
 const fsPromisesMock = fsPromises as typeof fsPromises & {
   readFile: ReturnType<typeof vi.fn>;
@@ -55,13 +56,26 @@ const fsPromisesMock = fsPromises as typeof fsPromises & {
 };
 const registryMock = registry as typeof registry & {
   loadRegistry: ReturnType<typeof vi.fn>;
-  saveRegistry: ReturnType<typeof vi.fn>;
+  patchProjectMetadata: ReturnType<typeof vi.fn>;
 };
 const fsMock = fs as typeof fs & { existsSync: ReturnType<typeof vi.fn> };
+
+function mockStatusReads(projectYaml: unknown, state: unknown | Error = {}): void {
+  fsPromisesMock.readFile.mockImplementation(async (path: string) => {
+    if (path.endsWith('/.project.yaml')) {
+      return JSON.stringify(projectYaml);
+    }
+    if (state instanceof Error) {
+      throw state;
+    }
+    return JSON.stringify(state);
+  });
+}
 
 describe('switchProject', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    clearSessionProjectBinding();
     // By default, mock existsSync to return false (no CLAUDE.md/AGENTS.md)
     fsMock.existsSync.mockReturnValue(false);
     yamlMock.parse.mockImplementation((content: string) => {
@@ -74,6 +88,7 @@ describe('switchProject', () => {
   });
 
   afterEach(() => {
+    clearSessionProjectBinding();
     vi.restoreAllMocks();
   });
 
@@ -105,7 +120,7 @@ describe('switchProject', () => {
     expect(result).toContain('Switched to project');
     expect(result).toContain('My Project');
     expect(result).toContain('/test/path');
-    expect(registryMock.saveRegistry).toHaveBeenCalled();
+    expect(registryMock.patchProjectMetadata).toHaveBeenCalled();
   });
 
   it('finds project by name', async () => {
@@ -194,10 +209,12 @@ describe('switchProject', () => {
 
     await switchProject({ project: 'my-project' });
 
-    expect(registryMock.saveRegistry).toHaveBeenCalled();
-    const savedRegistry = registryMock.saveRegistry.mock.calls[0][0];
-    const switchedProject = savedRegistry.projects.find((p: any) => p.id === 'my-project');
-    expect(switchedProject.last_accessed).not.toBe('2020-01-01T00:00:00.000Z');
+    expect(registryMock.patchProjectMetadata).toHaveBeenCalledWith(
+      'my-project',
+      expect.objectContaining({
+        last_accessed: expect.any(String),
+      }),
+    );
   });
 
   it('creates CLAUDE.md if missing', async () => {
@@ -509,7 +526,7 @@ describe('switchProject', () => {
 
     expect(result).toContain('archived reference content');
     expect(result).toContain('agenticos-standards');
-    expect(registryMock.saveRegistry).not.toHaveBeenCalled();
+    expect(registryMock.patchProjectMetadata).not.toHaveBeenCalled();
   });
 
   it('refuses to switch into a legacy project that has not completed topology initialization', async () => {
@@ -536,16 +553,18 @@ describe('switchProject', () => {
     const result = await switchProject({ project: 'legacy-project' });
 
     expect(result).toContain('has not completed source-control topology initialization');
-    expect(registryMock.saveRegistry).not.toHaveBeenCalled();
+    expect(registryMock.patchProjectMetadata).not.toHaveBeenCalled();
   });
 });
 
 describe('listProjects', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    clearSessionProjectBinding();
   });
 
   afterEach(() => {
+    clearSessionProjectBinding();
     vi.restoreAllMocks();
   });
 
@@ -564,6 +583,12 @@ describe('listProjects', () => {
   });
 
   it('formats registry with projects', async () => {
+    bindSessionProject({
+      projectId: 'project-a',
+      projectName: 'Project A',
+      projectPath: '/path/a',
+    });
+
     registryMock.loadRegistry.mockResolvedValue({
       version: '1.0.0',
       last_updated: '2025-01-01T00:00:00.000Z',
@@ -629,6 +654,7 @@ describe('listProjects', () => {
 describe('getStatus', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    clearSessionProjectBinding();
     // Set up yamlMock.parse to handle JSON.parse, fall back to undefined
     yamlMock.parse.mockImplementation((content: string) => {
       try { return JSON.parse(content); } catch { return undefined; }
@@ -636,10 +662,11 @@ describe('getStatus', () => {
   });
 
   afterEach(() => {
+    clearSessionProjectBinding();
     vi.restoreAllMocks();
   });
 
-  it('returns error when no active project', async () => {
+  it('returns error when no session project and no fallback project are available', async () => {
     registryMock.loadRegistry.mockResolvedValue({
       version: '1.0.0',
       last_updated: '2025-01-01T00:00:00.000Z',
@@ -649,11 +676,11 @@ describe('getStatus', () => {
 
     const result = await getStatus();
 
-    expect(result).toContain('No active project');
+    expect(result).toContain('No project provided and no session project is bound');
     expect(result).toContain('agenticos_switch');
   });
 
-  it('returns error when active project not found in registry', async () => {
+  it('ignores a populated legacy registry active_project when no session project is bound', async () => {
     registryMock.loadRegistry.mockResolvedValue({
       version: '1.0.0',
       last_updated: '2025-01-01T00:00:00.000Z',
@@ -663,10 +690,16 @@ describe('getStatus', () => {
 
     const result = await getStatus();
 
-    expect(result).toContain('not found in registry');
+    expect(result).toContain('No project provided and no session project is bound');
   });
 
-  it('returns status for active project', async () => {
+  it('returns status for the resolved session project', async () => {
+    bindSessionProject({
+      projectId: 'test-project',
+      projectName: 'Test Project',
+      projectPath: '/test/path',
+    });
+
     registryMock.loadRegistry.mockResolvedValue({
       version: '1.0.0',
       last_updated: '2025-01-01T00:00:00.000Z',
@@ -684,8 +717,12 @@ describe('getStatus', () => {
       ],
     });
 
-    fsPromisesMock.readFile.mockResolvedValue(
-      JSON.stringify({
+    mockStatusReads(
+      {
+        meta: { id: 'test-project', name: 'Test Project' },
+        source_control: { topology: 'local_directory_only' },
+      },
+      {
         source_control: { topology: 'local_directory_only' },
         session: { last_backup: '2025-01-02T12:00:00.000Z' },
         current_task: { title: 'Implement X', status: 'in_progress' },
@@ -693,7 +730,7 @@ describe('getStatus', () => {
           pending: ['task 1', 'task 2', 'task 3'],
           decisions: ['decision 1', 'decision 2'],
         },
-      })
+      }
     );
 
     const result = await getStatus();
@@ -706,6 +743,12 @@ describe('getStatus', () => {
   });
 
   it('uses configured canonical state paths for self-hosting status output', async () => {
+    bindSessionProject({
+      projectId: 'agenticos',
+      projectName: 'AgenticOS',
+      projectPath: '/workspace/projects/agenticos',
+    });
+
     registryMock.loadRegistry.mockResolvedValue({
       version: '1.0.0',
       last_updated: '2025-01-01T00:00:00.000Z',
@@ -722,16 +765,17 @@ describe('getStatus', () => {
       ],
     });
 
-    fsPromisesMock.readFile
-      .mockResolvedValueOnce(JSON.stringify({
+    mockStatusReads(
+      {
         meta: { id: 'agenticos', name: 'AgenticOS' },
         source_control: { topology: 'local_directory_only' },
         agent_context: { current_state: 'standards/.context/state.yaml' },
-      }))
-      .mockResolvedValueOnce(JSON.stringify({
+      },
+      {
         current_task: { title: 'Canonical status', status: 'active' },
         working_memory: { pending: [], decisions: [] },
-      }));
+      }
+    );
 
     const result = await getStatus();
 
@@ -740,6 +784,12 @@ describe('getStatus', () => {
   });
 
   it('handles project with no state.yaml', async () => {
+    bindSessionProject({
+      projectId: 'test-project',
+      projectName: 'Test Project',
+      projectPath: '/test/path',
+    });
+
     registryMock.loadRegistry.mockResolvedValue({
       version: '1.0.0',
       last_updated: '2025-01-01T00:00:00.000Z',
@@ -756,11 +806,13 @@ describe('getStatus', () => {
       ],
     });
 
-    fsPromisesMock.readFile
-      .mockResolvedValueOnce(JSON.stringify({
+    mockStatusReads(
+      {
+        meta: { id: 'test-project', name: 'Test Project' },
         source_control: { topology: 'local_directory_only' },
-      }))
-      .mockRejectedValue(new Error('ENOENT'));
+      },
+      new Error('ENOENT')
+    );
 
     const result = await getStatus();
 
@@ -768,6 +820,12 @@ describe('getStatus', () => {
   });
 
   it('shows None for current task when not set', async () => {
+    bindSessionProject({
+      projectId: 'test-project',
+      projectName: 'Test Project',
+      projectPath: '/test/path',
+    });
+
     registryMock.loadRegistry.mockResolvedValue({
       version: '1.0.0',
       last_updated: '2025-01-01T00:00:00.000Z',
@@ -785,12 +843,16 @@ describe('getStatus', () => {
       ],
     });
 
-    fsPromisesMock.readFile.mockResolvedValue(
-      JSON.stringify({
+    mockStatusReads(
+      {
+        meta: { id: 'test-project', name: 'Test Project' },
+        source_control: { topology: 'local_directory_only' },
+      },
+      {
         source_control: { topology: 'local_directory_only' },
         session: { last_backup: '2025-01-02T12:00:00.000Z' },
         working_memory: { pending: [], decisions: [] },
-      })
+      }
     );
 
     const result = await getStatus();
@@ -800,6 +862,12 @@ describe('getStatus', () => {
   });
 
   it('shows a friendly guardrail placeholder when no guardrail evidence exists', async () => {
+    bindSessionProject({
+      projectId: 'test-project',
+      projectName: 'Test Project',
+      projectPath: '/test/path',
+    });
+
     registryMock.loadRegistry.mockResolvedValue({
       version: '1.0.0',
       last_updated: '2025-01-01T00:00:00.000Z',
@@ -816,12 +884,16 @@ describe('getStatus', () => {
       ],
     });
 
-    fsPromisesMock.readFile.mockResolvedValue(
-      JSON.stringify({
+    mockStatusReads(
+      {
+        meta: { id: 'test-project', name: 'Test Project' },
+        source_control: { topology: 'local_directory_only' },
+      },
+      {
         source_control: { topology: 'local_directory_only' },
         session: { last_backup: '2025-01-02T12:00:00.000Z' },
         working_memory: { pending: [], decisions: [] },
-      })
+      }
     );
 
     const result = await getStatus();
@@ -830,6 +902,12 @@ describe('getStatus', () => {
   });
 
   it('shows a friendly issue bootstrap placeholder when no issue bootstrap evidence exists', async () => {
+    bindSessionProject({
+      projectId: 'test-project',
+      projectName: 'Test Project',
+      projectPath: '/test/path',
+    });
+
     registryMock.loadRegistry.mockResolvedValue({
       version: '1.0.0',
       last_updated: '2025-01-01T00:00:00.000Z',
@@ -846,12 +924,16 @@ describe('getStatus', () => {
       ],
     });
 
-    fsPromisesMock.readFile.mockResolvedValue(
-      JSON.stringify({
+    mockStatusReads(
+      {
+        meta: { id: 'test-project', name: 'Test Project' },
+        source_control: { topology: 'local_directory_only' },
+      },
+      {
         source_control: { topology: 'local_directory_only' },
         session: { last_backup: '2025-01-02T12:00:00.000Z' },
         working_memory: { pending: [], decisions: [] },
-      })
+      }
     );
 
     const result = await getStatus();
@@ -860,6 +942,12 @@ describe('getStatus', () => {
   });
 
   it('shows the latest issue bootstrap summary in status output when evidence exists', async () => {
+    bindSessionProject({
+      projectId: 'test-project',
+      projectName: 'Test Project',
+      projectPath: '/test/path',
+    });
+
     registryMock.loadRegistry.mockResolvedValue({
       version: '1.0.0',
       last_updated: '2025-01-01T00:00:00.000Z',
@@ -876,8 +964,12 @@ describe('getStatus', () => {
       ],
     });
 
-    fsPromisesMock.readFile.mockResolvedValue(
-      JSON.stringify({
+    mockStatusReads(
+      {
+        meta: { id: 'test-project', name: 'Test Project' },
+        source_control: { topology: 'local_directory_only' },
+      },
+      {
         source_control: { topology: 'local_directory_only' },
         session: { last_backup: '2025-01-02T12:00:00.000Z' },
         working_memory: { pending: [], decisions: [] },
@@ -892,7 +984,7 @@ describe('getStatus', () => {
             additional_context: [{ path: 'knowledge/issue-158.md', reason: 'design reference' }],
           },
         },
-      })
+      }
     );
 
     const result = await getStatus();
@@ -902,6 +994,12 @@ describe('getStatus', () => {
   });
 
   it('shows the latest BLOCK guardrail summary and reason', async () => {
+    bindSessionProject({
+      projectId: 'test-project',
+      projectName: 'Test Project',
+      projectPath: '/test/path',
+    });
+
     registryMock.loadRegistry.mockResolvedValue({
       version: '1.0.0',
       last_updated: '2025-01-01T00:00:00.000Z',
@@ -918,8 +1016,12 @@ describe('getStatus', () => {
       ],
     });
 
-    fsPromisesMock.readFile.mockResolvedValue(
-      JSON.stringify({
+    mockStatusReads(
+      {
+        meta: { id: 'test-project', name: 'Test Project' },
+        source_control: { topology: 'local_directory_only' },
+      },
+      {
         source_control: { topology: 'local_directory_only' },
         session: { last_backup: '2025-01-02T12:00:00.000Z' },
         working_memory: { pending: [], decisions: [] },
@@ -936,7 +1038,7 @@ describe('getStatus', () => {
             },
           },
         },
-      })
+      }
     );
 
     const result = await getStatus();
@@ -947,6 +1049,12 @@ describe('getStatus', () => {
   });
 
   it('shows the latest REDIRECT guardrail summary and redirect action', async () => {
+    bindSessionProject({
+      projectId: 'test-project',
+      projectName: 'Test Project',
+      projectPath: '/test/path',
+    });
+
     registryMock.loadRegistry.mockResolvedValue({
       version: '1.0.0',
       last_updated: '2025-01-01T00:00:00.000Z',
@@ -963,8 +1071,12 @@ describe('getStatus', () => {
       ],
     });
 
-    fsPromisesMock.readFile.mockResolvedValue(
-      JSON.stringify({
+    mockStatusReads(
+      {
+        meta: { id: 'test-project', name: 'Test Project' },
+        source_control: { topology: 'local_directory_only' },
+      },
+      {
         source_control: { topology: 'local_directory_only' },
         session: { last_backup: '2025-01-02T12:00:00.000Z' },
         working_memory: { pending: [], decisions: [] },
@@ -981,7 +1093,7 @@ describe('getStatus', () => {
             },
           },
         },
-      })
+      }
     );
 
     const result = await getStatus();
@@ -991,6 +1103,12 @@ describe('getStatus', () => {
   });
 
   it('refuses status for an archived active project', async () => {
+    bindSessionProject({
+      projectId: 'archived-project',
+      projectName: 'Archived Project',
+      projectPath: '/test/path',
+    });
+
     registryMock.loadRegistry.mockResolvedValue({
       version: '1.0.0',
       last_updated: '2025-01-01T00:00:00.000Z',
@@ -1007,8 +1125,9 @@ describe('getStatus', () => {
       ],
     });
 
-    fsPromisesMock.readFile.mockResolvedValue(
-      JSON.stringify({
+    mockStatusReads(
+      {
+        meta: { id: 'archived-project', name: 'Archived Project' },
         archive_contract: {
           version: 1,
           kind: 'archived_reference',
@@ -1016,7 +1135,7 @@ describe('getStatus', () => {
           execution_mode: 'reference_only',
           replacement_project: 'agenticos-standards',
         },
-      })
+      }
     );
 
     const result = await getStatus();
@@ -1026,6 +1145,12 @@ describe('getStatus', () => {
   });
 
   it('refuses status for an active project that has not completed topology initialization', async () => {
+    bindSessionProject({
+      projectId: 'legacy-project',
+      projectName: 'Legacy Project',
+      projectPath: '/test/path',
+    });
+
     registryMock.loadRegistry.mockResolvedValue({
       version: '1.0.0',
       last_updated: '2025-01-01T00:00:00.000Z',

--- a/mcp-server/src/tools/__tests__/record.test.ts
+++ b/mcp-server/src/tools/__tests__/record.test.ts
@@ -30,7 +30,7 @@ vi.mock('yaml', () => ({
 
 vi.mock('../../utils/registry.js', () => ({
   loadRegistry: vi.fn(),
-  saveRegistry: vi.fn(),
+  patchProjectMetadata: vi.fn(),
   getAgenticOSHome: vi.fn(() => '/home/testuser/AgenticOS'),
   resolvePath: vi.fn((p: string) => p),
 }));
@@ -42,6 +42,7 @@ vi.mock('../../utils/distill.js', () => ({
 import { recordSession } from '../record.js';
 import * as fsPromises from 'fs/promises';
 import * as registry from '../../utils/registry.js';
+import { bindSessionProject, clearSessionProjectBinding } from '../../utils/session-context.js';
 
 const fsPromisesMock = fsPromises as typeof fsPromises & {
   readFile: ReturnType<typeof vi.fn>;
@@ -50,7 +51,7 @@ const fsPromisesMock = fsPromises as typeof fsPromises & {
 };
 const registryMock = registry as typeof registry & {
   loadRegistry: ReturnType<typeof vi.fn>;
-  saveRegistry: ReturnType<typeof vi.fn>;
+  patchProjectMetadata: ReturnType<typeof vi.fn>;
 };
 
 function buildRegistry(overrides: Record<string, unknown> = {}) {
@@ -113,11 +114,17 @@ function mockProjectFiles(options?: {
 
 describe('recordSession', () => {
   beforeEach(() => {
+    clearSessionProjectBinding();
+    bindSessionProject({
+      projectId: 'test-project',
+      projectName: 'Test Project',
+      projectPath: '/test/path',
+    });
     // Clear mock calls but preserve implementations
     fsPromisesMock.readFile.mockClear();
     fsPromisesMock.writeFile.mockClear();
     registryMock.loadRegistry.mockClear();
-    registryMock.saveRegistry.mockClear();
+    registryMock.patchProjectMetadata.mockClear();
     yamlMock.parse.mockClear();
     yamlMock.stringify.mockClear();
     // Set up default yamlMock implementations
@@ -132,11 +139,12 @@ describe('recordSession', () => {
       active_project: null,
       projects: [],
     });
-    registryMock.saveRegistry.mockResolvedValue(undefined);
+    registryMock.patchProjectMetadata.mockResolvedValue(undefined);
     mockProjectFiles();
   });
 
   afterEach(() => {
+    clearSessionProjectBinding();
     vi.restoreAllMocks();
   });
 
@@ -145,12 +153,15 @@ describe('recordSession', () => {
     expect(result).toContain('summary is required');
   });
 
-  it('returns error when no active project', async () => {
+  it('returns error when no explicit project and no session project are available', async () => {
+    clearSessionProjectBinding();
     const result = await recordSession({ summary: 'test summary' });
-    expect(result).toContain('No active project');
+    expect(result).toContain('No project provided and no session project is bound');
+    expect(result).toContain('agenticos_switch');
   });
 
-  it('returns error when active project not found in registry', async () => {
+  it('ignores a populated legacy registry active_project when no session project is bound', async () => {
+    clearSessionProjectBinding();
     registryMock.loadRegistry.mockResolvedValue({
       version: '1.0.0',
       last_updated: '2025-01-01T00:00:00.000Z',
@@ -168,7 +179,7 @@ describe('recordSession', () => {
     });
 
     const result = await recordSession({ summary: 'test summary' });
-    expect(result).toContain('not found in registry');
+    expect(result).toContain('No project provided and no session project is bound');
   });
 
   it('creates conversation file with correct date-based filename', async () => {
@@ -354,10 +365,12 @@ describe('recordSession', () => {
 
     await recordSession({ summary: 'test' });
 
-    expect(registryMock.saveRegistry).toHaveBeenCalled();
-    const savedRegistry = registryMock.saveRegistry.mock.calls[0][0];
-    const testProject = savedRegistry.projects.find((p: any) => p.id === 'test-project');
-    expect(testProject.last_recorded).toBeDefined();
+    expect(registryMock.patchProjectMetadata).toHaveBeenCalledWith(
+      'test-project',
+      expect.objectContaining({
+        last_recorded: expect.any(String),
+      }),
+    );
   });
 
   it('parses JSON-stringified array arguments without spreading as characters', async () => {
@@ -578,15 +591,15 @@ describe('recordSession', () => {
 
     await recordSession({ summary: 'test session' });
 
-    const savedRegistry = registryMock.saveRegistry.mock.calls[0][0];
-    const testProject = savedRegistry.projects.find((p: any) => p.id === 'test-project');
-    const otherProject = savedRegistry.projects.find((p: any) => p.id === 'other-project');
-
-    expect(testProject.last_recorded).toBeDefined();
-    expect(otherProject.last_recorded).toBe('2025-01-01T12:00:00.000Z');
+    expect(registryMock.patchProjectMetadata).toHaveBeenCalledWith(
+      'test-project',
+      expect.objectContaining({
+        last_recorded: expect.any(String),
+      }),
+    );
   });
 
-  it('fails closed when explicit project does not match the active project', async () => {
+  it('allows an explicit project even when legacy active_project differs', async () => {
     registryMock.loadRegistry.mockResolvedValue({
       ...buildRegistry(),
       projects: [
@@ -601,14 +614,105 @@ describe('recordSession', () => {
         },
       ],
     });
+    fsPromisesMock.readFile.mockImplementation(async (path: string) => {
+      if (path === '/other/path/.project.yaml') {
+        return JSON.stringify({
+          meta: { id: 'other-project', name: 'Other Project' },
+          source_control: { topology: 'local_directory_only' },
+        });
+      }
+      if (path === '/other/path/.context/state.yaml') {
+        return JSON.stringify({
+          session: {},
+          working_memory: { decisions: [], facts: [], pending: [] },
+        });
+      }
+      if (path === '/other/path/.context/quick-start.md') {
+        return '# Quick Start\n\n1. Define project goals';
+      }
+      if (path.includes('/other/path/.context/conversations/') && path.endsWith('.md')) {
+        return '';
+      }
+      if (path === '/test/path/.project.yaml') {
+        return JSON.stringify({
+          meta: { id: 'test-project', name: 'Test Project' },
+          source_control: { topology: 'local_directory_only' },
+        });
+      }
+      if (path === '/test/path/.context/state.yaml') {
+        return JSON.stringify({
+          session: {},
+          working_memory: { decisions: [], facts: [], pending: [] },
+        });
+      }
+      if (path === '/test/path/.context/quick-start.md') {
+        return '# Quick Start\n\n1. Define project goals';
+      }
+      if (path.includes('/test/path/.context/conversations/') && path.endsWith('.md')) {
+        return '';
+      }
+      return '';
+    });
 
     const result = await recordSession({
       project: 'other-project',
       summary: 'test',
     });
 
-    expect(result).toContain('does not match active project');
-    expect(fsPromisesMock.writeFile).not.toHaveBeenCalled();
+    expect(result).toContain('Session recorded for "Other Project"');
+    expect(registryMock.patchProjectMetadata).toHaveBeenCalledWith(
+      'other-project',
+      expect.objectContaining({
+        last_recorded: expect.any(String),
+      }),
+    );
+  });
+
+  it('uses the session-local bound project when no explicit project is provided', async () => {
+    bindSessionProject({
+      projectId: 'other-project',
+      projectName: 'Other Project',
+      projectPath: '/other/path',
+    });
+    registryMock.loadRegistry.mockResolvedValue({
+      ...buildRegistry({ active_project: null }),
+      projects: [
+        ...buildRegistry().projects,
+        {
+          id: 'other-project',
+          name: 'Other Project',
+          path: '/other/path',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+    fsPromisesMock.readFile.mockImplementation(async (path: string) => {
+      if (path === '/other/path/.project.yaml') {
+        return JSON.stringify({
+          meta: { id: 'other-project', name: 'Other Project' },
+          source_control: { topology: 'local_directory_only' },
+        });
+      }
+      if (path === '/other/path/.context/state.yaml') {
+        return JSON.stringify({
+          session: {},
+          working_memory: { decisions: [], facts: [], pending: [] },
+        });
+      }
+      if (path === '/other/path/.context/quick-start.md') {
+        return '# Quick Start\n\n1. Define project goals';
+      }
+      if (path.includes('/other/path/.context/conversations/') && path.endsWith('.md')) {
+        return '';
+      }
+      throw new Error(`unexpected path: ${path}`);
+    });
+
+    const result = await recordSession({ summary: 'session-bound record' });
+
+    expect(result).toContain('Session recorded for "Other Project"');
   });
 
   it('fails closed when .project.yaml identity mismatches the registry project', async () => {

--- a/mcp-server/src/tools/__tests__/save.test.ts
+++ b/mcp-server/src/tools/__tests__/save.test.ts
@@ -50,6 +50,7 @@ import * as fsPromises from 'fs/promises';
 import * as registry from '../../utils/registry.js';
 import * as childProcess from 'child_process';
 import { updateClaudeMdState } from '../../utils/distill.js';
+import { bindSessionProject, clearSessionProjectBinding } from '../../utils/session-context.js';
 
 const fsPromisesMock = fsPromises as typeof fsPromises & {
   readFile: ReturnType<typeof vi.fn>;
@@ -107,6 +108,12 @@ function mockProjectFiles(options?: {
 
 describe('saveState', () => {
   beforeEach(() => {
+    clearSessionProjectBinding();
+    bindSessionProject({
+      projectId: 'test-project',
+      projectName: 'Test Project',
+      projectPath: '/test/path',
+    });
     // Clear specific mocks but preserve yaml mock implementation
     fsPromisesMock.readFile.mockReset();
     fsPromisesMock.writeFile.mockReset();
@@ -139,16 +146,19 @@ describe('saveState', () => {
   });
 
   afterEach(() => {
+    clearSessionProjectBinding();
     vi.restoreAllMocks();
   });
 
-  it('returns error when no active project', async () => {
+  it('returns error when no explicit project and no session project are available', async () => {
+    clearSessionProjectBinding();
     const result = await saveState({ message: 'test' });
-    expect(result).toContain('No active project');
+    expect(result).toContain('No project provided and no session project is bound');
     expect(result).toContain('agenticos_switch');
   });
 
-  it('returns error when active project not found in registry', async () => {
+  it('ignores a populated legacy registry active_project when no session project is bound', async () => {
+    clearSessionProjectBinding();
     registryMock.loadRegistry.mockResolvedValue({
       version: '1.0.0',
       last_updated: '2025-01-01T00:00:00.000Z',
@@ -166,7 +176,7 @@ describe('saveState', () => {
     });
 
     const result = await saveState({ message: 'test' });
-    expect(result).toContain('Active project "non-existent" not found in registry');
+    expect(result).toContain('No project provided and no session project is bound');
   });
 
   it('saves state.yaml with backup timestamp when no git repo', async () => {
@@ -471,7 +481,7 @@ describe('saveState', () => {
     expect(result).toContain('Push failed (committed locally, not synced)');
   });
 
-  it('fails closed when explicit project does not match the active project', async () => {
+  it('allows an explicit project even when legacy active_project differs', async () => {
     registryMock.loadRegistry.mockResolvedValue({
       ...buildRegistry(),
       projects: [
@@ -486,11 +496,87 @@ describe('saveState', () => {
         },
       ],
     });
+    fsPromisesMock.readFile.mockImplementation(async (path: string) => {
+      if (path === '/other/path/.project.yaml') {
+        return JSON.stringify({
+          meta: { id: 'other-project', name: 'Other Project' },
+          source_control: { topology: 'local_directory_only' },
+        });
+      }
+      if (path === '/other/path/.context/state.yaml') {
+        return JSON.stringify({ session: {}, working_memory: { pending: [], decisions: [], facts: [] } });
+      }
+      if (path === '/test/path/.project.yaml') {
+        return JSON.stringify({
+          meta: { id: 'test-project', name: 'Test Project' },
+          source_control: { topology: 'local_directory_only' },
+        });
+      }
+      if (path === '/test/path/.context/state.yaml') {
+        return JSON.stringify({ session: {}, working_memory: { pending: [], decisions: [], facts: [] } });
+      }
+      return '';
+    });
+    childProcessMock.exec.mockImplementation(
+      (cmd: string, cb: (err: Error | null, stdout?: string, stderr?: string) => void) => {
+        if (cmd.includes('rev-parse --show-toplevel')) {
+          cb(new Error('not a git repo'), '', '');
+          return;
+        }
+        cb(null, '', '');
+      }
+    );
 
     const result = await saveState({ project: 'other-project', message: 'test' });
 
-    expect(result).toContain('does not match active project');
-    expect(childProcessMock.exec).not.toHaveBeenCalled();
+    expect(result).toContain('State saved but no git repo found at /other/path');
+  });
+
+  it('uses the session-local bound project when no explicit project is provided', async () => {
+    bindSessionProject({
+      projectId: 'other-project',
+      projectName: 'Other Project',
+      projectPath: '/other/path',
+    });
+    registryMock.loadRegistry.mockResolvedValue({
+      ...buildRegistry({ active_project: null }),
+      projects: [
+        ...buildRegistry().projects,
+        {
+          id: 'other-project',
+          name: 'Other Project',
+          path: '/other/path',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+    fsPromisesMock.readFile.mockImplementation(async (path: string) => {
+      if (path === '/other/path/.project.yaml') {
+        return JSON.stringify({
+          meta: { id: 'other-project', name: 'Other Project' },
+          source_control: { topology: 'local_directory_only' },
+        });
+      }
+      if (path === '/other/path/.context/state.yaml') {
+        return JSON.stringify({ session: {}, working_memory: { pending: [], decisions: [], facts: [] } });
+      }
+      throw new Error(`unexpected path: ${path}`);
+    });
+    childProcessMock.exec.mockImplementation(
+      (cmd: string, cb: (err: Error | null, stdout?: string, stderr?: string) => void) => {
+        if (cmd.includes('rev-parse --show-toplevel')) {
+          cb(new Error('not a git repo'), '', '');
+          return;
+        }
+        cb(null, '', '');
+      }
+    );
+
+    const result = await saveState({ message: 'test' });
+
+    expect(result).toContain('State saved but no git repo found at /other/path');
   });
 
   it('fails closed when .project.yaml identity mismatches the registry project', async () => {

--- a/mcp-server/src/tools/__tests__/standard-kit.test.ts
+++ b/mcp-server/src/tools/__tests__/standard-kit.test.ts
@@ -5,6 +5,7 @@ import { join } from 'path';
 import yaml from 'yaml';
 import { runStandardKitAdopt, runStandardKitConformanceCheck, runStandardKitUpgradeCheck } from '../standard-kit.js';
 import { CURRENT_TEMPLATE_VERSION, generateAgentsMd } from '../../utils/distill.js';
+import { bindSessionProject, clearSessionProjectBinding } from '../../utils/session-context.js';
 
 async function writeRegistry(home: string, registry: unknown): Promise<void> {
   await mkdir(join(home, '.agent-workspace'), { recursive: true });
@@ -109,7 +110,7 @@ async function setupKitHome(): Promise<{ home: string; projectRoot: string }> {
         automation_rationale: ['agent-owned config'],
         session_start_sequence: [
           'call `agenticos_status` before meaningful work',
-          'if the active project is missing or wrong, call `agenticos_switch`',
+          'if no session project is bound or the bound project is not the intended one, call `agenticos_switch`',
           'review the latest `agenticos_issue_bootstrap` record',
         ],
       },
@@ -219,6 +220,7 @@ async function setupKitHome(): Promise<{ home: string; projectRoot: string }> {
 
 describe('standard kit commands', () => {
   afterEach(() => {
+    clearSessionProjectBinding();
     delete process.env.AGENTICOS_HOME;
   });
 
@@ -310,9 +312,29 @@ describe('standard kit commands', () => {
     expect(subAgentHandoffStatus).toMatchObject({ status: 'missing' });
   });
 
-  it('adopt can resolve the active project from registry and upgrades stale generated files while skipping current ones', async () => {
+  it('adopt can resolve the session-local project and upgrades stale generated files while skipping current ones', async () => {
     const { home, projectRoot } = await setupKitHome();
     process.env.AGENTICOS_HOME = home;
+    await writeRegistry(home, {
+      version: '1.0.0',
+      last_updated: new Date().toISOString(),
+      active_project: null,
+      projects: [
+        {
+          id: 'sample-project',
+          name: 'Sample Project',
+          path: 'projects/sample-project',
+          status: 'active',
+          created: '2026-03-23',
+          last_accessed: new Date().toISOString(),
+        },
+      ],
+    });
+    bindSessionProject({
+      projectId: 'sample-project',
+      projectName: 'Sample Project',
+      projectPath: projectRoot,
+    });
 
     await writeFile(join(projectRoot, 'AGENTS.md'), generateAgentsMd('Sample Project', ''), 'utf-8');
     await writeFile(
@@ -489,9 +511,29 @@ describe('standard kit commands', () => {
     expect(result.missing_required_files).toEqual([]);
   });
 
-  it('upgrade check can resolve project identity from an existing .project.yaml through the active registry project', async () => {
+  it('upgrade check can resolve project identity from an existing .project.yaml through the session-local project', async () => {
     const { home, projectRoot } = await setupKitHome();
     process.env.AGENTICOS_HOME = home;
+    await writeRegistry(home, {
+      version: '1.0.0',
+      last_updated: new Date().toISOString(),
+      active_project: null,
+      projects: [
+        {
+          id: 'sample-project',
+          name: 'Sample Project',
+          path: 'projects/sample-project',
+          status: 'active',
+          created: '2026-03-23',
+          last_accessed: new Date().toISOString(),
+        },
+      ],
+    });
+    bindSessionProject({
+      projectId: 'sample-project',
+      projectName: 'Sample Project',
+      projectPath: projectRoot,
+    });
 
     await writeFile(
       join(projectRoot, '.project.yaml'),
@@ -506,6 +548,40 @@ describe('standard kit commands', () => {
 
     expect(result.project_name).toBe('Yaml Project');
     expect(result.project_id).toBe('yaml-project');
+  });
+
+  it('adopt can resolve an explicit managed project without relying on session fallback state', async () => {
+    const { home, projectRoot } = await setupKitHome();
+    process.env.AGENTICOS_HOME = home;
+
+    await writeRegistry(home, {
+      version: '1.0.0',
+      last_updated: new Date().toISOString(),
+      active_project: null,
+      projects: [
+        {
+          id: 'sample-project',
+          name: 'Sample Project',
+          path: 'projects/sample-project',
+          status: 'active',
+          created: '2026-03-23',
+          last_accessed: new Date().toISOString(),
+        },
+      ],
+    });
+
+    const result = JSON.parse(await runStandardKitAdopt({
+      project: 'sample-project',
+    })) as {
+      project_name: string;
+      project_id: string;
+      status: string;
+    };
+
+    expect(result.status).toBe('ADOPTED');
+    expect(result.project_name).toBe('Sample Project');
+    expect(result.project_id).toBe('sample-project');
+    expect(await readFile(join(projectRoot, '.project.yaml'), 'utf-8')).toContain('sample-project');
   });
 
   it('adopt upgrades stale AGENTS.md files to the current generated template', async () => {
@@ -697,7 +773,7 @@ describe('standard kit commands', () => {
     expect(result.copied_templates).toEqual([]);
   });
 
-  it('adopt blocks when no active project exists and no project_path is provided', async () => {
+  it('adopt blocks when no explicit target and no session project are available', async () => {
     const { home } = await setupKitHome();
     process.env.AGENTICOS_HOME = home;
 
@@ -709,11 +785,11 @@ describe('standard kit commands', () => {
     });
 
     await expect(runStandardKitAdopt(undefined)).rejects.toThrow(
-      'No project_path provided and no active project found in registry.',
+      'No project_path provided, no explicit project provided, and no session project is bound.',
     );
   });
 
-  it('adopt blocks when the registry active project cannot be resolved', async () => {
+  it('adopt ignores a populated legacy registry active_project when no session project is bound', async () => {
     const { home } = await setupKitHome();
     process.env.AGENTICOS_HOME = home;
 
@@ -725,7 +801,7 @@ describe('standard kit commands', () => {
     });
 
     await expect(runStandardKitAdopt({})).rejects.toThrow(
-      'Active project "missing-project" not found in registry.',
+      'No project_path provided, no explicit project provided, and no session project is bound.',
     );
   });
 

--- a/mcp-server/src/tools/init.ts
+++ b/mcp-server/src/tools/init.ts
@@ -1,7 +1,7 @@
 import { mkdir, writeFile, access, readFile } from 'fs/promises';
 import { join } from 'path';
 import yaml from 'yaml';
-import { loadRegistry, saveRegistry, getAgenticOSHome } from '../utils/registry.js';
+import { loadRegistry, patchRegistry, getAgenticOSHome } from '../utils/registry.js';
 import { generateClaudeMd, generateAgentsMd } from '../utils/distill.js';
 import { buildProjectTopologyInitializationMessage, validateContextPublicationPolicy, type ContextPublicationPolicy, type ProjectTopology } from '../utils/project-contract.js';
 import { resolveManagedProjectContextDisplayPaths, resolveManagedProjectContextPaths } from '../utils/agent-context-paths.js';
@@ -157,8 +157,6 @@ export async function initProject(args: any): Promise<string> {
     if (!publicationValidation.ok) {
       return `${publicationValidation.message} Re-run agenticos_init with normalize_existing=true and the intended topology/publication contract.`;
     }
-    registry.active_project = id;
-    await saveRegistry(registry);
     return `Project '${name}' already exists at ${projectPath}. Use \`agenticos_switch\` to activate it.`;
   }
 
@@ -167,8 +165,12 @@ export async function initProject(args: any): Promise<string> {
   }
 
   if (!pathExists && registryHasId) {
-    registry.projects.splice(existingIdx, 1);
-    await saveRegistry(registry);
+    await patchRegistry((current) => {
+      current.projects = current.projects.filter((project) => project.id !== id);
+      if (current.active_project === id) {
+        current.active_project = null;
+      }
+    });
   }
 
   const existingProjectYaml = pathExists ? await loadExistingProjectYaml(projectPath) : {};
@@ -243,12 +245,11 @@ ${description ?? existingProjectYaml?.meta?.description ?? ''}
     last_accessed: new Date().toISOString(),
   };
 
-  if (existingIdx >= 0) {
-    registry.projects.splice(existingIdx, 1);
-  }
-  registry.projects.push(projectEntry);
-  registry.active_project = id;
-  await saveRegistry(registry);
+  await patchRegistry((current) => {
+    current.projects = current.projects.filter((project) => project.id !== id);
+    current.projects.push(projectEntry);
+    current.active_project = null;
+  });
 
   const topologyLine = topology === 'github_versioned'
     ? `Topology: github_versioned (${githubRepo}, github_flow)`

--- a/mcp-server/src/tools/preflight.ts
+++ b/mcp-server/src/tools/preflight.ts
@@ -189,10 +189,13 @@ export async function runPreflight(args: PreflightArgs): Promise<string> {
 
   if (!projectResolution.targetProject) {
     result.block_reasons.push(...projectResolution.resolutionErrors);
-    if (!projectResolution.activeProjectId) {
-      result.redirect_actions.push('call agenticos_switch or pass project_path before implementation-affecting work');
+    if (project_path) {
+      result.redirect_actions.push('pass a valid project_path pointing at the intended managed project root');
     } else {
-      result.redirect_actions.push('pass project_path explicitly if the active project is not the intended target');
+      result.redirect_actions.push('pass project_path explicitly if repo_path cannot be proven against the intended managed project');
+      if (!projectResolution.activeProjectId) {
+        result.redirect_actions.push('call agenticos_switch before implementation-affecting work when no explicit project identity is available');
+      }
     }
   }
 

--- a/mcp-server/src/tools/project.ts
+++ b/mcp-server/src/tools/project.ts
@@ -2,13 +2,14 @@ import { existsSync } from 'fs';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
 import yaml from 'yaml';
-import { loadRegistry, saveRegistry } from '../utils/registry.js';
+import { loadRegistry, patchProjectMetadata } from '../utils/registry.js';
 import { generateClaudeMd, generateAgentsMd, updateClaudeMdState, upgradeClaudeMd, CURRENT_TEMPLATE_VERSION, extractTemplateVersion } from '../utils/distill.js';
 import { writeFile } from 'fs/promises';
 import { buildArchivedReferenceMessage, isArchivedReferenceProject, validateManagedProjectTopology } from '../utils/project-contract.js';
-import { resolveManagedProjectContextPaths } from '../utils/project-target.js';
+import { resolveManagedProjectContextPaths, resolveManagedProjectTarget } from '../utils/project-target.js';
 import { type IssueBootstrapRecord, type IssueBootstrapState } from '../utils/guardrail-evidence.js';
 import { resolveManagedProjectContextDisplayPaths } from '../utils/agent-context-paths.js';
+import { bindSessionProject, getSessionProjectBinding } from '../utils/session-context.js';
 
 type GuardrailCommand = 'agenticos_preflight' | 'agenticos_branch_bootstrap' | 'agenticos_pr_scope_check';
 
@@ -240,12 +241,22 @@ export async function switchProject(args: any): Promise<string> {
     return `❌ ${topologyValidation.message}`;
   }
 
-  registry.active_project = found.id;
   found.last_accessed = new Date().toISOString();
-  await saveRegistry(registry);
+  bindSessionProject({
+    projectId: found.id,
+    projectName: found.name,
+    projectPath: found.path,
+  });
 
   // Auto-bootstrap: generate or upgrade CLAUDE.md / AGENTS.md
   const bootstrapNotes: string[] = [];
+  try {
+    await patchProjectMetadata(found.id, {
+      last_accessed: found.last_accessed,
+    });
+  } catch (error: any) {
+    bootstrapNotes.push(`⚠️ Session bound, but registry metadata was not updated: ${error.message}`);
+  }
   const claudeMdPath = join(found.path, 'CLAUDE.md');
   const agentsMdPath = join(found.path, 'AGENTS.md');
 
@@ -305,6 +316,7 @@ export async function switchProject(args: any): Promise<string> {
 
 export async function listProjects(): Promise<string> {
   const registry = await loadRegistry();
+  const sessionProject = getSessionProjectBinding();
 
   if (registry.projects.length === 0) {
     return 'No projects found. Use agenticos_init to create your first project.';
@@ -313,7 +325,7 @@ export async function listProjects(): Promise<string> {
   const lines = ['# AgenticOS Projects\n'];
 
   for (const p of registry.projects) {
-    const active = p.id === registry.active_project ? '🟢 ' : '';
+    const active = p.id === sessionProject?.projectId ? '🟢 ' : '';
     lines.push(`${active}**${p.name}** (${p.id})`);
     lines.push(`  Path: ${p.path}`);
     lines.push(`  Status: ${p.status}`);
@@ -329,32 +341,18 @@ export async function listProjects(): Promise<string> {
   return lines.join('\n');
 }
 
-export async function getStatus(): Promise<string> {
-  const registry = await loadRegistry();
-
-  if (!registry.active_project) {
-    return '❌ No active project. Use agenticos_switch first.';
-  }
-
-  const project = registry.projects.find((p) => p.id === registry.active_project);
-  if (!project) return '❌ Active project not found in registry.';
-
-  let projectYaml: any = {};
+export async function getStatus(args: any = {}): Promise<string> {
+  let resolved;
   try {
-    projectYaml = yaml.parse(await readFile(join(project.path, '.project.yaml'), 'utf-8')) || {};
-  } catch {}
-
-  if (isArchivedReferenceProject(projectYaml, project.status)) {
-    return `❌ ${buildArchivedReferenceMessage(project.name, projectYaml?.archive_contract?.replacement_project)}`;
+    resolved = await resolveManagedProjectTarget({
+      project: args?.project,
+      commandName: 'agenticos_status',
+    });
+  } catch (error: any) {
+    return `❌ ${error.message}`;
   }
 
-  const topologyValidation = validateManagedProjectTopology(project.name, projectYaml);
-  if (!topologyValidation.ok) {
-    return `❌ ${topologyValidation.message}`;
-  }
-
-  const contextPaths = resolveManagedProjectContextPaths(project.path, projectYaml);
-  const statePath = contextPaths.statePath;
+  const { project, statePath } = resolved;
   let state: any = {};
   try {
     const content = await readFile(statePath, 'utf-8');

--- a/mcp-server/src/tools/record.ts
+++ b/mcp-server/src/tools/record.ts
@@ -1,6 +1,6 @@
 import { readFile, writeFile, mkdir } from 'fs/promises';
 import yaml from 'yaml';
-import { saveRegistry } from '../utils/registry.js';
+import { patchProjectMetadata } from '../utils/registry.js';
 import { updateClaudeMdState } from '../utils/distill.js';
 import { resolveManagedProjectTarget } from '../utils/project-target.js';
 
@@ -35,7 +35,7 @@ export async function recordSession(args: any): Promise<string> {
     return `❌ ${error.message}`;
   }
 
-  const { registry, project, projectPath, statePath, conversationsDir: convDir, markerPath } = resolved;
+  const { project, projectPath, statePath, conversationsDir: convDir, markerPath } = resolved;
   const now = new Date();
   const today = now.toISOString().split('T')[0];
   const time = now.toISOString().substring(11, 16);
@@ -115,12 +115,9 @@ export async function recordSession(args: any): Promise<string> {
   await writeFile(markerPath, now.toISOString(), 'utf-8');
 
   // 5. Update registry with last_recorded timestamp
-  registry.projects = registry.projects.map((p) =>
-    p.id === project.id
-      ? { ...p, last_recorded: now.toISOString() }
-      : p
-  );
-  await saveRegistry(registry);
+  await patchProjectMetadata(project.id, {
+    last_recorded: now.toISOString(),
+  });
 
   return `✅ Session recorded for "${project.name}"\n\n` +
     `📝 Conversation: .context/conversations/${today}.md\n` +

--- a/mcp-server/src/utils/__tests__/distill.test.ts
+++ b/mcp-server/src/utils/__tests__/distill.test.ts
@@ -19,8 +19,8 @@ describe('distill templates', () => {
   it('generates AGENTS.md with the current template marker, adapter role, and guardrail flow', () => {
     const content = generateAgentsMd('Demo Project', 'Guardrail test');
 
-    expect(CURRENT_TEMPLATE_VERSION).toBe(10);
-    expect(content).toContain('<!-- agenticos-template: v10 -->');
+    expect(CURRENT_TEMPLATE_VERSION).toBe(11);
+    expect(content).toContain('<!-- agenticos-template: v11 -->');
     expect(content).toContain('## Adapter Role');
     expect(content).toContain(AGENTS_ADAPTER_LINES[0]);
     expect(content).toContain(AGENTS_ADAPTER_LINES[1]);
@@ -40,6 +40,10 @@ describe('distill templates', () => {
     expect(content).toContain('agenticos_preflight');
     expect(content).toContain('agenticos_status');
     expect(content).toContain('agenticos_switch');
+    expect(content).toContain('current session project');
+    expect(content).toContain('no session project is bound');
+    expect(content).not.toContain('confirm the active project');
+    expect(content).not.toContain('active project is missing or wrong');
     expect(content).toContain('agenticos_issue_bootstrap');
     expect(content).toContain('agenticos_edit_guard');
     expect(content).toContain('agenticos_branch_bootstrap');
@@ -71,6 +75,10 @@ describe('distill templates', () => {
     expect(content).toContain('agenticos_preflight');
     expect(content).toContain('agenticos_status');
     expect(content).toContain('agenticos_switch');
+    expect(content).toContain('current session project');
+    expect(content).toContain('no session project is bound');
+    expect(content).not.toContain('confirm the active project');
+    expect(content).not.toContain('active project is missing or wrong');
     expect(content).toContain('agenticos_issue_bootstrap');
     expect(content).toContain('agenticos_edit_guard');
     expect(content).toContain('agenticos_branch_bootstrap');

--- a/mcp-server/src/utils/__tests__/project-target.test.ts
+++ b/mcp-server/src/utils/__tests__/project-target.test.ts
@@ -19,6 +19,7 @@ vi.mock('../registry.js', () => ({
 
 import { readFile } from 'fs/promises';
 import { loadRegistry } from '../registry.js';
+import { bindSessionProject, clearSessionProjectBinding } from '../session-context.js';
 import { resolveManagedProjectContextPaths, resolveManagedProjectTarget } from '../project-target.js';
 
 const readFileMock = readFile as unknown as ReturnType<typeof vi.fn>;
@@ -46,6 +47,12 @@ function buildRegistry(overrides: Record<string, unknown> = {}) {
 describe('resolveManagedProjectTarget', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    clearSessionProjectBinding();
+    bindSessionProject({
+      projectId: 'alpha',
+      projectName: 'Alpha Project',
+      projectPath: '/workspace/alpha',
+    });
     yamlMock.parse.mockImplementation((content: string) => {
       try {
         return JSON.parse(content);
@@ -71,10 +78,11 @@ describe('resolveManagedProjectTarget', () => {
   });
 
   afterEach(() => {
+    clearSessionProjectBinding();
     vi.restoreAllMocks();
   });
 
-  it('resolves the active project when identity is valid', async () => {
+  it('resolves the session-bound project when identity is valid', async () => {
     const result = await resolveManagedProjectTarget({
       commandName: 'agenticos_record',
     });
@@ -111,12 +119,13 @@ describe('resolveManagedProjectTarget', () => {
     expect(result.markerPath).toBe('/workspace/alpha/standards/.context/.last_record');
   });
 
-  it('fails when there is no active project and no explicit project', async () => {
+  it('fails when there is no explicit project and no session project', async () => {
+    clearSessionProjectBinding();
     loadRegistryMock.mockResolvedValue(buildRegistry({ active_project: null }));
 
     await expect(resolveManagedProjectTarget({
       commandName: 'agenticos_record',
-    })).rejects.toThrow('No active project. Use agenticos_switch first or pass project to agenticos_record.');
+    })).rejects.toThrow('No project provided and no session project is bound. Use agenticos_switch first or pass project to agenticos_record.');
   });
 
   it('fails when the requested project is missing', async () => {
@@ -155,7 +164,7 @@ describe('resolveManagedProjectTarget', () => {
     })).rejects.toThrow('Project "Shared Name" is ambiguous in registry.');
   });
 
-  it('fails when explicit project does not match the active project', async () => {
+  it('allows explicit project resolution even when legacy active_project differs', async () => {
     loadRegistryMock.mockResolvedValue(buildRegistry({
       active_project: 'alpha',
       projects: [
@@ -178,10 +187,100 @@ describe('resolveManagedProjectTarget', () => {
       ],
     }));
 
-    await expect(resolveManagedProjectTarget({
+    readFileMock.mockImplementation(async (path: string) => {
+      if (path.endsWith('/workspace/beta/.project.yaml')) {
+        return JSON.stringify({
+          meta: {
+            id: 'beta',
+            name: 'Beta Project',
+          },
+          source_control: {
+            topology: 'local_directory_only',
+          },
+        });
+      }
+      if (path.endsWith('/workspace/alpha/.project.yaml')) {
+        return JSON.stringify({
+          meta: {
+            id: 'alpha',
+            name: 'Alpha Project',
+          },
+          source_control: {
+            topology: 'local_directory_only',
+          },
+        });
+      }
+      throw new Error(`unexpected path: ${path}`);
+    });
+
+    const result = await resolveManagedProjectTarget({
       commandName: 'agenticos_record',
       project: 'beta',
-    })).rejects.toThrow('Requested project "beta" does not match active project "alpha".');
+    });
+
+    expect(result.projectId).toBe('beta');
+    expect(result.projectPath).toBe('/workspace/beta');
+  });
+
+  it('uses the session-local bound project even when legacy registry state has drifted elsewhere', async () => {
+    bindSessionProject({
+      projectId: 'beta',
+      projectName: 'Beta Project',
+      projectPath: '/workspace/beta',
+    });
+    loadRegistryMock.mockResolvedValue(buildRegistry({
+      active_project: 'alpha',
+      projects: [
+        {
+          id: 'alpha',
+          name: 'Alpha Project',
+          path: '/workspace/alpha',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+        {
+          id: 'beta',
+          name: 'Beta Project',
+          path: '/workspace/beta',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    }));
+    readFileMock.mockImplementation(async (path: string) => {
+      if (path.endsWith('/workspace/beta/.project.yaml')) {
+        return JSON.stringify({
+          meta: {
+            id: 'beta',
+            name: 'Beta Project',
+          },
+          source_control: {
+            topology: 'local_directory_only',
+          },
+        });
+      }
+      if (path.endsWith('/workspace/alpha/.project.yaml')) {
+        return JSON.stringify({
+          meta: {
+            id: 'alpha',
+            name: 'Alpha Project',
+          },
+          source_control: {
+            topology: 'local_directory_only',
+          },
+        });
+      }
+      throw new Error(`unexpected path: ${path}`);
+    });
+
+    const result = await resolveManagedProjectTarget({
+      commandName: 'agenticos_status',
+    });
+
+    expect(result.projectId).toBe('beta');
+    expect(result.projectPath).toBe('/workspace/beta');
   });
 
   it('fails when registry id is duplicated', async () => {

--- a/mcp-server/src/utils/__tests__/registry.test.ts
+++ b/mcp-server/src/utils/__tests__/registry.test.ts
@@ -39,6 +39,8 @@ vi.mock('fs/promises', () => ({
   writeFile: vi.fn(),
   mkdir: vi.fn(),
   access: vi.fn(),
+  rename: vi.fn(),
+  rm: vi.fn(),
 }));
 
 vi.mock('yaml', () => ({
@@ -53,6 +55,7 @@ vi.mock('../canonical-main-guard.js', () => ({
 import {
   loadRegistry,
   saveRegistry,
+  patchProjectMetadata,
   getAgenticOSHome,
   MISSING_AGENTICOS_HOME_MESSAGE,
 } from '../registry.js';
@@ -64,6 +67,8 @@ const fsPromisesMock = fsPromises as typeof fsPromises & {
   writeFile: ReturnType<typeof vi.fn>;
   mkdir: ReturnType<typeof vi.fn>;
   access: ReturnType<typeof vi.fn>;
+  rename: ReturnType<typeof vi.fn>;
+  rm: ReturnType<typeof vi.fn>;
 };
 const detectCanonicalMainWriteProtectionMock = detectCanonicalMainWriteProtection as unknown as ReturnType<typeof vi.fn>;
 
@@ -72,6 +77,8 @@ describe('registry utilities', () => {
     vi.clearAllMocks();
     process.env.AGENTICOS_HOME = '/home/testuser/AgenticOS';
     detectCanonicalMainWriteProtectionMock.mockResolvedValue({ blocked: false });
+    fsPromisesMock.rename.mockResolvedValue(undefined);
+    fsPromisesMock.rm.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -149,7 +156,9 @@ describe('registry utilities', () => {
     });
 
     it('returns default registry when YAML parse fails', async () => {
-      yamlMock.parse.mockRejectedValue(new Error('parse error'));
+      yamlMock.parse.mockImplementation(() => {
+        throw new Error('parse error');
+      });
       fsPromisesMock.readFile.mockResolvedValue('invalid: yaml: content:');
 
       const registry = await loadRegistry();
@@ -233,6 +242,46 @@ describe('registry utilities', () => {
 
       await expect(saveRegistry(registry)).rejects.toThrow('write-protected');
       expect(fsPromisesMock.writeFile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('patchProjectMetadata', () => {
+    it('reloads the current registry and patches only the requested project metadata', async () => {
+      yamlMock.parse.mockReturnValue({
+        version: '1.0.0',
+        last_updated: '2025-01-01T00:00:00.000Z',
+        active_project: null,
+        projects: [
+          {
+            id: 'alpha',
+            name: 'Alpha',
+            path: 'projects/alpha',
+            status: 'active',
+            created: '2025-01-01',
+            last_accessed: '2025-01-01T00:00:00.000Z',
+          },
+          {
+            id: 'beta',
+            name: 'Beta',
+            path: 'projects/beta',
+            status: 'active',
+            created: '2025-01-01',
+            last_accessed: '2025-01-01T12:00:00.000Z',
+          },
+        ],
+      } as any);
+      fsPromisesMock.readFile.mockResolvedValue('registry');
+
+      await patchProjectMetadata('alpha', {
+        last_recorded: '2026-04-10T10:00:00.000Z',
+      });
+
+      const writeCall = fsPromisesMock.writeFile.mock.calls[0];
+      const writtenContent = writeCall[1] as string;
+      expect(writtenContent).toContain('last_recorded: 2026-04-10T10:00:00.000Z');
+      expect(writtenContent).toContain('last_accessed: 2025-01-01T12:00:00.000Z');
+      expect(fsPromisesMock.rename).toHaveBeenCalled();
+      expect(fsPromisesMock.rm).toHaveBeenCalled();
     });
   });
 });

--- a/mcp-server/src/utils/__tests__/repo-boundary.test.ts
+++ b/mcp-server/src/utils/__tests__/repo-boundary.test.ts
@@ -6,7 +6,6 @@ const yamlMock = vi.hoisted(() => ({
   parse: vi.fn(),
 }));
 const loadRegistryMock = vi.hoisted(() => vi.fn());
-const resolveManagedProjectTargetMock = vi.hoisted(() => vi.fn());
 
 vi.mock('fs/promises', () => ({
   access: accessMock,
@@ -21,32 +20,49 @@ vi.mock('../registry.js', () => ({
   loadRegistry: loadRegistryMock,
 }));
 
-vi.mock('../project-target.js', () => ({
-  resolveManagedProjectTarget: resolveManagedProjectTargetMock,
-}));
-
 import { resolveGuardrailProjectTarget } from '../repo-boundary.js';
+import { bindSessionProject, clearSessionProjectBinding } from '../session-context.js';
 
 describe('resolveGuardrailProjectTarget', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    clearSessionProjectBinding();
     yamlMock.parse.mockImplementation((content: string) => JSON.parse(content));
     accessMock.mockResolvedValue(undefined);
-    readFileMock.mockResolvedValue(JSON.stringify({
-      meta: {
-        id: 'alpha',
-        name: 'Alpha Project',
-      },
-      agent_context: {
-        current_state: '.context/state.yaml',
-      },
-      execution: {
-        source_repo_roots: ['../..'],
-      },
-    }));
+    readFileMock.mockImplementation(async (path: string) => {
+      if (path.endsWith('/alpha/.project.yaml')) {
+        return JSON.stringify({
+          meta: {
+            id: 'alpha',
+            name: 'Alpha Project',
+          },
+          agent_context: {
+            current_state: '.context/state.yaml',
+          },
+          execution: {
+            source_repo_roots: ['../../source/alpha'],
+          },
+        });
+      }
+      if (path.endsWith('/beta/.project.yaml')) {
+        return JSON.stringify({
+          meta: {
+            id: 'beta',
+            name: 'Beta Project',
+          },
+          agent_context: {
+            current_state: '.context/state.yaml',
+          },
+          execution: {
+            source_repo_roots: ['../../source/beta'],
+          },
+        });
+      }
+      throw new Error(`unexpected path: ${path}`);
+    });
   });
 
-  it('prefers the active managed project and resolves relative source repo roots', async () => {
+  it('prefers repo_path proof over a drifted legacy registry active_project field', async () => {
     loadRegistryMock.mockResolvedValue({
       active_project: 'alpha',
       projects: [
@@ -58,33 +74,10 @@ describe('resolveGuardrailProjectTarget', () => {
           created: '2026-04-06',
           last_accessed: '2026-04-06T00:00:00.000Z',
         },
-      ],
-    });
-    resolveManagedProjectTargetMock.mockResolvedValue({
-      projectId: 'alpha',
-      projectName: 'Alpha Project',
-      projectPath: '/workspace/projects/alpha',
-    });
-
-    const result = await resolveGuardrailProjectTarget({
-      commandName: 'agenticos_preflight',
-      repoPath: '/workspace/repo/worktrees/alpha-160',
-    });
-
-    expect(result.activeProjectId).toBe('alpha');
-    expect(result.targetProject?.id).toBe('alpha');
-    expect(result.targetProject?.sourceRepoRoots).toEqual(['/workspace']);
-    expect(result.resolutionSource).toBe('active_project');
-  });
-
-  it('falls back to repo_path containment when no active project is set', async () => {
-    loadRegistryMock.mockResolvedValue({
-      active_project: null,
-      projects: [
         {
-          id: 'alpha',
-          name: 'Alpha Project',
-          path: '/workspace/projects/alpha',
+          id: 'beta',
+          name: 'Beta Project',
+          path: '/workspace/projects/beta',
           status: 'active',
           created: '2026-04-06',
           last_accessed: '2026-04-06T00:00:00.000Z',
@@ -94,11 +87,51 @@ describe('resolveGuardrailProjectTarget', () => {
 
     const result = await resolveGuardrailProjectTarget({
       commandName: 'agenticos_preflight',
-      repoPath: '/workspace/projects/alpha/src',
+      repoPath: '/workspace/source/beta/worktrees/issue-160',
     });
 
-    expect(result.targetProject?.id).toBe('alpha');
+    expect(result.activeProjectId).toBe('alpha');
+    expect(result.targetProject?.id).toBe('beta');
+    expect(result.targetProject?.sourceRepoRoots).toEqual(['/workspace/source/beta']);
     expect(result.resolutionSource).toBe('repo_path_match');
+  });
+
+  it('uses the session-bound project when repo_path cannot be proven', async () => {
+    bindSessionProject({
+      projectId: 'beta',
+      projectName: 'Beta Project',
+      projectPath: '/workspace/projects/beta',
+    });
+    loadRegistryMock.mockResolvedValue({
+      active_project: 'alpha',
+      projects: [
+        {
+          id: 'alpha',
+          name: 'Alpha Project',
+          path: '/workspace/projects/alpha',
+          status: 'active',
+          created: '2026-04-06',
+          last_accessed: '2026-04-06T00:00:00.000Z',
+        },
+        {
+          id: 'beta',
+          name: 'Beta Project',
+          path: '/workspace/projects/beta',
+          status: 'active',
+          created: '2026-04-06',
+          last_accessed: '2026-04-06T00:00:00.000Z',
+        },
+      ],
+    });
+
+    const result = await resolveGuardrailProjectTarget({
+      commandName: 'agenticos_preflight',
+      repoPath: '/workspace/unmatched/repo',
+    });
+
+    expect(result.activeProjectId).toBe('alpha');
+    expect(result.targetProject?.id).toBe('beta');
+    expect(result.resolutionSource).toBe('session_project');
   });
 
   it('resolves an explicit project_path even when active_project has drifted elsewhere', async () => {
@@ -135,23 +168,52 @@ describe('resolveGuardrailProjectTarget', () => {
     expect(result.targetProject?.path).toBe('/workspace/projects/alpha');
     expect(result.resolutionSource).toBe('explicit_project_path');
     expect(result.resolutionErrors).toEqual([]);
-    expect(resolveManagedProjectTargetMock).not.toHaveBeenCalled();
   });
 
-  it('returns a fail-closed resolution error when project metadata cannot be proven', async () => {
+  it('fails closed when only the legacy registry active_project field is available', async () => {
     loadRegistryMock.mockResolvedValue({
       active_project: 'alpha',
-      projects: [],
+      projects: [
+        {
+          id: 'alpha',
+          name: 'Alpha Project',
+          path: '/workspace/projects/alpha',
+          status: 'active',
+          created: '2026-04-06',
+          last_accessed: '2026-04-06T00:00:00.000Z',
+        },
+      ],
     });
-    resolveManagedProjectTargetMock.mockRejectedValue(new Error('Project identity could not be proven.'));
 
     const result = await resolveGuardrailProjectTarget({
       commandName: 'agenticos_preflight',
-      repoPath: '/workspace/repo',
     });
 
     expect(result.targetProject).toBeNull();
-    expect(result.resolutionErrors[0]).toContain('could not be proven');
+    expect(result.resolutionSource).toBeNull();
+    expect(result.resolutionErrors[0]).toContain('No project_path, repo_path proof, or session binding is available');
+  });
+
+  it('ignores a populated legacy registry active_project field even when its metadata exists', async () => {
+    loadRegistryMock.mockResolvedValue({
+      active_project: 'alpha',
+      projects: [
+        {
+          id: 'alpha',
+          name: 'Alpha Project',
+          path: '/workspace/projects/alpha',
+          status: 'active',
+          created: '2026-04-06',
+          last_accessed: '2026-04-06T00:00:00.000Z',
+        },
+      ],
+    });
+    const result = await resolveGuardrailProjectTarget({
+      commandName: 'agenticos_preflight',
+    });
+
+    expect(result.targetProject).toBeNull();
+    expect(result.resolutionErrors[0]).toContain('No project_path, repo_path proof, or session binding is available');
     expect(result.resolutionSource).toBeNull();
   });
 });

--- a/mcp-server/src/utils/distill.ts
+++ b/mcp-server/src/utils/distill.ts
@@ -6,7 +6,7 @@ import { joinDisplayPath, type ManagedProjectContextDisplayPaths } from './agent
  * Current template version. Increment when templates change.
  * Used for auto-upgrade on project switch.
  */
-export const CURRENT_TEMPLATE_VERSION = 10;
+export const CURRENT_TEMPLATE_VERSION = 11;
 
 /** Version marker format in generated files */
 const VERSION_MARKER = `<!-- agenticos-template: v${CURRENT_TEMPLATE_VERSION} -->`;
@@ -123,7 +123,7 @@ ${AGENTS_ADAPTER_LINES[1]}
 
 ${renderSharedPolicySection()}${renderRuntimeGuidanceSection(AGENTS_RUNTIME_GUIDANCE_TITLE, AGENTS_RUNTIME_GUIDANCE_BULLETS)}${renderRuntimeGuidanceSection(TASK_INTAKE_RULE_TITLE, TASK_INTAKE_RULE_BULLETS)}## Guardrail Protocol (MANDATORY)
 
-Before implementation edits, confirm project alignment with \`agenticos_status\`; if the active project is missing or wrong, call \`agenticos_switch\`.
+Before implementation edits, confirm session/project alignment with \`agenticos_status\`; if no session project is bound or the bound project is not the intended one, call \`agenticos_switch\`.
 
 Implementation work must use the executable guardrail flow:
 
@@ -159,8 +159,8 @@ After recording, call \`agenticos_save\` to commit to Git.
 ### Session Start
 
 On session start, align the runtime before meaningful work:
-1. call \`agenticos_status\` to confirm the active project, current task, pending work, and latest recorded state
-2. if the active project is missing or not \`${name}\`, call \`agenticos_switch\`
+1. call \`agenticos_status\` to confirm the current session project, current task, pending work, and latest recorded state
+2. if no session project is bound or the bound project is not \`${name}\`, call \`agenticos_switch\`
 3. read \`.project.yaml\`, \`${contextPaths.quickStartPath}\`, \`${contextPaths.statePath}\`, and \`${contextPaths.conversationsDir}\`
 4. review the latest guardrail evidence and latest \`agenticos_issue_bootstrap\` record before implementation-affecting work
 5. if implementation work is requested, follow the Guardrail Protocol above exactly before editing
@@ -278,7 +278,7 @@ ${CLAUDE_ADAPTER_LINES[1]}
 
 ${renderSharedPolicySection()}${renderRuntimeGuidanceSection(CLAUDE_RUNTIME_GUIDANCE_TITLE, CLAUDE_RUNTIME_GUIDANCE_BULLETS)}${renderRuntimeGuidanceSection(TASK_INTAKE_RULE_TITLE, TASK_INTAKE_RULE_BULLETS)}## Guardrail Protocol (MANDATORY)
 
-Before implementation edits, confirm project alignment with \`agenticos_status\`; if the active project is missing or wrong, call \`agenticos_switch\`.
+Before implementation edits, confirm session/project alignment with \`agenticos_status\`; if no session project is bound or the bound project is not the intended one, call \`agenticos_switch\`.
 
 For implementation-affecting work:
 
@@ -324,8 +324,8 @@ When the user signals session end (says goodbye, thanks, done, or stops respondi
 
 When you open this project in a new session, **immediately do the following**:
 
-1. Call \`agenticos_status\` to confirm the active project, current task, pending work, and latest recorded state
-2. If the active project is missing or not \`${name}\`, call \`agenticos_switch\`
+1. Call \`agenticos_status\` to confirm the current session project, current task, pending work, and latest recorded state
+2. If no session project is bound or the bound project is not \`${name}\`, call \`agenticos_switch\`
 3. Read \`.project.yaml\`, the "Current State" section below, \`${contextPaths.quickStartPath}\`, and \`${contextPaths.conversationsDir}\`
 4. Review the latest guardrail evidence and latest \`agenticos_issue_bootstrap\` record before implementation-affecting work
 5. Greet the user with a brief status report:

--- a/mcp-server/src/utils/project-target.ts
+++ b/mcp-server/src/utils/project-target.ts
@@ -3,6 +3,7 @@ import { join } from 'path';
 import yaml from 'yaml';
 import { loadRegistry, type Project, type Registry } from './registry.js';
 import { buildArchivedReferenceMessage, isArchivedReferenceProject, validateManagedProjectTopology } from './project-contract.js';
+import { getSessionProjectBinding } from './session-context.js';
 import {
   type ManagedProjectContextPaths,
   resolveManagedProjectContextPaths,
@@ -61,12 +62,13 @@ export async function resolveManagedProjectTarget(args: ResolveManagedProjectTar
   const requestedProject = typeof args.project === 'string' && args.project.trim().length > 0
     ? args.project.trim()
     : null;
+  const sessionProject = getSessionProjectBinding();
 
-  if (!requestedProject && !registry.active_project) {
-    throw new Error(`No active project. Use agenticos_switch first or pass project to ${args.commandName}.`);
+  if (!requestedProject && !sessionProject) {
+    throw new Error(`No project provided and no session project is bound. Use agenticos_switch first or pass project to ${args.commandName}.`);
   }
 
-  let project: Project;
+  let project: Project | null = null;
   if (requestedProject) {
     const matches = registry.projects.filter((candidate) =>
       candidate.id === requestedProject ||
@@ -78,18 +80,18 @@ export async function resolveManagedProjectTarget(args: ResolveManagedProjectTar
       `Project "${requestedProject}" not found in registry.`,
       `Project "${requestedProject}" is ambiguous in registry.`
     );
-
-    if (registry.active_project && registry.active_project !== project.id) {
-      throw new Error(
-        `Requested project "${requestedProject}" does not match active project "${registry.active_project}". Switch first or pass the active project explicitly.`
-      );
-    }
-  } else {
+  } else if (sessionProject) {
     project = uniqueMatch(
-      registry.projects.filter((candidate) => candidate.id === registry.active_project),
-      `Active project "${registry.active_project}" not found in registry.`,
-      `Active project "${registry.active_project}" is ambiguous in registry.`
+      registry.projects.filter((candidate) =>
+        candidate.id === sessionProject.projectId || candidate.path === sessionProject.projectPath
+      ),
+      `Session project "${sessionProject.projectId}" not found in registry.`,
+      `Session project "${sessionProject.projectId}" is ambiguous in registry.`,
     );
+  }
+
+  if (!project) {
+    throw new Error(`No project provided and no session project is bound. Use agenticos_switch first or pass project to ${args.commandName}.`);
   }
 
   assertRegistryUniqueness(registry, project, requestedProject || undefined);

--- a/mcp-server/src/utils/registry.ts
+++ b/mcp-server/src/utils/registry.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile, mkdir } from 'fs/promises';
+import { readFile, writeFile, mkdir, rename, rm } from 'fs/promises';
 import { join, isAbsolute, relative } from 'path';
 import yaml from 'yaml';
 import { detectCanonicalMainWriteProtection } from './canonical-main-guard.js';
@@ -52,42 +52,146 @@ export interface Registry {
   projects: Project[];
 }
 
-export async function loadRegistry(): Promise<Registry> {
+function defaultRegistry(): Registry {
+  return {
+    version: '1.0.0',
+    last_updated: new Date().toISOString(),
+    active_project: null,
+    projects: [],
+  };
+}
+
+function normalizeLoadedRegistry(raw: Registry): Registry {
+  return {
+    ...raw,
+    projects: Array.isArray(raw.projects)
+      ? raw.projects.map((p) => ({
+          ...p,
+          path: resolvePath(p.path),
+        }))
+      : [],
+  };
+}
+
+async function loadRegistryFresh(): Promise<Registry> {
   const registryPath = getRegistryPath();
   try {
     const content = await readFile(registryPath, 'utf-8');
     const raw: Registry = yaml.parse(content);
-    // Resolve relative paths to absolute at load time
-    raw.projects = raw.projects.map((p) => ({
-      ...p,
-      path: resolvePath(p.path),
-    }));
-    return raw;
+    if (!raw || typeof raw !== 'object') {
+      throw new Error('registry yaml did not parse into an object');
+    }
+    return normalizeLoadedRegistry(raw);
   } catch {
-    return {
-      version: '1.0.0',
-      last_updated: new Date().toISOString(),
-      active_project: null,
-      projects: [],
-    };
+    return defaultRegistry();
   }
 }
 
-export async function saveRegistry(registry: Registry): Promise<void> {
-  const writeProtection = await detectCanonicalMainWriteProtection(getAgenticOSHome());
-  if (writeProtection.blocked) {
-    throw new Error(writeProtection.reason);
-  }
+export async function loadRegistry(): Promise<Registry> {
+  return await loadRegistryFresh();
+}
 
-  registry.last_updated = new Date().toISOString();
-  // Convert absolute paths to relative before storing
-  const toStore: Registry = {
+function toStoredRegistry(registry: Registry): Registry {
+  return {
     ...registry,
     projects: registry.projects.map((p) => ({
       ...p,
       path: toRelative(p.path),
     })),
   };
+}
+
+function getRegistryLockPath(): string {
+  return join(getAgenticOSHome(), '.agent-workspace', 'registry.lock');
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function withRegistryLock<T>(callback: () => Promise<T>): Promise<T> {
+  const writeProtection = await detectCanonicalMainWriteProtection(getAgenticOSHome());
+  if (writeProtection.blocked) {
+    throw new Error(writeProtection.reason);
+  }
+
+  const workspaceDir = join(getAgenticOSHome(), '.agent-workspace');
+  const lockPath = getRegistryLockPath();
+  await mkdir(workspaceDir, { recursive: true });
+
+  let locked = false;
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    try {
+      await mkdir(lockPath);
+      locked = true;
+      break;
+    } catch {
+      await sleep(10);
+    }
+  }
+
+  if (!locked) {
+    throw new Error(`failed to acquire registry lock at ${lockPath}`);
+  }
+
+  try {
+    return await callback();
+  } finally {
+    await rm(lockPath, { recursive: true, force: true }).catch(() => undefined);
+  }
+}
+
+async function writeRegistrySnapshot(registry: Registry): Promise<Registry> {
+  const nextRegistry: Registry = {
+    ...registry,
+    last_updated: new Date().toISOString(),
+  };
+  const registryPath = getRegistryPath();
+  const tempPath = `${registryPath}.tmp-${process.pid}-${Date.now()}`;
+  const toStore = toStoredRegistry(nextRegistry);
+
   await mkdir(join(getAgenticOSHome(), '.agent-workspace'), { recursive: true });
-  await writeFile(getRegistryPath(), yaml.stringify(toStore), 'utf-8');
+  await writeFile(tempPath, yaml.stringify(toStore), 'utf-8');
+  await rename(tempPath, registryPath);
+  return normalizeLoadedRegistry(nextRegistry);
+}
+
+export async function saveRegistry(registry: Registry): Promise<void> {
+  await withRegistryLock(async () => {
+    await writeRegistrySnapshot(registry);
+  });
+}
+
+export async function patchRegistry(
+  mutator: (registry: Registry) => void | Registry | Promise<void | Registry>,
+): Promise<Registry> {
+  return await withRegistryLock(async () => {
+    const current = await loadRegistryFresh();
+    const maybeNext = await mutator(current);
+    return await writeRegistrySnapshot(maybeNext || current);
+  });
+}
+
+export async function patchProjectMetadata(
+  projectId: string,
+  patch:
+    | Partial<Project>
+    | ((project: Project) => Partial<Project> | void | Promise<Partial<Project> | void>),
+): Promise<Registry> {
+  return await patchRegistry(async (registry) => {
+    const projectIndex = registry.projects.findIndex((candidate) => candidate.id === projectId);
+    if (projectIndex < 0) {
+      throw new Error(`Project "${projectId}" not found in registry.`);
+    }
+
+    const currentProject = registry.projects[projectIndex];
+    const nextPatch = typeof patch === 'function'
+      ? await patch(currentProject)
+      : patch;
+
+    registry.projects[projectIndex] = {
+      ...currentProject,
+      ...(nextPatch || {}),
+    };
+  });
 }

--- a/mcp-server/src/utils/repo-boundary.ts
+++ b/mcp-server/src/utils/repo-boundary.ts
@@ -1,8 +1,8 @@
 import { access, readFile } from 'fs/promises';
 import { basename, isAbsolute, join, resolve, sep } from 'path';
 import yaml from 'yaml';
-import { resolveManagedProjectTarget } from './project-target.js';
 import { loadRegistry } from './registry.js';
+import { getSessionProjectBinding } from './session-context.js';
 
 export type GuardrailTaskType =
   | 'discussion_only'
@@ -23,7 +23,7 @@ export interface GuardrailProjectTarget {
 
 export interface GuardrailProjectResolution {
   activeProjectId: string | null;
-  resolutionSource: 'explicit_project_path' | 'active_project' | 'repo_path_match' | null;
+  resolutionSource: 'explicit_project_path' | 'repo_path_match' | 'session_project' | null;
   targetProject: GuardrailProjectTarget | null;
   resolutionErrors: string[];
 }
@@ -103,6 +103,24 @@ async function buildTargetFromProjectPath(
   };
 }
 
+function uniqueRegistryProjectMatch<T>(matches: T[], notFound: string, ambiguous: string): T {
+  if (matches.length === 0) {
+    throw new Error(notFound);
+  }
+  if (matches.length > 1) {
+    throw new Error(ambiguous);
+  }
+  return matches[0];
+}
+
+async function resolveRegistryProjectTarget(project: {
+  id: string;
+  name: string;
+  path: string;
+}): Promise<GuardrailProjectTarget | null> {
+  return await buildTargetFromProjectPath(project.path, project.id, project.name);
+}
+
 export function isImplementationAffectingTask(taskType: GuardrailTaskType): boolean {
   return taskType === 'implementation' || taskType === 'bugfix';
 }
@@ -115,6 +133,7 @@ export async function resolveGuardrailProjectTarget(args: {
   const { commandName, repoPath, projectPath } = args;
   const registry = await loadRegistry();
   const activeProjectId = registry.active_project || null;
+  const sessionProject = getSessionProjectBinding();
 
   if (projectPath) {
     try {
@@ -135,61 +154,94 @@ export async function resolveGuardrailProjectTarget(args: {
     }
   }
 
-  if (activeProjectId) {
+  if (repoPath) {
     try {
-      const resolved = await resolveManagedProjectTarget({
-        commandName,
-      });
-      const targetProject = await buildTargetFromProjectPath(
-        resolved.projectPath,
-        resolved.projectId,
-        resolved.projectName,
-      );
+      const normalizedRepoPath = normalizePath(repoPath);
+      const candidates: Array<{
+        targetProject: GuardrailProjectTarget;
+        matchLength: number;
+      }> = [];
+
+      for (const project of registry.projects) {
+        const targetProject = await resolveRegistryProjectTarget(project);
+        if (!targetProject) continue;
+
+        const matchedRoots = [
+          targetProject.path,
+          ...targetProject.sourceRepoRoots,
+        ].filter((candidatePath) => isWithinProject(normalizedRepoPath, candidatePath));
+
+        if (matchedRoots.length === 0) continue;
+
+        candidates.push({
+          targetProject,
+          matchLength: Math.max(...matchedRoots.map((candidatePath) => normalizePath(candidatePath).length)),
+        });
+      }
+
+      if (candidates.length > 0) {
+        candidates.sort((a, b) => b.matchLength - a.matchLength);
+        const strongestMatchLength = candidates[0].matchLength;
+        const strongestMatches = candidates.filter((candidate) => candidate.matchLength === strongestMatchLength);
+
+        if (strongestMatches.length > 1) {
+          return {
+            activeProjectId,
+            resolutionSource: null,
+            targetProject: null,
+            resolutionErrors: [`repo_path "${repoPath}" matches multiple managed projects; pass project_path explicitly`],
+          };
+        }
+
+        return {
+          activeProjectId,
+          resolutionSource: 'repo_path_match',
+          targetProject: strongestMatches[0].targetProject,
+          resolutionErrors: [],
+        };
+      }
+    } catch (error) {
       return {
         activeProjectId,
-        resolutionSource: 'active_project',
+        resolutionSource: null,
+        targetProject: null,
+        resolutionErrors: [error instanceof Error ? error.message : `failed to resolve repo_path: ${repoPath}`],
+      };
+    }
+  }
+
+  if (sessionProject) {
+    try {
+      const project = uniqueRegistryProjectMatch(
+        registry.projects.filter((candidate) =>
+          candidate.id === sessionProject.projectId || candidate.path === sessionProject.projectPath
+        ),
+        `Session project "${sessionProject.projectId}" not found in registry.`,
+        `Session project "${sessionProject.projectId}" is ambiguous in registry.`,
+      );
+      const targetProject = await resolveRegistryProjectTarget(project);
+      return {
+        activeProjectId,
+        resolutionSource: targetProject ? 'session_project' : null,
         targetProject,
-        resolutionErrors: targetProject ? [] : [`active project "${activeProjectId}" is missing a readable .project.yaml`],
+        resolutionErrors: targetProject ? [] : [`session project "${sessionProject.projectId}" is missing a readable .project.yaml`],
       };
     } catch (error) {
       return {
         activeProjectId,
         resolutionSource: null,
         targetProject: null,
-        resolutionErrors: [error instanceof Error ? error.message : 'failed to resolve active project'],
+        resolutionErrors: [error instanceof Error ? error.message : 'failed to resolve session project'],
       };
     }
   }
 
-  if (!repoPath) {
-    return {
-      activeProjectId,
-      resolutionSource: null,
-      targetProject: null,
-      resolutionErrors: ['no active project is set'],
-    };
-  }
-
-  const normalizedRepoPath = normalizePath(repoPath);
-  const match = registry.projects
-    .map((project) => ({ ...project, path: normalizePath(project.path) }))
-    .filter((project) => isWithinProject(normalizedRepoPath, project.path))
-    .sort((a, b) => b.path.length - a.path.length)[0];
-
-  if (!match) {
-    return {
-      activeProjectId,
-      resolutionSource: null,
-      targetProject: null,
-      resolutionErrors: ['target project could not be resolved from repo_path; pass project_path explicitly'],
-    };
-  }
-
-  const targetProject = await buildTargetFromProjectPath(match.path, match.id, match.name);
   return {
     activeProjectId,
-    resolutionSource: targetProject ? 'repo_path_match' : null,
-    targetProject,
-    resolutionErrors: targetProject ? [] : [`project_path is not a resolvable managed project: ${match.path}`],
+    resolutionSource: null,
+    targetProject: null,
+    resolutionErrors: repoPath
+      ? ['target project could not be resolved from repo_path or session binding; pass project_path explicitly']
+      : [`No project_path, repo_path proof, or session binding is available for ${commandName}.`],
   };
 }

--- a/mcp-server/src/utils/session-context.ts
+++ b/mcp-server/src/utils/session-context.ts
@@ -1,0 +1,24 @@
+export interface SessionProjectBinding {
+  projectId: string;
+  projectName: string;
+  projectPath: string;
+  boundAt: string;
+}
+
+let currentSessionProject: SessionProjectBinding | null = null;
+
+export function bindSessionProject(binding: Omit<SessionProjectBinding, 'boundAt'> & { boundAt?: string }): SessionProjectBinding {
+  currentSessionProject = {
+    ...binding,
+    boundAt: binding.boundAt || new Date().toISOString(),
+  };
+  return currentSessionProject;
+}
+
+export function getSessionProjectBinding(): SessionProjectBinding | null {
+  return currentSessionProject;
+}
+
+export function clearSessionProjectBinding(): void {
+  currentSessionProject = null;
+}

--- a/mcp-server/src/utils/standard-kit.ts
+++ b/mcp-server/src/utils/standard-kit.ts
@@ -9,6 +9,7 @@ import { buildArchivedReferenceMessage, isArchivedReferenceProject } from './pro
 import { validateContextPublicationPolicy } from './project-contract.js';
 import { resolveAgenticOSProductPath, resolveAgenticOSProductRoot, toCanonicalProductRelativePath } from './product-source-root.js';
 import { resolveManagedProjectContextDisplayPaths, resolveManagedProjectContextPaths, type ManagedProjectContextDisplayPaths } from './agent-context-paths.js';
+import { getSessionProjectBinding } from './session-context.js';
 
 interface StandardKitEntry {
   path: string;
@@ -135,20 +136,52 @@ function nowIso(): string {
   return new Date().toISOString();
 }
 
-async function resolveProjectPath(projectPath?: string): Promise<string> {
+function uniqueProjectMatch<T>(matches: T[], notFound: string, ambiguous: string): T {
+  if (matches.length === 0) {
+    throw new Error(notFound);
+  }
+  if (matches.length > 1) {
+    throw new Error(ambiguous);
+  }
+  return matches[0];
+}
+
+async function resolveProjectPath(projectPath?: string, project?: string): Promise<string> {
   if (projectPath) return projectPath;
 
   const registry = await loadRegistry();
-  if (!registry.active_project) {
-    throw new Error('No project_path provided and no active project found in registry.');
+  const requestedProject = typeof project === 'string' && project.trim().length > 0
+    ? project.trim()
+    : null;
+  const sessionProject = getSessionProjectBinding();
+
+  if (requestedProject) {
+    const match = uniqueProjectMatch(
+      registry.projects.filter((candidate) =>
+        candidate.id === requestedProject ||
+        candidate.name === requestedProject ||
+        candidate.path === requestedProject
+      ),
+      `Project "${requestedProject}" not found in registry.`,
+      `Project "${requestedProject}" is ambiguous in registry.`,
+    );
+    return match.path;
   }
 
-  const active = registry.projects.find((project) => project.id === registry.active_project);
-  if (!active) {
-    throw new Error(`Active project "${registry.active_project}" not found in registry.`);
+  if (sessionProject) {
+    const match = uniqueProjectMatch(
+      registry.projects.filter((candidate) =>
+        candidate.id === sessionProject.projectId || candidate.path === sessionProject.projectPath
+      ),
+      `Session project "${sessionProject.projectId}" not found in registry.`,
+      `Session project "${sessionProject.projectId}" is ambiguous in registry.`,
+    );
+    return match.path;
   }
 
-  return active.path;
+  throw new Error(
+    'No project_path provided, no explicit project provided, and no session project is bound. Pass project_path, pass project, or call agenticos_switch first.'
+  );
 }
 
 async function readProjectYaml(projectPath: string): Promise<any | null> {
@@ -280,9 +313,13 @@ function fileContainsAll(content: string | null, needles: string[]): boolean {
   return !!content && needles.every((needle) => content.includes(needle));
 }
 
-export async function adoptStandardKit(args: { project_path?: string; project_name?: string; project_description?: string }): Promise<AdoptResult> {
+function fileContainsNone(content: string | null, needles: string[]): boolean {
+  return !!content && needles.every((needle) => !content.includes(needle));
+}
+
+export async function adoptStandardKit(args: { project_path?: string; project?: string; project_name?: string; project_description?: string }): Promise<AdoptResult> {
   const manifest = await loadStandardKitManifest();
-  const projectPath = await resolveProjectPath(args.project_path);
+  const projectPath = await resolveProjectPath(args.project_path, args.project);
   const project = await resolveProjectIdentity(projectPath, args.project_name, args.project_description);
 
   await ensureStandardDirectories(project);
@@ -347,9 +384,9 @@ export async function adoptStandardKit(args: { project_path?: string; project_na
   };
 }
 
-export async function checkStandardKitUpgrade(args: { project_path?: string; project_name?: string; project_description?: string }): Promise<UpgradeCheckResult> {
+export async function checkStandardKitUpgrade(args: { project_path?: string; project?: string; project_name?: string; project_description?: string }): Promise<UpgradeCheckResult> {
   const manifest = await loadStandardKitManifest();
-  const projectPath = await resolveProjectPath(args.project_path);
+  const projectPath = await resolveProjectPath(args.project_path, args.project);
   const project = await resolveProjectIdentity(projectPath, args.project_name, args.project_description);
 
   const missingRequiredFiles: string[] = [];
@@ -419,9 +456,9 @@ export async function checkStandardKitUpgrade(args: { project_path?: string; pro
   };
 }
 
-export async function checkStandardKitConformance(args: { project_path?: string; project_name?: string; project_description?: string }): Promise<StandardKitConformanceResult> {
+export async function checkStandardKitConformance(args: { project_path?: string; project?: string; project_name?: string; project_description?: string }): Promise<StandardKitConformanceResult> {
   const manifest = await loadStandardKitManifest();
-  const projectPath = await resolveProjectPath(args.project_path);
+  const projectPath = await resolveProjectPath(args.project_path, args.project);
   const project = await resolveProjectIdentity(projectPath, args.project_name, args.project_description);
   const projectYaml = yaml.parse((await readProjectFile(project.projectPath, '.project.yaml')) || '{}') as any;
 
@@ -538,8 +575,10 @@ export async function checkStandardKitConformance(args: { project_path?: string;
         break;
       }
       case 'session_start_alignment': {
-        const pass = fileContainsAll(agentsMd, ['agenticos_status', 'agenticos_switch', 'agenticos_issue_bootstrap'])
-          && fileContainsAll(claudeMd, ['agenticos_status', 'agenticos_switch', 'agenticos_issue_bootstrap'])
+        const pass = fileContainsAll(agentsMd, ['agenticos_status', 'agenticos_switch', 'agenticos_issue_bootstrap', 'current session project', 'no session project is bound'])
+          && fileContainsNone(agentsMd, ['confirm the active project', 'active project is missing or wrong'])
+          && fileContainsAll(claudeMd, ['agenticos_status', 'agenticos_switch', 'agenticos_issue_bootstrap', 'current session project', 'no session project is bound'])
+          && fileContainsNone(claudeMd, ['confirm the active project', 'active project is missing or wrong'])
           && fileContainsAll(bootstrapMatrixSource, ['session_start_sequence', 'agenticos_status', 'agenticos_switch', 'agenticos_issue_bootstrap'])
           && fileContainsAll(adapterMatrixSource, ['agenticos_status', 'agenticos_switch', 'agenticos_issue_bootstrap'])
           && fileContainsAll(crossAgentContractSource, ['session_start_alignment', 'issue_bootstrap_entry']);
@@ -547,8 +586,8 @@ export async function checkStandardKitConformance(args: { project_path?: string;
           behavior,
           status: pass ? 'PASS' : 'FAIL',
           summary: pass
-            ? 'Adapter surfaces and canonical bootstrap metadata preserve the session-start alignment and issue-bootstrap entry contract.'
-            : 'Session-start alignment or issue-bootstrap entry guidance is missing from adapter surfaces or canonical bootstrap metadata.',
+            ? 'Adapter surfaces and canonical bootstrap metadata preserve session-local startup alignment and issue-bootstrap entry semantics.'
+            : 'Session-start alignment, session-local binding semantics, or issue-bootstrap entry guidance is missing from adapter surfaces or canonical bootstrap metadata.',
           evidence_paths: [
             'AGENTS.md',
             'CLAUDE.md',

--- a/standards/.context/quick-start.md
+++ b/standards/.context/quick-start.md
@@ -1,133 +1,37 @@
-# AgenticOS Standards - Quick Start
+# AgenticOS - Quick Start
 
 ## Project Overview
 
-`projects/agenticos/standards/` is the canonical standards and protocol area inside the main AgenticOS product repository.
-
-Its job is to define and evolve:
-
-- project metadata and context conventions
-- executable agent workflow rules
-- reusable downstream standards and templates
-- migration and execution reports that future agents can resume from
+Self-hosting AgenticOS product project. Canonical operational context lives under standards/.context while the root .context files remain compatibility shims.
 
 ## Current Status
 
-- canonical standards location has been frozen in the main repo by issue `#66` / PR `#67`
-- the old standalone `projects/agentic-os-development` repo is now treated as a retired archive-only snapshot
-- issue `#68` has already landed as PR `#69`
-- selected high-signal standards reports from the retired standalone repo have been backfilled into `knowledge/`
-- `knowledge/runtime-project-extraction-closure-report-2026-03-23.md` has now also been restored as the final remaining high-signal closure report
-- the retired standalone `.context/`, issue-draft history, and entry files are now preserved under:
-  - `archive/standalone-agentic-os-development-2026-03-23/`
-- live standards guidance now points only to this main-repo standards area
-- `knowledge/standalone-standards-retirement-resolution-2026-03-23.md` now records the final decision that no second broad merge wave is needed
-- reusable downstream templates are canonically surfaced under:
-  - `projects/agenticos/.meta/templates/`
-  - `projects/agenticos/.meta/standard-kit/`
-- `non-code-evaluation-rubric.yaml` has been restored into the main template surface as part of this consolidation wave
-- issue `#72` is now implementing first-class standard-kit commands for adopt and upgrade-check
-- `knowledge/standard-kit-command-design-v1-2026-03-23.md` records the command contract for the first slice
-- `knowledge/standard-kit-command-implementation-report-2026-03-23.md` records the landed implementation scope and verification
-- issue `#74` now upgrades project status output to summarize the latest persisted guardrail evidence
-- `knowledge/status-guardrail-evidence-implementation-report-2026-03-24.md` records the status-surface implementation and verification
-- issue `#76` now extends the same compact latest-guardrail summary into `agenticos_switch`
-- `knowledge/switch-guardrail-evidence-implementation-report-2026-03-24.md` records the switch-surface implementation and verification
-- issue `#79` now reconciles the historical open backlog against landed self-hosting, standards, and guardrail changes
-- `knowledge/backlog-reconciliation-matrix-2026-03-24.md` records which old issues were closed, which remain open, and which required scope rewrite
-- issue `#78` now restores `/Users/jeking/dev/AgenticOS` as a clean canonical workspace home aligned with `origin/main`
-- `knowledge/canonical-working-copy-cleanup-report-2026-03-24.md` records what was preserved, what was removed from the product-source project, and how the local main workspace was verified
-- issue `#24` now fixes `agenticos_record` so JSON-stringified array arguments are normalized into real persisted list items instead of degrading into malformed state updates
-- `knowledge/record-array-parsing-fix-report-2026-03-24.md` records the fix, regression coverage, and verification for the restored `#24` work
-- issue `#23` now upgrades `agenticos_switch` so it returns inline actionable project context instead of only file paths
-- `knowledge/switch-inline-context-implementation-report-2026-03-24.md` records the landed switch-context formatter, quick-start fallback, and verification
-- issue `#25` now enforces fail-closed project-boundary validation for record, save, and context reads
-- `knowledge/project-boundary-isolation-implementation-report-2026-03-25.md` records the boundary-proof design, coverage evidence, and verification
-- issue `#26` now freezes the canonical memory-layer contract and pushes it into the downstream standard kit and templates
-- `knowledge/memory-layer-contract-spec-2026-03-25.md` records the contract itself
-- `knowledge/memory-layer-contract-implementation-report-2026-03-25.md` records the template, kit, and documentation alignment work
-- issue `#28` now defines the canonical sub-agent inheritance packet and verification echo requirements for delegated non-trivial work
-- `knowledge/sub-agent-inheritance-protocol-2026-03-25.md` records the protocol itself
-- `knowledge/sub-agent-inheritance-implementation-report-2026-03-25.md` records the template, standards-doc, and standard-kit adoption changes
-- issue `#29` now defines the canonical per-agent bootstrap standard for Claude Code, Codex, Cursor, and Gemini CLI
-- `projects/agenticos/.meta/bootstrap/agent-bootstrap-matrix.yaml` is now the machine-readable source of truth for supported-agent bootstrap
-- `knowledge/per-agent-bootstrap-standard-2026-03-25.md` records the transport-vs-routing contract and official support surface
-- `knowledge/per-agent-bootstrap-standard-implementation-report-2026-03-25.md` records the landed matrix, parser, and docs alignment work
-- issue `#30` now defines the Homebrew post-install contract as reminder-only, not automatic agent activation
-- `knowledge/homebrew-post-install-contract-2026-03-25.md` records the product decision for install vs activation
-- `knowledge/homebrew-post-install-implementation-report-2026-03-25.md` records the formula, tap README, root README, and MCP README alignment work
-- issue `#31` now defines the canonical integration mode matrix for MCP-native, MCP + Skills Assist, CLI Wrapper, and Skills-only Guidance
-- `projects/agenticos/.meta/bootstrap/integration-mode-matrix.yaml` is now the machine-readable source of truth for primary vs fallback integration modes
-- `knowledge/integration-mode-matrix-2026-03-25.md` records the product decision for primary and fallback modes
-- `knowledge/integration-mode-matrix-implementation-report-2026-03-25.md` records the parser, docs, and roadmap alignment work
-- issue `#92` now closes the last strict-verification gap left after `#25` by raising the touched project-boundary runtime files to full branch coverage
-- `knowledge/project-boundary-coverage-closure-report-2026-03-25.md` records the added fallback-path regression cases and the final `100 / 100 / 100 / 100` targeted coverage result
-- issue `#98` now freezes the canonical sync contract for `/Users/jeking/dev/AgenticOS` and the freshness contract for live standards entry surfaces
-- `knowledge/canonical-sync-contract-2026-03-25.md` records when the local canonical checkout may be trusted and when `quick-start.md` and `state.yaml` must be refreshed
-- `knowledge/canonical-sync-implementation-report-2026-03-25.md` records the executable verification procedure and the intended post-merge proof run
-- issue `#99` now adds a deterministic refresh surface for `quick-start.md` and `state.yaml` instead of relying on manual post-merge edits
-- `knowledge/entry-surface-refresh-design-2026-03-25.md` records why bounded structured refresh is preferred over freeform summarization
-- `knowledge/entry-surface-refresh-implementation-report-2026-03-25.md` records the landed command, runtime files, and verification
-- issue `#97` now adds one bounded `agenticos_health` surface for canonical checkout freshness, entry-surface refresh freshness, guardrail visibility, and optional standard-kit drift
-- `knowledge/health-command-design-2026-03-25.md` records why this should be a compact pre-work health gate instead of a dashboard
-- `knowledge/health-command-implementation-report-2026-03-25.md` records the landed gates, runtime files, and verification
-- issue `#96` now adds one bounded first-class non-code evaluation command that validates completed rubric files and persists the latest structured evidence into project state
-- `knowledge/non-code-evaluation-command-design-2026-03-25.md` records why this issue should validate and persist rubric results rather than inventing a second scoring system
-- `knowledge/non-code-evaluation-command-implementation-report-2026-03-25.md` records the landed command, persistence contract, and full targeted coverage result
-- issue `#104` now corrects the overreaching migration interpretation and restores the preserved visible project layout in the workspace home
-- `knowledge/project-layout-restoration-report-2026-03-25.md` records the root cause, verified restored paths, and the corrected repository boundary rule
-- issue `#106` now audits whether `t5t` and `okr-management` can be honestly restored from verified local evidence
-- `knowledge/missing-project-source-audit-2026-03-25.md` records that `t5t` is reconstructable from verified local sources, while `okr-management` currently only supports an external-source or archive recovery model
-- issue `#108` now restores `projects/t5t` as a recovered snapshot using the verified local source set rather than pretending to have a byte-identical Git restoration
-- `knowledge/t5t-reconstruction-report-2026-03-25.md` records the restored project surface, provenance boundary, and remaining `okr-management` gap
-- issue `#110` now restores `projects/okr-management` as an external-source wrapper project rooted in the verified corpus under `/Users/jeking/work/02.目标绩效/00.OKR管理/`
-- `knowledge/okr-management-wrapper-recovery-report-2026-03-25.md` records the wrapper-recovery decision, restored project surface, and verification boundary
-- the immediate priority is now to resume the higher-order backlog starting from delegated-work runtime enforcement in `#95`
+- **Status**: in_progress
+- **Last Action**: Issue #262 now removes runtime target resolution dependence on legacy registry.active_project, standardizes session-local project semantics, hardens registry patch writes, and refreshes normative docs to the runtime-home/project model.
+- **Current Focus**: Finish #262 residual review, then prepare the branch for issue/PR update.
+- **Resume Here**: Review any remaining historical docs that should only get superseded notes rather than body edits.
+- **Refreshed At**: 2026-04-10T10:58:11.098Z
+
+## Key Facts
+- AGENTICOS_HOME is modeled as a long-term runtime workspace, not necessarily a source checkout.
+- Projects under AGENTICOS_HOME/Projects may be source-managed or local knowledge/runtime-only.
+- Multi-agent and multi-project concurrency requires fail-closed resolution when no explicit or session-local target is available.
+
+## Latest Landed Reports
+
+- tasks/issue-262-concurrent-runtime-project-resolution.md
+- tasks/issue-263-legacy-project-migration-plan.md
 
 ## Recommended Entry Documents
 
-Start here:
+1. tasks/issue-262-concurrent-runtime-project-resolution.md
+2. tasks/issue-263-legacy-project-migration-plan.md
+3. mcp-server/README.md
+4. standards/knowledge/complete-design.md
 
-1. `knowledge/standalone-standards-repo-consolidation-audit-2026-03-23.md`
-2. `knowledge/standalone-standards-first-consolidation-wave-2026-03-23.md`
-3. `knowledge/standalone-standards-retirement-resolution-2026-03-23.md`
-4. `knowledge/product-positioning-and-design-review-2026-03-22.md`
-5. `knowledge/agent-preflight-and-execution-protocol-2026-03-23.md`
-6. `knowledge/guardrail-flow-wiring-report-2026-03-23.md`
-7. `knowledge/standard-kit-command-design-v1-2026-03-23.md`
-8. `knowledge/standard-kit-command-implementation-report-2026-03-23.md`
-9. `knowledge/status-guardrail-evidence-implementation-report-2026-03-24.md`
-10. `knowledge/switch-guardrail-evidence-implementation-report-2026-03-24.md`
-11. `knowledge/backlog-reconciliation-matrix-2026-03-24.md`
-12. `knowledge/canonical-working-copy-cleanup-report-2026-03-24.md`
-13. `knowledge/record-array-parsing-fix-report-2026-03-24.md`
-14. `knowledge/switch-inline-context-implementation-report-2026-03-24.md`
-15. `knowledge/project-boundary-isolation-implementation-report-2026-03-25.md`
-16. `knowledge/memory-layer-contract-spec-2026-03-25.md`
-17. `knowledge/memory-layer-contract-implementation-report-2026-03-25.md`
-18. `knowledge/sub-agent-inheritance-protocol-2026-03-25.md`
-19. `knowledge/sub-agent-inheritance-implementation-report-2026-03-25.md`
-20. `knowledge/per-agent-bootstrap-standard-2026-03-25.md`
-21. `knowledge/per-agent-bootstrap-standard-implementation-report-2026-03-25.md`
-22. `knowledge/homebrew-post-install-contract-2026-03-25.md`
-23. `knowledge/homebrew-post-install-implementation-report-2026-03-25.md`
-24. `knowledge/integration-mode-matrix-2026-03-25.md`
-25. `knowledge/integration-mode-matrix-implementation-report-2026-03-25.md`
-26. `knowledge/project-boundary-coverage-closure-report-2026-03-25.md`
-27. `knowledge/canonical-sync-contract-2026-03-25.md`
-28. `knowledge/canonical-sync-implementation-report-2026-03-25.md`
-29. `knowledge/entry-surface-refresh-design-2026-03-25.md`
-30. `knowledge/entry-surface-refresh-implementation-report-2026-03-25.md`
-31. `knowledge/health-command-design-2026-03-25.md`
-32. `knowledge/health-command-implementation-report-2026-03-25.md`
-33. `knowledge/non-code-evaluation-command-design-2026-03-25.md`
-34. `knowledge/non-code-evaluation-command-implementation-report-2026-03-25.md`
-35. `knowledge/project-layout-restoration-report-2026-03-25.md`
-36. `knowledge/missing-project-source-audit-2026-03-25.md`
-37. `knowledge/t5t-reconstruction-report-2026-03-25.md`
-38. `knowledge/okr-management-wrapper-recovery-report-2026-03-25.md`
-
-## Next Steps
-
-1. Resume `#95` now that the missing-project recovery path is explicit
-2. Revisit `#94` after the higher-priority enforcement work is done
+## Canonical Layers
+- Operational state: `standards/.context/state.yaml`
+- Session history: `standards/.context/conversations/`
+- Durable knowledge: `knowledge/`
+- Execution plans: `tasks/`
+- Deliverables: `artifacts/`

--- a/standards/.context/state.yaml
+++ b/standards/.context/state.yaml
@@ -27,33 +27,60 @@ issue_bootstrap:
     recorded_at: 2026-04-10T08:45:19.949Z
 working_memory:
   facts:
-    - Fixed `resolveGuardrailProjectTarget()` so explicit `project_path` no
-      longer routes through active-project mismatch enforcement.
-    - Fixed `persistIssueBootstrapEvidence()` so canonical `main` checkouts are
-      not dirtied by runtime persistence.
-    - Added regression coverage for explicit-project resolution drift and
-      issue-bootstrap write protection.
-    - "Ran targeted tests, full `npm test`, and `npm run lint` successfully in
-      the #260 worktree."
-    - "Pushed branch fix/260-stop-active-project-drift-and-main-state-pollution
-      and opened PR #261."
+    - AGENTICOS_HOME is modeled as a long-term runtime workspace, not
+      necessarily a source checkout.
+    - Projects under AGENTICOS_HOME/Projects may be source-managed or local
+      knowledge/runtime-only.
+    - Multi-agent and multi-project concurrency requires fail-closed resolution
+      when no explicit or session-local target is available.
   decisions:
-    - Guardrail commands should honor an explicit `project_path` even when
-      global `active_project` has drifted to another managed project.
-    - Canonical `main` write protection must apply to
-      `agenticos_issue_bootstrap` persistence exactly as it already applies to
-      other guardrail evidence writes.
-    - Keep strict active-project matching in general managed-project resolution;
-      loosen only the guardrail-side explicit-project path.
+    - Runtime target resolution now prefers explicit target, repo-path proof
+      where applicable, and session-local binding; it no longer resolves through
+      legacy registry.active_project.
+    - registry.active_project remains compatibility-only metadata rather than a
+      home-global enforcement primitive.
+    - Normative design/spec docs were updated to reflect the runtime-home plus
+      projects model and session-local project semantics.
   pending:
-    - "Review and merge PR #261."
-    - "After #260 lands, continue remaining backlog in priority order: #245
-      public github_versioned raw conversation isolation, then #244 private
-      github_versioned full continuity persistence."
+    - Review any remaining historical docs that should only get superseded notes
+      rather than body edits.
+    - "Prepare the #262 issue/PR update with the final scope: runtime
+      resolution, standard-kit semantics, and normative doc refresh."
+    - "Keep #263 focused on migration/audit guidance for legacy projects rather
+      than mutate-first runtime fallback."
 session:
-  last_backup: 2026-04-10T08:55:55.177Z
+  last_backup: 2026-04-10T10:58:11.098Z
+  id: entry-refresh-2026-04-10
+  started: 2026-04-10T10:58:11.098Z
+  agent: agenticos-entry-refresh
+  last_entry_surface_refresh: 2026-04-10T10:58:11.098Z
 current_task:
-  title: "fix: stop active-project drift and canonical-main runtime persistence
-    pollution"
-  status: completed
-  updated: 2026-04-10T08:55:46.474Z
+  title: "Implement #262 concurrent runtime project resolution"
+  status: in_progress
+  updated: 2026-04-10T10:58:11.098Z
+  next_step: Review any remaining historical docs that should only get superseded
+    notes rather than body edits.
+loaded_context:
+  - .project.yaml
+  - standards/.context/quick-start.md
+  - tasks/issue-262-concurrent-runtime-project-resolution.md
+  - tasks/issue-263-legacy-project-migration-plan.md
+  - mcp-server/README.md
+  - standards/knowledge/complete-design.md
+entry_surface_refresh:
+  refreshed_at: 2026-04-10T10:58:11.098Z
+  issue_id: null
+  summary: "Issue #262 now removes runtime target resolution dependence on legacy
+    registry.active_project, standardizes session-local project semantics,
+    hardens registry patch writes, and refreshes normative docs to the
+    runtime-home/project model."
+  status: in_progress
+  current_focus: "Finish #262 residual review, then prepare the branch for issue/PR update."
+  report_paths:
+    - tasks/issue-262-concurrent-runtime-project-resolution.md
+    - tasks/issue-263-legacy-project-migration-plan.md
+  recommended_entry_documents:
+    - tasks/issue-262-concurrent-runtime-project-resolution.md
+    - tasks/issue-263-legacy-project-migration-plan.md
+    - mcp-server/README.md
+    - standards/knowledge/complete-design.md

--- a/standards/knowledge/agent-friendly-readme-spec-v1.md
+++ b/standards/knowledge/agent-friendly-readme-spec-v1.md
@@ -343,7 +343,7 @@ brew install madlouse/agenticos/agenticos
 npm install -g agenticos-mcp
 
 ### Verify
-agenticos-list   # should output: No active project
+agenticos-list   # should list registered projects; no session project is highlighted until you switch
 ```
 
 **反面示例**：

--- a/standards/knowledge/complete-design.md
+++ b/standards/knowledge/complete-design.md
@@ -47,16 +47,16 @@ project/
 
 **核心工具**:
 - `agenticos_init` - 创建项目
-- `agenticos_switch` - 切换项目
+- `agenticos_switch` - 绑定当前会话项目
 - `agenticos_list` - 列出项目
 - `agenticos_save` - 保存备份
 
 **核心资源**:
-- `agenticos://context/current` - 项目上下文
+- `agenticos://context/current` - 当前会话项目上下文
 
 **Registry 管理**:
 - 位置: `~/AgenticOS/.agent-workspace/registry.yaml`
-- 作用: 跟踪所有项目、活跃项目
+- 作用: 跟踪所有已注册项目与兼容性元数据；当前项目不再由 home-global registry authoritative 决定
 - 格式: 人类可读的 YAML
 
 ### Layer 3: Agent 适配层（Agent-Specific Layer）
@@ -229,7 +229,7 @@ agenticos-mcp/
 ```yaml
 version: "1.0.0"
 last_updated: "2026-03-16T08:52:20Z"
-active_project: "my-project"
+active_project: null   # legacy compatibility field, not current-session truth
 projects:
   - id: "my-project"
     name: "My Project"

--- a/standards/knowledge/standard-kit-command-design-v1-2026-03-23.md
+++ b/standards/knowledge/standard-kit-command-design-v1-2026-03-23.md
@@ -89,9 +89,10 @@ v1 should not:
 Target resolution should support:
 
 1. explicit `project_path`
-2. fallback to the active project in the registry
+2. explicit `project`
+3. session-local project binding established by `agenticos_switch`
 
-This keeps the command usable both for registered AgenticOS projects and for directed adoption flows.
+This keeps the command usable both for directed adoption flows and for already-bound AgenticOS sessions without reintroducing a home-global active-project truth model.
 
 ## Verification
 

--- a/tasks/issue-262-active-project-drift-live-rca-2026-04-10.md
+++ b/tasks/issue-262-active-project-drift-live-rca-2026-04-10.md
@@ -1,0 +1,203 @@
+# Issue #262 Live RCA Confirmation — 2026-04-10
+
+## Purpose
+
+This note captures a concrete live reproduction of the remaining
+`active_project` drift behavior on the machine runtime after `#260`, and
+explains why `#262` is still necessary.
+
+The important conclusion is:
+
+- the drift is not random
+- the drift is not caused by the Agentic Home directory layout itself
+- the drift is the expected outcome of the old home-global
+  `registry.active_project` runtime model still being live
+
+## Observed Symptom
+
+During concurrent project work on 2026-04-10:
+
+1. the session explicitly switched to `AgenticOS`
+2. a subsequent `agenticos_record(project="AgenticOS")` failed because the
+   runtime believed the active project was `agent-cli-api`
+3. the shared home registry confirmed that `active_project` had already drifted
+   back to `agent-cli-api`
+
+Relevant registry evidence:
+
+- `AGENTICOS_HOME/.agent-workspace/registry.yaml`
+- at observation time:
+  - `active_project: agent-cli-api`
+  - `agenticos.last_accessed: 2026-04-10T14:26:25.659Z`
+  - `agenticos.last_recorded: 2026-04-10T14:26:37.346Z`
+  - `agent-cli-api.last_accessed: 2026-04-10T14:26:54.276Z`
+  - `agent-cli-api.last_recorded: 2026-04-10T14:27:10.425Z`
+
+This proves a different project session updated the global current-project field
+immediately after the `AgenticOS` session had been working correctly.
+
+## Root Cause
+
+### 1. The live runtime still treats `registry.active_project` as authoritative
+
+On the current `main` checkout, `resolveManagedProjectTarget()` still:
+
+- fails when no `registry.active_project` exists
+- rejects an explicit `project` if it does not match `registry.active_project`
+- falls back to `registry.active_project` as the default target
+
+Evidence:
+
+- `mcp-server/src/utils/project-target.ts`
+  - lines 65-66: no active project -> hard failure
+  - lines 82-85: explicit project mismatch -> hard failure
+  - lines 87-92: default target comes from `registry.active_project`
+
+This is exactly the error string observed in the live failed `agenticos_record`
+attempt, which confirms the runtime was still executing the pre-`#262`
+semantics.
+
+### 2. `agenticos_switch` still writes a home-global current project on `main`
+
+On `main`, `agenticos_switch` does:
+
+- `registry.active_project = found.id`
+- then persists the entire registry
+
+Evidence:
+
+- `mcp-server/src/tools/project.ts`
+  - lines 243-245
+
+That means any session switching to any project overwrites the shared
+home-global current project for all other sessions.
+
+### 3. `status` and `list` still read the same home-global field on `main`
+
+On `main`:
+
+- `agenticos_list` highlights the project whose id equals
+  `registry.active_project`
+- `agenticos_status` loads whatever project is stored in
+  `registry.active_project`
+
+Evidence:
+
+- `mcp-server/src/tools/project.ts`
+  - lines 315-317
+  - lines 332-340
+
+So even if one session is logically working in project A, a different session's
+later switch to project B will redirect status/list output back to B.
+
+### 4. Guardrail resolution still prefers the global field on `main`
+
+On `main`, `resolveGuardrailProjectTarget()` does this order:
+
+1. explicit `project_path`
+2. `active_project`
+3. `repo_path` match
+
+Evidence:
+
+- `mcp-server/src/utils/repo-boundary.ts`
+  - lines 116-169
+
+This is the wrong precedence for the target runtime model because a stale or
+unrelated global field can outrank a provable repository location.
+
+### 5. `init` also repopulates the home-global field on `main`
+
+On `main`, `agenticos_init` writes `registry.active_project = id` in both the
+"already exists" normalization path and the final project registration path.
+
+Evidence:
+
+- `mcp-server/src/tools/init.ts`
+  - lines 160-161
+  - lines 250-251
+
+So the drift is not only caused by explicit switching. Project creation or
+normalization can also silently move the global current-project pointer.
+
+### 6. Registry persistence on `main` still uses full-object rewrite
+
+On `main`, `saveRegistry(registry)` writes the full registry snapshot without
+lock + reload + field patch semantics.
+
+Evidence:
+
+- `mcp-server/src/utils/registry.ts`
+  - lines 76-92
+
+This creates a second class of problem:
+
+- even lightweight metadata updates can replay stale in-memory registry state
+- concurrent sessions can overwrite unrelated registry changes
+
+That amplifies the impact of the global `active_project` design.
+
+## Why Multiple Projects All See The Same Problem
+
+The bug is structural, not project-specific.
+
+As long as the runtime model is:
+
+- one shared `AGENTICOS_HOME`
+- one shared `registry.yaml`
+- one authoritative `active_project` field inside that shared file
+
+then any concurrent project session can overwrite the selection observed by any
+other project session.
+
+That is why the symptom appears across unrelated projects.
+
+## Why `#262` Fixes The Actual Root Cause
+
+The `#262` branch changes the model instead of only patching the symptom.
+
+Key differences already implemented there:
+
+1. `resolveManagedProjectTarget()` uses:
+   - explicit `project`
+   - otherwise session-local project binding
+   - otherwise fail closed
+   - no runtime veto from `registry.active_project`
+2. `agenticos_switch` binds session-local context and only patches
+   lightweight metadata such as `last_accessed`
+3. `agenticos_status` and `agenticos_list` read the session-local binding
+4. guardrail resolution prefers:
+   - explicit `project_path`
+   - provable `repo_path`
+   - session-local binding
+   - otherwise fail closed
+5. registry business-path writes now use lock + reload + patch + atomic rename
+
+Relevant `#262` evidence:
+
+- `mcp-server/src/utils/project-target.ts`
+  - lines 65-95 in the `#262` worktree
+- `mcp-server/src/tools/project.ts`
+  - lines 244-257
+  - lines 317-350
+- `mcp-server/src/utils/repo-boundary.ts`
+  - lines 133-240
+- `mcp-server/src/utils/registry.ts`
+  - lines 112-190
+
+## Final Judgment
+
+The live drift observed on 2026-04-10 is explained by one fact:
+
+- the installed/runtime MCP behavior on the machine is still effectively
+  pre-`#262`
+
+So the required corrective action is not another local workaround around
+`active_project`.
+
+The required corrective action is:
+
+1. merge `#262` / PR `#264`
+2. ship the updated runtime so the installed MCP stops using the old semantics
+3. continue `#263` only for compatibility-state migration and operator guidance,
+   not as a substitute for the `#262` runtime redesign

--- a/tasks/issue-262-concurrent-runtime-project-resolution.md
+++ b/tasks/issue-262-concurrent-runtime-project-resolution.md
@@ -34,6 +34,10 @@ GitHub issue:
 
 - https://github.com/madlouse/AgenticOS/issues/262
 
+Live RCA confirmation:
+
+- `tasks/issue-262-active-project-drift-live-rca-2026-04-10.md`
+
 ## Problem Statement
 
 Current behavior is centered around a single mutable `active_project` stored in

--- a/tasks/issue-262-concurrent-runtime-project-resolution.md
+++ b/tasks/issue-262-concurrent-runtime-project-resolution.md
@@ -1,0 +1,438 @@
+# Issue #262: Concurrent Runtime Project Resolution Redesign
+
+## Summary
+
+`#262` redesigns AgenticOS project-resolution semantics for the intended runtime model:
+
+- `AGENTICOS_HOME` is a long-term runtime workspace
+- `projects/` contains many managed projects
+- multiple projects may be active in parallel
+- a single project may have multiple agents working different issues and worktrees in parallel
+
+The current implementation does not satisfy that model because it still treats
+`registry.active_project` as a home-global enforcement primitive.
+
+## Landed Progress
+
+The following tranches are now implemented in the `#262` worktree:
+
+- session-local project binding for `switch`, `status`, `list`, and context reads
+- project-tool precedence updates for `record`, `save`, and `standard-kit`
+- `init` no longer repopulates a home-global authoritative current project
+- guardrail precedence updates for `preflight`, `edit-guard`, `issue-bootstrap`,
+  `branch-bootstrap`, and `pr-scope-check`
+- registry patch APIs with lock + reload + field patch + temp-file atomic rename
+- patch-based registry writes for `switch`, `record`, and `init`
+
+Still pending inside `#262`:
+
+- review whether any remaining runtime write paths should migrate to patch APIs
+- refresh broader generated/docs/status surfaces so all user-facing wording reflects the new model
+- decide whether schema cleanup such as `last_selected_project` belongs in `#262` or should wait for `#263`
+
+GitHub issue:
+
+- https://github.com/madlouse/AgenticOS/issues/262
+
+## Problem Statement
+
+Current behavior is centered around a single mutable `active_project` stored in
+`AGENTICOS_HOME/.agent-workspace/registry.yaml`.
+
+This creates four structural failures:
+
+1. `agenticos_switch` and `agenticos_init` mutate a home-global current-project value.
+2. explicit `project` or `project_path` can still be rejected if they disagree with that unrelated global value.
+3. registry persistence is a full-object rewrite, so stale snapshots can overwrite newer metadata.
+4. tools that should only update lightweight metadata can accidentally replay or revert unrelated registry state.
+
+This is not only a guardrail bug. It is a state-model bug.
+
+## Non-Goals
+
+- Do not directly implement `#245` public raw conversation isolation in this issue.
+- Do not directly implement `#244` private full continuity persistence in this issue.
+- Do not reopen `#260` scope.
+- Do not perform the larger root Git detachment / product repo extraction here.
+
+## State Model Contract
+
+`#262` should formalize four distinct state layers.
+
+### 1. Home-Global Registry
+
+Purpose:
+
+- project index
+- project metadata
+- lightweight workspace-level metadata
+
+Allowed examples:
+
+- project id, name, path, status, created
+- last accessed
+- last recorded
+- optional compatibility metadata such as `last_selected_project`
+
+Forbidden examples:
+
+- global authoritative current project
+- issue-local execution context
+- worktree-local execution identity
+- session-local project selection
+
+### 2. Project-Global State
+
+Purpose:
+
+- project-shared durable operational memory
+
+Allowed examples:
+
+- quick-start
+- current state
+- knowledge
+- tasks
+- latest guardrail evidence
+- latest issue bootstrap evidence
+
+This layer already mostly exists inside each project's configured context paths.
+
+### 3. Session-Local Context
+
+Purpose:
+
+- the current project bound to one MCP server session / agent process
+
+Allowed examples:
+
+- current project id
+- current project path
+- bound timestamp
+- optional session-local notes for diagnostics
+
+Design choice for `#262`:
+
+- implement session-local context as in-memory state within the MCP server process
+- do not persist it into the shared home-global registry
+
+Rationale:
+
+- current server model is stdio MCP, effectively one server process per agent session
+- in-memory storage matches the meaning of session-local
+- it avoids creating a second shared mutable file with the same class of race condition
+
+### 4. Issue/Worktree-Local Identity
+
+Purpose:
+
+- execution identity for implementation-affecting work
+
+Allowed examples:
+
+- `project_path`
+- `repo_path`
+- `issue_id`
+- branch
+- worktree type
+- git common root
+- latest preflight / bootstrap / edit-guard evidence
+
+This layer should become the primary trust chain for guardrail tools.
+
+## Core Contract Changes
+
+## A. `active_project` Semantics
+
+Current problem:
+
+- `resolveManagedProjectTarget()` rejects explicit `project` when it differs from `registry.active_project`
+
+Required change:
+
+- `active_project` must stop acting as a blocking enforcement source
+- explicit `project`, explicit `project_path`, and provable `repo_path` must not be vetoed by a global registry value
+
+Compatibility plan:
+
+- keep loading legacy `active_project` during migration
+- stop using it for fail-closed validation
+- optionally rename the write-side concept to `last_selected_project` in a later schema cleanup
+
+## B. Session-Local `switch`
+
+Current problem:
+
+- `agenticos_switch` mutates the home-global registry current project
+
+Required change:
+
+- `agenticos_switch` binds the current session to a target project
+- it may patch lightweight registry metadata such as `last_accessed`
+- it must not change a home-global current-project enforcement field
+
+`agenticos_status`, `agenticos_list`, and `agenticos://context/current` must all
+be updated to read session-local current project semantics.
+
+## C. Registry Persistence
+
+Current problem:
+
+- `saveRegistry(registry)` rewrites the entire registry object
+
+Required change:
+
+- add registry patch APIs
+- use file locking
+- reload fresh inside the critical section
+- apply only field-level mutations
+- write through a temporary file and atomic rename
+
+Recommended write API shape:
+
+- `withRegistryLock()`
+- `loadRegistryFresh()`
+- `patchRegistry(mutationFn)`
+- `patchProjectMetadata(projectId, patch)`
+- `registerProject(...)`
+
+`saveRegistry(registry)` should stop being the default business-path API.
+
+Current landed state:
+
+- `patchRegistry()` and `patchProjectMetadata()` now exist
+- business-path writes for `switch`, `record`, and `init` already use patch-based writes
+- `saveRegistry()` remains as a lower-level compatibility write path, not the preferred business API
+
+## D. Unified Resolution Order
+
+The system should stop using different and conflicting target-resolution rules.
+
+Recommended unified precedence:
+
+### Project Tools
+
+Applies to:
+
+- `record`
+- `save`
+- `status`
+- `context/current`
+- standard-kit helpers
+
+Resolution order:
+
+1. explicit `project_path` if supported
+2. explicit `project`
+3. session-local current project
+4. otherwise fail closed; do not resolve through legacy registry current-project state
+
+### Guardrail and Execution Tools
+
+Applies to:
+
+- `preflight`
+- `branch-bootstrap`
+- `pr-scope-check`
+- `issue-bootstrap`
+- `edit-guard`
+
+Resolution order:
+
+1. explicit `project_path`
+2. provable `repo_path`
+3. session-local project only as advisory fallback
+4. otherwise fail closed; never let unrelated legacy global state substitute for explicit or provable identity
+
+## Command-by-Command Design
+
+### `resolveManagedProjectTarget()`
+
+Refactor into two concepts:
+
+- explicit/provable target resolution
+- session-default target resolution
+
+It should no longer combine explicit target proof with a legacy active-project consistency check.
+
+### `agenticos_switch`
+
+Should:
+
+- validate target project
+- bind session-local current project
+- patch project `last_accessed`
+- return the same rich context summary as today
+
+Should not:
+
+- mutate global current-project enforcement state
+
+### `agenticos_status`
+
+Should:
+
+- accept optional `project`
+- use session-local current project when no explicit project is passed
+- fail clearly if there is no explicit target and no session binding
+
+### `agenticos_list`
+
+Should:
+
+- list registry projects
+- optionally highlight the session-local current project
+- stop presenting a home-global active project as the single current truth
+
+### `agenticos://context/current`
+
+Should:
+
+- mean current session project context
+- fail clearly when the session is unbound
+- optionally gain a separate explicit-project variant in a later iteration if useful
+
+### `agenticos_record`
+
+Should:
+
+- resolve project explicitly or from session-local binding
+- update only the target project's `last_recorded`
+- stop writing stale registry snapshots back
+
+### `agenticos_save`
+
+Should:
+
+- resolve project explicitly or from session-local binding
+- remain project-scoped
+- stop depending on legacy global current-project state
+
+### `standard-kit`
+
+Should:
+
+- prefer explicit `project_path`
+- otherwise use session-local current project
+- stop consulting registry `active_project` as a hidden fallback
+
+### Guardrail Tools
+
+Should:
+
+- trust explicit `project_path`
+- trust provable `repo_path`
+- use issue/worktree evidence as the main execution identity chain
+- treat session-local current project only as supportive context
+
+### `edit-guard`
+
+Should:
+
+- block on mismatched resolved target identity versus latest issue/bootstrap/preflight evidence
+- stop centering its logic on `active_project mismatch`
+
+## Concurrency Design
+
+Recommended solution:
+
+- session-local current project: in-memory only
+- home-global registry: lock + reload + field patch + temp file + atomic rename
+
+Why this combination:
+
+- lock prevents cross-process concurrent writes from interleaving
+- reload prevents stale in-memory objects from overwriting newer state
+- field patch avoids replaying unrelated fields
+- atomic rename avoids partial-file corruption
+
+Rejected alternatives for `#262`:
+
+- CAS only: still leaves high retry/merge complexity
+- append log / event sourcing: too heavy for this scope
+- unprotected patch writes: still unsafe across processes
+
+## Migration and Compatibility
+
+Migration goals:
+
+- old registries with `active_project` still load
+- old docs and tests do not remain semantically wrong
+- commands fail with clear messages when session binding is missing
+
+Compatibility policy:
+
+- read legacy `active_project`
+- stop using it as a hard gate
+- update tool descriptions and generated docs to stop telling operators that a single global active project is authoritative
+
+## Required Documentation Updates
+
+At minimum update:
+
+- `CLAUDE.md`
+- `AGENTS.md`
+- `mcp-server/README.md`
+- tool descriptions in `mcp-server/src/index.ts`
+- generated distill / entry-surface wording
+- any audit scripts or knowledge docs that still prescribe “switch the global active project” as the truth model
+
+## Required Test Matrix
+
+### Session-Local Behavior
+
+- two parallel sessions bind different projects and do not interfere
+- status and context/current reflect the current session binding
+- unbound session returns the correct error
+
+### Explicit Precedence
+
+- explicit `project_path` beats any legacy registry state
+- explicit `project` beats session fallback
+- provable `repo_path` beats legacy registry state
+
+### Registry Concurrency
+
+- concurrent `last_accessed` and `last_recorded` updates are both preserved
+- stale snapshot cannot overwrite newer fields
+- atomic write path never leaves malformed YAML on disk
+- lock release and retry behavior is covered
+
+### Command Regression Coverage
+
+- `record` works without legacy active-project checks
+- `save` works without legacy active-project checks
+- `standard-kit` no longer depends on registry active project
+- guardrail tools keep explicit/provable target precedence
+- edit-guard blocks on evidence mismatch rather than legacy active-project mismatch
+
+### Migration Coverage
+
+- legacy registry containing `active_project` loads correctly
+- new schema writes remain readable
+- no runtime command resolves its target through legacy `active_project`
+- no command still emits “must match active project” semantics
+
+## Execution Order
+
+1. Introduce session-context abstraction.
+2. Introduce registry lock and patch APIs.
+3. Migrate `switch/status/list/context/current`.
+4. Migrate `record/save`.
+5. Migrate `standard-kit`.
+6. Migrate guardrail and edit-guard resolution semantics.
+7. Update docs, templates, tool descriptions, and tests.
+
+Current state:
+
+- 1 through 6 are implemented in the worktree
+- 7 is partially implemented and remains open for broader wording/template cleanup
+
+## Acceptance Checks
+
+- no explicit or provable project identity is blocked by unrelated registry global state
+- `switch` no longer mutates a home-global authoritative current project
+- registry writes are concurrency-safe
+- stale registry snapshots cannot revert newer state
+- session-local project binding is observable and reliable
+- docs and tool descriptions reflect the new runtime model

--- a/tasks/issue-262-pr-draft.md
+++ b/tasks/issue-262-pr-draft.md
@@ -1,5 +1,7 @@
 # PR Draft for #262
 
+Closes #262.
+
 ## Title
 
 `redesign: make project resolution session-local and remove runtime fallback to global active_project`

--- a/tasks/issue-262-pr-draft.md
+++ b/tasks/issue-262-pr-draft.md
@@ -58,6 +58,7 @@ Result:
 - `mcp-server/src/utils/standard-kit.ts`
 - `mcp-server/src/utils/distill.ts`
 - `mcp-server/src/index.ts`
+- `tasks/issue-262-active-project-drift-live-rca-2026-04-10.md`
 - `standards/knowledge/agent-friendly-readme-spec-v1.md`
 - `standards/knowledge/standard-kit-command-design-v1-2026-03-23.md`
 - `standards/knowledge/complete-design.md`
@@ -70,4 +71,5 @@ Result:
 ## Risks / Notes
 
 - the local installed/runtime MCP on the machine will still reflect old behavior until this branch is merged and shipped
+- live validation on 2026-04-10 confirmed the old runtime still drifts through home-global `registry.active_project`; see `tasks/issue-262-active-project-drift-live-rca-2026-04-10.md`
 - legacy `registry.active_project` still exists in schema/compatibility surfaces, but runtime command resolution no longer depends on it

--- a/tasks/issue-262-pr-draft.md
+++ b/tasks/issue-262-pr-draft.md
@@ -1,0 +1,71 @@
+# PR Draft for #262
+
+## Title
+
+`redesign: make project resolution session-local and remove runtime fallback to global active_project`
+
+## Summary
+
+This PR completes the main runtime-model redesign from `#262`.
+
+It removes hidden runtime dependence on home-global `registry.active_project` and makes
+project resolution rely on:
+
+1. explicit target selection
+2. provable `repo_path` identity where guardrails can prove it
+3. session-local project binding
+4. otherwise fail closed
+
+The change also hardens registry persistence, refreshes generated adapter templates,
+and updates normative design/spec docs to the runtime-home / multi-project model.
+
+## What Changed
+
+- added session-local project binding support and switched `agenticos_switch` semantics to bind the current MCP session
+- removed runtime target resolution fallback through legacy `registry.active_project` for:
+  - `record`
+  - `save`
+  - `status`
+  - `agenticos://context/current`
+  - standard-kit helpers
+- updated guardrail resolution to prefer explicit `project_path`, then provable `repo_path`, then session-local binding, otherwise fail closed
+- added registry patch/lock/reload/atomic-write semantics on the main write paths
+- updated generated `AGENTS.md` / `CLAUDE.md` template wording and bumped template version to `v11`
+- tightened standard-kit conformance/tests so session-start guidance must match the new semantics
+- refreshed operator-facing/normative docs to reflect:
+  - runtime home vs project workspaces
+  - session-local project context
+  - compatibility-only status of legacy `active_project`
+
+## Verification
+
+- `npm test`
+- `npm run lint`
+
+Result:
+
+- `32` test files passed
+- `255` tests passed
+- lint passed
+
+## Key Files
+
+- `mcp-server/src/utils/project-target.ts`
+- `mcp-server/src/utils/repo-boundary.ts`
+- `mcp-server/src/utils/registry.ts`
+- `mcp-server/src/utils/standard-kit.ts`
+- `mcp-server/src/utils/distill.ts`
+- `mcp-server/src/index.ts`
+- `standards/knowledge/agent-friendly-readme-spec-v1.md`
+- `standards/knowledge/standard-kit-command-design-v1-2026-03-23.md`
+- `standards/knowledge/complete-design.md`
+
+## Follow-Ups
+
+- `#263` remains the migration-policy / operator-guidance follow-up for legacy managed projects
+- historical RCA / implementation-report artifacts were intentionally preserved as historical evidence instead of being rewritten as current truth
+
+## Risks / Notes
+
+- the local installed/runtime MCP on the machine will still reflect old behavior until this branch is merged and shipped
+- legacy `registry.active_project` still exists in schema/compatibility surfaces, but runtime command resolution no longer depends on it

--- a/tasks/issue-262-submission-evidence.md
+++ b/tasks/issue-262-submission-evidence.md
@@ -1,0 +1,59 @@
+# Submission Evidence
+
+## Scope
+- Issue: `#262` redesign: remove global `active_project` as a concurrency-critical enforcement primitive
+- Task type: runtime semantics redesign, guardrail resolution cleanup, registry write-safety hardening, normative doc refresh
+- Branch: `redesign/262-concurrent-runtime-project-resolution`
+- Worktree: `/Users/jeking/dev/AgenticOS/worktrees/agenticos-262-concurrent-runtime-project-resolution`
+
+## Preflight
+- Preflight passed: not applicable for this product-repo design/runtime change tranche
+- Blocking exceptions: none during local implementation verification
+
+## Design Loop
+- Design pass count: 1 persisted design for `#262`, 1 persisted migration split-out for `#263`, multiple in-turn refinement passes before implementation
+- Critique completed: yes; runtime semantics, policy surfaces, and normative docs were re-audited after implementation
+- Acceptance defined before edit: yes; persisted in [tasks/issue-262-concurrent-runtime-project-resolution.md](/Users/jeking/dev/AgenticOS/worktrees/agenticos-262-concurrent-runtime-project-resolution/tasks/issue-262-concurrent-runtime-project-resolution.md)
+
+## Sub-Agent Verification
+- Sub-agents used: 3 parallel audits
+- Inheritance packet defined: yes; each audit received the overall runtime-home / multi-project concurrency model and `#262` redesign target
+- Sub-agent understanding verified before work: yes; the audit scopes were separated into runtime semantics, generated policy surfaces, and normative docs
+- Parent agent distilled important results back into canonical files: yes; results were reflected into runtime code, tests, issue design notes, and normative docs
+
+## Verification
+- Deliverable type: MCP runtime behavior change plus supporting docs/spec updates
+- Commands run:
+  - `npm test`
+  - `npm run lint`
+- Coverage result:
+  - `32` test files passed
+  - `255` tests passed
+  - lint passed
+- Rubric evaluation result: not applicable
+- Evidence files:
+  - [tasks/issue-262-concurrent-runtime-project-resolution.md](/Users/jeking/dev/AgenticOS/worktrees/agenticos-262-concurrent-runtime-project-resolution/tasks/issue-262-concurrent-runtime-project-resolution.md)
+  - [tasks/issue-263-legacy-project-migration-plan.md](/Users/jeking/dev/AgenticOS/worktrees/agenticos-262-concurrent-runtime-project-resolution/tasks/issue-263-legacy-project-migration-plan.md)
+  - [mcp-server/src/utils/project-target.ts](/Users/jeking/dev/AgenticOS/worktrees/agenticos-262-concurrent-runtime-project-resolution/mcp-server/src/utils/project-target.ts)
+  - [mcp-server/src/utils/repo-boundary.ts](/Users/jeking/dev/AgenticOS/worktrees/agenticos-262-concurrent-runtime-project-resolution/mcp-server/src/utils/repo-boundary.ts)
+  - [mcp-server/src/utils/registry.ts](/Users/jeking/dev/AgenticOS/worktrees/agenticos-262-concurrent-runtime-project-resolution/mcp-server/src/utils/registry.ts)
+  - [mcp-server/src/utils/standard-kit.ts](/Users/jeking/dev/AgenticOS/worktrees/agenticos-262-concurrent-runtime-project-resolution/mcp-server/src/utils/standard-kit.ts)
+  - [mcp-server/src/utils/distill.ts](/Users/jeking/dev/AgenticOS/worktrees/agenticos-262-concurrent-runtime-project-resolution/mcp-server/src/utils/distill.ts)
+  - [mcp-server/src/index.ts](/Users/jeking/dev/AgenticOS/worktrees/agenticos-262-concurrent-runtime-project-resolution/mcp-server/src/index.ts)
+  - [standards/knowledge/agent-friendly-readme-spec-v1.md](/Users/jeking/dev/AgenticOS/worktrees/agenticos-262-concurrent-runtime-project-resolution/standards/knowledge/agent-friendly-readme-spec-v1.md)
+  - [standards/knowledge/standard-kit-command-design-v1-2026-03-23.md](/Users/jeking/dev/AgenticOS/worktrees/agenticos-262-concurrent-runtime-project-resolution/standards/knowledge/standard-kit-command-design-v1-2026-03-23.md)
+  - [standards/knowledge/complete-design.md](/Users/jeking/dev/AgenticOS/worktrees/agenticos-262-concurrent-runtime-project-resolution/standards/knowledge/complete-design.md)
+
+## Residual Risk
+- Remaining limitations:
+  - historical RCA / implementation-report documents still contain pre-`#262` terminology by design; they were intentionally preserved as historical evidence
+  - installed Homebrew/runtime MCP on the machine does not inherit this redesign until the branch is landed and shipped
+  - `#263` is still required for legacy-project migration guidance and operator workflow
+- Explicit exceptions:
+  - did not rewrite historical issue/RCA artifacts into current truth
+  - did not perform mutate-first migration of existing projects
+  - did not open or submit a PR in this tranche
+
+## Ready To Submit
+- Yes/No: yes, for commit/PR preparation
+- If no, what is blocked:

--- a/tasks/issue-263-legacy-project-migration-plan.md
+++ b/tasks/issue-263-legacy-project-migration-plan.md
@@ -1,0 +1,385 @@
+# Legacy Managed-Project Migration Plan After #262
+
+## Summary
+
+After `#262` lands, existing managed projects may still contain legacy state and
+registry assumptions that were valid under the old `active_project` model but are
+unsafe or misleading under the new concurrent runtime model.
+
+This migration problem should be tracked as a separate issue from `#262`.
+
+The migration contract should answer three questions:
+
+1. Which existing projects actually require migration?
+2. Which changes can be repaired lazily and safely during normal commands?
+3. Which changes require an explicit migration flow with audit visibility?
+
+## Recommendation
+
+Do **not** require a one-shot global migration before the system can be used.
+
+Do **not** rely only on silent switch-time mutation either.
+
+Use a **hybrid migration model**:
+
+1. Backward-compatible reads from old registry/project data remain supported.
+2. Safe metadata-only normalization may happen lazily when a project is
+   explicitly targeted or switched into.
+3. Structural changes that affect execution identity, persistence layout,
+   registry semantics, or auditability must use an explicit migration command or
+   guided workflow with dry-run output.
+
+This gives three benefits:
+
+- existing installations continue working immediately after `#262`
+- operators are not forced to migrate every project up front
+- high-risk changes remain explicit, reviewable, and auditable
+
+## Why A Full One-Time Migration Is The Wrong Default
+
+`AGENTICOS_HOME` can contain many projects, and not all of them will be active.
+
+A mandatory one-shot migration is a poor default because:
+
+- it touches dormant projects that may not need immediate modification
+- it increases blast radius if migration logic is wrong
+- it couples rollout of `#262` to the correctness of every project repair path
+- it creates avoidable friction on machines where only one or two projects are
+  currently active
+
+## Why Pure Switch-Time Migration Is Also Insufficient
+
+Pure switch-time migration is also incomplete because:
+
+- some changes should not happen silently inside a routine context-load command
+- migration may need dry-run reporting, operator review, and evidence logging
+- some projects may need bulk audit/remediation before teams rely on them again
+- schema repair and registry rewrite changes have concurrency implications
+
+## Migration Classes
+
+### Class A: Read-Compatible Legacy Data
+
+Examples:
+
+- registry still contains `active_project`
+- registry project entries still use legacy path shapes that are still resolvable
+- project data still assumes legacy fallback behavior, but explicit identity is
+  provable
+
+Handling:
+
+- continue reading without blocking
+- do not require immediate mutation
+- treat as compatibility input only
+
+### Class B: Safe Metadata Repair
+
+Examples:
+
+- `registry.active_project` still populated with a stale project id
+- project `last_accessed` or other lightweight metadata is missing
+- registry stores absolute or relative paths that can be normalized without
+  changing project meaning
+
+Handling:
+
+- allow repair during explicit `switch` or explicit project-target resolution
+- only mutate fields that are local, low-risk, and reversible
+- log what changed
+- never silently rewrite unrelated registry state
+
+Candidate lazy repairs:
+
+- clear or downgrade legacy `active_project`
+- fill missing non-authoritative metadata
+- normalize path formatting
+
+### Class C: Explicit Structural Migration
+
+Examples:
+
+- changing registry write semantics to patch-based / lock-based mutation
+- renaming `active_project` to `last_selected_project`
+- moving or normalizing project context paths
+- repairing project files whose identity cannot be proven cleanly
+- rewriting guardrail evidence/state shapes
+
+Handling:
+
+- require explicit migrate command or guided workflow
+- support `dry_run`
+- produce a report of planned changes
+- write audit evidence to project state or migration report artifacts
+- fail closed when project identity is ambiguous
+
+## Proposed UX Contract
+
+### 1. `#262` Runtime Behavior
+
+Immediately after `#262`:
+
+- old registries still load
+- old projects still resolve if identity is provable
+- legacy `active_project` is compatibility-only, not authoritative
+
+### 2. Lazy Repair On Explicit Project Entry
+
+When the operator calls `agenticos_switch` or another explicit project-targeted
+command:
+
+- inspect whether the project/registry is in a safe Class B legacy state
+- if yes, optionally apply a minimal repair patch
+- surface a short note such as:
+  - `Applied safe legacy metadata normalization`
+  - `Legacy registry current-project field was cleared`
+
+This should be:
+
+- deterministic
+- narrow in scope
+- field-patch based
+- concurrency-safe
+
+### 3. Explicit Migration Workflow
+
+Add a dedicated migration issue and later implementation surface for commands
+such as:
+
+- `agenticos_migrate_project`
+- `agenticos_migrate_home --report-only`
+- `agenticos_migration_audit`
+
+Minimum behavior:
+
+- detect legacy projects
+- classify findings by risk
+- support dry-run
+- support per-project execution
+- support home-wide audit reporting without forced mutation
+
+## Scope For The Follow-Up Migration Issue
+
+The follow-up issue should include:
+
+1. Legacy-state inventory
+   - registry fields
+   - project file/state fields
+   - guardrail evidence/state records
+
+2. Migration classifier
+   - read-compatible only
+   - safe lazy repair
+   - explicit migration required
+
+3. Operator workflow
+   - audit first
+   - migrate selected project
+   - optional home-wide migration report
+
+4. Concurrency and safety rules
+   - no blind full-object registry rewrites
+   - lock + reload + field patch + atomic rename
+   - explicit identity proof before mutation
+
+5. Documentation
+   - upgrade guide for existing Agentic Home installations
+   - per-project migration checklist
+   - notes for mixed old/new runtime states during rollout
+
+## Implementation Breakdown
+
+The migration issue should be executed as four concrete workstreams.
+
+### Workstream 1: Audit / Report-Only Surface
+
+Goal:
+
+- detect legacy state without mutating anything
+- let operators understand whether migration is needed and how risky it is
+
+Suggested command shape:
+
+- `agenticos_migration_audit`
+- `agenticos_migrate_home --report-only`
+
+Minimum inputs:
+
+- optional `project_path`
+- optional `project`
+- optional `home_scope=true`
+
+Minimum outputs:
+
+- detected project identity
+- finding list with severity
+- finding classification: `compatible_only`, `safe_lazy_repair`, `explicit_migration_required`
+- recommended next action per finding
+- whether the project is safe to continue operating without migration
+
+Findings to detect:
+
+- legacy `active_project` still populated
+- registry/project path normalization drift
+- missing or stale non-authoritative metadata
+- project identity ambiguity
+- context path divergence from current contract
+- guardrail evidence/state using old shapes
+
+Acceptance criteria:
+
+- no writes occur in report-only mode
+- output is deterministic and machine-readable
+- ambiguous identity fails closed
+- the same project can be audited repeatedly without side effects
+
+### Workstream 2: Per-Project Explicit Migration
+
+Goal:
+
+- migrate one target project deliberately and safely
+
+Suggested command shape:
+
+- `agenticos_migrate_project`
+
+Minimum inputs:
+
+- `project_path` or `project`
+- optional `dry_run=true`
+- optional `apply_safe_repairs_only=true`
+
+Minimum behaviors:
+
+- prove project identity before mutation
+- show planned actions in dry-run mode
+- apply only the selected migration classes
+- emit a structured migration report
+- persist migration evidence into project state or artifacts
+
+Mutation classes:
+
+- safe metadata repair
+- explicit structural migration
+
+Must not do:
+
+- mutate unrelated projects
+- rewrite the whole registry from a stale snapshot
+- silently downgrade ambiguous findings into automatic mutation
+
+Acceptance criteria:
+
+- dry-run and apply modes produce matching action plans
+- rerunning after success is idempotent or no-op where appropriate
+- project-local artifacts clearly show what changed
+- concurrency-safe registry writes are used
+
+### Workstream 3: Home-Wide Migration Report
+
+Goal:
+
+- give operators a complete estate-level view of legacy state across one
+  `AGENTICOS_HOME`
+
+Suggested command shape:
+
+- `agenticos_migrate_home --report-only`
+- optional later `agenticos_migrate_home --apply-safe-repairs`
+
+Why report-first:
+
+- a long-lived home may contain many dormant projects
+- estate-wide mutation should not be the default first step
+
+Minimum outputs:
+
+- list of managed projects discovered from registry
+- per-project migration class summary
+- blocked/ambiguous projects
+- which projects are safe to defer
+- which projects need explicit operator review
+
+Optional later capability:
+
+- apply only Class B safe repairs home-wide
+
+Non-goal for first iteration:
+
+- bulk automatic Class C structural migration across the entire home
+
+Acceptance criteria:
+
+- estate-level report can be generated without mutating any project
+- per-project findings match single-project audit results
+- blocked projects are called out explicitly instead of being skipped silently
+
+### Workstream 4: Upgrade Guide And Operator Docs
+
+Goal:
+
+- make migration and mixed-state rollout understandable without reading code or
+  issue archaeology
+
+Required documentation outputs:
+
+- upgrade guide for existing Agentic Home installations
+- migration FAQ
+- per-project migration checklist
+- explanation of what is repaired lazily vs explicitly
+- rollback/recovery guidance for migration failures
+
+Required topics:
+
+- what changed after `#262`
+- why `active_project` is no longer authoritative
+- when operators should run audit only
+- when operators should run explicit migration
+- what commands are safe during mixed old/new state
+
+Acceptance criteria:
+
+- an operator can decide whether to migrate now, later, or only audit
+- docs distinguish runtime compatibility from full normalization
+- docs include examples for both runtime-only homes and source-managed projects
+
+## Recommended Sequencing
+
+Recommended order:
+
+1. Workstream 1: audit / report-only
+2. Workstream 4: docs drafted in parallel with audit output schema
+3. Workstream 2: per-project explicit migration
+4. Workstream 3: home-wide report and optional safe-repair expansion
+
+Reasoning:
+
+- audit must exist before operators can trust migration decisions
+- docs should be written against a real audit/migration contract, not guesses
+- per-project explicit migration is safer than starting with home-wide mutation
+- estate-level apply behavior should only come after single-project migration is
+  proven
+
+## Suggested Issue Checklist
+
+- [ ] Define the migration finding schema and severity model.
+- [ ] Implement report-only audit for a single project.
+- [ ] Implement home-wide report-only migration inventory.
+- [ ] Define the per-project migration action plan and dry-run output.
+- [ ] Implement per-project explicit migration with evidence logging.
+- [ ] Document safe lazy repair cases allowed during explicit project entry.
+- [ ] Publish the upgrade guide and migration checklist.
+- [ ] Decide whether home-wide apply-safe-repairs is warranted after single-project migration is proven.
+
+## Decision
+
+The recommended strategy is:
+
+- **not** a mandatory one-shot migration gate
+- **not** silent migration of all legacy state during `switch`
+- **yes** to compatibility-on-read
+- **yes** to narrow safe lazy repair for metadata-only fixes
+- **yes** to explicit migration tooling/workflow for structural changes
+
+That is the safest design for a long-lived `AGENTICOS_HOME` that manages many
+projects concurrently.


### PR DESCRIPTION
Closes #262.

## Summary

This PR completes the main runtime-model redesign for concurrent AgenticOS runtime work.

It removes hidden runtime dependence on home-global `registry.active_project` and makes project resolution rely on:

1. explicit target selection
2. provable `repo_path` identity where guardrails can prove it
3. session-local project binding
4. otherwise fail closed

The change also hardens registry persistence, refreshes generated adapter templates, and updates normative design/spec docs to the runtime-home / multi-project model.

## What Changed

- added session-local project binding support and changed `agenticos_switch` to bind the current MCP session
- removed runtime target-resolution fallback through legacy `registry.active_project` for `record`, `save`, `status`, `agenticos://context/current`, and standard-kit helpers
- updated guardrail resolution to prefer explicit `project_path`, then provable `repo_path`, then session-local binding, otherwise fail closed
- added registry patch/lock/reload/atomic-write semantics on the main write paths
- updated generated `AGENTS.md` / `CLAUDE.md` template wording and bumped template version to `v11`
- tightened standard-kit conformance/tests so session-start guidance must match the new semantics
- refreshed operator-facing and normative docs to reflect the runtime-home / multi-project / session-local model

## Verification

- `npm test`
- `npm run lint`
- GitHub Actions CI
- GitHub README lint

Result:

- `32` test files passed
- `255` tests passed
- local lint passed
- PR checks passed

## Follow-Ups

- `#263` remains the migration-policy and operator-guidance follow-up for legacy managed projects
- historical RCA and implementation-report artifacts were intentionally preserved as historical evidence instead of being rewritten as current truth

## Notes

- the local installed/runtime MCP on the machine will still reflect old behavior until this branch is merged and shipped
- legacy `registry.active_project` still exists in schema and compatibility surfaces, but runtime command resolution no longer depends on it
