### PR TITLE
design: add deterministic legacy project migration workflow

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -361,6 +361,30 @@ Current behavior:
   - `safe_lazy_repair`
   - `explicit_migration_required`
 
+### agenticos_migrate_project
+Build a deterministic per-project migration plan for a legacy managed project.
+
+**Parameters**:
+- `project_path` (optional) - Explicit project path to migrate
+- `project` (optional) - Managed project id, name, or path when `project_path` is not provided
+- `mode` (optional) - `plan` or `apply`; the current phase-2 slice supports `plan` only
+- `apply_scope` (optional) - `safe_repairs_only` or `full`
+- `expected_plan_hash` (optional) - Reserved for future apply mode
+
+**Returns**: JSON with `READY`, `BLOCK`, or `NOOP`, plus deterministic planned actions, manual blocks, and a `plan_hash`
+
+Current behavior:
+- requires an explicit `project` or `project_path`
+- does not use session fallback
+- builds a deterministic plan from the current audit state
+- separates:
+  - planned actions
+  - deferred compatible-only findings
+  - manual blocks
+- exposes a stable `plan_hash` and preconditions for the future apply path
+- blocks `mode=apply` in the current phase-2 slice
+- does not write project or registry state
+
 ### agenticos_migrate_home
 Generate a registry-backed legacy-project migration inventory across one `AGENTICOS_HOME`.
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -367,23 +367,33 @@ Build a deterministic per-project migration plan for a legacy managed project.
 **Parameters**:
 - `project_path` (optional) - Explicit project path to migrate
 - `project` (optional) - Managed project id, name, or path when `project_path` is not provided
-- `mode` (optional) - `plan` or `apply`; the current phase-2 slice supports `plan` only
+- `mode` (optional) - `plan` or `apply`
 - `apply_scope` (optional) - `safe_repairs_only` or `full`
-- `expected_plan_hash` (optional) - Reserved for future apply mode
+- `expected_plan_hash` (optional) - Required for `mode=apply`
 
-**Returns**: JSON with `READY`, `BLOCK`, or `NOOP`, plus deterministic planned actions, manual blocks, and a `plan_hash`
+**Returns**: JSON with:
+- `READY`, `BLOCK`, or `NOOP` in `mode=plan`
+- `APPLIED` or `BLOCK` in `mode=apply`
 
 Current behavior:
 - requires an explicit `project` or `project_path`
 - does not use session fallback
 - builds a deterministic plan from the current audit state
+- supports guarded per-project `apply` for the currently implemented deterministic actions
 - separates:
   - planned actions
   - deferred compatible-only findings
   - manual blocks
-- exposes a stable `plan_hash` and preconditions for the future apply path
-- blocks `mode=apply` in the current phase-2 slice
-- does not write project or registry state
+- exposes a stable `plan_hash` and preconditions
+- `mode=apply` requires `expected_plan_hash`
+- `mode=apply` writes:
+  - project-local migration evidence
+  - latest migration summary pointer in state
+  - patch-based registry repairs for supported deterministic actions
+- current `apply` scope is still intentionally narrow:
+  - no home-wide apply
+  - no orphan discovery
+  - no structural guessing for ambiguous identity/topology cases
 
 ### agenticos_migrate_home
 Generate a registry-backed legacy-project migration inventory across one `AGENTICOS_HOME`.
@@ -397,7 +407,7 @@ Current behavior:
 - report-only
 - scans managed projects currently registered in the home registry without mutating them
 - highlights blocked projects explicitly instead of skipping them silently
-- is intended to be the operator-first inventory step before any future explicit migration command
+- is intended to be the operator-first inventory step before explicit per-project migration
 
 ### agenticos_refresh_entry_surfaces
 Deterministically refresh the configured quick-start and state paths from structured merged-work inputs, honoring `.project.yaml.agent_context` when present and defaulting to root `.context/*` otherwise.

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -342,6 +342,39 @@ Evaluate whether a canonical checkout and project context are fresh enough to tr
 
 **Returns**: JSON with overall `PASS`, `WARN`, or `BLOCK`
 
+### agenticos_migration_audit
+Audit one managed project for legacy post-`#262` migration findings without mutating anything.
+
+**Parameters**:
+- `project_path` (optional) - Explicit project path to audit
+- `project` (optional) - Managed project id, name, or path when `project_path` is not provided
+
+**Returns**: JSON with `PASS`, `WARN`, or `BLOCK`, plus structured findings
+
+Current behavior:
+- report-only
+- supports explicit project path, explicit project selector, or the current session project
+- if neither `project_path` nor `project` is passed, a session-bound project must already exist or the audit fails closed
+- fails closed when identity is ambiguous
+- classifies findings into:
+  - `compatible_only`
+  - `safe_lazy_repair`
+  - `explicit_migration_required`
+
+### agenticos_migrate_home
+Generate a registry-backed legacy-project migration inventory across one `AGENTICOS_HOME`.
+
+**Parameters**:
+- `report_only` (optional) - Must remain `true` for the current `#263` slice
+
+**Returns**: JSON with aggregate `PASS`, `WARN`, or `BLOCK`, per-project summaries, and home-wide finding totals
+
+Current behavior:
+- report-only
+- scans managed projects currently registered in the home registry without mutating them
+- highlights blocked projects explicitly instead of skipping them silently
+- is intended to be the operator-first inventory step before any future explicit migration command
+
 ### agenticos_refresh_entry_surfaces
 Deterministically refresh the configured quick-start and state paths from structured merged-work inputs, honoring `.project.yaml.agent_context` when present and defaulting to root `.context/*` otherwise.
 

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -366,15 +366,15 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     },
     {
       name: 'agenticos_migrate_project',
-      description: 'Build a deterministic per-project migration plan. The current phase-2 slice is plan-only and blocks apply mode.',
+      description: 'Build or apply a deterministic per-project migration plan. Apply is limited to the currently supported deterministic actions and requires expected_plan_hash.',
       inputSchema: {
         type: 'object',
         properties: {
           project_path: { type: 'string', description: 'Explicit project path to migrate.' },
           project: { type: 'string', description: 'Managed project id, name, or path when project_path is not provided.' },
-          mode: { type: 'string', enum: ['plan', 'apply'], description: 'Migration execution mode. The current phase-2 slice supports plan only.' },
-          apply_scope: { type: 'string', enum: ['safe_repairs_only', 'full'], description: 'Planned apply scope. The current phase-2 slice uses this only to shape the deterministic plan output.' },
-          expected_plan_hash: { type: 'string', description: 'Reserved for future apply mode. Not yet honored because apply is not implemented.' },
+          mode: { type: 'string', enum: ['plan', 'apply'], description: 'Migration execution mode.' },
+          apply_scope: { type: 'string', enum: ['safe_repairs_only', 'full'], description: 'Apply scope. The current phase-2 slice supports deterministic per-project actions only.' },
+          expected_plan_hash: { type: 'string', description: 'Required for apply mode. Must match the reviewed deterministic plan.' },
         },
       },
     },

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -34,7 +34,7 @@ import {
   ListResourcesRequestSchema,
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { initProject, switchProject, listProjects, getStatus, saveState, recordSession, runPreflight, runIssueBootstrap, runBranchBootstrap, runPrScopeCheck, runHealth, runEditGuard, runEntrySurfaceRefresh, runStandardKitAdopt, runStandardKitUpgradeCheck, runStandardKitConformanceCheck, runNonCodeEvaluate, runArchiveImportEvaluate } from './tools/index.js';
+import { initProject, switchProject, listProjects, getStatus, saveState, recordSession, runPreflight, runIssueBootstrap, runBranchBootstrap, runPrScopeCheck, runHealth, runEditGuard, runEntrySurfaceRefresh, runStandardKitAdopt, runStandardKitUpgradeCheck, runStandardKitConformanceCheck, runNonCodeEvaluate, runArchiveImportEvaluate, runMigrationAudit, runMigrateHome } from './tools/index.js';
 import { getProjectContext } from './resources/index.js';
 
 const server = new Server(
@@ -364,6 +364,27 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         required: ['project_path', 'candidate_paths'],
       },
     },
+    {
+      name: 'agenticos_migration_audit',
+      description: 'Audit one managed project for legacy post-#262 migration findings without mutating anything.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          project_path: { type: 'string', description: 'Optional explicit project path to audit. If omitted, uses project or the current session project.' },
+          project: { type: 'string', description: 'Optional managed project id, name, or path when project_path is not provided.' },
+        },
+      },
+    },
+    {
+      name: 'agenticos_migrate_home',
+      description: 'Generate a registry-backed home migration inventory. The current #263 slice is report-only.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          report_only: { type: 'boolean', description: 'Must remain true for the current report-only implementation.' },
+        },
+      },
+    },
   ],
 }));
 
@@ -408,6 +429,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       return { content: [{ type: 'text', text: await runNonCodeEvaluate(args ?? {}) }] };
     case 'agenticos_archive_import_evaluate':
       return { content: [{ type: 'text', text: await runArchiveImportEvaluate(args ?? {}) }] };
+    case 'agenticos_migration_audit':
+      return { content: [{ type: 'text', text: await runMigrationAudit(args ?? {}) }] };
+    case 'agenticos_migrate_home':
+      return { content: [{ type: 'text', text: await runMigrateHome(args ?? {}) }] };
     default:
       throw new Error(`Unknown tool: ${name}`);
   }

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -34,7 +34,7 @@ import {
   ListResourcesRequestSchema,
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { initProject, switchProject, listProjects, getStatus, saveState, recordSession, runPreflight, runIssueBootstrap, runBranchBootstrap, runPrScopeCheck, runHealth, runEditGuard, runEntrySurfaceRefresh, runStandardKitAdopt, runStandardKitUpgradeCheck, runStandardKitConformanceCheck, runNonCodeEvaluate, runArchiveImportEvaluate, runMigrationAudit, runMigrateHome } from './tools/index.js';
+import { initProject, switchProject, listProjects, getStatus, saveState, recordSession, runPreflight, runIssueBootstrap, runBranchBootstrap, runPrScopeCheck, runHealth, runEditGuard, runEntrySurfaceRefresh, runStandardKitAdopt, runStandardKitUpgradeCheck, runStandardKitConformanceCheck, runNonCodeEvaluate, runArchiveImportEvaluate, runMigrationAudit, runMigrateHome, runMigrateProject } from './tools/index.js';
 import { getProjectContext } from './resources/index.js';
 
 const server = new Server(
@@ -365,6 +365,20 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
       },
     },
     {
+      name: 'agenticos_migrate_project',
+      description: 'Build a deterministic per-project migration plan. The current phase-2 slice is plan-only and blocks apply mode.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          project_path: { type: 'string', description: 'Explicit project path to migrate.' },
+          project: { type: 'string', description: 'Managed project id, name, or path when project_path is not provided.' },
+          mode: { type: 'string', enum: ['plan', 'apply'], description: 'Migration execution mode. The current phase-2 slice supports plan only.' },
+          apply_scope: { type: 'string', enum: ['safe_repairs_only', 'full'], description: 'Planned apply scope. The current phase-2 slice uses this only to shape the deterministic plan output.' },
+          expected_plan_hash: { type: 'string', description: 'Reserved for future apply mode. Not yet honored because apply is not implemented.' },
+        },
+      },
+    },
+    {
       name: 'agenticos_migration_audit',
       description: 'Audit one managed project for legacy post-#262 migration findings without mutating anything.',
       inputSchema: {
@@ -429,6 +443,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       return { content: [{ type: 'text', text: await runNonCodeEvaluate(args ?? {}) }] };
     case 'agenticos_archive_import_evaluate':
       return { content: [{ type: 'text', text: await runArchiveImportEvaluate(args ?? {}) }] };
+    case 'agenticos_migrate_project':
+      return { content: [{ type: 'text', text: await runMigrateProject(args ?? {}) }] };
     case 'agenticos_migration_audit':
       return { content: [{ type: 'text', text: await runMigrationAudit(args ?? {}) }] };
     case 'agenticos_migrate_home':

--- a/mcp-server/src/tools/__tests__/migration-audit.test.ts
+++ b/mcp-server/src/tools/__tests__/migration-audit.test.ts
@@ -1,0 +1,500 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtemp, mkdir, readFile, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import yaml from 'yaml';
+import { runMigrationAudit, runMigrateHome } from '../migration-audit.js';
+import { bindSessionProject, clearSessionProjectBinding } from '../../utils/session-context.js';
+
+async function writeRegistry(home: string, registry: unknown): Promise<void> {
+  await mkdir(join(home, '.agent-workspace'), { recursive: true });
+  await writeFile(join(home, '.agent-workspace', 'registry.yaml'), yaml.stringify(registry), 'utf-8');
+}
+
+async function createProject(
+  home: string,
+  id: string,
+  options?: {
+    name?: string;
+    projectYaml?: any;
+    stateYaml?: any;
+  },
+): Promise<string> {
+  const projectRoot = join(home, 'projects', id);
+  await mkdir(join(projectRoot, '.context'), { recursive: true });
+
+  const projectYaml = options?.projectYaml ?? {
+    meta: {
+      id,
+      name: options?.name || id,
+    },
+    source_control: {
+      topology: 'local_directory_only',
+      context_publication_policy: 'local_private',
+    },
+  };
+  const stateYaml = options?.stateYaml ?? {
+    session: {},
+    working_memory: { facts: [], decisions: [], pending: [] },
+  };
+
+  await writeFile(join(projectRoot, '.project.yaml'), yaml.stringify(projectYaml), 'utf-8');
+  await writeFile(join(projectRoot, '.context', 'state.yaml'), yaml.stringify(stateYaml), 'utf-8');
+  await writeFile(join(projectRoot, '.context', 'quick-start.md'), '# Quick Start\n', 'utf-8');
+  return projectRoot;
+}
+
+describe('migration audit tools', () => {
+  afterEach(() => {
+    clearSessionProjectBinding();
+    delete process.env.AGENTICOS_HOME;
+  });
+
+  it('reports safe lazy repair and compatibility findings for a legacy but still operable project', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'agenticos-migration-audit-'));
+    process.env.AGENTICOS_HOME = home;
+
+    const projectRoot = await createProject(home, 'sample-project', {
+      name: 'Sample Project',
+      stateYaml: {
+        session: {},
+        guardrail_evidence: {
+          preflight: {
+            result: {
+              active_project: 'legacy-project',
+            },
+          },
+        },
+      },
+    });
+
+    await writeRegistry(home, {
+      version: '1.0.0',
+      last_updated: new Date().toISOString(),
+      active_project: 'sample-project',
+      projects: [
+        {
+          id: 'sample-project',
+          name: 'Sample Project',
+          path: projectRoot,
+          status: 'active',
+          created: '2026-04-10',
+        },
+      ],
+    });
+
+    const result = JSON.parse(await runMigrationAudit({
+      project: 'sample-project',
+    })) as {
+      status: string;
+      safe_to_continue_without_migration: boolean;
+      finding_counts: { compatible_only: number; safe_lazy_repair: number; explicit_migration_required: number };
+      findings: Array<{ code: string }>;
+    };
+
+    expect(result.status).toBe('WARN');
+    expect(result.safe_to_continue_without_migration).toBe(true);
+    expect(result.finding_counts.compatible_only).toBe(1);
+    expect(result.finding_counts.safe_lazy_repair).toBe(3);
+    expect(result.finding_counts.explicit_migration_required).toBe(0);
+    expect(result.findings.map((finding) => finding.code)).toEqual(expect.arrayContaining([
+      'legacy_active_project_present',
+      'registry_path_stored_absolute_under_home',
+      'registry_last_accessed_missing',
+      'legacy_active_project_evidence_present',
+    ]));
+  });
+
+  it('blocks when a project still needs structural topology normalization', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'agenticos-migration-audit-'));
+    process.env.AGENTICOS_HOME = home;
+
+    await createProject(home, 'broken-project', {
+      name: 'Broken Project',
+      projectYaml: {
+        meta: {
+          id: 'broken-project',
+          name: 'Broken Project',
+        },
+      },
+    });
+
+    await writeRegistry(home, {
+      version: '1.0.0',
+      last_updated: new Date().toISOString(),
+      active_project: null,
+      projects: [
+        {
+          id: 'broken-project',
+          name: 'Broken Project',
+          path: 'projects/broken-project',
+          status: 'active',
+          created: '2026-04-10',
+          last_accessed: new Date().toISOString(),
+        },
+      ],
+    });
+
+    const result = JSON.parse(await runMigrationAudit({
+      project: 'broken-project',
+    })) as {
+      status: string;
+      project: { identity_proven: boolean };
+      safe_to_continue_without_migration: boolean;
+      findings: Array<{ code: string }>;
+      block_reasons: string[];
+    };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.project.identity_proven).toBe(true);
+    expect(result.safe_to_continue_without_migration).toBe(false);
+    expect(result.findings.map((finding) => finding.code)).toContain('topology_contract_invalid');
+    expect(result.block_reasons.join(' ')).toContain('topology');
+  });
+
+  it('blocks explicit path audits when the target project is not registered', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'agenticos-migration-audit-'));
+    process.env.AGENTICOS_HOME = home;
+
+    const projectRoot = await createProject(home, 'orphan-project', {
+      name: 'Orphan Project',
+    });
+
+    await writeRegistry(home, {
+      version: '1.0.0',
+      last_updated: new Date().toISOString(),
+      active_project: null,
+      projects: [],
+    });
+
+    const result = JSON.parse(await runMigrationAudit({
+      project_path: projectRoot,
+    })) as {
+      status: string;
+      findings: Array<{ code: string }>;
+      block_reasons: string[];
+    };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.findings.map((finding) => finding.code)).toContain('registry_entry_missing');
+    expect(result.block_reasons.join(' ')).toContain('not registered');
+  });
+
+  it('supports session-bound fallback when no explicit selector is provided', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'agenticos-migration-audit-'));
+    process.env.AGENTICOS_HOME = home;
+
+    const projectRoot = await createProject(home, 'session-project', {
+      name: 'Session Project',
+    });
+
+    await writeRegistry(home, {
+      version: '1.0.0',
+      last_updated: new Date().toISOString(),
+      active_project: null,
+      projects: [
+        {
+          id: 'session-project',
+          name: 'Session Project',
+          path: 'projects/session-project',
+          status: 'active',
+          created: '2026-04-10',
+          last_accessed: new Date().toISOString(),
+        },
+      ],
+    });
+
+    bindSessionProject({
+      projectId: 'session-project',
+      projectName: 'Session Project',
+      projectPath: projectRoot,
+    });
+
+    const result = JSON.parse(await runMigrationAudit({})) as {
+      status: string;
+      project: { project_id: string | null; resolution_source: string };
+    };
+
+    expect(result.status).toBe('PASS');
+    expect(result.project.project_id).toBe('session-project');
+    expect(result.project.resolution_source).toBe('session');
+  });
+
+  it('fails closed when no selector and no session project are available', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'agenticos-migration-audit-'));
+    process.env.AGENTICOS_HOME = home;
+
+    await writeRegistry(home, {
+      version: '1.0.0',
+      last_updated: new Date().toISOString(),
+      active_project: null,
+      projects: [],
+    });
+
+    const result = JSON.parse(await runMigrationAudit({})) as {
+      status: string;
+      block_reasons: string[];
+    };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons[0]).toContain('No project_path, project, or session project');
+  });
+
+  it('accepts workspace-relative project paths through the project selector contract', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'agenticos-migration-audit-'));
+    process.env.AGENTICOS_HOME = home;
+
+    await createProject(home, 'relative-selector', {
+      name: 'Relative Selector',
+    });
+
+    await writeRegistry(home, {
+      version: '1.0.0',
+      last_updated: new Date().toISOString(),
+      active_project: null,
+      projects: [
+        {
+          id: 'relative-selector',
+          name: 'Relative Selector',
+          path: 'projects/relative-selector',
+          status: 'active',
+          created: '2026-04-10',
+          last_accessed: new Date().toISOString(),
+        },
+      ],
+    });
+
+    const result = JSON.parse(await runMigrationAudit({
+      project: 'projects/relative-selector',
+    })) as {
+      status: string;
+      project: { project_id: string | null };
+    };
+
+    expect(result.status).toBe('PASS');
+    expect(result.project.project_id).toBe('relative-selector');
+  });
+
+  it('generates a home-wide report-only inventory with per-project statuses', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'agenticos-migration-audit-'));
+    process.env.AGENTICOS_HOME = home;
+
+    await createProject(home, 'good-project', {
+      name: 'Good Project',
+    });
+    await createProject(home, 'needs-migration', {
+      name: 'Needs Migration',
+      projectYaml: {
+        meta: {
+          id: 'needs-migration',
+          name: 'Needs Migration',
+        },
+      },
+    });
+
+    await writeRegistry(home, {
+      version: '1.0.0',
+      last_updated: new Date().toISOString(),
+      active_project: null,
+      projects: [
+        {
+          id: 'good-project',
+          name: 'Good Project',
+          path: 'projects/good-project',
+          status: 'active',
+          created: '2026-04-10',
+          last_accessed: new Date().toISOString(),
+        },
+        {
+          id: 'needs-migration',
+          name: 'Needs Migration',
+          path: 'projects/needs-migration',
+          status: 'active',
+          created: '2026-04-10',
+          last_accessed: new Date().toISOString(),
+        },
+      ],
+    });
+
+    const result = JSON.parse(await runMigrateHome({
+      report_only: true,
+    })) as {
+      status: string;
+      total_projects: number;
+      blocked_projects: number;
+      projects: Array<{ project_id: string | null; status: string }>;
+    };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.total_projects).toBe(2);
+    expect(result.blocked_projects).toBe(1);
+    expect(result.projects).toEqual(expect.arrayContaining([
+      expect.objectContaining({ project_id: 'good-project', status: 'PASS' }),
+      expect.objectContaining({ project_id: 'needs-migration', status: 'BLOCK' }),
+    ]));
+  });
+
+  it('treats archived reference projects as inventory-only instead of requiring active topology normalization', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'agenticos-migration-audit-'));
+    process.env.AGENTICOS_HOME = home;
+
+    const projectRoot = join(home, 'projects', 'legacy-archive');
+    await mkdir(projectRoot, { recursive: true });
+    await writeFile(join(projectRoot, '.project.yaml'), yaml.stringify({
+      meta: {
+        id: 'legacy-archive',
+        name: 'Legacy Archive',
+      },
+      archive_contract: {
+        kind: 'archived_reference',
+        execution_mode: 'reference_only',
+        replacement_project: 'agenticos-standards',
+      },
+    }), 'utf-8');
+
+    await writeRegistry(home, {
+      version: '1.0.0',
+      last_updated: new Date().toISOString(),
+      active_project: null,
+      projects: [
+        {
+          id: 'legacy-archive',
+          name: 'Legacy Archive',
+          path: 'projects/legacy-archive',
+          status: 'archived',
+          created: '2026-04-10',
+          last_accessed: new Date().toISOString(),
+        },
+      ],
+    });
+
+    const result = JSON.parse(await runMigrationAudit({
+      project: 'legacy-archive',
+    })) as {
+      status: string;
+      safe_to_continue_without_migration: boolean;
+      findings: Array<{ code: string }>;
+      notes: string[];
+    };
+
+    expect(result.status).toBe('WARN');
+    expect(result.safe_to_continue_without_migration).toBe(true);
+    expect(result.findings.map((finding) => finding.code)).toContain('archived_reference_project');
+    expect(result.findings.map((finding) => finding.code)).not.toContain('topology_contract_invalid');
+    expect(result.findings.map((finding) => finding.code)).not.toContain('state_surface_missing');
+    expect(result.notes.join(' ')).toContain('inventory-only');
+  });
+
+  it('blocks when registry identity is duplicated in the home-wide inventory', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'agenticos-migration-audit-'));
+    process.env.AGENTICOS_HOME = home;
+
+    await createProject(home, 'shared-id', {
+      name: 'Alpha Project',
+    });
+    await createProject(home, 'second-project', {
+      name: 'Beta Project',
+      projectYaml: {
+        meta: {
+          id: 'shared-id',
+          name: 'Beta Project',
+        },
+        source_control: {
+          topology: 'local_directory_only',
+          context_publication_policy: 'local_private',
+        },
+      },
+    });
+
+    await writeRegistry(home, {
+      version: '1.0.0',
+      last_updated: new Date().toISOString(),
+      active_project: null,
+      projects: [
+        {
+          id: 'shared-id',
+          name: 'Alpha Project',
+          path: 'projects/shared-id',
+          status: 'active',
+          created: '2026-04-10',
+          last_accessed: new Date().toISOString(),
+        },
+        {
+          id: 'shared-id',
+          name: 'Beta Project',
+          path: 'projects/second-project',
+          status: 'active',
+          created: '2026-04-10',
+          last_accessed: new Date().toISOString(),
+        },
+      ],
+    });
+
+    const result = JSON.parse(await runMigrateHome({
+      report_only: true,
+    })) as {
+      status: string;
+      blocked_projects: number;
+      projects: Array<{ project_id: string | null; status: string }>;
+    };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.blocked_projects).toBe(2);
+    expect(result.projects).toEqual(expect.arrayContaining([
+      expect.objectContaining({ project_id: 'shared-id', status: 'BLOCK' }),
+    ]));
+  });
+
+  it('fails closed when non-report-only home migration is requested', async () => {
+    const result = JSON.parse(await runMigrateHome({
+      report_only: false,
+    })) as {
+      status: string;
+      block_reasons: string[];
+    };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons[0]).toContain('report_only=true');
+  });
+
+  it('does not mutate registry state in home report-only mode', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'agenticos-migration-audit-'));
+    process.env.AGENTICOS_HOME = home;
+
+    await createProject(home, 'report-only-project', {
+      name: 'Report Only Project',
+    });
+
+    await writeRegistry(home, {
+      version: '1.0.0',
+      last_updated: '2026-04-10T00:00:00.000Z',
+      active_project: 'report-only-project',
+      projects: [
+        {
+          id: 'report-only-project',
+          name: 'Report Only Project',
+          path: 'projects/report-only-project',
+          status: 'active',
+          created: '2026-04-10',
+          last_accessed: '2026-04-10T00:00:00.000Z',
+        },
+      ],
+    });
+
+    const registryPath = join(home, '.agent-workspace', 'registry.yaml');
+    const before = await readFile(registryPath, 'utf-8');
+
+    const result = JSON.parse(await runMigrateHome({
+      report_only: true,
+    })) as {
+      status: string;
+      total_projects: number;
+    };
+
+    const after = await readFile(registryPath, 'utf-8');
+
+    expect(result.status).toBe('PASS');
+    expect(result.total_projects).toBe(1);
+    expect(after).toBe(before);
+  });
+});

