### PR TITLE
release: prepare v0.4.3 for session-local runtime resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No unreleased changes._
 
+## [0.4.3] — 2026-04-10
+
+### Fixed
+- Homebrew-installed runtime now includes the merged `#260` and `#262`
+  project-resolution fixes, so runtime command resolution no longer depends on
+  a home-global authoritative `registry.active_project`
+- explicit project selection, session-bound project tools, and guardrail
+  `repo_path` proof are no longer vetoed by unrelated cross-project current
+  selection drift in the installed runtime
+- registry business-path writes now use patch-based locked atomic updates on
+  the shipped runtime paths, which reduces cross-session metadata replay and
+  stale full-registry overwrite risk
+
+### Changed
+- `agenticos_switch` now binds the current MCP session instead of mutating a
+  home-global runtime current-project selector
+- generated `AGENTS.md` and `CLAUDE.md` guidance now describes session-local
+  project alignment instead of a shared active-project model
+
 ## [0.4.2] — 2026-04-09
 
 ### Fixed

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenticos-mcp",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenticos-mcp",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-mcp",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "MCP Server for AgenticOS - AI-native project management system",
   "type": "module",
   "bin": {

--- a/tasks/issue-266-homebrew-runtime-session-local-release.md
+++ b/tasks/issue-266-homebrew-runtime-session-local-release.md
@@ -1,0 +1,56 @@
+---
+issue: 266
+title: ship patch release so Homebrew runtime includes #262 session-local project resolution
+status: in_progress
+owners:
+  - codex
+created: 2026-04-10
+---
+
+## Goal
+
+Ship the next AgenticOS patch release so the standard Homebrew-installed
+runtime includes the merged `#262` session-local project resolution redesign.
+
+## Why
+
+Live validation on 2026-04-10 confirmed:
+
+- `#262` / `PR #264` is merged to source `main`
+- the machine runtime is still Homebrew `agenticos-mcp 0.4.2`
+- running MCP processes still come from `/opt/homebrew/bin/agenticos-mcp`
+- the installed runtime therefore still reproduces cross-project
+  `active_project` drift and mismatch semantics
+
+So release parity, not source correctness, is now the blocker.
+
+## Deliverables
+
+- bump `mcp-server/package.json` to the next patch version
+- update `mcp-server/package-lock.json` version metadata
+- add release notes to `CHANGELOG.md`
+- tag and publish the new GitHub release artifact
+- update the Homebrew tap formula version/url/sha256
+- upgrade and verify the Homebrew-installed runtime on this machine
+
+## Notes
+
+- this issue exists because closed `#215` only covered the earlier
+  canonical-main write-protection release parity tranche
+- this tranche is specifically about shipping the merged `#262` runtime-model
+  redesign into the installed Homebrew runtime
+- do not expand `#263` migration-policy scope in this issue
+
+## Self-check
+
+### Rule-based
+
+- patch bump only
+- no new runtime-model design changes here; ship the merged fix set
+- changelog must describe the real install-time runtime impact
+
+### Executable
+
+- `npm test`
+- `npm run lint`
+- `agenticos-mcp --version` from the built output reports `0.4.3`

--- a/tasks/issue-266-pr-draft.md
+++ b/tasks/issue-266-pr-draft.md
@@ -1,0 +1,60 @@
+# PR Draft for #266
+
+Closes #266.
+
+## Title
+
+`release: prepare v0.4.3 for session-local runtime resolution`
+
+## Summary
+
+This PR prepares the next AgenticOS patch release so the standard
+Homebrew-installed runtime can pick up the merged `#262` session-local project
+resolution redesign.
+
+This tranche is release-prep only:
+
+1. patch version bump to `0.4.3`
+2. changelog entry for the runtime-model fix set
+3. issue task record for the release-parity work
+
+Release artifact publication, tag push, Homebrew formula sha update, and local
+reinstall/verification remain the follow-up execution steps after merge.
+
+## What Changed
+
+- bumped `mcp-server/package.json` to `0.4.3`
+- updated `mcp-server/package-lock.json` version metadata
+- added the `0.4.3` changelog entry describing the installed-runtime impact of
+  `#260` and `#262`
+- added the issue task file for runtime release parity execution
+
+## Verification
+
+- `npm test`
+- `npm run lint`
+- `node build/index.js --version`
+
+Result:
+
+- `32` test files passed
+- `255` tests passed
+- lint passed
+- build output reports `0.4.3`
+
+## Key Files
+
+- `mcp-server/package.json`
+- `mcp-server/package-lock.json`
+- `CHANGELOG.md`
+- `tasks/issue-266-homebrew-runtime-session-local-release.md`
+
+## Follow-Ups
+
+- merge this PR
+- create and push tag `v0.4.3`
+- wait for the GitHub release asset `agenticos-mcp.tgz`
+- update `madlouse/homebrew-agenticos` formula version/url/sha256
+- `brew upgrade agenticos`
+- restart MCP clients and verify the installed runtime no longer reproduces the
+  old `active_project` mismatch semantics


### PR DESCRIPTION
# PR Draft for #266

Closes #266.

## Title

`release: prepare v0.4.3 for session-local runtime resolution`

## Summary

This PR prepares the next AgenticOS patch release so the standard
Homebrew-installed runtime can pick up the merged `#262` session-local project
resolution redesign.

This tranche is release-prep only:

1. patch version bump to `0.4.3`
2. changelog entry for the runtime-model fix set
3. issue task record for the release-parity work

Release artifact publication, tag push, Homebrew formula sha update, and local
reinstall/verification remain the follow-up execution steps after merge.

## What Changed

- bumped `mcp-server/package.json` to `0.4.3`
- updated `mcp-server/package-lock.json` version metadata
- added the `0.4.3` changelog entry describing the installed-runtime impact of
  `#260` and `#262`
- added the issue task file for runtime release parity execution

## Verification

- `npm test`
- `npm run lint`
- `node build/index.js --version`

Result:

- `32` test files passed
- `255` tests passed
- lint passed
- build output reports `0.4.3`

## Key Files

- `mcp-server/package.json`
- `mcp-server/package-lock.json`
- `CHANGELOG.md`
- `tasks/issue-266-homebrew-runtime-session-local-release.md`

## Follow-Ups

- merge this PR
- create and push tag `v0.4.3`
- wait for the GitHub release asset `agenticos-mcp.tgz`
- update `madlouse/homebrew-agenticos` formula version/url/sha256
- `brew upgrade agenticos`
- restart MCP clients and verify the installed runtime no longer reproduces the
  old `active_project` mismatch semantics