--- a/mcp-server/src/tools/__tests__/migration-project.test.ts
+++ b/mcp-server/src/tools/__tests__/migration-project.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtemp, mkdir, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import yaml from 'yaml';
+import { runMigrateProject } from '../migration-project.js';
+import { clearSessionProjectBinding } from '../../utils/session-context.js';
+
+async function writeRegistry(home: string, registry: unknown): Promise<void> {
+  await mkdir(join(home, '.agent-workspace'), { recursive: true });
+  await writeFile(join(home, '.agent-workspace', 'registry.yaml'), yaml.stringify(registry), 'utf-8');
+}
+
+async function createProject(
+  home: string,
+  id: string,
+  options?: {
+    name?: string;
+    projectYaml?: any;
+    stateYaml?: any;
+  },
+): Promise<string> {
+  const projectRoot = join(home, 'projects', id);
+  await mkdir(join(projectRoot, '.context'), { recursive: true });
+
+  const projectYaml = options?.projectYaml ?? {
+    meta: {
+      id,
+      name: options?.name || id,
+    },
+    source_control: {
+      topology: 'local_directory_only',
+      context_publication_policy: 'local_private',
+    },
+  };
+  const stateYaml = options?.stateYaml ?? {
+    session: {},
+    working_memory: { facts: [], decisions: [], pending: [] },
+  };
+
+  await writeFile(join(projectRoot, '.project.yaml'), yaml.stringify(projectYaml), 'utf-8');
+  await writeFile(join(projectRoot, '.context', 'state.yaml'), yaml.stringify(stateYaml), 'utf-8');
+  await writeFile(join(projectRoot, '.context', 'quick-start.md'), '# Quick Start\n', 'utf-8');
+  return projectRoot;
+}
+
+describe('migration project planner', () => {
+  afterEach(() => {
+    clearSessionProjectBinding();
+    delete process.env.AGENTICOS_HOME;
+  });
+
+  it('builds a deterministic plan for safe registry repairs', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'agenticos-migrate-project-'));
+    process.env.AGENTICOS_HOME = home;
+
+    const projectRoot = await createProject(home, 'sample-project', {
+      name: 'Sample Project',
+    });
+
+    await writeRegistry(home, {
+      version: '1.0.0',
+      last_updated: new Date().toISOString(),
+      active_project: 'sample-project',
+      projects: [
+        {
+          id: 'sample-project',
+          name: 'Sample Project',
+          path: projectRoot,
+          status: 'active',
+          created: '2026-04-10',
+        },
+      ],
+    });
+
+    const first = JSON.parse(await runMigrateProject({
+      project: 'sample-project',
+      mode: 'plan',
+    })) as {
+      status: string;
+      apply_ready: boolean;
+      plan_hash: string | null;
+      planned_actions: Array<{ id: string }>;
+      manual_blocks: Array<{ code: string }>;
+      notes: string[];
+    };
+    const second = JSON.parse(await runMigrateProject({
+      project: 'sample-project',
+      mode: 'plan',
+    })) as {
+      plan_hash: string | null;
+      planned_actions: Array<{ id: string }>;
+    };
+
+    expect(first.status).toBe('READY');
+    expect(first.apply_ready).toBe(true);
+    expect(first.plan_hash).toBeTruthy();
+    expect(first.plan_hash).toBe(second.plan_hash);
+    expect(first.planned_actions.map((action) => action.id)).toEqual([
+      'registry.backfill_last_accessed',
+      'registry.clear_legacy_active_project',
+      'registry.normalize_project_path',
+    ]);
+    expect(first.manual_blocks).toHaveLength(0);
+    expect(first.notes.join(' ')).toContain('deterministic migration plan');
+  });
+
+  it('blocks plan mode when explicit structural/manual issues remain', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'agenticos-migrate-project-'));
+    process.env.AGENTICOS_HOME = home;
+
+    await createProject(home, 'broken-project', {
+      name: 'Broken Project',
+      projectYaml: {
+        meta: {
+          id: 'broken-project',
+          name: 'Broken Project',
+        },
+      },
+    });
+
+    await writeRegistry(home, {
+      version: '1.0.0',
+      last_updated: new Date().toISOString(),
+      active_project: null,
+      projects: [
+        {
+          id: 'broken-project',
+          name: 'Broken Project',
+          path: 'projects/broken-project',
+          status: 'active',
+          created: '2026-04-10',
+          last_accessed: new Date().toISOString(),
+        },
+      ],
+    });
+
+    const result = JSON.parse(await runMigrateProject({
+      project: 'broken-project',
+      mode: 'plan',
+    })) as {
+      status: string;
+      apply_ready: boolean;
+      manual_blocks: Array<{ code: string }>;
+      block_reasons: string[];
+    };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.apply_ready).toBe(false);
+    expect(result.manual_blocks.map((block) => block.code)).toContain('topology_contract_invalid');
+    expect(result.block_reasons.join(' ')).toContain('topology');
+  });
+
+  it('requires an explicit target for migrate_project plan mode', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'agenticos-migrate-project-'));
+    process.env.AGENTICOS_HOME = home;
+
+    await writeRegistry(home, {
+      version: '1.0.0',
+      last_updated: new Date().toISOString(),
+      active_project: null,
+      projects: [],
+    });
+
+    const result = JSON.parse(await runMigrateProject({
+      mode: 'plan',
+    })) as {
+      status: string;
+      block_reasons: string[];
+    };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons[0]).toContain('requires an explicit project');
+  });
+
+  it('fails closed for apply mode in the current phase-2 slice', async () => {
+    const result = JSON.parse(await runMigrateProject({
+      mode: 'apply',
+      project: 'anything',
+    })) as {
+      status: string;
+      block_reasons: string[];
+    };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons[0]).toContain('apply mode is not implemented yet');
+  });
+
+  it('supports safe_repairs_only planning scope', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'agenticos-migrate-project-'));
+    process.env.AGENTICOS_HOME = home;
+
+    const projectRoot = await createProject(home, 'scoped-project', {
+      name: 'Scoped Project',
+    });
+
+    await writeRegistry(home, {
+      version: '1.0.0',
+      last_updated: new Date().toISOString(),
+      active_project: 'scoped-project',
+      projects: [
+        {
+          id: 'scoped-project',
+          name: 'Scoped Project',
+          path: projectRoot,
+          status: 'active',
+          created: '2026-04-10',
+        },
+      ],
+    });
+
+    const result = JSON.parse(await runMigrateProject({
+      project: 'scoped-project',
+      mode: 'plan',
+      apply_scope: 'safe_repairs_only',
+    })) as {
+      status: string;
+      apply_scope: string;
+      preconditions: { apply_scope: string } | null;
+      planned_actions: Array<{ actionability: string }>;
+    };
+
+    expect(result.status).toBe('READY');
+    expect(result.apply_scope).toBe('safe_repairs_only');
+    expect(result.preconditions?.apply_scope).toBe('safe_repairs_only');
+    expect(result.planned_actions.every((action) => action.actionability === 'safe_repair')).toBe(true);
+  });
+});

--- a/mcp-server/src/tools/__tests__/migration-project.test.ts
+++ b/mcp-server/src/tools/__tests__/migration-project.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { mkdtemp, mkdir, writeFile } from 'fs/promises';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import yaml from 'yaml';
@@ -173,17 +173,39 @@ describe('migration project planner', () => {
     expect(result.block_reasons[0]).toContain('requires an explicit project');
   });
 
-  it('fails closed for apply mode in the current phase-2 slice', async () => {
+  it('requires expected_plan_hash for apply mode', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'agenticos-migrate-project-'));
+    process.env.AGENTICOS_HOME = home;
+
+    const projectRoot = await createProject(home, 'apply-project', {
+      name: 'Apply Project',
+    });
+
+    await writeRegistry(home, {
+      version: '1.0.0',
+      last_updated: new Date().toISOString(),
+      active_project: 'apply-project',
+      projects: [
+        {
+          id: 'apply-project',
+          name: 'Apply Project',
+          path: projectRoot,
+          status: 'active',
+          created: '2026-04-10',
+        },
+      ],
+    });
+
     const result = JSON.parse(await runMigrateProject({
       mode: 'apply',
-      project: 'anything',
+      project: 'apply-project',
     })) as {
       status: string;
       block_reasons: string[];
     };
 
     expect(result.status).toBe('BLOCK');
-    expect(result.block_reasons[0]).toContain('apply mode is not implemented yet');
+    expect(result.block_reasons[0]).toContain('expected_plan_hash is required');
   });
 
   it('supports safe_repairs_only planning scope', async () => {
@@ -224,5 +246,185 @@ describe('migration project planner', () => {
     expect(result.apply_scope).toBe('safe_repairs_only');
     expect(result.preconditions?.apply_scope).toBe('safe_repairs_only');
     expect(result.planned_actions.every((action) => action.actionability === 'safe_repair')).toBe(true);
+  });
+
+  it('applies deterministic safe repairs and writes migration evidence', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'agenticos-migrate-project-'));
+    process.env.AGENTICOS_HOME = home;
+
+    const projectRoot = await createProject(home, 'apply-project', {
+      name: 'Apply Project',
+      stateYaml: {
+        session: {},
+        working_memory: { facts: [], decisions: [], pending: [] },
+      },
+    });
+
+    await writeRegistry(home, {
+      version: '1.0.0',
+      last_updated: new Date().toISOString(),
+      active_project: 'apply-project',
+      projects: [
+        {
+          id: 'apply-project',
+          name: 'Apply Project',
+          path: projectRoot,
+          status: 'active',
+          created: '2026-04-10',
+        },
+      ],
+    });
+
+    const planned = JSON.parse(await runMigrateProject({
+      project: 'apply-project',
+      mode: 'plan',
+    })) as {
+      status: string;
+      plan_hash: string;
+    };
+
+    const applied = JSON.parse(await runMigrateProject({
+      project: 'apply-project',
+      mode: 'apply',
+      expected_plan_hash: planned.plan_hash,
+    })) as {
+      status: string;
+      applied_actions: Array<{ id: string }>;
+      evidence_paths: string[];
+      post_audit_status: string;
+    };
+
+    const registry = yaml.parse(await readFile(join(home, '.agent-workspace', 'registry.yaml'), 'utf-8')) as any;
+    const state = yaml.parse(await readFile(join(projectRoot, '.context', 'state.yaml'), 'utf-8')) as any;
+    const reportPath = applied.evidence_paths.find((path) => path.includes('/artifacts/migrations/'));
+    if (!reportPath) {
+      throw new Error('expected migration report path to be written');
+    }
+    const report = yaml.parse(await readFile(reportPath, 'utf-8')) as any;
+
+    expect(applied.status).toBe('APPLIED');
+    expect(applied.applied_actions.map((action) => action.id)).toEqual([
+      'registry.backfill_last_accessed',
+      'registry.clear_legacy_active_project',
+      'registry.normalize_project_path',
+    ]);
+    expect(applied.post_audit_status).toBe('PASS');
+    expect(registry.active_project).toBeNull();
+    expect(registry.projects[0].path).toBe('projects/apply-project');
+    expect(typeof registry.projects[0].last_accessed).toBe('string');
+    expect(state.migrations.latest.report_path).toContain('artifacts/migrations/');
+    expect(report.plan_hash).toBe(planned.plan_hash);
+    expect(report.applied_actions).toHaveLength(3);
+  });
+
+  it('blocks apply when the reviewed plan hash is stale', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'agenticos-migrate-project-'));
+    process.env.AGENTICOS_HOME = home;
+
+    const projectRoot = await createProject(home, 'stale-project', {
+      name: 'Stale Project',
+    });
+
+    await writeRegistry(home, {
+      version: '1.0.0',
+      last_updated: new Date().toISOString(),
+      active_project: 'stale-project',
+      projects: [
+        {
+          id: 'stale-project',
+          name: 'Stale Project',
+          path: projectRoot,
+          status: 'active',
+          created: '2026-04-10',
+        },
+      ],
+    });
+
+    const planned = JSON.parse(await runMigrateProject({
+      project: 'stale-project',
+      mode: 'plan',
+    })) as {
+      plan_hash: string;
+    };
+
+    await writeRegistry(home, {
+      version: '1.0.0',
+      last_updated: new Date().toISOString(),
+      active_project: null,
+      projects: [
+        {
+          id: 'stale-project',
+          name: 'Stale Project',
+          path: 'projects/stale-project',
+          status: 'active',
+          created: '2026-04-10',
+          last_accessed: new Date().toISOString(),
+        },
+      ],
+    });
+
+    const applied = JSON.parse(await runMigrateProject({
+      project: 'stale-project',
+      mode: 'apply',
+      expected_plan_hash: planned.plan_hash,
+    })) as {
+      status: string;
+      block_reasons: string[];
+    };
+
+    expect(applied.status).toBe('BLOCK');
+    expect(applied.block_reasons[0]).toContain('plan hash no longer matches');
+  });
+
+  it('rebuilds a missing state surface during apply when the plan is ready', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'agenticos-migrate-project-'));
+    process.env.AGENTICOS_HOME = home;
+
+    const projectRoot = await createProject(home, 'stateful-project', {
+      name: 'Stateful Project',
+    });
+    await rm(join(projectRoot, '.context', 'state.yaml'));
+
+    await writeRegistry(home, {
+      version: '1.0.0',
+      last_updated: new Date().toISOString(),
+      active_project: null,
+      projects: [
+        {
+          id: 'stateful-project',
+          name: 'Stateful Project',
+          path: 'projects/stateful-project',
+          status: 'active',
+          created: '2026-04-10',
+          last_accessed: new Date().toISOString(),
+        },
+      ],
+    });
+
+    const planned = JSON.parse(await runMigrateProject({
+      project: 'stateful-project',
+      mode: 'plan',
+    })) as {
+      status: string;
+      plan_hash: string;
+      planned_actions: Array<{ id: string }>;
+    };
+
+    const applied = JSON.parse(await runMigrateProject({
+      project: 'stateful-project',
+      mode: 'apply',
+      expected_plan_hash: planned.plan_hash,
+    })) as {
+      status: string;
+      evidence_paths: string[];
+    };
+
+    const state = yaml.parse(await readFile(join(projectRoot, '.context', 'state.yaml'), 'utf-8')) as any;
+
+    expect(planned.status).toBe('READY');
+    expect(planned.planned_actions.map((action) => action.id)).toContain('state.rebuild_missing_surface');
+    expect(applied.status).toBe('APPLIED');
+    expect(state.memory_contract.version).toBe(1);
+    expect(applied.evidence_paths).toContain(join(projectRoot, '.context', 'state.yaml'));
   });
 });

--- a/mcp-server/src/tools/index.ts
+++ b/mcp-server/src/tools/index.ts
@@ -13,3 +13,4 @@ export { runStandardKitAdopt, runStandardKitUpgradeCheck, runStandardKitConforma
 export { runNonCodeEvaluate } from './non-code-evaluate.js';
 export { runArchiveImportEvaluate } from './archive-import-evaluate.js';
 export { runMigrationAudit, runMigrateHome } from './migration-audit.js';
+export { runMigrateProject } from './migration-project.js';

--- a/mcp-server/src/tools/index.ts
+++ b/mcp-server/src/tools/index.ts
@@ -12,3 +12,4 @@ export { runEntrySurfaceRefresh } from './entry-surface-refresh.js';
 export { runStandardKitAdopt, runStandardKitUpgradeCheck, runStandardKitConformanceCheck } from './standard-kit.js';
 export { runNonCodeEvaluate } from './non-code-evaluate.js';
 export { runArchiveImportEvaluate } from './archive-import-evaluate.js';
+export { runMigrationAudit, runMigrateHome } from './migration-audit.js';

--- a/mcp-server/src/tools/migration-audit.ts
+++ b/mcp-server/src/tools/migration-audit.ts
@@ -1,0 +1,11 @@
+import { runMigrationAuditCheck, runMigrateHomeReport } from '../utils/migration-audit.js';
+
+export async function runMigrationAudit(args: any): Promise<string> {
+  const result = await runMigrationAuditCheck(args ?? {});
+  return JSON.stringify(result, null, 2);
+}
+
+export async function runMigrateHome(args: any): Promise<string> {
+  const result = await runMigrateHomeReport(args ?? {});
+  return JSON.stringify(result, null, 2);
+}

--- a/mcp-server/src/tools/migration-project.ts
+++ b/mcp-server/src/tools/migration-project.ts
@@ -1,0 +1,6 @@
+import { runMigrationProjectPlan } from '../utils/migration-project.js';
+
+export async function runMigrateProject(args: any): Promise<string> {
+  const result = await runMigrationProjectPlan(args ?? {});
+  return JSON.stringify(result, null, 2);
+}

--- a/mcp-server/src/utils/migration-audit.ts
+++ b/mcp-server/src/utils/migration-audit.ts
@@ -1,0 +1,837 @@
+import { existsSync } from 'fs';
+import { readFile } from 'fs/promises';
+import { basename, isAbsolute, join, resolve as resolveFsPath } from 'path';
+import yaml from 'yaml';
+import { resolveManagedProjectContextPaths } from './agent-context-paths.js';
+import { getSessionProjectBinding } from './session-context.js';
+import { getAgenticOSHome, loadRegistry, resolvePath, type Project, type Registry } from './registry.js';
+import {
+  buildArchivedReferenceMessage,
+  isArchivedReferenceProject,
+  validateContextPublicationPolicy,
+  validateManagedProjectTopology,
+} from './project-contract.js';
+
+type MigrationFindingClass = 'compatible_only' | 'safe_lazy_repair' | 'explicit_migration_required';
+type MigrationFindingSeverity = 'info' | 'warning' | 'error';
+type AuditStatus = 'PASS' | 'WARN' | 'BLOCK';
+
+interface MigrationFinding {
+  code: string;
+  migration_class: MigrationFindingClass;
+  severity: MigrationFindingSeverity;
+  summary: string;
+  evidence: string[];
+  recommended_action: string;
+  safe_to_defer: boolean;
+}
+
+interface AuditProjectSummary {
+  project_id: string | null;
+  project_name: string | null;
+  project_path: string;
+  registry_entry_found: boolean;
+  registry_status: Project['status'] | null;
+  resolution_source: 'project' | 'project_path' | 'session';
+  project_yaml_present: boolean;
+  identity_proven: boolean;
+}
+
+interface AuditCounts {
+  compatible_only: number;
+  safe_lazy_repair: number;
+  explicit_migration_required: number;
+}
+
+export interface MigrationAuditResult {
+  command: 'agenticos_migration_audit';
+  status: AuditStatus;
+  project: AuditProjectSummary | null;
+  findings: MigrationFinding[];
+  finding_counts: AuditCounts;
+  safe_to_continue_without_migration: boolean;
+  recommended_next_action: string;
+  block_reasons: string[];
+  notes: string[];
+}
+
+interface HomeProjectSummary {
+  project_id: string | null;
+  project_name: string | null;
+  project_path: string;
+  status: AuditStatus;
+  finding_counts: AuditCounts;
+  safe_to_continue_without_migration: boolean;
+  recommended_next_action: string;
+}
+
+export interface MigrateHomeResult {
+  command: 'agenticos_migrate_home';
+  status: AuditStatus;
+  report_only: true;
+  total_projects: number;
+  safe_to_defer_projects: number;
+  blocked_projects: number;
+  findings_summary: AuditCounts;
+  projects: HomeProjectSummary[];
+  block_reasons: string[];
+  notes: string[];
+}
+
+interface RawRegistryProject {
+  id?: unknown;
+  name?: unknown;
+  path?: unknown;
+  status?: unknown;
+  created?: unknown;
+  last_accessed?: unknown;
+  last_recorded?: unknown;
+}
+
+interface RawRegistry {
+  version?: unknown;
+  last_updated?: unknown;
+  active_project?: unknown;
+  projects?: RawRegistryProject[];
+}
+
+interface RawRegistryState {
+  raw: RawRegistry;
+  error: string | null;
+  path: string;
+}
+
+interface AuditContext {
+  registry: Registry;
+  rawRegistryState: RawRegistryState;
+  registryEntry: Project | null;
+  rawRegistryEntry: RawRegistryProject | null;
+  projectPath: string;
+  resolutionSource: 'project' | 'project_path' | 'session';
+}
+
+interface BuildProjectAuditOptions {
+  includeHomeScopedRegistryFindings?: boolean;
+}
+
+interface RegistryDuplicateSummary {
+  duplicateIds: string[];
+  duplicatePaths: string[];
+  duplicateNames: string[];
+}
+
+function emptyCounts(): AuditCounts {
+  return {
+    compatible_only: 0,
+    safe_lazy_repair: 0,
+    explicit_migration_required: 0,
+  };
+}
+
+function buildRecommendedNextAction(status: AuditStatus): string {
+  if (status === 'BLOCK') {
+    return 'Run explicit per-project migration or normalization after reviewing the blocking findings.';
+  }
+  if (status === 'WARN') {
+    return 'Safe to continue operating, but schedule metadata normalization or explicit migration based on the findings.';
+  }
+  return 'No migration action is currently required.';
+}
+
+function computeCounts(findings: MigrationFinding[]): AuditCounts {
+  const counts = emptyCounts();
+  for (const finding of findings) {
+    counts[finding.migration_class] += 1;
+  }
+  return counts;
+}
+
+function computeStatus(findings: MigrationFinding[]): AuditStatus {
+  if (findings.some((finding) => finding.migration_class === 'explicit_migration_required')) {
+    return 'BLOCK';
+  }
+  if (findings.length > 0) {
+    return 'WARN';
+  }
+  return 'PASS';
+}
+
+function pushFinding(findings: MigrationFinding[], finding: MigrationFinding): void {
+  if (findings.some((existing) => existing.code === finding.code)) {
+    return;
+  }
+  findings.push(finding);
+}
+
+function computeRegistryDuplicates(registry: Registry, entry: Project): RegistryDuplicateSummary {
+  return {
+    duplicateIds: registry.projects
+      .filter((candidate) => candidate.id === entry.id)
+      .map((candidate) => candidate.id),
+    duplicatePaths: registry.projects
+      .filter((candidate) => candidate.path === entry.path)
+      .map((candidate) => candidate.path),
+    duplicateNames: registry.projects
+      .filter((candidate) => candidate.name === entry.name)
+      .map((candidate) => candidate.name),
+  };
+}
+
+function registryFilePath(): string {
+  return join(getAgenticOSHome(), '.agent-workspace', 'registry.yaml');
+}
+
+async function loadRawRegistryState(): Promise<RawRegistryState> {
+  const path = registryFilePath();
+  try {
+    const content = await readFile(path, 'utf-8');
+    const parsed = yaml.parse(content);
+    if (!parsed || typeof parsed !== 'object') {
+      throw new Error('registry yaml did not parse into an object');
+    }
+    const raw = parsed as RawRegistry;
+    return {
+      raw: {
+        ...raw,
+        projects: Array.isArray(raw.projects) ? raw.projects : [],
+      },
+      error: null,
+      path,
+    };
+  } catch (error: any) {
+    if (error?.code === 'ENOENT') {
+      return {
+        raw: { active_project: null, projects: [] },
+        error: null,
+        path,
+      };
+    }
+    return {
+      raw: { active_project: null, projects: [] },
+      error: error instanceof Error ? error.message : 'failed to read registry.yaml',
+      path,
+    };
+  }
+}
+
+function resolveInputProjectPath(rawPath: string): string {
+  return isAbsolute(rawPath)
+    ? resolveFsPath(rawPath)
+    : resolveFsPath(getAgenticOSHome(), rawPath);
+}
+
+function normalizeProjectSelector(rawSelector: string): string {
+  if (isAbsolute(rawSelector) || rawSelector.includes('/') || rawSelector.includes('\\') || rawSelector.startsWith('.')) {
+    return resolveInputProjectPath(rawSelector);
+  }
+  return rawSelector;
+}
+
+function findRawRegistryEntry(rawRegistry: RawRegistry, entry: Project): RawRegistryProject | null {
+  const projects = Array.isArray(rawRegistry.projects) ? rawRegistry.projects : [];
+  const matches = projects.filter((candidate) => {
+    const candidateId = typeof candidate.id === 'string' ? candidate.id.trim() : '';
+    const candidatePath = typeof candidate.path === 'string' ? resolvePath(candidate.path) : '';
+    return candidateId === entry.id || candidatePath === entry.path;
+  });
+  if (matches.length === 1) {
+    return matches[0];
+  }
+  return null;
+}
+
+function resolveProjectMatches(registry: Registry, selector: string): Project[] {
+  const normalizedSelector = normalizeProjectSelector(selector);
+  return registry.projects.filter((candidate) =>
+    candidate.id === selector ||
+    candidate.name === selector ||
+    candidate.path === normalizedSelector
+  );
+}
+
+async function resolveAuditContext(args: any): Promise<{ context: AuditContext | null; blockReasons: string[] }> {
+  const registry = await loadRegistry();
+  const rawRegistryState = await loadRawRegistryState();
+  const requestedProject = typeof args?.project === 'string' && args.project.trim().length > 0
+    ? args.project.trim()
+    : null;
+  const requestedProjectPath = typeof args?.project_path === 'string' && args.project_path.trim().length > 0
+    ? resolveInputProjectPath(args.project_path.trim())
+    : null;
+  const sessionProject = getSessionProjectBinding();
+
+  if (requestedProjectPath) {
+    const matches = registry.projects.filter((candidate) => candidate.path === requestedProjectPath);
+    if (matches.length > 1) {
+      return {
+        context: null,
+        blockReasons: [`Project identity is ambiguous because registry path "${requestedProjectPath}" is duplicated.`],
+      };
+    }
+    const registryEntry = matches[0] || null;
+    return {
+      context: {
+        registry,
+        rawRegistryState,
+        registryEntry,
+        rawRegistryEntry: registryEntry ? findRawRegistryEntry(rawRegistryState.raw, registryEntry) : null,
+        projectPath: requestedProjectPath,
+        resolutionSource: 'project_path',
+      },
+      blockReasons: [],
+    };
+  }
+
+  if (requestedProject) {
+    const matches = resolveProjectMatches(registry, requestedProject);
+    if (matches.length === 0) {
+      return {
+        context: null,
+        blockReasons: [`Project "${requestedProject}" not found in registry.`],
+      };
+    }
+    if (matches.length > 1) {
+      return {
+        context: null,
+        blockReasons: [`Project "${requestedProject}" is ambiguous in registry.`],
+      };
+    }
+    const registryEntry = matches[0];
+    return {
+      context: {
+        registry,
+        rawRegistryState,
+        registryEntry,
+        rawRegistryEntry: findRawRegistryEntry(rawRegistryState.raw, registryEntry),
+        projectPath: registryEntry.path,
+        resolutionSource: 'project',
+      },
+      blockReasons: [],
+    };
+  }
+
+  if (sessionProject) {
+    const matches = registry.projects.filter((candidate) =>
+      candidate.id === sessionProject.projectId || candidate.path === sessionProject.projectPath
+    );
+    if (matches.length === 0) {
+      return {
+        context: null,
+        blockReasons: [`Session project "${sessionProject.projectId}" not found in registry.`],
+      };
+    }
+    if (matches.length > 1) {
+      return {
+        context: null,
+        blockReasons: [`Session project "${sessionProject.projectId}" is ambiguous in registry.`],
+      };
+    }
+    const registryEntry = matches[0];
+    return {
+      context: {
+        registry,
+        rawRegistryState,
+        registryEntry,
+        rawRegistryEntry: findRawRegistryEntry(rawRegistryState.raw, registryEntry),
+        projectPath: registryEntry.path,
+        resolutionSource: 'session',
+      },
+      blockReasons: [],
+    };
+  }
+
+  return {
+    context: null,
+    blockReasons: ['No project_path, project, or session project is available for agenticos_migration_audit.'],
+  };
+}
+
+async function readYamlFile(filePath: string): Promise<{ exists: boolean; data: any | null; error: string | null }> {
+  try {
+    const content = await readFile(filePath, 'utf-8');
+    return {
+      exists: true,
+      data: yaml.parse(content) || {},
+      error: null,
+    };
+  } catch (error: any) {
+    if (error?.code === 'ENOENT') {
+      return { exists: false, data: null, error: null };
+    }
+    return {
+      exists: false,
+      data: null,
+      error: error instanceof Error ? error.message : 'failed to read yaml file',
+    };
+  }
+}
+
+function collectLegacyActiveProjectPaths(value: unknown, currentPath = ''): string[] {
+  if (!value || typeof value !== 'object') {
+    return [];
+  }
+
+  const matches: string[] = [];
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => {
+      matches.push(...collectLegacyActiveProjectPaths(item, `${currentPath}[${index}]`));
+    });
+    return matches;
+  }
+
+  for (const [key, nested] of Object.entries(value)) {
+    const nextPath = currentPath ? `${currentPath}.${key}` : key;
+    if (key === 'active_project') {
+      matches.push(nextPath);
+    }
+    matches.push(...collectLegacyActiveProjectPaths(nested, nextPath));
+  }
+
+  return matches;
+}
+
+async function buildProjectAudit(
+  context: AuditContext,
+  options: BuildProjectAuditOptions = {},
+): Promise<MigrationAuditResult> {
+  const findings: MigrationFinding[] = [];
+  const blockReasons: string[] = [];
+  const notes: string[] = [];
+  const rawRegistry = context.rawRegistryState.raw;
+  let identityProven = !!context.registryEntry;
+
+  if (context.rawRegistryState.error) {
+    pushFinding(findings, {
+      code: 'registry_read_error',
+      migration_class: 'explicit_migration_required',
+      severity: 'error',
+      summary: 'The registry could not be read cleanly, so migration inventory is incomplete.',
+      evidence: [context.rawRegistryState.path, context.rawRegistryState.error],
+      recommended_action: 'Repair or restore registry.yaml before relying on migration audit output.',
+      safe_to_defer: false,
+    });
+    blockReasons.push('Registry could not be read cleanly.');
+  }
+
+  if (
+    options.includeHomeScopedRegistryFindings !== false &&
+    typeof rawRegistry.active_project === 'string' &&
+    rawRegistry.active_project.trim().length > 0
+  ) {
+    pushFinding(findings, {
+      code: 'legacy_active_project_present',
+      migration_class: 'safe_lazy_repair',
+      severity: 'warning',
+      summary: 'The legacy registry current-project field is still populated.',
+      evidence: [context.rawRegistryState.path, `active_project=${rawRegistry.active_project.trim()}`],
+      recommended_action: 'Clear or downgrade the legacy current-project field during explicit migration or safe lazy repair.',
+      safe_to_defer: true,
+    });
+  }
+
+  if (!context.registryEntry) {
+    identityProven = false;
+    pushFinding(findings, {
+      code: 'registry_entry_missing',
+      migration_class: 'explicit_migration_required',
+      severity: 'error',
+      summary: 'The target project path is not registered in the current AgenticOS home.',
+      evidence: [context.projectPath],
+      recommended_action: 'Re-register the project explicitly before relying on managed-project migration tooling.',
+      safe_to_defer: false,
+    });
+    blockReasons.push('Target project is not registered.');
+  } else {
+    const duplicates = computeRegistryDuplicates(context.registry, context.registryEntry);
+
+    if (duplicates.duplicateIds.length > 1) {
+      identityProven = false;
+      pushFinding(findings, {
+        code: 'registry_project_id_duplicated',
+        migration_class: 'explicit_migration_required',
+        severity: 'error',
+        summary: 'The registry contains duplicate project ids for this managed project.',
+        evidence: [context.rawRegistryState.path, `project.id=${context.registryEntry.id}`],
+        recommended_action: 'Deduplicate registry project ids before relying on migration or runtime project targeting.',
+        safe_to_defer: false,
+      });
+      blockReasons.push('Registry project id is duplicated.');
+    }
+
+    if (duplicates.duplicatePaths.length > 1) {
+      identityProven = false;
+      pushFinding(findings, {
+        code: 'registry_project_path_duplicated',
+        migration_class: 'explicit_migration_required',
+        severity: 'error',
+        summary: 'The registry contains duplicate project paths for this managed project.',
+        evidence: [context.rawRegistryState.path, context.registryEntry.path],
+        recommended_action: 'Deduplicate registry project paths before relying on migration or runtime project targeting.',
+        safe_to_defer: false,
+      });
+      blockReasons.push('Registry project path is duplicated.');
+    }
+
+    if (duplicates.duplicateNames.length > 1) {
+      identityProven = false;
+      pushFinding(findings, {
+        code: 'registry_project_name_duplicated',
+        migration_class: 'explicit_migration_required',
+        severity: 'error',
+        summary: 'The registry contains duplicate project names for this managed project.',
+        evidence: [context.rawRegistryState.path, `project.name=${context.registryEntry.name}`],
+        recommended_action: 'Deduplicate registry project names before relying on name-based migration or runtime project targeting.',
+        safe_to_defer: false,
+      });
+      blockReasons.push('Registry project name is duplicated.');
+    }
+  }
+
+  const projectYamlPath = join(context.projectPath, '.project.yaml');
+  const projectYamlResult = await readYamlFile(projectYamlPath);
+  const projectYaml = projectYamlResult.data || {};
+  const projectName =
+    context.registryEntry?.name ||
+    projectYaml?.meta?.name ||
+    basename(context.projectPath);
+  const projectId =
+    context.registryEntry?.id ||
+    projectYaml?.meta?.id ||
+    null;
+
+  if (!projectYamlResult.exists) {
+    identityProven = false;
+    pushFinding(findings, {
+      code: 'project_yaml_missing',
+      migration_class: 'explicit_migration_required',
+      severity: 'error',
+      summary: 'The project is missing .project.yaml, so managed-project identity cannot be proven.',
+      evidence: [projectYamlPath],
+      recommended_action: 'Restore or recreate .project.yaml before running explicit migration.',
+      safe_to_defer: false,
+    });
+    blockReasons.push('.project.yaml is missing.');
+  } else if (projectYamlResult.error) {
+    identityProven = false;
+    pushFinding(findings, {
+      code: 'project_yaml_unreadable',
+      migration_class: 'explicit_migration_required',
+      severity: 'error',
+      summary: 'The project .project.yaml could not be read cleanly.',
+      evidence: [projectYamlPath, projectYamlResult.error],
+      recommended_action: 'Repair .project.yaml before running explicit migration.',
+      safe_to_defer: false,
+    });
+    blockReasons.push('.project.yaml could not be read.');
+  } else {
+    const metaId = typeof projectYaml?.meta?.id === 'string' ? projectYaml.meta.id.trim() : '';
+    const metaName = typeof projectYaml?.meta?.name === 'string' ? projectYaml.meta.name.trim() : '';
+    const archivedReference = isArchivedReferenceProject(projectYaml, context.registryEntry?.status);
+
+    if (!metaId) {
+      identityProven = false;
+      pushFinding(findings, {
+        code: 'project_meta_id_missing',
+        migration_class: 'explicit_migration_required',
+        severity: 'error',
+        summary: 'The project .project.yaml is missing meta.id.',
+        evidence: [projectYamlPath],
+        recommended_action: 'Write a stable meta.id before running explicit migration.',
+        safe_to_defer: false,
+      });
+      blockReasons.push('.project.yaml is missing meta.id.');
+    }
+
+    if (context.registryEntry && metaId && metaId !== context.registryEntry.id) {
+      identityProven = false;
+      pushFinding(findings, {
+        code: 'project_id_mismatch',
+        migration_class: 'explicit_migration_required',
+        severity: 'error',
+        summary: 'The registry project id and .project.yaml meta.id disagree.',
+        evidence: [
+          `registry.id=${context.registryEntry.id}`,
+          `project.meta.id=${metaId}`,
+          projectYamlPath,
+        ],
+        recommended_action: 'Repair project identity before applying migration.',
+        safe_to_defer: false,
+      });
+      blockReasons.push('Registry/project identity mismatch.');
+    }
+
+    if (context.registryEntry && metaName && metaName !== context.registryEntry.name) {
+      identityProven = false;
+      pushFinding(findings, {
+        code: 'project_name_mismatch',
+        migration_class: 'explicit_migration_required',
+        severity: 'error',
+        summary: 'The registry project name and .project.yaml meta.name disagree.',
+        evidence: [
+          `registry.name=${context.registryEntry.name}`,
+          `project.meta.name=${metaName}`,
+          projectYamlPath,
+        ],
+        recommended_action: 'Repair project identity before applying migration.',
+        safe_to_defer: false,
+      });
+      blockReasons.push('Registry/project name mismatch.');
+    }
+
+    if (archivedReference) {
+      pushFinding(findings, {
+        code: 'archived_reference_project',
+        migration_class: 'compatible_only',
+        severity: 'info',
+        summary: buildArchivedReferenceMessage(projectName, projectYaml?.archive_contract?.replacement_project),
+        evidence: [projectYamlPath],
+        recommended_action: 'Migration can usually be deferred for archived reference projects unless their metadata must be normalized for reporting.',
+        safe_to_defer: true,
+      });
+      notes.push('Archived reference projects are inventory-only in migration audit; active managed-project topology and state checks were skipped.');
+    } else {
+      const topologyValidation = validateManagedProjectTopology(projectName, projectYaml);
+      if (!topologyValidation.ok) {
+        pushFinding(findings, {
+          code: 'topology_contract_invalid',
+          migration_class: 'explicit_migration_required',
+          severity: 'error',
+          summary: topologyValidation.message,
+          evidence: [projectYamlPath],
+          recommended_action: 'Normalize the project topology before relying on managed-project migration behavior.',
+          safe_to_defer: false,
+        });
+        blockReasons.push('Project topology contract is not normalized.');
+      } else {
+        const publicationValidation = validateContextPublicationPolicy(projectName, projectYaml);
+        if (!publicationValidation.ok) {
+          pushFinding(findings, {
+            code: 'context_publication_policy_invalid',
+            migration_class: 'explicit_migration_required',
+            severity: 'error',
+            summary: publicationValidation.message,
+            evidence: [projectYamlPath],
+            recommended_action: 'Normalize source_control.context_publication_policy before applying migration.',
+            safe_to_defer: false,
+          });
+          blockReasons.push('Context publication policy is not normalized.');
+        }
+      }
+
+      const contextPaths = resolveManagedProjectContextPaths(context.projectPath, projectYaml);
+      if (!existsSync(contextPaths.statePath)) {
+        pushFinding(findings, {
+          code: 'state_surface_missing',
+          migration_class: 'safe_lazy_repair',
+          severity: 'warning',
+          summary: 'The project state surface is missing.',
+          evidence: [contextPaths.statePath],
+          recommended_action: 'Regenerate or normalize state.yaml during explicit migration or entry-surface repair.',
+          safe_to_defer: true,
+        });
+      } else {
+        const stateYamlResult = await readYamlFile(contextPaths.statePath);
+        if (stateYamlResult.error) {
+          pushFinding(findings, {
+            code: 'state_surface_unreadable',
+            migration_class: 'explicit_migration_required',
+            severity: 'error',
+            summary: 'The project state surface exists but could not be read cleanly.',
+            evidence: [contextPaths.statePath, stateYamlResult.error],
+            recommended_action: 'Repair the state surface before applying migration.',
+            safe_to_defer: false,
+          });
+          blockReasons.push('state.yaml could not be read.');
+        } else {
+          const activeProjectPaths = collectLegacyActiveProjectPaths(stateYamlResult.data);
+          if (activeProjectPaths.length > 0) {
+            pushFinding(findings, {
+              code: 'legacy_active_project_evidence_present',
+              migration_class: 'compatible_only',
+              severity: 'info',
+              summary: 'The project state still contains legacy active_project evidence fields.',
+              evidence: activeProjectPaths.slice(0, 5).map((item) => `${contextPaths.statePath}:${item}`),
+              recommended_action: 'This is compatibility-only historical evidence; rewrite only if explicit migration chooses to normalize old evidence shapes.',
+              safe_to_defer: true,
+            });
+          }
+        }
+      }
+    }
+  }
+
+  if (context.rawRegistryEntry) {
+    const rawPath = typeof context.rawRegistryEntry.path === 'string' ? context.rawRegistryEntry.path : '';
+    if (rawPath && isAbsolute(rawPath) && rawPath.startsWith(getAgenticOSHome())) {
+      pushFinding(findings, {
+        code: 'registry_path_stored_absolute_under_home',
+        migration_class: 'safe_lazy_repair',
+        severity: 'warning',
+        summary: 'The registry stores this project path as an absolute path under AGENTICOS_HOME.',
+        evidence: [context.rawRegistryState.path, rawPath],
+        recommended_action: 'Normalize the registry path to a relative workspace path during explicit migration or safe lazy repair.',
+        safe_to_defer: true,
+      });
+    }
+
+    if (typeof context.rawRegistryEntry.last_accessed !== 'string' || context.rawRegistryEntry.last_accessed.trim().length === 0) {
+      pushFinding(findings, {
+        code: 'registry_last_accessed_missing',
+        migration_class: 'safe_lazy_repair',
+        severity: 'info',
+        summary: 'The registry project entry is missing last_accessed metadata.',
+        evidence: [context.rawRegistryState.path, `project.id=${context.registryEntry?.id || projectId || 'unknown'}`],
+        recommended_action: 'Backfill lightweight metadata during safe lazy repair or explicit migration.',
+        safe_to_defer: true,
+      });
+    }
+  }
+
+  const status = computeStatus(findings);
+  const counts = computeCounts(findings);
+  const safeToContinue = status !== 'BLOCK';
+  if (safeToContinue && findings.length > 0) {
+    notes.push('Report-only audit found legacy state, but current runtime compatibility should remain usable.');
+  }
+
+  return {
+    command: 'agenticos_migration_audit',
+    status,
+    project: {
+      project_id: projectId,
+      project_name: projectName,
+      project_path: context.projectPath,
+      registry_entry_found: !!context.registryEntry,
+      registry_status: context.registryEntry?.status || null,
+      resolution_source: context.resolutionSource,
+      project_yaml_present: projectYamlResult.exists,
+      identity_proven: identityProven,
+    },
+    findings,
+    finding_counts: counts,
+    safe_to_continue_without_migration: safeToContinue,
+    recommended_next_action: buildRecommendedNextAction(status),
+    block_reasons: blockReasons,
+    notes,
+  };
+}
+
+export async function runMigrationAuditCheck(args: any): Promise<MigrationAuditResult> {
+  const resolved = await resolveAuditContext(args ?? {});
+  if (!resolved.context) {
+    return {
+      command: 'agenticos_migration_audit',
+      status: 'BLOCK',
+      project: null,
+      findings: [],
+      finding_counts: emptyCounts(),
+      safe_to_continue_without_migration: false,
+      recommended_next_action: buildRecommendedNextAction('BLOCK'),
+      block_reasons: resolved.blockReasons,
+      notes: [],
+    };
+  }
+
+  return await buildProjectAudit(resolved.context);
+}
+
+export async function runMigrateHomeReport(args: any): Promise<MigrateHomeResult> {
+  if (args?.report_only === false) {
+    return {
+      command: 'agenticos_migrate_home',
+      status: 'BLOCK',
+      report_only: true,
+      total_projects: 0,
+      safe_to_defer_projects: 0,
+      blocked_projects: 0,
+      findings_summary: emptyCounts(),
+      projects: [],
+      block_reasons: ['apply mode is not implemented yet; use report_only=true for the current #263 slice.'],
+      notes: [],
+    };
+  }
+
+  const registry = await loadRegistry();
+  const rawRegistryState = await loadRawRegistryState();
+  if (rawRegistryState.error) {
+    return {
+      command: 'agenticos_migrate_home',
+      status: 'BLOCK',
+      report_only: true,
+      total_projects: 0,
+      safe_to_defer_projects: 0,
+      blocked_projects: 0,
+      findings_summary: emptyCounts(),
+      projects: [],
+      block_reasons: ['Registry could not be read cleanly; home-wide migration inventory is unavailable.'],
+      notes: [rawRegistryState.error],
+    };
+  }
+
+  const projects: HomeProjectSummary[] = [];
+  const findingsSummary = emptyCounts();
+  let blockedProjects = 0;
+  let safeToDeferProjects = 0;
+
+  if (typeof rawRegistryState.raw.active_project === 'string' && rawRegistryState.raw.active_project.trim().length > 0) {
+    findingsSummary.safe_lazy_repair += 1;
+  }
+
+  for (const registryEntry of registry.projects) {
+    const result = await buildProjectAudit({
+      registry,
+      rawRegistryState,
+      registryEntry,
+      rawRegistryEntry: findRawRegistryEntry(rawRegistryState.raw, registryEntry),
+      projectPath: registryEntry.path,
+      resolutionSource: 'project',
+    }, {
+      includeHomeScopedRegistryFindings: false,
+    });
+
+    findingsSummary.compatible_only += result.finding_counts.compatible_only;
+    findingsSummary.safe_lazy_repair += result.finding_counts.safe_lazy_repair;
+    findingsSummary.explicit_migration_required += result.finding_counts.explicit_migration_required;
+
+    if (result.status === 'BLOCK') {
+      blockedProjects += 1;
+    }
+    if (result.safe_to_continue_without_migration) {
+      safeToDeferProjects += 1;
+    }
+
+    projects.push({
+      project_id: result.project?.project_id || null,
+      project_name: result.project?.project_name || null,
+      project_path: result.project?.project_path || registryEntry.path,
+      status: result.status,
+      finding_counts: result.finding_counts,
+      safe_to_continue_without_migration: result.safe_to_continue_without_migration,
+      recommended_next_action: result.recommended_next_action,
+    });
+  }
+
+  const status: AuditStatus = blockedProjects > 0
+    ? 'BLOCK'
+    : projects.some((project) => project.status === 'WARN')
+      ? 'WARN'
+      : 'PASS';
+
+  return {
+    command: 'agenticos_migrate_home',
+    status,
+    report_only: true,
+    total_projects: registry.projects.length,
+    safe_to_defer_projects: safeToDeferProjects,
+    blocked_projects: blockedProjects,
+    findings_summary: findingsSummary,
+    projects,
+    block_reasons: [],
+    notes: [
+      ...(projects.length === 0 ? ['No managed projects are currently registered in this AgenticOS home.'] : []),
+      ...(typeof rawRegistryState.raw.active_project === 'string' && rawRegistryState.raw.active_project.trim().length > 0
+        ? ['The home registry still contains a populated legacy active_project field.']
+        : []),
+    ],
+  };
+}

--- a/mcp-server/src/utils/migration-project.ts
+++ b/mcp-server/src/utils/migration-project.ts
@@ -1,9 +1,9 @@
 import { createHash } from 'crypto';
-import { readFile } from 'fs/promises';
-import { basename, isAbsolute, join, resolve as resolveFsPath } from 'path';
+import { mkdir, readFile, rename, rm, writeFile } from 'fs/promises';
+import { basename, dirname, isAbsolute, join, resolve as resolveFsPath } from 'path';
 import yaml from 'yaml';
 import { resolveManagedProjectContextPaths } from './agent-context-paths.js';
-import { getAgenticOSHome, loadRegistry, resolvePath, type Project, type Registry } from './registry.js';
+import { getAgenticOSHome, loadRegistry, patchRegistry, resolvePath, type Project, type Registry } from './registry.js';
 import { runMigrationAuditCheck, type MigrationAuditResult } from './migration-audit.js';
 
 type ApplyScope = 'safe_repairs_only' | 'full';
@@ -82,7 +82,7 @@ export interface MigrationProjectPlanResult {
   mode: 'plan';
   status: PlanStatus;
   apply_scope: ApplyScope;
-  apply_supported: false;
+  apply_supported: true;
   project: MigrationAuditResult['project'];
   audit_status: MigrationAuditResult['status'] | 'BLOCK';
   audit_finding_counts: MigrationAuditResult['finding_counts'];
@@ -97,14 +97,31 @@ export interface MigrationProjectPlanResult {
   notes: string[];
 }
 
-export interface MigrationProjectApplyStubResult {
+export interface MigrationProjectApplyResult {
   command: 'agenticos_migrate_project';
   mode: 'apply';
-  status: 'BLOCK';
+  status: 'APPLIED' | 'BLOCK';
   apply_scope: ApplyScope;
-  apply_supported: false;
+  apply_supported: true;
+  project: MigrationAuditResult['project'];
+  applied_plan_hash: string | null;
+  applied_actions: MigrationAction[];
+  deferred_findings: MigrationDeferredFinding[];
+  manual_blocks: MigrationManualBlock[];
+  evidence_paths: string[];
+  post_audit_status: MigrationAuditResult['status'] | 'BLOCK';
   block_reasons: string[];
   notes: string[];
+}
+
+interface ResolvedPlan {
+  audit: MigrationAuditResult;
+  plannedActions: MigrationAction[];
+  deferredFindings: MigrationDeferredFinding[];
+  manualBlocks: MigrationManualBlock[];
+  preconditions: MigrationPlanPreconditions | null;
+  planHash: string | null;
+  status: PlanStatus;
 }
 
 function registryFilePath(): string {
@@ -244,6 +261,14 @@ function digest(value: string): string {
   return createHash('sha256').update(value).digest('hex');
 }
 
+function emptyCounts(): MigrationAuditResult['finding_counts'] {
+  return {
+    compatible_only: 0,
+    safe_lazy_repair: 0,
+    explicit_migration_required: 0,
+  };
+}
+
 async function digestFileOrMarker(filePath: string): Promise<string> {
   try {
     return digest(await readFile(filePath, 'utf-8'));
@@ -296,6 +321,78 @@ async function buildPreconditions(
 
 function buildStateSurfacePath(projectPath: string): string {
   return join(projectPath, '.context', 'state.yaml');
+}
+
+function buildDefaultState(): any {
+  return {
+    session: {},
+    current_task: {
+      id: null,
+      title: null,
+      status: 'pending',
+      next_step: null,
+    },
+    working_memory: {
+      facts: [],
+      decisions: [],
+      pending: [],
+    },
+    memory_contract: {
+      version: 1,
+      quick_start_role: 'project_orientation',
+      state_role: 'operational_working_state',
+      conversations_role: 'append_only_session_history',
+      knowledge_role: 'durable_synthesis',
+      tasks_role: 'execution_artifacts',
+      artifacts_role: 'deliverables',
+    },
+    loaded_context: ['.project.yaml'],
+  };
+}
+
+async function readYamlFileOrDefault(filePath: string, fallback: any): Promise<any> {
+  try {
+    return yaml.parse(await readFile(filePath, 'utf-8')) || fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+async function writeFileAtomic(filePath: string, content: string): Promise<void> {
+  await mkdir(dirname(filePath), { recursive: true });
+  const tempPath = `${filePath}.tmp-${process.pid}-${Date.now()}`;
+  await writeFile(tempPath, content, 'utf-8');
+  await rename(tempPath, filePath);
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function withProjectMigrationLock<T>(projectPath: string, callback: () => Promise<T>): Promise<T> {
+  const lockPath = join(projectPath, '.context', '.migration.lock');
+  await mkdir(dirname(lockPath), { recursive: true });
+
+  let locked = false;
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    try {
+      await mkdir(lockPath);
+      locked = true;
+      break;
+    } catch {
+      await sleep(10);
+    }
+  }
+
+  if (!locked) {
+    throw new Error(`failed to acquire project migration lock at ${lockPath}`);
+  }
+
+  try {
+    return await callback();
+  } finally {
+    await rm(lockPath, { recursive: true, force: true }).catch(() => undefined);
+  }
 }
 
 function buildActions(audit: MigrationAuditResult, applyScope: ApplyScope): {
@@ -445,52 +542,10 @@ function buildPlanHash(
   }));
 }
 
-export async function runMigrationProjectPlan(args: any): Promise<MigrationProjectPlanResult | MigrationProjectApplyStubResult> {
-  const mode = args?.mode === 'apply' ? 'apply' : 'plan';
-  const applyScope: ApplyScope = args?.apply_scope === 'safe_repairs_only' ? 'safe_repairs_only' : 'full';
-
-  if (mode === 'apply') {
-    return {
-      command: 'agenticos_migrate_project',
-      mode: 'apply',
-      status: 'BLOCK',
-      apply_scope: applyScope,
-      apply_supported: false,
-      block_reasons: ['apply mode is not implemented yet; use mode=plan to review the deterministic migration plan in the current #263 slice.'],
-      notes: [],
-    };
-  }
-
-  const resolved = await resolveMigrationCandidate(args ?? {});
-  if (!resolved.candidate) {
-    return {
-      command: 'agenticos_migrate_project',
-      mode: 'plan',
-      status: 'BLOCK',
-      apply_scope: applyScope,
-      apply_supported: false,
-      project: null,
-      audit_status: 'BLOCK',
-      audit_finding_counts: {
-        compatible_only: 0,
-        safe_lazy_repair: 0,
-        explicit_migration_required: 0,
-      },
-      safe_to_continue_without_migration: false,
-      plan_hash: null,
-      apply_ready: false,
-      planned_actions: [],
-      deferred_findings: [],
-      manual_blocks: [],
-      preconditions: null,
-      block_reasons: resolved.blockReasons,
-      notes: ['No writes occurred. Plan mode requires an explicit project selector in the current phase-2 slice.'],
-    };
-  }
-
-  const audit = await runMigrationAuditCheck({ project_path: resolved.candidate.projectPath });
+async function resolvePlan(candidate: MigrationCandidate, applyScope: ApplyScope): Promise<ResolvedPlan> {
+  const audit = await runMigrationAuditCheck({ project_path: candidate.projectPath });
   const { plannedActions, deferredFindings, manualBlocks } = buildActions(audit, applyScope);
-  const preconditions = await buildPreconditions(resolved.candidate, audit, applyScope);
+  const preconditions = await buildPreconditions(candidate, audit, applyScope);
   const planHash = buildPlanHash(audit, applyScope, plannedActions, deferredFindings, manualBlocks, preconditions);
 
   const status: PlanStatus = manualBlocks.length > 0
@@ -500,11 +555,25 @@ export async function runMigrationProjectPlan(args: any): Promise<MigrationProje
       : 'NOOP';
 
   return {
+    audit,
+    plannedActions,
+    deferredFindings,
+    manualBlocks,
+    preconditions,
+    planHash,
+    status,
+  };
+}
+
+function buildPlanModeResult(resolved: ResolvedPlan, applyScope: ApplyScope): MigrationProjectPlanResult {
+  const { audit, plannedActions, deferredFindings, manualBlocks, preconditions, planHash, status } = resolved;
+
+  return {
     command: 'agenticos_migrate_project',
     mode: 'plan',
     status,
     apply_scope: applyScope,
-    apply_supported: false,
+    apply_supported: true,
     project: audit.project,
     audit_status: audit.status,
     audit_finding_counts: audit.finding_counts,
@@ -527,4 +596,306 @@ export async function runMigrationProjectPlan(args: any): Promise<MigrationProje
       ...(status === 'NOOP' ? ['No writes occurred. The current project has no deterministic migration actions in this phase-2 slice.'] : []),
     ],
   };
+}
+
+async function applyResolvedPlan(
+  candidate: MigrationCandidate,
+  resolved: ResolvedPlan,
+  applyScope: ApplyScope,
+): Promise<MigrationProjectApplyResult> {
+  if (!resolved.audit.project || !candidate.registryEntry) {
+    return {
+      command: 'agenticos_migrate_project',
+      mode: 'apply',
+      status: 'BLOCK',
+      apply_scope: applyScope,
+      apply_supported: true,
+      project: resolved.audit.project,
+      applied_plan_hash: resolved.planHash,
+      applied_actions: [],
+      deferred_findings: resolved.deferredFindings,
+      manual_blocks: resolved.manualBlocks,
+      evidence_paths: [],
+      post_audit_status: 'BLOCK',
+      block_reasons: ['The target project identity is not proven enough for apply mode.'],
+      notes: [],
+    };
+  }
+
+  const projectYaml = yaml.parse(await readFile(join(candidate.projectPath, '.project.yaml'), 'utf-8')) || {};
+  const contextPaths = resolveManagedProjectContextPaths(candidate.projectPath, projectYaml);
+  const statePath = contextPaths.statePath;
+  const artifactsDir = contextPaths.artifactsDir;
+  const appliedAt = new Date().toISOString();
+  const reportFileName = `migration-${appliedAt.replace(/[:.]/g, '-')}.yaml`;
+  const reportPath = join(artifactsDir, 'migrations', reportFileName);
+  const reportDisplayPath = reportPath.startsWith(`${candidate.projectPath}/`)
+    ? reportPath.substring(candidate.projectPath.length + 1)
+    : reportPath;
+
+  const appliedActions: MigrationAction[] = [];
+
+  const hasAction = (id: string): boolean =>
+    resolved.plannedActions.some((action) => action.id === id);
+
+  if (hasAction('state.rebuild_missing_surface')) {
+    const existingState = await readYamlFileOrDefault(statePath, null);
+    const nextState = existingState && typeof existingState === 'object'
+      ? existingState
+      : buildDefaultState();
+    await writeFileAtomic(statePath, yaml.stringify(nextState));
+    appliedActions.push(resolved.plannedActions.find((action) => action.id === 'state.rebuild_missing_surface')!);
+  }
+
+  const needsRegistryPatch =
+    hasAction('registry.clear_legacy_active_project') ||
+    hasAction('registry.normalize_project_path') ||
+    hasAction('registry.backfill_last_accessed');
+
+  if (needsRegistryPatch) {
+    await patchRegistry(async (registry) => {
+      const projectIndex = registry.projects.findIndex((project) => project.id === candidate.registryEntry!.id);
+      if (projectIndex < 0) {
+        throw new Error(`Project "${candidate.registryEntry!.id}" not found in registry during apply.`);
+      }
+
+      if (hasAction('registry.clear_legacy_active_project')) {
+        registry.active_project = null;
+      }
+
+      if (hasAction('registry.normalize_project_path')) {
+        registry.projects[projectIndex] = {
+          ...registry.projects[projectIndex],
+          path: candidate.projectPath,
+        };
+      }
+
+      if (hasAction('registry.backfill_last_accessed')) {
+        registry.projects[projectIndex] = {
+          ...registry.projects[projectIndex],
+          last_accessed: appliedAt,
+        };
+      }
+    });
+
+    for (const actionId of [
+      'registry.backfill_last_accessed',
+      'registry.clear_legacy_active_project',
+      'registry.normalize_project_path',
+    ]) {
+      const action = resolved.plannedActions.find((candidateAction) => candidateAction.id === actionId);
+      if (action) {
+        appliedActions.push(action);
+      }
+    }
+  }
+
+  const state = await readYamlFileOrDefault(statePath, buildDefaultState());
+  if (!state.migrations || typeof state.migrations !== 'object') {
+    state.migrations = {};
+  }
+  const existingReports = Array.isArray(state.migrations.reports) ? state.migrations.reports : [];
+  state.migrations.latest = {
+    applied_at: appliedAt,
+    plan_hash: resolved.planHash,
+    apply_scope: applyScope,
+    report_path: reportDisplayPath,
+    applied_action_ids: appliedActions.map((action) => action.id),
+  };
+  state.migrations.reports = [
+    ...existingReports,
+    {
+      applied_at: appliedAt,
+      plan_hash: resolved.planHash,
+      report_path: reportDisplayPath,
+    },
+  ];
+  await writeFileAtomic(statePath, yaml.stringify(state));
+
+  const report = {
+    command: 'agenticos_migrate_project',
+    applied_at: appliedAt,
+    project: resolved.audit.project,
+    apply_scope: applyScope,
+    plan_hash: resolved.planHash,
+    applied_actions: appliedActions.map((action) => ({
+      id: action.id,
+      actionability: action.actionability,
+      action_type: action.action_type,
+      summary: action.summary,
+      target_paths: action.target_paths,
+    })),
+    deferred_findings: resolved.deferredFindings,
+    manual_blocks: resolved.manualBlocks,
+  };
+  await writeFileAtomic(reportPath, yaml.stringify(report));
+
+  const postAudit = await runMigrationAuditCheck({ project_path: candidate.projectPath });
+
+  return {
+    command: 'agenticos_migrate_project',
+    mode: 'apply',
+    status: 'APPLIED',
+    apply_scope: applyScope,
+    apply_supported: true,
+    project: postAudit.project,
+    applied_plan_hash: resolved.planHash,
+    applied_actions: appliedActions,
+    deferred_findings: postAudit.findings
+      .filter((finding) => finding.migration_class === 'compatible_only')
+      .map((finding) => ({
+        code: finding.code,
+        actionability: 'defer_only' as const,
+        summary: finding.summary,
+        reason: finding.recommended_action,
+      })),
+    manual_blocks: [],
+    evidence_paths: [statePath, reportPath],
+    post_audit_status: postAudit.status,
+    block_reasons: [],
+    notes: [
+      ...postAudit.notes,
+      'Apply mode executed deterministic per-project migration actions only.',
+    ],
+  };
+}
+
+export async function runMigrationProjectPlan(args: any): Promise<MigrationProjectPlanResult | MigrationProjectApplyResult> {
+  const mode = args?.mode === 'apply' ? 'apply' : 'plan';
+  const applyScope: ApplyScope = args?.apply_scope === 'safe_repairs_only' ? 'safe_repairs_only' : 'full';
+
+  const resolved = await resolveMigrationCandidate(args ?? {});
+  if (!resolved.candidate) {
+    const planResult: MigrationProjectPlanResult = {
+      command: 'agenticos_migrate_project',
+      mode: 'plan',
+      status: 'BLOCK',
+      apply_scope: applyScope,
+      apply_supported: true,
+      project: null,
+      audit_status: 'BLOCK',
+      audit_finding_counts: emptyCounts(),
+      safe_to_continue_without_migration: false,
+      plan_hash: null,
+      apply_ready: false,
+      planned_actions: [],
+      deferred_findings: [],
+      manual_blocks: [],
+      preconditions: null,
+      block_reasons: resolved.blockReasons,
+      notes: ['No writes occurred. Plan mode requires an explicit project selector in the current phase-2 slice.'],
+    };
+    if (mode === 'apply') {
+      return {
+        command: 'agenticos_migrate_project',
+        mode: 'apply',
+        status: 'BLOCK',
+        apply_scope: applyScope,
+        apply_supported: true,
+        project: null,
+        applied_plan_hash: null,
+        applied_actions: [],
+        deferred_findings: [],
+        manual_blocks: [],
+        evidence_paths: [],
+        post_audit_status: 'BLOCK',
+        block_reasons: resolved.blockReasons,
+        notes: ['No writes occurred. Apply mode requires an explicit project selector in the current phase-2 slice.'],
+      };
+    }
+    return planResult;
+  }
+
+  const resolvedPlan = await resolvePlan(resolved.candidate, applyScope);
+
+  if (mode === 'plan') {
+    return buildPlanModeResult(resolvedPlan, applyScope);
+  }
+
+  const expectedPlanHash = typeof args?.expected_plan_hash === 'string' && args.expected_plan_hash.trim().length > 0
+    ? args.expected_plan_hash.trim()
+    : null;
+
+  if (!expectedPlanHash) {
+    return {
+      command: 'agenticos_migrate_project',
+      mode: 'apply',
+      status: 'BLOCK',
+      apply_scope: applyScope,
+      apply_supported: true,
+      project: resolvedPlan.audit.project,
+      applied_plan_hash: resolvedPlan.planHash,
+      applied_actions: [],
+      deferred_findings: resolvedPlan.deferredFindings,
+      manual_blocks: resolvedPlan.manualBlocks,
+      evidence_paths: [],
+      post_audit_status: 'BLOCK',
+      block_reasons: ['expected_plan_hash is required for apply mode.'],
+      notes: [],
+    };
+  }
+
+  if (resolvedPlan.planHash && resolvedPlan.planHash !== expectedPlanHash) {
+    return {
+      command: 'agenticos_migrate_project',
+      mode: 'apply',
+      status: 'BLOCK',
+      apply_scope: applyScope,
+      apply_supported: true,
+      project: resolvedPlan.audit.project,
+      applied_plan_hash: resolvedPlan.planHash,
+      applied_actions: [],
+      deferred_findings: resolvedPlan.deferredFindings,
+      manual_blocks: resolvedPlan.manualBlocks,
+      evidence_paths: [],
+      post_audit_status: 'BLOCK',
+      block_reasons: ['The reviewed plan hash no longer matches the current deterministic migration plan. Rerun mode=plan and review the new plan before applying.'],
+      notes: [],
+    };
+  }
+
+  if (resolvedPlan.status !== 'READY' || !resolvedPlan.planHash) {
+    return {
+      command: 'agenticos_migrate_project',
+      mode: 'apply',
+      status: 'BLOCK',
+      apply_scope: applyScope,
+      apply_supported: true,
+      project: resolvedPlan.audit.project,
+      applied_plan_hash: resolvedPlan.planHash,
+      applied_actions: [],
+      deferred_findings: resolvedPlan.deferredFindings,
+      manual_blocks: resolvedPlan.manualBlocks,
+      evidence_paths: [],
+      post_audit_status: 'BLOCK',
+      block_reasons: [
+        ...resolvedPlan.audit.block_reasons,
+        ...resolvedPlan.manualBlocks.map((block) => `${block.code}: ${block.reason}`),
+      ],
+      notes: ['Apply mode is only available when plan mode returns READY.'],
+    };
+  }
+
+  try {
+    return await withProjectMigrationLock(resolved.candidate.projectPath, async () =>
+      await applyResolvedPlan(resolved.candidate!, resolvedPlan, applyScope)
+    );
+  } catch (error: any) {
+    return {
+      command: 'agenticos_migrate_project',
+      mode: 'apply',
+      status: 'BLOCK',
+      apply_scope: applyScope,
+      apply_supported: true,
+      project: resolvedPlan.audit.project,
+      applied_plan_hash: resolvedPlan.planHash,
+      applied_actions: [],
+      deferred_findings: resolvedPlan.deferredFindings,
+      manual_blocks: resolvedPlan.manualBlocks,
+      evidence_paths: [],
+      post_audit_status: 'BLOCK',
+      block_reasons: [error instanceof Error ? error.message : 'migration apply failed'],
+      notes: [],
+    };
+  }
 }

--- a/mcp-server/src/utils/migration-project.ts
+++ b/mcp-server/src/utils/migration-project.ts
@@ -1,0 +1,530 @@
+import { createHash } from 'crypto';
+import { readFile } from 'fs/promises';
+import { basename, isAbsolute, join, resolve as resolveFsPath } from 'path';
+import yaml from 'yaml';
+import { resolveManagedProjectContextPaths } from './agent-context-paths.js';
+import { getAgenticOSHome, loadRegistry, resolvePath, type Project, type Registry } from './registry.js';
+import { runMigrationAuditCheck, type MigrationAuditResult } from './migration-audit.js';
+
+type ApplyScope = 'safe_repairs_only' | 'full';
+type PlanStatus = 'READY' | 'BLOCK' | 'NOOP';
+type Actionability = 'defer_only' | 'safe_repair' | 'explicit_apply' | 'manual_block';
+type ActionType = 'registry_patch' | 'project_yaml_patch' | 'state_surface_repair' | 'evidence_write';
+
+interface RawRegistryProject {
+  id?: unknown;
+  name?: unknown;
+  path?: unknown;
+  status?: unknown;
+  created?: unknown;
+  last_accessed?: unknown;
+  last_recorded?: unknown;
+}
+
+interface RawRegistry {
+  version?: unknown;
+  last_updated?: unknown;
+  active_project?: unknown;
+  projects?: RawRegistryProject[];
+}
+
+interface RawRegistryState {
+  raw: RawRegistry;
+  error: string | null;
+  path: string;
+}
+
+interface MigrationCandidate {
+  registry: Registry;
+  rawRegistryState: RawRegistryState;
+  registryEntry: Project | null;
+  rawRegistryEntry: RawRegistryProject | null;
+  projectPath: string;
+  resolutionSource: 'project' | 'project_path';
+}
+
+interface MigrationAction {
+  id: string;
+  actionability: Exclude<Actionability, 'defer_only' | 'manual_block'>;
+  action_type: ActionType;
+  summary: string;
+  source_finding_codes: string[];
+  target_paths: string[];
+}
+
+interface MigrationDeferredFinding {
+  code: string;
+  actionability: 'defer_only';
+  summary: string;
+  reason: string;
+}
+
+interface MigrationManualBlock {
+  code: string;
+  actionability: 'manual_block';
+  summary: string;
+  evidence: string[];
+  reason: string;
+}
+
+interface MigrationPlanPreconditions {
+  registry_path: string;
+  registry_subset_digest: string;
+  project_yaml_path: string;
+  project_yaml_digest: string;
+  state_path: string | null;
+  state_digest: string | null;
+  apply_scope: ApplyScope;
+}
+
+export interface MigrationProjectPlanResult {
+  command: 'agenticos_migrate_project';
+  mode: 'plan';
+  status: PlanStatus;
+  apply_scope: ApplyScope;
+  apply_supported: false;
+  project: MigrationAuditResult['project'];
+  audit_status: MigrationAuditResult['status'] | 'BLOCK';
+  audit_finding_counts: MigrationAuditResult['finding_counts'];
+  safe_to_continue_without_migration: boolean;
+  plan_hash: string | null;
+  apply_ready: boolean;
+  planned_actions: MigrationAction[];
+  deferred_findings: MigrationDeferredFinding[];
+  manual_blocks: MigrationManualBlock[];
+  preconditions: MigrationPlanPreconditions | null;
+  block_reasons: string[];
+  notes: string[];
+}
+
+export interface MigrationProjectApplyStubResult {
+  command: 'agenticos_migrate_project';
+  mode: 'apply';
+  status: 'BLOCK';
+  apply_scope: ApplyScope;
+  apply_supported: false;
+  block_reasons: string[];
+  notes: string[];
+}
+
+function registryFilePath(): string {
+  return join(getAgenticOSHome(), '.agent-workspace', 'registry.yaml');
+}
+
+async function loadRawRegistryState(): Promise<RawRegistryState> {
+  const path = registryFilePath();
+  try {
+    const content = await readFile(path, 'utf-8');
+    const parsed = yaml.parse(content);
+    if (!parsed || typeof parsed !== 'object') {
+      throw new Error('registry yaml did not parse into an object');
+    }
+    const raw = parsed as RawRegistry;
+    return {
+      raw: {
+        ...raw,
+        projects: Array.isArray(raw.projects) ? raw.projects : [],
+      },
+      error: null,
+      path,
+    };
+  } catch (error: any) {
+    if (error?.code === 'ENOENT') {
+      return {
+        raw: { active_project: null, projects: [] },
+        error: null,
+        path,
+      };
+    }
+    return {
+      raw: { active_project: null, projects: [] },
+      error: error instanceof Error ? error.message : 'failed to read registry.yaml',
+      path,
+    };
+  }
+}
+
+function resolveInputProjectPath(rawPath: string): string {
+  return isAbsolute(rawPath)
+    ? resolveFsPath(rawPath)
+    : resolveFsPath(getAgenticOSHome(), rawPath);
+}
+
+function normalizeProjectSelector(rawSelector: string): string {
+  if (isAbsolute(rawSelector) || rawSelector.includes('/') || rawSelector.includes('\\') || rawSelector.startsWith('.')) {
+    return resolveInputProjectPath(rawSelector);
+  }
+  return rawSelector;
+}
+
+function findRawRegistryEntry(rawRegistry: RawRegistry, entry: Project): RawRegistryProject | null {
+  const projects = Array.isArray(rawRegistry.projects) ? rawRegistry.projects : [];
+  const matches = projects.filter((candidate) => {
+    const candidateId = typeof candidate.id === 'string' ? candidate.id.trim() : '';
+    const candidatePath = typeof candidate.path === 'string' ? resolvePath(candidate.path) : '';
+    return candidateId === entry.id || candidatePath === entry.path;
+  });
+  return matches.length === 1 ? matches[0] : null;
+}
+
+async function resolveMigrationCandidate(args: any): Promise<{ candidate: MigrationCandidate | null; blockReasons: string[] }> {
+  const registry = await loadRegistry();
+  const rawRegistryState = await loadRawRegistryState();
+  const requestedProject = typeof args?.project === 'string' && args.project.trim().length > 0
+    ? args.project.trim()
+    : null;
+  const requestedProjectPath = typeof args?.project_path === 'string' && args.project_path.trim().length > 0
+    ? resolveInputProjectPath(args.project_path.trim())
+    : null;
+
+  if (!requestedProject && !requestedProjectPath) {
+    return {
+      candidate: null,
+      blockReasons: ['agenticos_migrate_project requires an explicit project or project_path.'],
+    };
+  }
+
+  if (requestedProjectPath) {
+    const matches = registry.projects.filter((candidate) => candidate.path === requestedProjectPath);
+    if (matches.length > 1) {
+      return {
+        candidate: null,
+        blockReasons: [`Project identity is ambiguous because registry path "${requestedProjectPath}" is duplicated.`],
+      };
+    }
+    const registryEntry = matches[0] || null;
+    return {
+      candidate: {
+        registry,
+        rawRegistryState,
+        registryEntry,
+        rawRegistryEntry: registryEntry ? findRawRegistryEntry(rawRegistryState.raw, registryEntry) : null,
+        projectPath: requestedProjectPath,
+        resolutionSource: 'project_path',
+      },
+      blockReasons: [],
+    };
+  }
+
+  const normalizedSelector = normalizeProjectSelector(requestedProject!);
+  const matches = registry.projects.filter((candidate) =>
+    candidate.id === requestedProject ||
+    candidate.name === requestedProject ||
+    candidate.path === normalizedSelector
+  );
+  if (matches.length === 0) {
+    return {
+      candidate: null,
+      blockReasons: rawRegistryState.error
+        ? ['Registry could not be read cleanly, so the explicit project selector could not be resolved.']
+        : [`Project "${requestedProject}" not found in registry.`],
+    };
+  }
+  if (matches.length > 1) {
+    return {
+      candidate: null,
+      blockReasons: [`Project "${requestedProject}" is ambiguous in registry.`],
+    };
+  }
+  const registryEntry = matches[0];
+  return {
+    candidate: {
+      registry,
+      rawRegistryState,
+      registryEntry,
+      rawRegistryEntry: findRawRegistryEntry(rawRegistryState.raw, registryEntry),
+      projectPath: registryEntry.path,
+      resolutionSource: 'project',
+    },
+    blockReasons: [],
+  };
+}
+
+function digest(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+async function digestFileOrMarker(filePath: string): Promise<string> {
+  try {
+    return digest(await readFile(filePath, 'utf-8'));
+  } catch (error: any) {
+    if (error?.code === 'ENOENT') {
+      return digest(`MISSING:${filePath}`);
+    }
+    return digest(`ERROR:${filePath}:${error instanceof Error ? error.message : 'read-failed'}`);
+  }
+}
+
+async function buildPreconditions(
+  candidate: MigrationCandidate,
+  audit: MigrationAuditResult,
+  applyScope: ApplyScope,
+): Promise<MigrationPlanPreconditions | null> {
+  if (!audit.project) {
+    return null;
+  }
+
+  const projectYamlPath = join(candidate.projectPath, '.project.yaml');
+  let statePath: string | null = null;
+  let stateDigest: string | null = null;
+
+  try {
+    const projectYaml = yaml.parse(await readFile(projectYamlPath, 'utf-8')) || {};
+    const contextPaths = resolveManagedProjectContextPaths(candidate.projectPath, projectYaml);
+    statePath = contextPaths.statePath;
+    stateDigest = await digestFileOrMarker(statePath);
+  } catch {
+    statePath = null;
+    stateDigest = null;
+  }
+
+  const registrySubset = {
+    active_project: candidate.rawRegistryState.raw.active_project ?? null,
+    target_entry: candidate.rawRegistryEntry || null,
+  };
+
+  return {
+    registry_path: candidate.rawRegistryState.path,
+    registry_subset_digest: digest(JSON.stringify(registrySubset)),
+    project_yaml_path: projectYamlPath,
+    project_yaml_digest: await digestFileOrMarker(projectYamlPath),
+    state_path: statePath,
+    state_digest: stateDigest,
+    apply_scope: applyScope,
+  };
+}
+
+function buildStateSurfacePath(projectPath: string): string {
+  return join(projectPath, '.context', 'state.yaml');
+}
+
+function buildActions(audit: MigrationAuditResult, applyScope: ApplyScope): {
+  plannedActions: MigrationAction[];
+  deferredFindings: MigrationDeferredFinding[];
+  manualBlocks: MigrationManualBlock[];
+} {
+  const plannedActions: MigrationAction[] = [];
+  const deferredFindings: MigrationDeferredFinding[] = [];
+  const manualBlocks: MigrationManualBlock[] = [];
+
+  const pushAction = (action: MigrationAction): void => {
+    if (plannedActions.some((candidate) => candidate.id === action.id)) {
+      return;
+    }
+    plannedActions.push(action);
+  };
+
+  const projectPath = audit.project?.project_path || null;
+
+  for (const finding of audit.findings) {
+    switch (finding.code) {
+      case 'legacy_active_project_present':
+        pushAction({
+          id: 'registry.clear_legacy_active_project',
+          actionability: 'safe_repair',
+          action_type: 'registry_patch',
+          summary: 'Clear compatibility-only registry.active_project.',
+          source_finding_codes: [finding.code],
+          target_paths: [join(getAgenticOSHome(), '.agent-workspace', 'registry.yaml')],
+        });
+        break;
+      case 'registry_path_stored_absolute_under_home':
+        pushAction({
+          id: 'registry.normalize_project_path',
+          actionability: 'safe_repair',
+          action_type: 'registry_patch',
+          summary: 'Normalize the target registry path to a relative workspace path.',
+          source_finding_codes: [finding.code],
+          target_paths: [join(getAgenticOSHome(), '.agent-workspace', 'registry.yaml')],
+        });
+        break;
+      case 'registry_last_accessed_missing':
+        pushAction({
+          id: 'registry.backfill_last_accessed',
+          actionability: 'safe_repair',
+          action_type: 'registry_patch',
+          summary: 'Backfill lightweight registry metadata for last_accessed.',
+          source_finding_codes: [finding.code],
+          target_paths: [join(getAgenticOSHome(), '.agent-workspace', 'registry.yaml')],
+        });
+        break;
+      case 'state_surface_missing':
+        if (projectPath) {
+          pushAction({
+            id: 'state.rebuild_missing_surface',
+            actionability: 'safe_repair',
+            action_type: 'state_surface_repair',
+            summary: 'Regenerate the missing project state surface using the current contract.',
+            source_finding_codes: [finding.code],
+            target_paths: [buildStateSurfacePath(projectPath)],
+          });
+        } else {
+          manualBlocks.push({
+            code: finding.code,
+            actionability: 'manual_block',
+            summary: finding.summary,
+            evidence: finding.evidence,
+            reason: 'State surface repair could not be planned because the target project path was not proven.',
+          });
+        }
+        break;
+      default:
+        if (finding.migration_class === 'compatible_only') {
+          deferredFindings.push({
+            code: finding.code,
+            actionability: 'defer_only',
+            summary: finding.summary,
+            reason: finding.recommended_action,
+          });
+        } else if (finding.migration_class === 'explicit_migration_required') {
+          manualBlocks.push({
+            code: finding.code,
+            actionability: 'manual_block',
+            summary: finding.summary,
+            evidence: finding.evidence,
+            reason: finding.recommended_action,
+          });
+        } else {
+          manualBlocks.push({
+            code: finding.code,
+            actionability: 'manual_block',
+            summary: finding.summary,
+            evidence: finding.evidence,
+            reason: 'This safe-lazy-repair finding does not yet have a deterministic apply action in the current phase-2 slice.',
+          });
+        }
+        break;
+    }
+  }
+
+  plannedActions.sort((left, right) => left.id.localeCompare(right.id));
+  deferredFindings.sort((left, right) => left.code.localeCompare(right.code));
+  manualBlocks.sort((left, right) => left.code.localeCompare(right.code));
+
+  if (applyScope === 'safe_repairs_only') {
+    return {
+      plannedActions: plannedActions.filter((action) => action.actionability === 'safe_repair'),
+      deferredFindings,
+      manualBlocks,
+    };
+  }
+
+  return {
+    plannedActions,
+    deferredFindings,
+    manualBlocks,
+  };
+}
+
+function buildPlanHash(
+  audit: MigrationAuditResult,
+  applyScope: ApplyScope,
+  plannedActions: MigrationAction[],
+  deferredFindings: MigrationDeferredFinding[],
+  manualBlocks: MigrationManualBlock[],
+  preconditions: MigrationPlanPreconditions | null,
+): string | null {
+  if (!audit.project || !preconditions) {
+    return null;
+  }
+
+  return digest(JSON.stringify({
+    project_id: audit.project.project_id,
+    project_path: audit.project.project_path,
+    apply_scope: applyScope,
+    planned_actions: plannedActions.map((action) => ({
+      id: action.id,
+      actionability: action.actionability,
+      action_type: action.action_type,
+      source_finding_codes: action.source_finding_codes,
+      target_paths: action.target_paths,
+    })),
+    deferred_findings: deferredFindings.map((finding) => finding.code),
+    manual_blocks: manualBlocks.map((block) => block.code),
+    preconditions,
+  }));
+}
+
+export async function runMigrationProjectPlan(args: any): Promise<MigrationProjectPlanResult | MigrationProjectApplyStubResult> {
+  const mode = args?.mode === 'apply' ? 'apply' : 'plan';
+  const applyScope: ApplyScope = args?.apply_scope === 'safe_repairs_only' ? 'safe_repairs_only' : 'full';
+
+  if (mode === 'apply') {
+    return {
+      command: 'agenticos_migrate_project',
+      mode: 'apply',
+      status: 'BLOCK',
+      apply_scope: applyScope,
+      apply_supported: false,
+      block_reasons: ['apply mode is not implemented yet; use mode=plan to review the deterministic migration plan in the current #263 slice.'],
+      notes: [],
+    };
+  }
+
+  const resolved = await resolveMigrationCandidate(args ?? {});
+  if (!resolved.candidate) {
+    return {
+      command: 'agenticos_migrate_project',
+      mode: 'plan',
+      status: 'BLOCK',
+      apply_scope: applyScope,
+      apply_supported: false,
+      project: null,
+      audit_status: 'BLOCK',
+      audit_finding_counts: {
+        compatible_only: 0,
+        safe_lazy_repair: 0,
+        explicit_migration_required: 0,
+      },
+      safe_to_continue_without_migration: false,
+      plan_hash: null,
+      apply_ready: false,
+      planned_actions: [],
+      deferred_findings: [],
+      manual_blocks: [],
+      preconditions: null,
+      block_reasons: resolved.blockReasons,
+      notes: ['No writes occurred. Plan mode requires an explicit project selector in the current phase-2 slice.'],
+    };
+  }
+
+  const audit = await runMigrationAuditCheck({ project_path: resolved.candidate.projectPath });
+  const { plannedActions, deferredFindings, manualBlocks } = buildActions(audit, applyScope);
+  const preconditions = await buildPreconditions(resolved.candidate, audit, applyScope);
+  const planHash = buildPlanHash(audit, applyScope, plannedActions, deferredFindings, manualBlocks, preconditions);
+
+  const status: PlanStatus = manualBlocks.length > 0
+    ? 'BLOCK'
+    : plannedActions.length > 0
+      ? 'READY'
+      : 'NOOP';
+
+  return {
+    command: 'agenticos_migrate_project',
+    mode: 'plan',
+    status,
+    apply_scope: applyScope,
+    apply_supported: false,
+    project: audit.project,
+    audit_status: audit.status,
+    audit_finding_counts: audit.finding_counts,
+    safe_to_continue_without_migration: audit.safe_to_continue_without_migration,
+    plan_hash: planHash,
+    apply_ready: status === 'READY',
+    planned_actions: plannedActions,
+    deferred_findings: deferredFindings,
+    manual_blocks: manualBlocks,
+    preconditions,
+    block_reasons: status === 'BLOCK'
+      ? [
+          ...audit.block_reasons,
+          ...manualBlocks.map((block) => `${block.code}: ${block.reason}`),
+        ]
+      : [],
+    notes: [
+      ...audit.notes,
+      ...(status === 'READY' ? ['No writes occurred. This phase-2 slice only produces a deterministic migration plan.'] : []),
+      ...(status === 'NOOP' ? ['No writes occurred. The current project has no deterministic migration actions in this phase-2 slice.'] : []),
+    ],
+  };
+}

--- a/tasks/issue-263-legacy-project-migration-plan.md
+++ b/tasks/issue-263-legacy-project-migration-plan.md
@@ -292,6 +292,13 @@ Suggested command shape:
 
 - `agenticos_migrate_project`
 
+Current implementation state:
+
+- phase 2 minimum planner landed
+- `agenticos_migrate_project` now supports deterministic `plan` output
+- `apply` remains intentionally unimplemented and fail-closed in the current
+  slice
+
 Minimum inputs:
 
 - `project_path` or `project`
@@ -422,10 +429,10 @@ Canonical reviewed follow-up design for Workstream 2 is persisted in:
 
 ## Suggested Issue Checklist
 
-- [ ] Define the migration finding schema and severity model.
-- [ ] Implement report-only audit for a single project.
-- [ ] Implement home-wide report-only migration inventory.
-- [ ] Define the per-project migration action plan and dry-run output.
+- [x] Define the migration finding schema and severity model.
+- [x] Implement report-only audit for a single project.
+- [x] Implement home-wide report-only migration inventory.
+- [x] Define the per-project migration action plan and dry-run output.
 - [ ] Implement per-project explicit migration with evidence logging.
 - [ ] Document safe lazy repair cases allowed during explicit project entry.
 - [ ] Publish the upgrade guide and migration checklist.

--- a/tasks/issue-263-legacy-project-migration-plan.md
+++ b/tasks/issue-263-legacy-project-migration-plan.md
@@ -233,6 +233,47 @@ Acceptance criteria:
 - ambiguous identity fails closed
 - the same project can be audited repeatedly without side effects
 
+Initial finding schema for the first implementation slice:
+
+- `code`
+  - stable machine-readable finding identifier
+- `migration_class`
+  - `compatible_only`
+  - `safe_lazy_repair`
+  - `explicit_migration_required`
+- `severity`
+  - `info`
+  - `warning`
+  - `error`
+- `summary`
+  - concise human-readable explanation
+- `evidence`
+  - concrete file paths, field names, or mismatch values
+- `recommended_action`
+  - bounded next step
+- `safe_to_defer`
+  - whether operators can keep using the project under compatibility-on-read without immediate migration
+
+Initial audit coverage should detect at least:
+
+- populated legacy `registry.active_project`
+- registry path normalization drift
+- missing lightweight registry metadata such as `last_accessed`
+- missing or unreadable `.project.yaml`
+- missing `meta.id`
+- registry / `.project.yaml` identity mismatches
+- missing or invalid topology/publication-policy normalization
+- compatibility-only legacy `active_project` evidence still present in state artifacts
+
+Explicit first-slice boundary:
+
+- `agenticos_migrate_home --report-only` inventories registry-backed managed
+  projects only; it does not yet scan arbitrary on-disk directories under
+  `AGENTICOS_HOME/projects`
+- guardrail/state archaeology is intentionally narrow in the first slice; the
+  initial implementation only detects compatibility-era `active_project`
+  evidence, not every historical guardrail record shape
+
 ### Workstream 2: Per-Project Explicit Migration
 
 Goal:

--- a/tasks/issue-263-legacy-project-migration-plan.md
+++ b/tasks/issue-263-legacy-project-migration-plan.md
@@ -8,6 +8,10 @@ unsafe or misleading under the new concurrent runtime model.
 
 This migration problem should be tracked as a separate issue from `#262`.
 
+Detailed phase-2 technical review for the next implementation tranche:
+
+- `tasks/issue-263-phase2-technical-design-review.md`
+
 The migration contract should answer three questions:
 
 1. Which existing projects actually require migration?
@@ -280,6 +284,10 @@ Goal:
 
 - migrate one target project deliberately and safely
 
+Canonical reviewed phase-2 design:
+
+- `tasks/issue-263-phase2-technical-design-review.md`
+
 Suggested command shape:
 
 - `agenticos_migrate_project`
@@ -393,6 +401,13 @@ Recommended order:
 3. Workstream 2: per-project explicit migration
 4. Workstream 3: home-wide report and optional safe-repair expansion
 
+Detailed follow-up design review for Workstream 2:
+
+- see [tasks/issue-263-phase2-design-review.md](/Users/jeking/dev/AgenticOS/worktrees/agenticos-263-legacy-project-migration-audit/tasks/issue-263-phase2-design-review.md)
+- canonical technical detail lives in [tasks/issue-263-phase2-technical-design-review.md](/Users/jeking/dev/AgenticOS/worktrees/agenticos-263-legacy-project-migration-audit/tasks/issue-263-phase2-technical-design-review.md)
+- the next safe milestone is `agenticos_migrate_project` with explicit
+  `plan/apply` semantics, not home-wide apply mode
+
 Reasoning:
 
 - audit must exist before operators can trust migration decisions
@@ -400,6 +415,10 @@ Reasoning:
 - per-project explicit migration is safer than starting with home-wide mutation
 - estate-level apply behavior should only come after single-project migration is
   proven
+
+Canonical reviewed follow-up design for Workstream 2 is persisted in:
+
+- [issue-263-phase2-technical-design-review.md](/Users/jeking/dev/AgenticOS/worktrees/agenticos-263-legacy-project-migration-audit/tasks/issue-263-phase2-technical-design-review.md)
 
 ## Suggested Issue Checklist
 

--- a/tasks/issue-263-legacy-project-migration-plan.md
+++ b/tasks/issue-263-legacy-project-migration-plan.md
@@ -429,6 +429,10 @@ Canonical reviewed follow-up design for Workstream 2 is persisted in:
 
 - [issue-263-phase2-technical-design-review.md](/Users/jeking/dev/AgenticOS/worktrees/agenticos-263-legacy-project-migration-audit/tasks/issue-263-phase2-technical-design-review.md)
 
+Operator migration guide is persisted in:
+
+- [issue-263-operator-migration-guide.md](/Users/jeking/dev/AgenticOS/worktrees/agenticos-263-legacy-project-migration-audit/tasks/issue-263-operator-migration-guide.md)
+
 ## Suggested Issue Checklist
 
 - [x] Define the migration finding schema and severity model.
@@ -436,8 +440,8 @@ Canonical reviewed follow-up design for Workstream 2 is persisted in:
 - [x] Implement home-wide report-only migration inventory.
 - [x] Define the per-project migration action plan and dry-run output.
 - [x] Implement per-project explicit migration with evidence logging.
-- [ ] Document safe lazy repair cases allowed during explicit project entry.
-- [ ] Publish the upgrade guide and migration checklist.
+- [x] Document safe lazy repair cases allowed during explicit project entry.
+- [x] Publish the upgrade guide and migration checklist.
 - [ ] Decide whether home-wide apply-safe-repairs is warranted after single-project migration is proven.
 
 ## Decision

--- a/tasks/issue-263-legacy-project-migration-plan.md
+++ b/tasks/issue-263-legacy-project-migration-plan.md
@@ -433,6 +433,10 @@ Operator migration guide is persisted in:
 
 - [issue-263-operator-migration-guide.md](/Users/jeking/dev/AgenticOS/worktrees/agenticos-263-legacy-project-migration-audit/tasks/issue-263-operator-migration-guide.md)
 
+Remaining-scope review is persisted in:
+
+- [issue-263-remaining-items-review.md](/Users/jeking/dev/AgenticOS/worktrees/agenticos-263-legacy-project-migration-audit/tasks/issue-263-remaining-items-review.md)
+
 ## Suggested Issue Checklist
 
 - [x] Define the migration finding schema and severity model.
@@ -443,6 +447,14 @@ Operator migration guide is persisted in:
 - [x] Document safe lazy repair cases allowed during explicit project entry.
 - [x] Publish the upgrade guide and migration checklist.
 - [ ] Decide whether home-wide apply-safe-repairs is warranted after single-project migration is proven.
+
+Current judgment:
+
+- home-wide apply-safe-repairs remains deferred, not required for the core
+  `#263` target
+- broader structural apply should only continue for narrow deterministic cases
+- historical evidence rewrite and schema rename are not part of the current
+  issue target
 
 ## Decision
 

--- a/tasks/issue-263-legacy-project-migration-plan.md
+++ b/tasks/issue-263-legacy-project-migration-plan.md
@@ -296,8 +296,10 @@ Current implementation state:
 
 - phase 2 minimum planner landed
 - `agenticos_migrate_project` now supports deterministic `plan` output
-- `apply` remains intentionally unimplemented and fail-closed in the current
-  slice
+- `apply` is now implemented for the currently supported deterministic
+  per-project actions
+- `apply` still fails closed on manual-block states and does not broaden into
+  home-wide mutation
 
 Minimum inputs:
 
@@ -433,7 +435,7 @@ Canonical reviewed follow-up design for Workstream 2 is persisted in:
 - [x] Implement report-only audit for a single project.
 - [x] Implement home-wide report-only migration inventory.
 - [x] Define the per-project migration action plan and dry-run output.
-- [ ] Implement per-project explicit migration with evidence logging.
+- [x] Implement per-project explicit migration with evidence logging.
 - [ ] Document safe lazy repair cases allowed during explicit project entry.
 - [ ] Publish the upgrade guide and migration checklist.
 - [ ] Decide whether home-wide apply-safe-repairs is warranted after single-project migration is proven.

--- a/tasks/issue-263-operator-migration-guide.md
+++ b/tasks/issue-263-operator-migration-guide.md
@@ -1,0 +1,251 @@
+# #263 Operator Migration Guide
+
+## Purpose
+
+This guide explains how to migrate existing managed projects after `#262` and
+the `#263` audit / per-project migration work.
+
+It is written for the normalized runtime model:
+
+- `AGENTICOS_HOME` is a long-lived runtime workspace
+- managed projects live under `projects/`
+- a project may be source-managed inside its own project directory, but the
+  home itself is not the authoritative runtime current-project switch
+
+## What Changed After #262
+
+After `#262`:
+
+- runtime target resolution no longer depends on global `registry.active_project`
+- runtime resolution now prefers:
+  1. explicit target
+  2. provable `repo_path`
+  3. session-local binding
+  4. otherwise fail closed
+- `registry.active_project` remains compatibility-only schema state
+
+That means old homes and old projects may still work, but they can contain
+legacy state that is no longer the desired normalized contract.
+
+## Current Tooling Status
+
+Available now:
+
+- `agenticos_migration_audit`
+  - report-only, per-project
+- `agenticos_migrate_home --report-only`
+  - report-only, registry-backed home inventory
+- `agenticos_migrate_project mode=plan`
+  - deterministic per-project migration plan
+- `agenticos_migrate_project mode=apply`
+  - guarded apply for the currently supported deterministic actions
+
+Still intentionally out of scope:
+
+- home-wide apply
+- orphan discovery under `AGENTICOS_HOME/projects`
+- topology / identity guessing for ambiguous projects
+- rewriting historical guardrail / bootstrap / RCA evidence
+
+## Migration Strategy
+
+Use the hybrid strategy below.
+
+Do:
+
+1. audit first
+2. migrate only the projects you actually need
+3. apply per-project with reviewed `plan_hash`
+4. leave dormant or ambiguous projects alone until they need explicit handling
+
+Do not:
+
+- run a one-shot global mutation across the entire home
+- treat `registry.active_project` as current truth
+- rely on `switch` to silently perform structural migration
+
+## Which Projects Need Immediate Attention
+
+Prioritize these first:
+
+- active projects you are about to work on
+- projects with `explicit_migration_required` findings that block intended work
+- projects whose registry identity/path metadata is obviously stale
+
+Defer these when safe:
+
+- archived/reference projects
+- dormant projects not currently being used
+- projects with compatibility-only historical evidence but no execution impact
+
+## Standard Workflow
+
+### 1. Inventory The Home
+
+Run:
+
+- `agenticos_migrate_home --report-only`
+
+Use this to answer:
+
+- which registered projects are `PASS`
+- which are `WARN`
+- which are `BLOCK`
+- which projects are safe to defer
+
+### 2. Audit One Target Project
+
+Run:
+
+- `agenticos_migration_audit`
+  - with explicit `project` or `project_path`
+
+Use this when:
+
+- a specific project is about to be worked on
+- the home inventory showed a `WARN` or `BLOCK`
+- you want the exact finding-level detail before planning migration
+
+### 3. Build A Deterministic Plan
+
+Run:
+
+- `agenticos_migrate_project mode=plan`
+
+Required operator checks:
+
+- target identity is the intended project
+- `manual_blocks` is empty
+- planned actions are narrow and expected
+- `plan_hash` is present
+
+If `manual_blocks` is non-empty:
+
+- stop
+- do not try to force apply
+- fix the ambiguous or damaged state explicitly first
+
+### 4. Apply The Reviewed Plan
+
+Run:
+
+- `agenticos_migrate_project mode=apply expected_plan_hash=...`
+
+Apply is allowed only when:
+
+- the target is explicit
+- the reviewed `plan_hash` still matches
+- the project is not in a manual-blocked state
+
+Apply currently performs only deterministic per-project actions such as:
+
+- clearing compatibility-only `registry.active_project`
+- normalizing registry path storage
+- backfilling lightweight metadata such as `last_accessed`
+- rebuilding a missing state surface when the target contract is already proven
+- writing additive migration evidence
+
+### 5. Review Post-Apply Evidence
+
+After apply, inspect:
+
+- post-apply audit status
+- migration report under `artifacts/migrations/`
+- latest migration summary in state
+
+The migration should leave:
+
+- a narrower or empty set of actionable findings
+- no hidden mutation outside the selected project and supported registry fields
+
+## Per-Project Checklist
+
+Before apply:
+
+- [ ] I selected the project explicitly with `project` or `project_path`
+- [ ] I ran `agenticos_migration_audit`
+- [ ] I ran `agenticos_migrate_project mode=plan`
+- [ ] I reviewed the `plan_hash`
+- [ ] `manual_blocks` is empty
+- [ ] The planned actions are only the deterministic actions I intend to run
+
+After apply:
+
+- [ ] `mode=apply` succeeded without a hash mismatch
+- [ ] post-apply audit no longer shows the repaired findings
+- [ ] a migration report was written under `artifacts/migrations/`
+- [ ] state contains the latest migration summary pointer
+- [ ] no unrelated project was mutated
+
+## Mixed-State Rollout Guidance
+
+During rollout, it is normal for one home to contain a mix of:
+
+- fully normalized projects
+- compatible-but-not-yet-normalized projects
+- blocked projects requiring explicit operator repair
+
+That mixed state is acceptable.
+
+The important rule is:
+
+- compatibility-on-read is allowed
+- mutation is per-project and explicit
+
+This is why the recommended migration order is:
+
+1. projects you are actively using now
+2. projects you will use soon
+3. everything else later, only if needed
+
+## FAQ
+
+### Should I migrate every project immediately?
+
+No.
+
+Only migrate projects that need near-term work or have blocking findings you
+must clear.
+
+### Should migration happen automatically during `agenticos_switch`?
+
+Only in the narrow metadata-repair sense, and only for registry-local cleanup.
+
+Structural migration must remain explicit.
+
+### Does `agenticos_migrate_home --report-only` find every directory under `projects/`?
+
+No.
+
+Current home inventory is registry-backed. Unregistered directories are not yet
+discovered automatically.
+
+### Can `mode=apply` fix ambiguous identity or missing topology automatically?
+
+No.
+
+If the tool cannot prove the intended meaning safely, it must keep blocking.
+
+### Should historical evidence be rewritten to remove old `active_project` traces?
+
+Not by default.
+
+Historical evidence stays historical. New migration evidence is written
+additively instead.
+
+## Recommended Order For Existing Installations
+
+For an existing machine with historical drift:
+
+1. run `agenticos_migrate_home --report-only`
+2. choose one active project
+3. run `agenticos_migration_audit`
+4. run `agenticos_migrate_project mode=plan`
+5. run `agenticos_migrate_project mode=apply`
+6. repeat only for the next project that actually matters
+
+This gives the intended effect:
+
+- once-only coherent correction where needed
+- no unnecessary mutation of dormant projects
+- no regression to a global runtime current-project model

--- a/tasks/issue-263-phase2-design-review.md
+++ b/tasks/issue-263-phase2-design-review.md
@@ -1,0 +1,39 @@
+# #263 Phase 2 Design Review
+
+This file is the lightweight index for the phase-2 review.
+
+The consolidated technical proposal now lives in:
+
+- `tasks/issue-263-phase2-technical-design-review.md`
+
+Reviewed by three parallel Sub-agents plus local synthesis:
+
+- runtime semantics / command contract
+- migration action model / evidence strategy
+- concurrency safety / failure recovery
+
+## Scope
+
+The reviewed tranche is the next implementation step after the report-only audit
+slice:
+
+- explicit per-project migration
+- narrow safe lazy repair boundary
+- concurrency-safe apply semantics
+- failure recovery and migration evidence
+
+## Status
+
+Review synthesis completed.
+
+Current decision:
+
+- proceed with a per-project `dry_run` / explicit `apply` design
+- require explicit target selection for apply
+- keep registry writes patch-based
+- add a per-project migration lock and plan fingerprint precondition
+- keep historical evidence additive by default rather than rewriting it
+- defer home-wide apply, schema rename, and orphan discovery
+
+For the full rationale, command contract, concurrency model, and rollout
+recommendation, use the technical review document above as the canonical source.

--- a/tasks/issue-263-phase2-design-review.md
+++ b/tasks/issue-263-phase2-design-review.md
@@ -35,5 +35,12 @@ Current decision:
 - keep historical evidence additive by default rather than rewriting it
 - defer home-wide apply, schema rename, and orphan discovery
 
+Current implementation status:
+
+- deterministic `plan` is implemented
+- guarded per-project `apply` is implemented for the current deterministic
+  actions
+- broader structural apply and home-wide mutation are still deferred
+
 For the full rationale, command contract, concurrency model, and rollout
 recommendation, use the technical review document above as the canonical source.

--- a/tasks/issue-263-phase2-technical-design-review.md
+++ b/tasks/issue-263-phase2-technical-design-review.md
@@ -1,0 +1,387 @@
+# #263 Phase 2 Technical Design Review
+
+## Purpose
+
+This document reviews the next implementation tranche for `#263` after the
+report-only audit slice landed.
+
+The goal is to define a migration design that remains consistent with `#262`
+while making legacy managed projects repairable without reintroducing
+home-global runtime coupling.
+
+## Review Basis
+
+Current contract already established by `#262` and the first `#263` slice:
+
+- `AGENTICOS_HOME` is a long-term runtime workspace, not an authoritative
+  single-project source checkout
+- `projects/` contains many managed projects that may be active in parallel
+- runtime target resolution must remain:
+  - explicit target
+  - then provable `repo_path` where applicable
+  - then session-local binding
+  - otherwise fail closed
+- `registry.active_project` is compatibility-only schema state, not runtime
+  truth
+- `#263` slice 1 already provides report-only detection through
+  `agenticos_migration_audit` and `agenticos_migrate_home`
+
+Review lenses used for this design:
+
+1. runtime semantics and command contract
+2. migration action model and idempotency
+3. concurrency safety and failure recovery
+4. operator rollout and upgrade path
+
+## Current Gap
+
+The current implementation can detect legacy state, but it cannot yet:
+
+- execute a reviewed per-project migration plan
+- apply safe metadata repair deterministically
+- persist migration evidence for later audit
+- recover cleanly from an interrupted apply
+- define a trustworthy switch-time lazy-repair boundary
+
+That means `#263` currently proves where migration is needed, but not how to
+repair a project safely.
+
+## Critical Findings
+
+### 1. Apply mode must be explicit-target only
+
+`report-only` audit can safely fall back to the session-bound project.
+
+`apply` must not do that.
+
+Reason:
+
+- session-local selection is runtime convenience, not a strong enough mutation
+  intent boundary
+- migration changes durable project or registry state
+- the operator must prove which project is being mutated
+
+Design consequence:
+
+- `agenticos_migrate_project --apply` must require explicit `project` or
+  explicit `project_path`
+- session fallback may remain allowed for dry-run only, but should be avoided if
+  we want one mutation contract instead of two
+
+Recommended choice:
+
+- require explicit `project` or `project_path` for both `dry_run=false` and
+  `dry_run=true`
+- keep session fallback only on `agenticos_migration_audit`
+
+### 2. Dry-run and apply must share one planner
+
+If dry-run builds one result and apply reinterprets findings ad hoc, the design
+will drift and operators will stop trusting the tool.
+
+Design consequence:
+
+- introduce one internal planner that converts current project state into a
+  deterministic migration plan
+- `agenticos_migration_audit` remains a pure classifier
+- `agenticos_migrate_project --dry_run` returns the planned action list
+- `agenticos_migrate_project --apply` recomputes that same plan and refuses to
+  continue if it no longer matches the reviewed dry-run
+
+### 3. Registry writes must stay patch-based
+
+`#262` already established that business-path registry writes must use lock +
+reload + field patch + atomic rename.
+
+That rule must remain non-negotiable for migration apply.
+
+Must use patch-based registry APIs for:
+
+- clearing or downgrading legacy `active_project`
+- normalizing a project's stored path
+- backfilling `last_accessed`
+- updating any future migration metadata recorded in the registry
+
+Must not do:
+
+- load registry once, mutate in memory, and later write a full stale snapshot
+- combine unrelated project updates into one broad rewrite
+
+### 4. Project-file mutation needs its own lock boundary
+
+`registry.lock` protects only the home registry.
+
+It does not protect `.project.yaml`, `state.yaml`, or any migration report file
+inside a project.
+
+Design consequence:
+
+- add a per-project migration lock, e.g. under the resolved project context root
+- allow only one `agenticos_migrate_project --apply` per project at a time
+- keep registry mutation inside existing patch-based APIs when registry changes
+  are required during that same apply
+
+### 5. Structural migration must not guess topology when identity is ambiguous
+
+Some legacy projects can be normalized deterministically.
+
+Some cannot.
+
+Examples that should still block:
+
+- missing `.project.yaml` and registry identity cannot be proven
+- missing topology where runtime evidence cannot distinguish
+  `local_directory_only` from `github_versioned`
+- conflicting registry / `.project.yaml` identity
+- public/private continuity policy cannot be derived safely
+
+Design consequence:
+
+- `agenticos_migrate_project` should repair only deterministic cases
+- ambiguous cases must remain `BLOCK` with an explicit operator action
+- this issue should not smuggle in an unsafe topology inference engine
+
+### 6. Migration evidence should be additive, not historical rewrite by default
+
+Legacy compatibility evidence such as old `active_project` fields inside
+historical guardrail records is not current truth, but it is still historical
+evidence.
+
+Design consequence:
+
+- default migration should add a new migration report and state summary
+- it should not rewrite old guardrail evidence blobs by default
+- any compatibility-evidence rewrite should be an opt-in later capability, not
+  part of the minimal sufficient tranche
+
+## Recommended Command Contract
+
+### `agenticos_migrate_project`
+
+Recommended inputs:
+
+- `project_path` or `project`
+- `dry_run` default `true`
+- `apply_safe_repairs_only` default `false`
+- `expected_plan_fingerprint` required when `dry_run=false`
+
+Recommended outputs:
+
+- resolved project identity
+- current migration status
+- deterministic `plan_fingerprint`
+- planned actions in stable order
+- touched files / surfaces
+- which actions are:
+  - `safe_lazy_repair`
+  - `explicit_structural_migration`
+- whether apply is blocked
+- block reasons
+- migration report path when apply succeeds
+
+Recommended rules:
+
+- if `dry_run=true`, no writes occur
+- if `dry_run=false`, explicit `project` or `project_path` is required
+- if `dry_run=false`, `expected_plan_fingerprint` is required
+- apply recomputes the plan and fails closed if the fingerprint changed
+
+## Recommended Action Model
+
+The planner should emit bounded actions, not free-form repair logic.
+
+Recommended action families:
+
+1. `registry_patch`
+   - clear compatibility-only `active_project`
+   - normalize stored project path
+   - backfill lightweight registry metadata
+
+2. `project_yaml_patch`
+   - repair deterministic identity fields
+   - normalize deterministic topology fields only when provable
+   - normalize deterministic publication-policy fields only when provable
+
+3. `state_surface_repair`
+   - create missing state surface from the current contract
+   - backfill deterministic migration summary nodes
+
+4. `evidence_write`
+   - write a machine-readable migration report
+   - write a concise latest-migration summary into state
+
+Recommended non-goal for this tranche:
+
+- rewriting arbitrary historical guardrail/state evidence blobs
+
+## Safe Lazy Repair Boundary
+
+Safe lazy repair should remain narrow.
+
+Allowed lazy repairs during explicit project entry:
+
+- clear compatibility-only `registry.active_project`
+- backfill missing `last_accessed`
+- normalize a stored path from absolute-under-home to relative form
+
+Not allowed as lazy repair during `switch`:
+
+- rewriting `.project.yaml`
+- generating or rewriting project state structures with structural meaning
+- changing topology or publication policy
+- repairing identity mismatches
+
+Reason:
+
+- `switch` is still a routine context-load command
+- silent structural mutation during `switch` would violate the design intent of
+  `#263`
+
+## Concurrency And Failure Recovery
+
+## Required Write Order
+
+Minimal sufficient apply sequence:
+
+1. resolve explicit project target and prove identity
+2. acquire a project-local migration lock
+3. build migration plan
+4. compare plan fingerprint with `expected_plan_fingerprint`
+5. write project-local files using temp file + atomic rename
+6. apply registry patches through `patchRegistry()` or
+   `patchProjectMetadata()`
+7. write additive migration evidence
+8. release lock
+
+## Recovery Contract
+
+If apply is interrupted:
+
+- rerunning dry-run must rebuild the current plan from disk
+- already-completed atomic file writes remain valid
+- partially completed steps are re-evaluated rather than assumed
+- registry writes remain safe because they are patch-based under lock
+
+This means recovery is based on idempotent recomputation, not a separate
+rollback engine.
+
+Recommended minimum safeguards:
+
+- per-project migration lock
+- temp-file atomic rename for project-local file writes
+- patch-based registry mutation
+- deterministic planner
+- plan fingerprint check before apply
+
+## Fingerprint / Preconditions
+
+The minimal sufficient design should include a plan fingerprint.
+
+Recommended contents of the fingerprint:
+
+- project id
+- project path
+- relevant audit findings
+- current raw registry entry subset affecting the target
+- current `.project.yaml` content digest
+- current `state.yaml` content digest or missing marker
+- selected apply mode
+
+Recommended semantics:
+
+- dry-run returns `plan_fingerprint`
+- apply requires `expected_plan_fingerprint`
+- if any relevant input changed, apply returns `BLOCK` and tells the operator to
+  rerun dry-run
+
+This is enough optimistic concurrency for the current scope.
+
+A heavier transactional system is not necessary yet.
+
+## Evidence Persistence
+
+Recommended outputs after successful apply:
+
+1. a machine-readable migration report under the resolved runtime context tree
+2. a concise latest-migration summary in `state.yaml`
+
+Recommended report content:
+
+- migrated project identity
+- executed plan fingerprint
+- executed actions
+- skipped actions
+- blocked findings that remained unresolved
+- timestamps
+
+Reason for runtime-context storage instead of repo-root historical docs:
+
+- it keeps operator evidence near current runtime surfaces
+- it avoids forcing publishability assumptions for every source-managed project
+- it keeps historical issue/RCA documents intact
+
+## Rollout Strategy
+
+Recommended rollout remains hybrid:
+
+1. operator runs `agenticos_migrate_home --report-only`
+2. operator picks one active project
+3. operator runs `agenticos_migrate_project --dry_run`
+4. operator reviews the plan
+5. operator runs `agenticos_migrate_project --apply`
+6. only after repeated success do we consider optional home-wide safe-repair
+
+This still satisfies the long-term home model because:
+
+- dormant projects are not mutated unnecessarily
+- active projects can be normalized deliberately
+- multiple projects remain independently migratable
+- concurrent project work is preserved
+
+## What Is Not Necessary Right Now
+
+These items are explicitly deferrable:
+
+- renaming `active_project` to `last_selected_project`
+- home-wide `--apply-safe-repairs` mutation
+- filesystem-wide orphan discovery under `AGENTICOS_HOME/projects`
+- compatibility-evidence rewrite of historical guardrail blobs
+- a general rollback subsystem
+
+Deferring them does not block the core goal if per-project dry-run/apply is
+implemented correctly.
+
+## Can This Reach The Goal?
+
+Yes, if implemented with these constraints:
+
+- explicit-target apply only
+- one deterministic planner for dry-run and apply
+- patch-based registry writes only
+- per-project migration lock
+- plan fingerprint precondition
+- additive evidence writes
+- narrow lazy-repair boundary
+- fail closed on ambiguous topology or identity
+
+No, if implementation drifts into any of these patterns:
+
+- silent structural migration during `switch`
+- home-wide mutate-first rollout
+- reintroducing runtime dependence on `registry.active_project`
+- full-object registry rewrites from stale snapshots
+- rewriting historical evidence as a default side effect
+
+## Recommended Next Implementation Tranche
+
+The next tranche should be limited to:
+
+1. planner + `agenticos_migrate_project --dry_run`
+2. plan fingerprint + explicit apply
+3. per-project migration lock
+4. patch-based registry actions
+5. project-local state / evidence writes
+6. operator docs for the dry-run/apply workflow
+
+That is the minimal sufficient path that advances `#263` without reopening the
+state-model mistakes that `#262` just removed.

--- a/tasks/issue-263-phase2-technical-design-review.md
+++ b/tasks/issue-263-phase2-technical-design-review.md
@@ -43,8 +43,14 @@ The current implementation can detect legacy state, but it cannot yet:
 - recover cleanly from an interrupted apply
 - define a trustworthy switch-time lazy-repair boundary
 
-That means `#263` currently proves where migration is needed, but not how to
-repair a project safely.
+That phase-2 gap has now been partially closed:
+
+- deterministic planning is implemented
+- deterministic per-project apply is implemented
+- migration evidence is written additively
+
+What still remains open is broader structural apply beyond the currently
+implemented deterministic action set.
 
 ## Critical Findings
 

--- a/tasks/issue-263-pr-draft.md
+++ b/tasks/issue-263-pr-draft.md
@@ -1,0 +1,82 @@
+# PR Draft for #263
+
+Closes #263.
+
+## Title
+
+`design: add report-only legacy managed-project migration audit surfaces`
+
+## Summary
+
+This PR lands the first safe slice of `#263`.
+
+It adds report-only migration inventory commands after `#262` so operators can
+audit legacy managed-project state without mutating projects or the home
+registry.
+
+The new surface is intentionally audit-first:
+
+1. per-project audit via `agenticos_migration_audit`
+2. registry-backed home inventory via `agenticos_migrate_home`
+3. explicit `BLOCK` output for ambiguous or structurally unsafe states
+4. no apply-mode mutation yet
+
+## What Changed
+
+- added `agenticos_migration_audit` for per-project report-only migration checks
+- added `agenticos_migrate_home` for registry-backed home-wide inventory
+- implemented a structured finding model:
+  - `compatible_only`
+  - `safe_lazy_repair`
+  - `explicit_migration_required`
+- added detection for:
+  - populated legacy `registry.active_project`
+  - registry path normalization drift
+  - missing lightweight metadata such as `last_accessed`
+  - missing/unreadable `.project.yaml`
+  - missing `meta.id`
+  - registry / `.project.yaml` identity mismatches
+  - duplicate registry identity fields (`id` / `path` / `name`)
+  - invalid topology / publication-policy normalization
+  - compatibility-only legacy `active_project` evidence in state artifacts
+- treated archived/reference projects as inventory-only during audit instead of
+  forcing active managed-project topology/state checks
+- documented the report-only first-slice boundary and clarified that
+  `agenticos_migrate_home` currently inventories registry-backed projects rather
+  than scanning arbitrary on-disk directories
+
+## Verification
+
+- `npm test`
+- `npm run lint`
+
+Result:
+
+- `33` test files passed
+- `266` tests passed
+- lint passed
+
+## Key Files
+
+- `mcp-server/src/utils/migration-audit.ts`
+- `mcp-server/src/tools/migration-audit.ts`
+- `mcp-server/src/tools/__tests__/migration-audit.test.ts`
+- `mcp-server/src/index.ts`
+- `mcp-server/README.md`
+- `tasks/issue-263-legacy-project-migration-plan.md`
+
+## Follow-Ups
+
+- per-project explicit migration (`agenticos_migrate_project`) remains future
+  work in `#263`
+- home-wide apply-safe-repair mode is still intentionally deferred until
+  single-project migration is proven
+- filesystem-wide orphan discovery under `AGENTICOS_HOME/projects` is not part
+  of this first report-only slice
+
+## Risks / Notes
+
+- `agenticos_migrate_home` is registry-backed by design in this slice, so
+  unregistered directories are not yet inventoried
+- report-only audit can prove that migration is needed, but it does not perform
+  any mutation or write migration evidence yet

--- a/tasks/issue-263-pr-draft.md
+++ b/tasks/issue-263-pr-draft.md
@@ -8,23 +8,22 @@ Closes #263.
 
 ## Summary
 
-This PR lands the first safe slice of `#263`.
+This PR now covers the first complete operator-safe tranche of `#263`.
 
-It adds report-only migration inventory commands after `#262` so operators can
-audit legacy managed-project state without mutating projects or the home
-registry.
+It adds:
 
-The new surface is intentionally audit-first:
-
-1. per-project audit via `agenticos_migration_audit`
-2. registry-backed home inventory via `agenticos_migrate_home`
-3. explicit `BLOCK` output for ambiguous or structurally unsafe states
-4. no apply-mode mutation yet
+1. report-only migration audit and registry-backed home inventory
+2. reviewed phase-2 design documentation
+3. deterministic per-project migration planning
+4. guarded per-project apply for the currently supported deterministic actions
+5. operator migration guide and per-project checklist
 
 ## What Changed
 
 - added `agenticos_migration_audit` for per-project report-only migration checks
 - added `agenticos_migrate_home` for registry-backed home-wide inventory
+- added `agenticos_migrate_project` for deterministic per-project migration
+  planning and guarded apply
 - implemented a structured finding model:
   - `compatible_only`
   - `safe_lazy_repair`
@@ -41,9 +40,23 @@ The new surface is intentionally audit-first:
   - compatibility-only legacy `active_project` evidence in state artifacts
 - treated archived/reference projects as inventory-only during audit instead of
   forcing active managed-project topology/state checks
-- documented the report-only first-slice boundary and clarified that
+- added a reviewed phase-2 migration design with explicit invariants for:
+  - explicit-target apply
+  - plan hash verification
+  - project-local migration lock
+  - additive migration evidence
+- implemented guarded apply for the currently supported deterministic actions:
+  - patch-based registry cleanup
+  - state surface rebuild when already provable
+  - additive migration report + state summary pointer
+- documented the current migration boundary and clarified that
   `agenticos_migrate_home` currently inventories registry-backed projects rather
   than scanning arbitrary on-disk directories
+- published an operator migration guide with:
+  - upgrade guidance
+  - per-project checklist
+  - mixed-state rollout advice
+  - FAQ
 
 ## Verification
 
@@ -53,30 +66,36 @@ The new surface is intentionally audit-first:
 Result:
 
 - `33` test files passed
-- `266` tests passed
+- `274` tests passed
 - lint passed
 
 ## Key Files
 
 - `mcp-server/src/utils/migration-audit.ts`
+- `mcp-server/src/utils/migration-project.ts`
 - `mcp-server/src/tools/migration-audit.ts`
+- `mcp-server/src/tools/migration-project.ts`
 - `mcp-server/src/tools/__tests__/migration-audit.test.ts`
+- `mcp-server/src/tools/__tests__/migration-project.test.ts`
 - `mcp-server/src/index.ts`
 - `mcp-server/README.md`
 - `tasks/issue-263-legacy-project-migration-plan.md`
+- `tasks/issue-263-phase2-technical-design-review.md`
+- `tasks/issue-263-operator-migration-guide.md`
 
 ## Follow-Ups
 
-- per-project explicit migration (`agenticos_migrate_project`) remains future
-  work in `#263`
 - home-wide apply-safe-repair mode is still intentionally deferred until
-  single-project migration is proven
-- filesystem-wide orphan discovery under `AGENTICOS_HOME/projects` is not part
-  of this first report-only slice
+  single-project migration is proven across more real projects
+- filesystem-wide orphan discovery under `AGENTICOS_HOME/projects` is still not
+  part of this tranche
+- ambiguous identity / topology remediation remains explicit operator work, not
+  automatic migration
 
 ## Risks / Notes
 
-- `agenticos_migrate_home` is registry-backed by design in this slice, so
+- `agenticos_migrate_home` is registry-backed by design in this tranche, so
   unregistered directories are not yet inventoried
-- report-only audit can prove that migration is needed, but it does not perform
-  any mutation or write migration evidence yet
+- `agenticos_migrate_project` apply remains intentionally narrow and will still
+  block on ambiguous/manual states
+- historical evidence is preserved additively rather than rewritten

--- a/tasks/issue-263-pr-draft.md
+++ b/tasks/issue-263-pr-draft.md
@@ -4,7 +4,7 @@ Closes #263.
 
 ## Title
 
-`design: add report-only legacy managed-project migration audit surfaces`
+`design: add deterministic legacy project migration workflow`
 
 ## Summary
 
@@ -65,7 +65,7 @@ It adds:
 
 Result:
 
-- `33` test files passed
+- `34` test files passed
 - `274` tests passed
 - lint passed
 

--- a/tasks/issue-263-remaining-items-review.md
+++ b/tasks/issue-263-remaining-items-review.md
@@ -1,0 +1,244 @@
+# #263 Remaining Items Review
+
+## Purpose
+
+This document re-evaluates the remaining tail items after the current `#263`
+delivery state:
+
+- report-only audit is implemented
+- per-project deterministic planning is implemented
+- guarded deterministic per-project apply is implemented
+- operator migration guide and checklist are published
+
+The question is no longer “what else could be built”.
+
+The question is:
+
+- what is still necessary to satisfy the actual target model
+- what can be explicitly deferred
+- what should be closed instead of expanded
+
+## Decision Standard
+
+An item should remain in active scope only if it materially improves one of
+these goals:
+
+1. preserve the runtime-home model
+2. preserve safe multi-project parallel work
+3. make existing installations operable without forcing global mutation
+4. improve operator correctness in realistic migration workflows
+
+If an item mainly expands surface area without materially improving those
+outcomes, it should be deferred or closed.
+
+## Current Delivery Baseline
+
+Already delivered inside `#263`:
+
+- `agenticos_migration_audit`
+- `agenticos_migrate_home --report-only`
+- `agenticos_migrate_project mode=plan`
+- `agenticos_migrate_project mode=apply` for the currently supported
+  deterministic actions
+- phase-2 technical review
+- operator migration guide
+
+That means the core migration contract is now present:
+
+- audit
+- plan
+- guarded apply
+- evidence
+- operator documentation
+
+## Remaining Items
+
+### A. Home-Wide `apply-safe-repairs`
+
+#### Assessment
+
+Not necessary for the core target model.
+
+Reason:
+
+- the runtime-home model does not require estate-wide mutation
+- per-project migration already satisfies the active-project workflow
+- home-wide apply increases blast radius immediately
+- the operator guide already gives a safe incremental path
+
+#### Decision
+
+Defer.
+
+#### Reopen Only If
+
+- repeated real-world use shows that per-project apply creates unacceptable
+  operational overhead
+- a large estate has many low-risk registry-only repairs where bulk apply would
+  materially reduce toil
+
+#### Current Status
+
+- not required to close `#263`
+- should not be implemented now
+
+### B. Filesystem Orphan Discovery Under `AGENTICOS_HOME/projects`
+
+#### Assessment
+
+Useful, but not necessary for the current migration contract.
+
+Reason:
+
+- current inventory is registry-backed by design
+- the runtime model already works when project targeting is explicit
+- orphan discovery is an estate hygiene capability, not a prerequisite for safe
+  per-project migration
+- adding it now would broaden `#263` from migration correctness into discovery
+  policy
+
+#### Decision
+
+Defer, likely as a follow-up issue rather than extending `#263`.
+
+#### Reopen Only If
+
+- operators repeatedly encounter materially important unregistered project
+  directories
+- a future home-integrity or estate-audit feature needs filesystem discovery as
+  a first-class capability
+
+### C. Broader Structural Apply Beyond The Current Deterministic Actions
+
+#### Assessment
+
+Partially necessary, but not all at once.
+
+Reason:
+
+- current apply only covers the deterministic safe subset
+- some blocked findings may remain too manual for comfortable operator use
+- however, broadening structural apply too fast risks reintroducing guessing and
+  silent scope creep
+
+#### Decision
+
+Keep open, but narrow the remaining active scope.
+
+#### What Stays In Scope
+
+- only additional deterministic, provable, per-project structural repairs
+- only when the planner can describe them precisely and fail closed on
+  ambiguity
+
+#### What Leaves Scope
+
+- topology guessing
+- identity conflict auto-repair
+- damage recovery for unreadable YAML without trustworthy source inputs
+
+#### Working Rule
+
+Every new apply action must pass this test:
+
+- can the tool prove the intended target meaning without inference?
+
+If not, it should remain `manual_block`.
+
+### D. Historical Evidence Rewrite
+
+#### Assessment
+
+Not necessary, and harmful as a default.
+
+Reason:
+
+- historical evidence should remain historical evidence
+- additive migration reports already solve the operator/auditability need
+- rewriting history would blur provenance and expand risk without improving the
+  runtime model
+
+#### Decision
+
+Close for `#263`.
+
+Do not continue this direction in the current issue.
+
+### E. Schema Rename `active_project -> last_selected_project`
+
+#### Assessment
+
+Not necessary.
+
+Reason:
+
+- `#262` already removed runtime dependence on `active_project`
+- the remaining field is compatibility-only schema baggage, not runtime truth
+- renaming it now adds migration surface but does not materially improve
+  operator outcomes
+
+#### Decision
+
+Close for `#263`.
+
+If ever revisited, it should be justified as a separate schema cleanup issue,
+not bundled into migration correctness work.
+
+### F. General Rollback Subsystem
+
+#### Assessment
+
+Not necessary right now.
+
+Reason:
+
+- the current apply path is already constrained to deterministic actions
+- writes are patch-based or atomic
+- rerun + post-audit is the current recovery model
+- a general rollback framework would add much more machinery than the current
+  scope justifies
+
+#### Decision
+
+Defer.
+
+Only reopen if actual field usage shows repeated partial-apply recovery pain.
+
+## Recommended Closure State For #263
+
+### Keep Active
+
+- narrowly expand deterministic per-project structural apply only if real
+  operator cases justify it
+
+### Defer
+
+- home-wide `apply-safe-repairs`
+- filesystem orphan discovery
+- general rollback subsystem
+
+### Close
+
+- historical evidence rewrite as a default migration behavior
+- schema rename of `active_project`
+
+## Final Judgment
+
+`#263` has already reached the core target.
+
+It now provides:
+
+- audit
+- deterministic plan
+- guarded per-project apply
+- additive evidence
+- operator migration guidance
+
+That is sufficient to support the long-term runtime-home / multi-project model
+without reintroducing global current-project semantics.
+
+So the correct posture from here is:
+
+- stop expanding by default
+- only reopen narrowly justified deterministic apply actions
+- move estate-hygiene extras into follow-up issues if they become necessary

--- a/tasks/issue-263-submission-evidence.md
+++ b/tasks/issue-263-submission-evidence.md
@@ -1,0 +1,56 @@
+# Submission Evidence
+
+## Scope
+- Issue: `#263` design: legacy managed-project migration plan after `#262`
+- Task type: report-only migration audit surface, operator contract clarification, first-slice documentation
+- Branch: `redesign/263-legacy-project-migration-audit`
+- Worktree: `/Users/jeking/dev/AgenticOS/worktrees/agenticos-263-legacy-project-migration-audit`
+
+## Preflight
+- Preflight passed: not applicable for this product-repo audit/design tooling tranche
+- Blocking exceptions: none during local implementation verification
+
+## Design Loop
+- Design pass count: 1 persisted migration plan, then 1 implementation refinement pass after code/test/doc review
+- Critique completed: yes; code semantics, test coverage, and operator-facing contract were re-audited before submission
+- Acceptance defined before edit: yes; persisted in [tasks/issue-263-legacy-project-migration-plan.md](/Users/jeking/dev/AgenticOS/worktrees/agenticos-263-legacy-project-migration-audit/tasks/issue-263-legacy-project-migration-plan.md)
+
+## Sub-Agent Verification
+- Sub-agents used: 3 parallel audits
+- Inheritance packet defined: yes; each audit received the `#262` concurrent-runtime background plus `#263` first-slice goal
+- Sub-agent understanding verified before work: yes; scopes were separated into runtime semantics, test coverage, and operator UX/docs
+- Parent agent distilled important results back into canonical files: yes; findings were reflected into runtime code, tests, and persisted task docs
+
+## Verification
+- Deliverable type: MCP report-only migration audit tooling plus supporting docs
+- Commands run:
+  - `npm test -- src/tools/__tests__/migration-audit.test.ts`
+  - `npm test`
+  - `npm run lint`
+- Coverage result:
+  - `33` test files passed
+  - `266` tests passed
+  - lint passed
+- Rubric evaluation result: not applicable
+- Evidence files:
+  - [tasks/issue-263-legacy-project-migration-plan.md](/Users/jeking/dev/AgenticOS/worktrees/agenticos-263-legacy-project-migration-audit/tasks/issue-263-legacy-project-migration-plan.md)
+  - [tasks/issue-263-pr-draft.md](/Users/jeking/dev/AgenticOS/worktrees/agenticos-263-legacy-project-migration-audit/tasks/issue-263-pr-draft.md)
+  - [mcp-server/src/utils/migration-audit.ts](/Users/jeking/dev/AgenticOS/worktrees/agenticos-263-legacy-project-migration-audit/mcp-server/src/utils/migration-audit.ts)
+  - [mcp-server/src/tools/migration-audit.ts](/Users/jeking/dev/AgenticOS/worktrees/agenticos-263-legacy-project-migration-audit/mcp-server/src/tools/migration-audit.ts)
+  - [mcp-server/src/tools/__tests__/migration-audit.test.ts](/Users/jeking/dev/AgenticOS/worktrees/agenticos-263-legacy-project-migration-audit/mcp-server/src/tools/__tests__/migration-audit.test.ts)
+  - [mcp-server/src/index.ts](/Users/jeking/dev/AgenticOS/worktrees/agenticos-263-legacy-project-migration-audit/mcp-server/src/index.ts)
+  - [mcp-server/README.md](/Users/jeking/dev/AgenticOS/worktrees/agenticos-263-legacy-project-migration-audit/mcp-server/README.md)
+
+## Residual Risk
+- Remaining limitations:
+  - apply-mode migration is intentionally not implemented in this slice
+  - `agenticos_migrate_home` inventories registry-backed managed projects only
+  - orphan directories under `AGENTICOS_HOME/projects` still require future discovery logic if that becomes part of the migration contract
+- Explicit exceptions:
+  - did not implement mutate-first migration
+  - did not add home-wide apply-safe-repair behavior
+  - did not broaden the first slice into generic historical guardrail archaeology
+
+## Ready To Submit
+- Yes/No: yes, for commit/PR preparation
+- If no, what is blocked:


### PR DESCRIPTION
# PR Draft for #263

Closes #263.

## Title

`design: add deterministic legacy project migration workflow`

## Summary

This PR now covers the first complete operator-safe tranche of `#263`.

It adds:

1. report-only migration audit and registry-backed home inventory
2. reviewed phase-2 design documentation
3. deterministic per-project migration planning
4. guarded per-project apply for the currently supported deterministic actions
5. operator migration guide and per-project checklist

## What Changed

- added `agenticos_migration_audit` for per-project report-only migration checks
- added `agenticos_migrate_home` for registry-backed home-wide inventory
- added `agenticos_migrate_project` for deterministic per-project migration
  planning and guarded apply
- implemented a structured finding model:
  - `compatible_only`
  - `safe_lazy_repair`
  - `explicit_migration_required`
- added detection for:
  - populated legacy `registry.active_project`
  - registry path normalization drift
  - missing lightweight metadata such as `last_accessed`
  - missing/unreadable `.project.yaml`
  - missing `meta.id`
  - registry / `.project.yaml` identity mismatches
  - duplicate registry identity fields (`id` / `path` / `name`)
  - invalid topology / publication-policy normalization
  - compatibility-only legacy `active_project` evidence in state artifacts
- treated archived/reference projects as inventory-only during audit instead of
  forcing active managed-project topology/state checks
- added a reviewed phase-2 migration design with explicit invariants for:
  - explicit-target apply
  - plan hash verification
  - project-local migration lock
  - additive migration evidence
- implemented guarded apply for the currently supported deterministic actions:
  - patch-based registry cleanup
  - state surface rebuild when already provable
  - additive migration report + state summary pointer
- documented the current migration boundary and clarified that
  `agenticos_migrate_home` currently inventories registry-backed projects rather
  than scanning arbitrary on-disk directories
- published an operator migration guide with:
  - upgrade guidance
  - per-project checklist
  - mixed-state rollout advice
  - FAQ

## Verification

- `npm test`
- `npm run lint`

Result:

- `34` test files passed
- `274` tests passed
- lint passed

## Key Files

- `mcp-server/src/utils/migration-audit.ts`
- `mcp-server/src/utils/migration-project.ts`
- `mcp-server/src/tools/migration-audit.ts`
- `mcp-server/src/tools/migration-project.ts`
- `mcp-server/src/tools/__tests__/migration-audit.test.ts`
- `mcp-server/src/tools/__tests__/migration-project.test.ts`
- `mcp-server/src/index.ts`
- `mcp-server/README.md`
- `tasks/issue-263-legacy-project-migration-plan.md`
- `tasks/issue-263-phase2-technical-design-review.md`
- `tasks/issue-263-operator-migration-guide.md`

## Follow-Ups

- home-wide apply-safe-repair mode is still intentionally deferred until
  single-project migration is proven across more real projects
- filesystem-wide orphan discovery under `AGENTICOS_HOME/projects` is still not
  part of this tranche
- ambiguous identity / topology remediation remains explicit operator work, not
  automatic migration

## Risks / Notes

- `agenticos_migrate_home` is registry-backed by design in this tranche, so
  unregistered directories are not yet inventoried
- `agenticos_migrate_project` apply remains intentionally narrow and will still
  block on ambiguous/manual states
- historical evidence is preserved additively rather than rewritten
