### PR TITLE
fix: validate guardrails against worktree repo identity

### DIFF
--- a/mcp-server/src/tools/__tests__/branch-bootstrap.test.ts
+++ b/mcp-server/src/tools/__tests__/branch-bootstrap.test.ts
@@ -179,10 +179,57 @@ describe('runBranchBootstrap', () => {
     expect(result.block_reasons[0]).toContain('failed to resolve remote base');
   });
 
-  it('returns BLOCK when the git common repo root is not declared for the target project', async () => {
+  it('returns CREATED when the worktree root is declared even if the common repo root differs', async () => {
+    resolveGuardrailProjectTargetMock.mockResolvedValue({
+      activeProjectId: 'agenticos',
+      resolutionSource: 'repo_path_match',
+      resolutionErrors: [],
+      targetProject: {
+        id: 'agenticos',
+        name: 'AgenticOS',
+        path: '/repo/worktrees/issue-160',
+        statePath: '/repo/worktrees/issue-160/.context/state.yaml',
+        projectYamlPath: '/repo/worktrees/issue-160/.project.yaml',
+        sourceRepoRoots: ['/repo/worktrees/issue-160'],
+        sourceRepoRootsDeclared: true,
+      },
+    });
     execAsyncMock.mockImplementation(async (cmd: string) => {
       if (cmd.includes('rev-parse --show-toplevel')) {
         return { stdout: '/repo/worktrees/issue-160\n', stderr: '' };
+      }
+      if (cmd.includes('rev-parse --git-common-dir')) {
+        return { stdout: '/external/.git\n', stderr: '' };
+      }
+      if (cmd.includes('rev-parse origin/main')) {
+        return { stdout: 'base123\n', stderr: '' };
+      }
+      if (cmd.includes('show-ref --verify --quiet refs/heads/fix/160-boundary')) {
+        throw new Error('branch missing');
+      }
+      if (cmd.includes('worktree add "/tmp/worktrees/external-160-boundary" -b fix/160-boundary base123')) {
+        return { stdout: 'Preparing worktree\n', stderr: '' };
+      }
+      throw new Error(`Unexpected command: ${cmd}`);
+    });
+
+    const result = JSON.parse(await runBranchBootstrap({
+      issue_id: '160',
+      branch_type: 'fix',
+      slug: 'boundary',
+      repo_path: '/repo/worktrees/issue-160',
+      worktree_root: '/tmp/worktrees',
+    })) as { status: string; block_reasons: string[]; worktree_path: string };
+
+    expect(result.status).toBe('CREATED');
+    expect(result.worktree_path).toBe('/tmp/worktrees/external-160-boundary');
+    expect(result.block_reasons).toEqual([]);
+  });
+
+  it('returns BLOCK when neither the worktree root nor the common repo root is declared for the target project', async () => {
+    execAsyncMock.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('rev-parse --show-toplevel')) {
+        return { stdout: '/wrong/worktrees/issue-160\n', stderr: '' };
       }
       if (cmd.includes('rev-parse --git-common-dir')) {
         return { stdout: '/external/.git\n', stderr: '' };
@@ -200,11 +247,11 @@ describe('runBranchBootstrap', () => {
       issue_id: '160',
       branch_type: 'fix',
       slug: 'boundary',
-      repo_path: '/repo/worktrees/issue-160',
+      repo_path: '/wrong/worktrees/issue-160',
       worktree_root: '/tmp/worktrees',
     })) as { status: string; block_reasons: string[] };
 
     expect(result.status).toBe('BLOCK');
-    expect(result.block_reasons.join(' ')).toContain('not declared for target project');
+    expect(result.block_reasons.join(' ')).toContain('neither git worktree root');
   });
 });

--- a/mcp-server/src/tools/__tests__/edit-guard.test.ts
+++ b/mcp-server/src/tools/__tests__/edit-guard.test.ts
@@ -266,7 +266,75 @@ describe('runEditGuard', () => {
     expect(result.block_reasons.join(' ')).toContain('exceed the latest preflight scope');
   });
 
-  it('blocks bugfix edits when the git common repo root is not declared for the target project', async () => {
+  it('passes bugfix edits when the worktree root is declared even if the common repo root differs', async () => {
+    resolveGuardrailProjectTargetMock.mockResolvedValue({
+      activeProjectId: 'agenticos-standards',
+      resolutionSource: 'repo_path_match',
+      resolutionErrors: [],
+      targetProject: {
+        id: 'agenticos-standards',
+        name: 'agenticos-standards',
+        path: '/workspace/worktrees/issue-268',
+        statePath: '/workspace/worktrees/issue-268/.context/state.yaml',
+        projectYamlPath: '/workspace/worktrees/issue-268/.project.yaml',
+        sourceRepoRoots: ['/workspace/worktrees/issue-268'],
+        sourceRepoRootsDeclared: true,
+      },
+    });
+    execAsyncMock.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('rev-parse --show-toplevel')) {
+        return { stdout: '/workspace/worktrees/issue-268\n', stderr: '' };
+      }
+      if (cmd.includes('rev-parse --git-common-dir')) {
+        return { stdout: '/workspace/projects/agenticos/.git\n', stderr: '' };
+      }
+      if (cmd.includes('rev-parse --abbrev-ref HEAD')) {
+        return { stdout: 'fix/268-fix-guardrail-worktree-repo-identity\n', stderr: '' };
+      }
+      throw new Error(`Unexpected command: ${cmd}`);
+    });
+    readFileMock.mockImplementation(async (path: string) => {
+      if (path.endsWith('/.context/state.yaml')) {
+        return JSON.stringify({
+          issue_bootstrap: {
+            latest: {
+              issue_id: '268',
+              repo_path: '/workspace/worktrees/issue-268',
+              current_branch: 'fix/268-fix-guardrail-worktree-repo-identity',
+            },
+          },
+          guardrail_evidence: {
+            preflight: {
+              issue_id: '268',
+              repo_path: '/workspace/worktrees/issue-268',
+              declared_target_files: [
+                'projects/agenticos/mcp-server/src/tools/preflight.ts',
+              ],
+              result: {
+                status: 'PASS',
+              },
+            },
+          },
+        });
+      }
+      throw new Error(`Unexpected path: ${path}`);
+    });
+
+    const result = JSON.parse(await runEditGuard({
+      issue_id: '268',
+      task_type: 'bugfix',
+      repo_path: '/workspace/worktrees/issue-268',
+      project_path: '/workspace/worktrees/issue-268',
+      declared_target_files: [
+        'projects/agenticos/mcp-server/src/tools/preflight.ts',
+      ],
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('PASS');
+    expect(result.block_reasons).toEqual([]);
+  });
+
+  it('blocks bugfix edits when neither the worktree root nor the common repo root is declared for the target project', async () => {
     execAsyncMock.mockImplementation(async (cmd: string) => {
       if (cmd.includes('rev-parse --show-toplevel')) {
         return { stdout: '/workspace/wrong-repo\n', stderr: '' };
@@ -291,6 +359,6 @@ describe('runEditGuard', () => {
     })) as { status: string; block_reasons: string[] };
 
     expect(result.status).toBe('BLOCK');
-    expect(result.block_reasons.join(' ')).toContain('not declared for target project');
+    expect(result.block_reasons.join(' ')).toContain('neither git worktree root');
   });
 });

--- a/mcp-server/src/tools/__tests__/issue-bootstrap.test.ts
+++ b/mcp-server/src/tools/__tests__/issue-bootstrap.test.ts
@@ -141,4 +141,47 @@ describe('runIssueBootstrap', () => {
     expect(result.block_reasons.join(' ')).toContain('context_reset_performed');
     expect(persistIssueBootstrapEvidenceMock).not.toHaveBeenCalled();
   });
+
+  it('records issue bootstrap evidence when the worktree root is declared even if the common repo root differs', async () => {
+    resolveGuardrailProjectTargetMock.mockResolvedValue({
+      activeProjectId: 'agenticos',
+      resolutionSource: 'repo_path_match',
+      resolutionErrors: [],
+      targetProject: {
+        id: 'agenticos',
+        name: 'AgenticOS',
+        path: '/workspace/worktrees/issue-268',
+        statePath: '/workspace/worktrees/issue-268/.context/state.yaml',
+        projectYamlPath: '/workspace/worktrees/issue-268/.project.yaml',
+        sourceRepoRoots: ['/workspace/worktrees/issue-268'],
+        sourceRepoRootsDeclared: true,
+      },
+    });
+    readFileMock.mockResolvedValue(JSON.stringify({
+      meta: { id: 'agenticos' },
+      agent_context: {
+        quick_start: '.context/quick-start.md',
+        current_state: '.context/state.yaml',
+      },
+    }));
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/workspace/worktrees/issue-268\n',
+      'rev-parse --git-common-dir': '/workspace/projects/agenticos/.git\n',
+      'rev-parse --abbrev-ref HEAD': 'fix/268-fix-guardrail-worktree-repo-identity\n',
+      'worktree list --porcelain': 'worktree /workspace/projects/agenticos\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /workspace/worktrees/issue-268\nHEAD abc123\nbranch refs/heads/fix/268-fix-guardrail-worktree-repo-identity\n',
+    });
+
+    const result = JSON.parse(await runIssueBootstrap({
+      issue_id: '268',
+      issue_title: 'Fix guardrail worktree false-block',
+      context_reset_performed: true,
+      project_hot_load_performed: true,
+      issue_payload_attached: true,
+      repo_path: '/workspace/worktrees/issue-268',
+      project_path: '/workspace/worktrees/issue-268',
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('RECORDED');
+    expect(result.block_reasons).toEqual([]);
+  });
 });

--- a/mcp-server/src/tools/__tests__/pr-scope-check.test.ts
+++ b/mcp-server/src/tools/__tests__/pr-scope-check.test.ts
@@ -253,7 +253,21 @@ describe('runPrScopeCheck', () => {
     expect(result.block_reasons[0]).toContain('not comparable');
   });
 
-  it('returns BLOCK when the git common repo root is not declared for the target project', async () => {
+  it('returns PASS when the worktree root is declared even if the common repo root differs', async () => {
+    resolveGuardrailProjectTargetMock.mockResolvedValue({
+      activeProjectId: 'agenticos',
+      resolutionSource: 'repo_path_match',
+      resolutionErrors: [],
+      targetProject: {
+        id: 'agenticos',
+        name: 'AgenticOS',
+        path: '/repo/worktrees/issue-160',
+        statePath: '/repo/worktrees/issue-160/.context/state.yaml',
+        projectYamlPath: '/repo/worktrees/issue-160/.project.yaml',
+        sourceRepoRoots: ['/repo/worktrees/issue-160'],
+        sourceRepoRootsDeclared: true,
+      },
+    });
     mockGitResponses({
       'rev-parse --show-toplevel': '/repo/worktrees/issue-160\n',
       'rev-parse --git-common-dir': '/external/.git\n',
@@ -270,7 +284,28 @@ describe('runPrScopeCheck', () => {
       expected_issue_scope: 'repo_boundary_enforcement',
     })) as { status: string; block_reasons: string[] };
 
+    expect(result.status).toBe('PASS');
+    expect(result.block_reasons).toEqual([]);
+  });
+
+  it('returns BLOCK when neither the worktree root nor the common repo root is declared for the target project', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/wrong/worktrees/issue-160\n',
+      'rev-parse --git-common-dir': '/external/.git\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'log --format=%s origin/main..HEAD': 'fix(mcp-server): enforce source repo bindings (#160)\n',
+      'diff --name-only origin/main...HEAD': 'projects/agenticos/mcp-server/src/tools/preflight.ts\n',
+    });
+
+    const result = JSON.parse(await runPrScopeCheck({
+      issue_id: '160',
+      repo_path: '/wrong/worktrees/issue-160',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/**'],
+      expected_issue_scope: 'repo_boundary_enforcement',
+    })) as { status: string; block_reasons: string[] };
+
     expect(result.status).toBe('BLOCK');
-    expect(result.block_reasons.join(' ')).toContain('not declared for target project');
+    expect(result.block_reasons.join(' ')).toContain('neither git worktree root');
   });
 });

--- a/mcp-server/src/tools/__tests__/preflight.test.ts
+++ b/mcp-server/src/tools/__tests__/preflight.test.ts
@@ -370,7 +370,7 @@ describe('runPreflight', () => {
     expect(result.block_reasons.join(' ')).toContain('clean_reproducibility_gate');
   });
 
-  it('returns PASS when the worktree root is declared even if the common repo root differs', async () => {
+  it('returns PASS when the worktree root is declared and the remote matches the declared github repo', async () => {
     resolveGuardrailProjectTargetMock.mockResolvedValue({
       activeProjectId: 'agenticos',
       resolutionSource: 'repo_path_match',
@@ -381,6 +381,63 @@ describe('runPreflight', () => {
         path: '/repo/worktrees/issue-160',
         statePath: '/repo/worktrees/issue-160/.context/state.yaml',
         projectYamlPath: '/repo/worktrees/issue-160/.project.yaml',
+        githubRepo: 'madlouse/AgenticOS',
+        sourceRepoRoots: ['/repo/worktrees/issue-160'],
+        sourceRepoRootsDeclared: true,
+      },
+    });
+    readFileMock.mockResolvedValue(JSON.stringify({
+      issue_bootstrap: {
+        latest: {
+          issue_id: '160',
+          repo_path: '/repo/worktrees/issue-160',
+          current_branch: 'fix/160-source-repo-boundary-enforcement',
+          startup_context_paths: ['/repo/worktrees/issue-160/.project.yaml'],
+          stages: {
+            context_reset_performed: true,
+            project_hot_load_performed: true,
+            issue_payload_attached: true,
+          },
+        },
+      },
+    }));
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo/worktrees/issue-160\n',
+      'rev-parse --git-common-dir': '/external/.git\n',
+      'config --get remote.origin.url': 'git@github.com:madlouse/AgenticOS.git\n',
+      'rev-parse --abbrev-ref HEAD': 'fix/160-source-repo-boundary-enforcement\n',
+      'rev-parse HEAD': 'abc123\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo/worktrees/issue-160\nHEAD abc123\nbranch refs/heads/fix/160-source-repo-boundary-enforcement\n',
+      'log --format=%s origin/main..HEAD': '',
+    });
+
+    const result = JSON.parse(await runPreflight({
+      issue_id: '160',
+      task_type: 'bugfix',
+      repo_path: '/repo/worktrees/issue-160',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/preflight.ts'],
+      worktree_required: true,
+    })) as { status: string; block_reasons: string[]; repo_identity_confirmed: boolean };
+
+    expect(result.status).toBe('PASS');
+    expect(result.repo_identity_confirmed).toBe(true);
+    expect(result.block_reasons).toEqual([]);
+  });
+
+  it('returns BLOCK when the worktree root is declared but the remote points at a different github repo', async () => {
+    resolveGuardrailProjectTargetMock.mockResolvedValue({
+      activeProjectId: 'agenticos',
+      resolutionSource: 'repo_path_match',
+      resolutionErrors: [],
+      targetProject: {
+        id: 'agenticos',
+        name: 'AgenticOS',
+        path: '/repo/worktrees/issue-160',
+        statePath: '/repo/worktrees/issue-160/.context/state.yaml',
+        projectYamlPath: '/repo/worktrees/issue-160/.project.yaml',
+        githubRepo: 'madlouse/AgenticOS',
         sourceRepoRoots: ['/repo/worktrees/issue-160'],
         sourceRepoRootsDeclared: true,
       },
@@ -420,9 +477,9 @@ describe('runPreflight', () => {
       worktree_required: true,
     })) as { status: string; block_reasons: string[]; repo_identity_confirmed: boolean };
 
-    expect(result.status).toBe('PASS');
-    expect(result.repo_identity_confirmed).toBe(true);
-    expect(result.block_reasons).toEqual([]);
+    expect(result.status).toBe('BLOCK');
+    expect(result.repo_identity_confirmed).toBe(false);
+    expect(result.block_reasons.join(' ')).toContain('does not match declared source_control.github_repo');
   });
 
   it('returns BLOCK when neither the worktree root nor the common repo root is declared for the active project', async () => {

--- a/mcp-server/src/tools/__tests__/preflight.test.ts
+++ b/mcp-server/src/tools/__tests__/preflight.test.ts
@@ -370,7 +370,36 @@ describe('runPreflight', () => {
     expect(result.block_reasons.join(' ')).toContain('clean_reproducibility_gate');
   });
 
-  it('returns BLOCK when the git common repo root is not declared for the active project', async () => {
+  it('returns PASS when the worktree root is declared even if the common repo root differs', async () => {
+    resolveGuardrailProjectTargetMock.mockResolvedValue({
+      activeProjectId: 'agenticos',
+      resolutionSource: 'repo_path_match',
+      resolutionErrors: [],
+      targetProject: {
+        id: 'agenticos',
+        name: 'AgenticOS',
+        path: '/repo/worktrees/issue-160',
+        statePath: '/repo/worktrees/issue-160/.context/state.yaml',
+        projectYamlPath: '/repo/worktrees/issue-160/.project.yaml',
+        sourceRepoRoots: ['/repo/worktrees/issue-160'],
+        sourceRepoRootsDeclared: true,
+      },
+    });
+    readFileMock.mockResolvedValue(JSON.stringify({
+      issue_bootstrap: {
+        latest: {
+          issue_id: '160',
+          repo_path: '/repo/worktrees/issue-160',
+          current_branch: 'fix/160-source-repo-boundary-enforcement',
+          startup_context_paths: ['/repo/worktrees/issue-160/.project.yaml'],
+          stages: {
+            context_reset_performed: true,
+            project_hot_load_performed: true,
+            issue_payload_attached: true,
+          },
+        },
+      },
+    }));
     mockGitResponses({
       'rev-parse --show-toplevel': '/repo/worktrees/issue-160\n',
       'rev-parse --git-common-dir': '/external/.git\n',
@@ -389,9 +418,35 @@ describe('runPreflight', () => {
       repo_path: '/repo/worktrees/issue-160',
       declared_target_files: ['projects/agenticos/mcp-server/src/tools/preflight.ts'],
       worktree_required: true,
+    })) as { status: string; block_reasons: string[]; repo_identity_confirmed: boolean };
+
+    expect(result.status).toBe('PASS');
+    expect(result.repo_identity_confirmed).toBe(true);
+    expect(result.block_reasons).toEqual([]);
+  });
+
+  it('returns BLOCK when neither the worktree root nor the common repo root is declared for the active project', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/wrong/worktrees/issue-160\n',
+      'rev-parse --git-common-dir': '/external/.git\n',
+      'config --get remote.origin.url': 'git@github.com:wrong/repo.git\n',
+      'rev-parse --abbrev-ref HEAD': 'fix/160-source-repo-boundary-enforcement\n',
+      'rev-parse HEAD': 'abc123\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /wrong/worktrees/issue-160\nHEAD abc123\nbranch refs/heads/fix/160-source-repo-boundary-enforcement\n',
+      'log --format=%s origin/main..HEAD': '',
+    });
+
+    const result = JSON.parse(await runPreflight({
+      issue_id: '160',
+      task_type: 'bugfix',
+      repo_path: '/wrong/worktrees/issue-160',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/preflight.ts'],
+      worktree_required: true,
     })) as { status: string; block_reasons: string[] };
 
     expect(result.status).toBe('BLOCK');
-    expect(result.block_reasons.join(' ')).toContain('not declared for target project');
+    expect(result.block_reasons.join(' ')).toContain('neither git worktree root');
   });
 });

--- a/mcp-server/src/tools/branch-bootstrap.ts
+++ b/mcp-server/src/tools/branch-bootstrap.ts
@@ -4,6 +4,7 @@ import { basename, dirname, join, resolve } from 'path';
 import { promisify } from 'util';
 import { persistGuardrailEvidence, type GuardrailPersistenceResult } from '../utils/guardrail-evidence.js';
 import { resolveGuardrailProjectTarget } from '../utils/repo-boundary.js';
+import { validateGuardrailRepoIdentity } from '../utils/guardrail-repo-identity.js';
 
 const execAsync = promisify(exec);
 
@@ -162,14 +163,16 @@ export async function runBranchBootstrap(args: BranchBootstrapArgs): Promise<str
     result.base_commit = await runGit(repo_path, `rev-parse ${remote_base_branch}`);
 
     if (projectResolution.targetProject) {
-      if (!projectResolution.targetProject.sourceRepoRootsDeclared || projectResolution.targetProject.sourceRepoRoots.length === 0) {
-        result.block_reasons.push(
-          `target project "${projectResolution.targetProject.id}" is missing execution.source_repo_roots in ${projectResolution.targetProject.projectYamlPath}`,
-        );
-      } else if (!projectResolution.targetProject.sourceRepoRoots.includes(gitCommonRepoRoot)) {
-        result.block_reasons.push(
-          `git common repo root "${gitCommonRepoRoot}" is not declared for target project "${projectResolution.targetProject.id}"`,
-        );
+      const repoIdentity = validateGuardrailRepoIdentity({
+        projectId: projectResolution.targetProject.id,
+        projectYamlPath: projectResolution.targetProject.projectYamlPath,
+        declaredSourceRepoRoots: projectResolution.targetProject.sourceRepoRoots,
+        sourceRepoRootsDeclared: projectResolution.targetProject.sourceRepoRootsDeclared,
+        gitWorktreeRoot,
+        gitCommonRepoRoot,
+      });
+      if (!repoIdentity.ok && repoIdentity.message) {
+        result.block_reasons.push(repoIdentity.message);
         result.notes.push(`declared source repo roots: ${projectResolution.targetProject.sourceRepoRoots.join(', ')}`);
       }
     }

--- a/mcp-server/src/tools/branch-bootstrap.ts
+++ b/mcp-server/src/tools/branch-bootstrap.ts
@@ -166,10 +166,12 @@ export async function runBranchBootstrap(args: BranchBootstrapArgs): Promise<str
       const repoIdentity = validateGuardrailRepoIdentity({
         projectId: projectResolution.targetProject.id,
         projectYamlPath: projectResolution.targetProject.projectYamlPath,
+        declaredGithubRepo: projectResolution.targetProject.githubRepo,
         declaredSourceRepoRoots: projectResolution.targetProject.sourceRepoRoots,
         sourceRepoRootsDeclared: projectResolution.targetProject.sourceRepoRootsDeclared,
         gitWorktreeRoot,
         gitCommonRepoRoot,
+        gitRemoteOrigin,
       });
       if (!repoIdentity.ok && repoIdentity.message) {
         result.block_reasons.push(repoIdentity.message);

--- a/mcp-server/src/tools/edit-guard.ts
+++ b/mcp-server/src/tools/edit-guard.ts
@@ -9,6 +9,7 @@ import {
   resolveGuardrailProjectTarget,
   type GuardrailTaskType,
 } from '../utils/repo-boundary.js';
+import { validateGuardrailRepoIdentity } from '../utils/guardrail-repo-identity.js';
 type GuardStatus = 'PASS' | 'BLOCK';
 const execAsync = promisify(exec);
 
@@ -153,16 +154,18 @@ export async function runEditGuard(args: EditGuardArgs): Promise<string> {
       result.evidence.git_common_repo_root = gitCommonRepoRoot;
 
       if (result.target_project) {
-        if (result.target_project.declared_source_repo_roots.length === 0) {
-          result.block_reasons.push(
-            `target project "${result.target_project.id}" is missing execution.source_repo_roots in ${result.target_project.project_yaml_path}`,
-          );
+        const repoIdentity = validateGuardrailRepoIdentity({
+          projectId: result.target_project.id,
+          projectYamlPath: result.target_project.project_yaml_path,
+          declaredSourceRepoRoots: result.target_project.declared_source_repo_roots,
+          sourceRepoRootsDeclared: result.target_project.declared_source_repo_roots.length > 0,
+          gitWorktreeRoot,
+          gitCommonRepoRoot,
+        });
+        if (!repoIdentity.ok && repoIdentity.message) {
+          result.block_reasons.push(repoIdentity.message);
           result.recovery_actions.push(
             `declare execution.source_repo_roots in ${result.target_project.project_yaml_path} before ${task_type} edits`,
-          );
-        } else if (!result.target_project.declared_source_repo_roots.includes(gitCommonRepoRoot)) {
-          result.block_reasons.push(
-            `git common repo root "${gitCommonRepoRoot}" is not declared for target project "${result.target_project.id}"`,
           );
           result.recovery_actions.push(
             `rerun in a declared source repo root: ${result.target_project.declared_source_repo_roots.join(', ')}`,

--- a/mcp-server/src/tools/edit-guard.ts
+++ b/mcp-server/src/tools/edit-guard.ts
@@ -154,13 +154,16 @@ export async function runEditGuard(args: EditGuardArgs): Promise<string> {
       result.evidence.git_common_repo_root = gitCommonRepoRoot;
 
       if (result.target_project) {
+        const gitRemoteOrigin = await runGit(repo_path, 'config --get remote.origin.url').catch(() => null);
         const repoIdentity = validateGuardrailRepoIdentity({
           projectId: result.target_project.id,
           projectYamlPath: result.target_project.project_yaml_path,
+          declaredGithubRepo: projectResolution.targetProject?.githubRepo || null,
           declaredSourceRepoRoots: result.target_project.declared_source_repo_roots,
           sourceRepoRootsDeclared: result.target_project.declared_source_repo_roots.length > 0,
           gitWorktreeRoot,
           gitCommonRepoRoot,
+          gitRemoteOrigin,
         });
         if (!repoIdentity.ok && repoIdentity.message) {
           result.block_reasons.push(repoIdentity.message);

--- a/mcp-server/src/tools/issue-bootstrap.ts
+++ b/mcp-server/src/tools/issue-bootstrap.ts
@@ -188,14 +188,17 @@ export async function runIssueBootstrap(args: IssueBootstrapArgs): Promise<strin
       const gitCommonRepoRoot = dirname(gitCommonDir);
       result.evidence.current_branch = await runGit(repo_path, 'rev-parse --abbrev-ref HEAD');
       result.evidence.workspace_type = await detectWorkspaceType(repo_path);
+      const gitRemoteOrigin = await runGit(repo_path, 'config --get remote.origin.url').catch(() => null);
 
       const repoIdentity = validateGuardrailRepoIdentity({
         projectId: projectResolution.targetProject!.id,
         projectYamlPath: projectResolution.targetProject!.projectYamlPath,
+        declaredGithubRepo: projectResolution.targetProject!.githubRepo,
         declaredSourceRepoRoots: projectResolution.targetProject!.sourceRepoRoots,
         sourceRepoRootsDeclared: projectResolution.targetProject!.sourceRepoRootsDeclared,
         gitWorktreeRoot,
         gitCommonRepoRoot,
+        gitRemoteOrigin,
       });
       if (!repoIdentity.ok && repoIdentity.message) {
         result.block_reasons.push(repoIdentity.message);

--- a/mcp-server/src/tools/issue-bootstrap.ts
+++ b/mcp-server/src/tools/issue-bootstrap.ts
@@ -7,6 +7,7 @@ import yaml from 'yaml';
 import { persistIssueBootstrapEvidence, type GuardrailPersistenceResult, type IssueBootstrapAdditionalContextEntry } from '../utils/guardrail-evidence.js';
 import { resolveGuardrailProjectTarget } from '../utils/repo-boundary.js';
 import { resolveManagedProjectContextPaths } from '../utils/project-target.js';
+import { validateGuardrailRepoIdentity } from '../utils/guardrail-repo-identity.js';
 
 const execAsync = promisify(exec);
 
@@ -188,16 +189,16 @@ export async function runIssueBootstrap(args: IssueBootstrapArgs): Promise<strin
       result.evidence.current_branch = await runGit(repo_path, 'rev-parse --abbrev-ref HEAD');
       result.evidence.workspace_type = await detectWorkspaceType(repo_path);
 
-      const declaredSourceRepoRoots = projectResolution.targetProject?.sourceRepoRoots || [];
-      const sourceRootsDeclared = projectResolution.targetProject?.sourceRepoRootsDeclared || false;
-      if (!sourceRootsDeclared || declaredSourceRepoRoots.length === 0) {
-        result.block_reasons.push(
-          `target project "${projectResolution.targetProject?.id}" is missing execution.source_repo_roots in ${projectResolution.targetProject?.projectYamlPath}`,
-        );
-      } else if (!declaredSourceRepoRoots.includes(gitCommonRepoRoot)) {
-        result.block_reasons.push(
-          `git common repo root "${gitCommonRepoRoot}" is not declared for target project "${projectResolution.targetProject?.id}"`,
-        );
+      const repoIdentity = validateGuardrailRepoIdentity({
+        projectId: projectResolution.targetProject!.id,
+        projectYamlPath: projectResolution.targetProject!.projectYamlPath,
+        declaredSourceRepoRoots: projectResolution.targetProject!.sourceRepoRoots,
+        sourceRepoRootsDeclared: projectResolution.targetProject!.sourceRepoRootsDeclared,
+        gitWorktreeRoot,
+        gitCommonRepoRoot,
+      });
+      if (!repoIdentity.ok && repoIdentity.message) {
+        result.block_reasons.push(repoIdentity.message);
       }
 
       const projectYaml = yaml.parse(await readFile(result.target_project.project_yaml_path, 'utf-8')) || {};

--- a/mcp-server/src/tools/pr-scope-check.ts
+++ b/mcp-server/src/tools/pr-scope-check.ts
@@ -182,10 +182,12 @@ export async function runPrScopeCheck(args: PrScopeCheckArgs): Promise<string> {
     const repoIdentity = validateGuardrailRepoIdentity({
       projectId: projectResolution.targetProject!.id,
       projectYamlPath: projectResolution.targetProject!.projectYamlPath,
+      declaredGithubRepo: projectResolution.targetProject!.githubRepo,
       declaredSourceRepoRoots: projectResolution.targetProject!.sourceRepoRoots,
       sourceRepoRootsDeclared: projectResolution.targetProject!.sourceRepoRootsDeclared,
       gitWorktreeRoot,
       gitCommonRepoRoot,
+      gitRemoteOrigin,
     });
     if (!repoIdentity.ok && repoIdentity.message) {
       result.block_reasons.push(repoIdentity.message);

--- a/mcp-server/src/tools/pr-scope-check.ts
+++ b/mcp-server/src/tools/pr-scope-check.ts
@@ -6,6 +6,7 @@ import yaml from 'yaml';
 import { persistGuardrailEvidence, type GuardrailPersistenceResult } from '../utils/guardrail-evidence.js';
 import { resolveGuardrailProjectTarget } from '../utils/repo-boundary.js';
 import { matchesRuntimeReviewExcludedPath, resolveRuntimeReviewSurfacePaths } from '../utils/runtime-review-surface.js';
+import { validateGuardrailRepoIdentity } from '../utils/guardrail-repo-identity.js';
 
 const execAsync = promisify(exec);
 
@@ -178,14 +179,16 @@ export async function runPrScopeCheck(args: PrScopeCheckArgs): Promise<string> {
     gitCommonRepoRoot = dirname(gitCommonDir);
     gitRemoteOrigin = await runGit(repo_path, 'config --get remote.origin.url').catch(() => null);
 
-    if (!projectResolution.targetProject?.sourceRepoRootsDeclared || projectResolution.targetProject.sourceRepoRoots.length === 0) {
-      result.block_reasons.push(
-        `target project "${projectResolution.targetProject?.id || 'unknown'}" is missing execution.source_repo_roots in ${projectResolution.targetProject?.projectYamlPath || 'unknown project metadata'}`,
-      );
-    } else if (!projectResolution.targetProject.sourceRepoRoots.includes(gitCommonRepoRoot)) {
-      result.block_reasons.push(
-        `git common repo root "${gitCommonRepoRoot}" is not declared for target project "${projectResolution.targetProject.id}"`,
-      );
+    const repoIdentity = validateGuardrailRepoIdentity({
+      projectId: projectResolution.targetProject!.id,
+      projectYamlPath: projectResolution.targetProject!.projectYamlPath,
+      declaredSourceRepoRoots: projectResolution.targetProject!.sourceRepoRoots,
+      sourceRepoRootsDeclared: projectResolution.targetProject!.sourceRepoRootsDeclared,
+      gitWorktreeRoot,
+      gitCommonRepoRoot,
+    });
+    if (!repoIdentity.ok && repoIdentity.message) {
+      result.block_reasons.push(repoIdentity.message);
     }
 
     await runGit(repo_path, `rev-parse ${remote_base_branch}`);

--- a/mcp-server/src/tools/preflight.ts
+++ b/mcp-server/src/tools/preflight.ts
@@ -221,10 +221,12 @@ export async function runPreflight(args: PreflightArgs): Promise<string> {
       const repoIdentity = validateGuardrailRepoIdentity({
         projectId: projectResolution.targetProject.id,
         projectYamlPath: projectResolution.targetProject.projectYamlPath,
+        declaredGithubRepo: projectResolution.targetProject.githubRepo,
         declaredSourceRepoRoots: projectResolution.targetProject.sourceRepoRoots,
         sourceRepoRootsDeclared: projectResolution.targetProject.sourceRepoRootsDeclared,
         gitWorktreeRoot,
         gitCommonRepoRoot,
+        gitRemoteOrigin: result.evidence.git_remote_origin,
       });
       if (!repoIdentity.ok && repoIdentity.message) {
         result.block_reasons.push(repoIdentity.message);

--- a/mcp-server/src/tools/preflight.ts
+++ b/mcp-server/src/tools/preflight.ts
@@ -9,6 +9,7 @@ import {
   resolveGuardrailProjectTarget,
   type GuardrailTaskType,
 } from '../utils/repo-boundary.js';
+import { validateGuardrailRepoIdentity } from '../utils/guardrail-repo-identity.js';
 
 const execAsync = promisify(exec);
 
@@ -217,16 +218,18 @@ export async function runPreflight(args: PreflightArgs): Promise<string> {
     result.evidence.workspace_type = await detectWorkspaceType(repo_path);
 
     if (projectResolution.targetProject) {
-      if (!projectResolution.targetProject.sourceRepoRootsDeclared || projectResolution.targetProject.sourceRepoRoots.length === 0) {
-        result.block_reasons.push(
-          `target project "${projectResolution.targetProject.id}" is missing execution.source_repo_roots in ${projectResolution.targetProject.projectYamlPath}`,
-        );
+      const repoIdentity = validateGuardrailRepoIdentity({
+        projectId: projectResolution.targetProject.id,
+        projectYamlPath: projectResolution.targetProject.projectYamlPath,
+        declaredSourceRepoRoots: projectResolution.targetProject.sourceRepoRoots,
+        sourceRepoRootsDeclared: projectResolution.targetProject.sourceRepoRootsDeclared,
+        gitWorktreeRoot,
+        gitCommonRepoRoot,
+      });
+      if (!repoIdentity.ok && repoIdentity.message) {
+        result.block_reasons.push(repoIdentity.message);
         result.redirect_actions.push(
           `declare execution.source_repo_roots in ${projectResolution.targetProject.projectYamlPath} before ${task_type} work`,
-        );
-      } else if (!projectResolution.targetProject.sourceRepoRoots.includes(gitCommonRepoRoot)) {
-        result.block_reasons.push(
-          `git common repo root "${gitCommonRepoRoot}" is not declared for target project "${projectResolution.targetProject.id}"`,
         );
         result.redirect_actions.push(
           `rerun in a declared source repo root: ${projectResolution.targetProject.sourceRepoRoots.join(', ')}`,

--- a/mcp-server/src/utils/__tests__/guardrail-repo-identity.test.ts
+++ b/mcp-server/src/utils/__tests__/guardrail-repo-identity.test.ts
@@ -6,10 +6,12 @@ describe('validateGuardrailRepoIdentity', () => {
     const result = validateGuardrailRepoIdentity({
       projectId: 'agenticos',
       projectYamlPath: '/workspace/worktrees/issue/.project.yaml',
+      declaredGithubRepo: 'madlouse/AgenticOS',
       declaredSourceRepoRoots: ['/workspace/worktrees/issue'],
       sourceRepoRootsDeclared: true,
       gitWorktreeRoot: '/workspace/worktrees/issue',
       gitCommonRepoRoot: '/workspace/projects/agenticos',
+      gitRemoteOrigin: 'git@github.com:madlouse/AgenticOS.git',
     });
 
     expect(result.ok).toBe(true);
@@ -29,6 +31,39 @@ describe('validateGuardrailRepoIdentity', () => {
     expect(result.ok).toBe(true);
     expect(result.matchedBy).toBe('git_worktree_root');
     expect(result.matchedDeclaredRoot).toBe('/workspace/source');
+  });
+
+  it('passes when only the git common repo root is declared and the remote matches', () => {
+    const result = validateGuardrailRepoIdentity({
+      projectId: 'agenticos',
+      projectYamlPath: '/workspace/project/.project.yaml',
+      declaredGithubRepo: 'madlouse/AgenticOS',
+      declaredSourceRepoRoots: ['/workspace/source'],
+      sourceRepoRootsDeclared: true,
+      gitWorktreeRoot: '/workspace/source/worktrees/issue-268',
+      gitCommonRepoRoot: '/workspace/source',
+      gitRemoteOrigin: 'https://github.com/madlouse/AgenticOS.git',
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.matchedBy).toBe('git_common_repo_root');
+    expect(result.matchedDeclaredRoot).toBe('/workspace/source');
+  });
+
+  it('fails when the worktree root matches but the remote points at a different github repo', () => {
+    const result = validateGuardrailRepoIdentity({
+      projectId: 'agenticos',
+      projectYamlPath: '/workspace/project/.project.yaml',
+      declaredGithubRepo: 'madlouse/AgenticOS',
+      declaredSourceRepoRoots: ['/workspace/source'],
+      sourceRepoRootsDeclared: true,
+      gitWorktreeRoot: '/workspace/source/worktrees/issue-268',
+      gitCommonRepoRoot: '/external/shared-git-root',
+      gitRemoteOrigin: 'git@github.com:wrong/repo.git',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('does not match declared source_control.github_repo');
   });
 
   it('fails when neither the worktree root nor the common repo root is declared', () => {

--- a/mcp-server/src/utils/__tests__/guardrail-repo-identity.test.ts
+++ b/mcp-server/src/utils/__tests__/guardrail-repo-identity.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { validateGuardrailRepoIdentity } from '../guardrail-repo-identity.js';
+
+describe('validateGuardrailRepoIdentity', () => {
+  it('passes when the git worktree root is declared directly', () => {
+    const result = validateGuardrailRepoIdentity({
+      projectId: 'agenticos',
+      projectYamlPath: '/workspace/worktrees/issue/.project.yaml',
+      declaredSourceRepoRoots: ['/workspace/worktrees/issue'],
+      sourceRepoRootsDeclared: true,
+      gitWorktreeRoot: '/workspace/worktrees/issue',
+      gitCommonRepoRoot: '/workspace/projects/agenticos',
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.matchedBy).toBe('git_worktree_root');
+  });
+
+  it('passes when the worktree root is nested under a declared source repo root', () => {
+    const result = validateGuardrailRepoIdentity({
+      projectId: 'agenticos',
+      projectYamlPath: '/workspace/project/.project.yaml',
+      declaredSourceRepoRoots: ['/workspace/source'],
+      sourceRepoRootsDeclared: true,
+      gitWorktreeRoot: '/workspace/source/worktrees/issue-268',
+      gitCommonRepoRoot: '/external/shared-git-root',
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.matchedBy).toBe('git_worktree_root');
+    expect(result.matchedDeclaredRoot).toBe('/workspace/source');
+  });
+
+  it('fails when neither the worktree root nor the common repo root is declared', () => {
+    const result = validateGuardrailRepoIdentity({
+      projectId: 'agenticos',
+      projectYamlPath: '/workspace/project/.project.yaml',
+      declaredSourceRepoRoots: ['/workspace/source'],
+      sourceRepoRootsDeclared: true,
+      gitWorktreeRoot: '/workspace/other/worktree',
+      gitCommonRepoRoot: '/workspace/other/common',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('neither git worktree root');
+  });
+});

--- a/mcp-server/src/utils/__tests__/repo-boundary.test.ts
+++ b/mcp-server/src/utils/__tests__/repo-boundary.test.ts
@@ -36,6 +36,9 @@ describe('resolveGuardrailProjectTarget', () => {
             id: 'alpha',
             name: 'Alpha Project',
           },
+          source_control: {
+            topology: 'local_directory_only',
+          },
           agent_context: {
             current_state: '.context/state.yaml',
           },
@@ -50,11 +53,44 @@ describe('resolveGuardrailProjectTarget', () => {
             id: 'beta',
             name: 'Beta Project',
           },
+          source_control: {
+            topology: 'local_directory_only',
+          },
           agent_context: {
             current_state: '.context/state.yaml',
           },
           execution: {
             source_repo_roots: ['../../source/beta'],
+          },
+        });
+      }
+      if (path.endsWith('/gamma/.project.yaml')) {
+        return JSON.stringify({
+          meta: {
+            id: 'gamma',
+            name: 'Gamma Project',
+          },
+          source_control: {
+            topology: 'github_versioned',
+            branch_strategy: 'github_flow',
+          },
+          execution: {
+            source_repo_roots: ['../../source/gamma'],
+          },
+        });
+      }
+      if (path.endsWith('/delta/.project.yaml')) {
+        return JSON.stringify({
+          meta: {
+            id: 'delta',
+            name: 'Delta Project',
+          },
+          source_control: {
+            topology: 'github_versioned',
+            branch_strategy: 'github_flow',
+          },
+          execution: {
+            source_repo_roots: ['../../source'],
           },
         });
       }
@@ -167,6 +203,124 @@ describe('resolveGuardrailProjectTarget', () => {
     expect(result.targetProject?.id).toBe('alpha');
     expect(result.targetProject?.path).toBe('/workspace/projects/alpha');
     expect(result.resolutionSource).toBe('explicit_project_path');
+    expect(result.resolutionErrors).toEqual([]);
+  });
+
+  it('fails closed for an explicit project_path whose github_versioned metadata is incomplete', async () => {
+    loadRegistryMock.mockResolvedValue({
+      active_project: 'beta',
+      projects: [
+        {
+          id: 'gamma',
+          name: 'Gamma Project',
+          path: '/workspace/projects/gamma',
+          status: 'active',
+          created: '2026-04-06',
+          last_accessed: '2026-04-06T00:00:00.000Z',
+        },
+      ],
+    });
+
+    const result = await resolveGuardrailProjectTarget({
+      commandName: 'agenticos_preflight',
+      projectPath: '/workspace/projects/gamma',
+    });
+
+    expect(result.targetProject).toBeNull();
+    expect(result.resolutionSource).toBeNull();
+    expect(result.resolutionErrors[0]).toContain('missing source_control.github_repo');
+  });
+
+  it('fails closed when repo_path matches a project with incomplete github_versioned metadata', async () => {
+    loadRegistryMock.mockResolvedValue({
+      active_project: 'alpha',
+      projects: [
+        {
+          id: 'gamma',
+          name: 'Gamma Project',
+          path: '/workspace/projects/gamma',
+          status: 'active',
+          created: '2026-04-06',
+          last_accessed: '2026-04-06T00:00:00.000Z',
+        },
+      ],
+    });
+
+    const result = await resolveGuardrailProjectTarget({
+      commandName: 'agenticos_preflight',
+      repoPath: '/workspace/source/gamma/worktrees/issue-268',
+    });
+
+    expect(result.targetProject).toBeNull();
+    expect(result.resolutionSource).toBeNull();
+    expect(result.resolutionErrors[0]).toContain('missing source_control.github_repo');
+  });
+
+  it('does not let an unrelated malformed project block a valid repo_path match', async () => {
+    loadRegistryMock.mockResolvedValue({
+      active_project: 'gamma',
+      projects: [
+        {
+          id: 'alpha',
+          name: 'Alpha Project',
+          path: '/workspace/projects/alpha',
+          status: 'active',
+          created: '2026-04-06',
+          last_accessed: '2026-04-06T00:00:00.000Z',
+        },
+        {
+          id: 'gamma',
+          name: 'Gamma Project',
+          path: '/workspace/projects/gamma',
+          status: 'active',
+          created: '2026-04-06',
+          last_accessed: '2026-04-06T00:00:00.000Z',
+        },
+      ],
+    });
+
+    const result = await resolveGuardrailProjectTarget({
+      commandName: 'agenticos_preflight',
+      repoPath: '/workspace/source/alpha/worktrees/issue-268',
+    });
+
+    expect(result.activeProjectId).toBe('gamma');
+    expect(result.targetProject?.id).toBe('alpha');
+    expect(result.resolutionSource).toBe('repo_path_match');
+    expect(result.resolutionErrors).toEqual([]);
+  });
+
+  it('prefers the strongest valid repo_path match over a broader malformed candidate', async () => {
+    loadRegistryMock.mockResolvedValue({
+      active_project: 'delta',
+      projects: [
+        {
+          id: 'delta',
+          name: 'Delta Project',
+          path: '/workspace/projects/delta',
+          status: 'active',
+          created: '2026-04-06',
+          last_accessed: '2026-04-06T00:00:00.000Z',
+        },
+        {
+          id: 'alpha',
+          name: 'Alpha Project',
+          path: '/workspace/projects/alpha',
+          status: 'active',
+          created: '2026-04-06',
+          last_accessed: '2026-04-06T00:00:00.000Z',
+        },
+      ],
+    });
+
+    const result = await resolveGuardrailProjectTarget({
+      commandName: 'agenticos_preflight',
+      repoPath: '/workspace/source/alpha/worktrees/issue-268',
+    });
+
+    expect(result.activeProjectId).toBe('delta');
+    expect(result.targetProject?.id).toBe('alpha');
+    expect(result.resolutionSource).toBe('repo_path_match');
     expect(result.resolutionErrors).toEqual([]);
   });
 

--- a/mcp-server/src/utils/guardrail-repo-identity.ts
+++ b/mcp-server/src/utils/guardrail-repo-identity.ts
@@ -1,0 +1,75 @@
+import { resolve, sep } from 'path';
+
+interface ValidateGuardrailRepoIdentityArgs {
+  projectId: string;
+  projectYamlPath: string;
+  declaredSourceRepoRoots: string[];
+  sourceRepoRootsDeclared: boolean;
+  gitWorktreeRoot: string;
+  gitCommonRepoRoot: string;
+}
+
+export interface GuardrailRepoIdentityResult {
+  ok: boolean;
+  matchedBy: 'git_worktree_root' | 'git_common_repo_root' | null;
+  matchedDeclaredRoot: string | null;
+  message: string | null;
+}
+
+function normalizePath(value: string): string {
+  return resolve(value);
+}
+
+function pathIsWithinDeclaredRoot(candidatePath: string, declaredRoot: string): boolean {
+  const normalizedCandidate = normalizePath(candidatePath);
+  const normalizedRoot = normalizePath(declaredRoot);
+  return normalizedCandidate === normalizedRoot || normalizedCandidate.startsWith(`${normalizedRoot}${sep}`);
+}
+
+export function validateGuardrailRepoIdentity(args: ValidateGuardrailRepoIdentityArgs): GuardrailRepoIdentityResult {
+  const {
+    projectId,
+    projectYamlPath,
+    declaredSourceRepoRoots,
+    sourceRepoRootsDeclared,
+    gitWorktreeRoot,
+    gitCommonRepoRoot,
+  } = args;
+
+  if (!sourceRepoRootsDeclared || declaredSourceRepoRoots.length === 0) {
+    return {
+      ok: false,
+      matchedBy: null,
+      matchedDeclaredRoot: null,
+      message: `target project "${projectId}" is missing execution.source_repo_roots in ${projectYamlPath}`,
+    };
+  }
+
+  const normalizedDeclaredRoots = declaredSourceRepoRoots.map((root) => normalizePath(root));
+  const worktreeMatch = normalizedDeclaredRoots.find((root) => pathIsWithinDeclaredRoot(gitWorktreeRoot, root));
+  if (worktreeMatch) {
+    return {
+      ok: true,
+      matchedBy: 'git_worktree_root',
+      matchedDeclaredRoot: worktreeMatch,
+      message: null,
+    };
+  }
+
+  const commonRepoMatch = normalizedDeclaredRoots.find((root) => pathIsWithinDeclaredRoot(gitCommonRepoRoot, root));
+  if (commonRepoMatch) {
+    return {
+      ok: true,
+      matchedBy: 'git_common_repo_root',
+      matchedDeclaredRoot: commonRepoMatch,
+      message: null,
+    };
+  }
+
+  return {
+    ok: false,
+    matchedBy: null,
+    matchedDeclaredRoot: null,
+    message: `neither git worktree root "${gitWorktreeRoot}" nor git common repo root "${gitCommonRepoRoot}" is declared for target project "${projectId}"`,
+  };
+}

--- a/mcp-server/src/utils/guardrail-repo-identity.ts
+++ b/mcp-server/src/utils/guardrail-repo-identity.ts
@@ -3,10 +3,12 @@ import { resolve, sep } from 'path';
 interface ValidateGuardrailRepoIdentityArgs {
   projectId: string;
   projectYamlPath: string;
+  declaredGithubRepo?: string | null;
   declaredSourceRepoRoots: string[];
   sourceRepoRootsDeclared: boolean;
   gitWorktreeRoot: string;
   gitCommonRepoRoot: string;
+  gitRemoteOrigin?: string | null;
 }
 
 export interface GuardrailRepoIdentityResult {
@@ -26,14 +28,44 @@ function pathIsWithinDeclaredRoot(candidatePath: string, declaredRoot: string): 
   return normalizedCandidate === normalizedRoot || normalizedCandidate.startsWith(`${normalizedRoot}${sep}`);
 }
 
+function normalizeGitHubRepo(value: string): string {
+  return value.trim().replace(/\.git$/i, '').replace(/^\/+|\/+$/g, '').toLowerCase();
+}
+
+function extractGitHubRepoFromRemoteOrigin(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const sshMatch = trimmed.match(/^git@github\.com:([^/]+\/[^/]+?)(?:\.git)?$/i);
+  if (sshMatch) {
+    return normalizeGitHubRepo(sshMatch[1]);
+  }
+
+  const httpsMatch = trimmed.match(/^https?:\/\/github\.com\/([^/]+\/[^/]+?)(?:\.git)?$/i);
+  if (httpsMatch) {
+    return normalizeGitHubRepo(httpsMatch[1]);
+  }
+
+  const sshUrlMatch = trimmed.match(/^ssh:\/\/git@github\.com\/([^/]+\/[^/]+?)(?:\.git)?$/i);
+  if (sshUrlMatch) {
+    return normalizeGitHubRepo(sshUrlMatch[1]);
+  }
+
+  return null;
+}
+
 export function validateGuardrailRepoIdentity(args: ValidateGuardrailRepoIdentityArgs): GuardrailRepoIdentityResult {
   const {
     projectId,
     projectYamlPath,
+    declaredGithubRepo,
     declaredSourceRepoRoots,
     sourceRepoRootsDeclared,
     gitWorktreeRoot,
     gitCommonRepoRoot,
+    gitRemoteOrigin,
   } = args;
 
   if (!sourceRepoRootsDeclared || declaredSourceRepoRoots.length === 0) {
@@ -47,21 +79,46 @@ export function validateGuardrailRepoIdentity(args: ValidateGuardrailRepoIdentit
 
   const normalizedDeclaredRoots = declaredSourceRepoRoots.map((root) => normalizePath(root));
   const worktreeMatch = normalizedDeclaredRoots.find((root) => pathIsWithinDeclaredRoot(gitWorktreeRoot, root));
+  const commonRepoMatch = normalizedDeclaredRoots.find((root) => pathIsWithinDeclaredRoot(gitCommonRepoRoot, root));
+  if (commonRepoMatch) {
+    if (declaredGithubRepo) {
+      const expectedRepo = normalizeGitHubRepo(declaredGithubRepo);
+      const actualRepo = extractGitHubRepoFromRemoteOrigin(gitRemoteOrigin || '');
+      if (actualRepo !== expectedRepo) {
+        return {
+          ok: false,
+          matchedBy: null,
+          matchedDeclaredRoot: null,
+          message: `git remote origin "${gitRemoteOrigin || 'missing'}" does not match declared source_control.github_repo "${declaredGithubRepo}" for target project "${projectId}"`,
+        };
+      }
+    }
+    return {
+      ok: true,
+      matchedBy: 'git_common_repo_root',
+      matchedDeclaredRoot: commonRepoMatch,
+      message: null,
+    };
+  }
+
+  if (worktreeMatch && declaredGithubRepo) {
+    const expectedRepo = normalizeGitHubRepo(declaredGithubRepo);
+    const actualRepo = extractGitHubRepoFromRemoteOrigin(gitRemoteOrigin || '');
+    if (actualRepo !== expectedRepo) {
+      return {
+        ok: false,
+        matchedBy: null,
+        matchedDeclaredRoot: null,
+        message: `git remote origin "${gitRemoteOrigin || 'missing'}" does not match declared source_control.github_repo "${declaredGithubRepo}" for target project "${projectId}"`,
+      };
+    }
+  }
+
   if (worktreeMatch) {
     return {
       ok: true,
       matchedBy: 'git_worktree_root',
       matchedDeclaredRoot: worktreeMatch,
-      message: null,
-    };
-  }
-
-  const commonRepoMatch = normalizedDeclaredRoots.find((root) => pathIsWithinDeclaredRoot(gitCommonRepoRoot, root));
-  if (commonRepoMatch) {
-    return {
-      ok: true,
-      matchedBy: 'git_common_repo_root',
-      matchedDeclaredRoot: commonRepoMatch,
       message: null,
     };
   }

--- a/mcp-server/src/utils/repo-boundary.ts
+++ b/mcp-server/src/utils/repo-boundary.ts
@@ -1,6 +1,7 @@
 import { access, readFile } from 'fs/promises';
 import { basename, isAbsolute, join, resolve, sep } from 'path';
 import yaml from 'yaml';
+import { validateManagedProjectTopology } from './project-contract.js';
 import { loadRegistry } from './registry.js';
 import { getSessionProjectBinding } from './session-context.js';
 
@@ -79,11 +80,15 @@ function resolveDeclaredSourceRepoRoots(projectPath: string, projectYaml: any): 
   };
 }
 
-async function buildTargetFromProjectPath(
+interface ProjectBoundaryMetadata extends GuardrailProjectTarget {
+  topologyValidationError: string | null;
+}
+
+async function loadProjectBoundaryMetadata(
   projectPath: string,
   fallbackId?: string,
   fallbackName?: string,
-): Promise<GuardrailProjectTarget | null> {
+): Promise<ProjectBoundaryMetadata | null> {
   const normalizedProjectPath = normalizePath(projectPath);
   const projectYamlPath = join(normalizedProjectPath, '.project.yaml');
   if (!(await pathExists(projectYamlPath))) {
@@ -92,10 +97,12 @@ async function buildTargetFromProjectPath(
 
   const projectYaml = yaml.parse(await readFile(projectYamlPath, 'utf-8')) || {};
   const sourceRepoRoots = resolveDeclaredSourceRepoRoots(normalizedProjectPath, projectYaml);
+  const name = String(projectYaml?.meta?.name || fallbackName || fallbackId || basename(normalizedProjectPath));
+  const topologyValidation = validateManagedProjectTopology(name, projectYaml);
 
   return {
     id: String(projectYaml?.meta?.id || fallbackId || basename(normalizedProjectPath)),
-    name: String(projectYaml?.meta?.name || fallbackName || fallbackId || basename(normalizedProjectPath)),
+    name,
     path: normalizedProjectPath,
     statePath: resolveProjectStatePath(normalizedProjectPath, projectYaml),
     projectYamlPath,
@@ -104,7 +111,26 @@ async function buildTargetFromProjectPath(
       : null,
     sourceRepoRoots: sourceRepoRoots.roots,
     sourceRepoRootsDeclared: sourceRepoRoots.declared,
+    topologyValidationError: topologyValidation.ok ? null : topologyValidation.message,
   };
+}
+
+async function buildTargetFromProjectPath(
+  projectPath: string,
+  fallbackId?: string,
+  fallbackName?: string,
+): Promise<GuardrailProjectTarget | null> {
+  const metadata = await loadProjectBoundaryMetadata(projectPath, fallbackId, fallbackName);
+  if (!metadata) {
+    return null;
+  }
+
+  if (metadata.topologyValidationError) {
+    throw new Error(metadata.topologyValidationError);
+  }
+
+  const { topologyValidationError: _topologyValidationError, ...target } = metadata;
+  return target;
 }
 
 function uniqueRegistryProjectMatch<T>(matches: T[], notFound: string, ambiguous: string): T {
@@ -162,24 +188,27 @@ export async function resolveGuardrailProjectTarget(args: {
     try {
       const normalizedRepoPath = normalizePath(repoPath);
       const candidates: Array<{
-        targetProject: GuardrailProjectTarget;
+        targetProject: GuardrailProjectTarget | null;
         matchLength: number;
+        resolutionError: string | null;
       }> = [];
 
       for (const project of registry.projects) {
-        const targetProject = await resolveRegistryProjectTarget(project);
-        if (!targetProject) continue;
+        const projectMetadata = await loadProjectBoundaryMetadata(project.path, project.id, project.name);
+        if (!projectMetadata) continue;
 
         const matchedRoots = [
-          targetProject.path,
-          ...targetProject.sourceRepoRoots,
+          projectMetadata.path,
+          ...projectMetadata.sourceRepoRoots,
         ].filter((candidatePath) => isWithinProject(normalizedRepoPath, candidatePath));
 
         if (matchedRoots.length === 0) continue;
+        const { topologyValidationError, ...targetProject } = projectMetadata;
 
         candidates.push({
-          targetProject,
+          targetProject: topologyValidationError ? null : targetProject,
           matchLength: Math.max(...matchedRoots.map((candidatePath) => normalizePath(candidatePath).length)),
+          resolutionError: topologyValidationError,
         });
       }
 
@@ -194,6 +223,15 @@ export async function resolveGuardrailProjectTarget(args: {
             resolutionSource: null,
             targetProject: null,
             resolutionErrors: [`repo_path "${repoPath}" matches multiple managed projects; pass project_path explicitly`],
+          };
+        }
+
+        if (strongestMatches[0].resolutionError) {
+          return {
+            activeProjectId,
+            resolutionSource: null,
+            targetProject: null,
+            resolutionErrors: [strongestMatches[0].resolutionError],
           };
         }
 

--- a/mcp-server/src/utils/repo-boundary.ts
+++ b/mcp-server/src/utils/repo-boundary.ts
@@ -17,6 +17,7 @@ export interface GuardrailProjectTarget {
   path: string;
   statePath: string;
   projectYamlPath: string;
+  githubRepo: string | null;
   sourceRepoRoots: string[];
   sourceRepoRootsDeclared: boolean;
 }
@@ -98,6 +99,9 @@ async function buildTargetFromProjectPath(
     path: normalizedProjectPath,
     statePath: resolveProjectStatePath(normalizedProjectPath, projectYaml),
     projectYamlPath,
+    githubRepo: typeof projectYaml?.source_control?.github_repo === 'string' && projectYaml.source_control.github_repo.trim().length > 0
+      ? projectYaml.source_control.github_repo.trim()
+      : null,
     sourceRepoRoots: sourceRepoRoots.roots,
     sourceRepoRootsDeclared: sourceRepoRoots.declared,
   };


### PR DESCRIPTION
## Summary\n- resolve guardrail repo identity against the active git worktree root instead of falsely requiring the common checkout root\n- keep compatibility for declarations that still point at the shared repo root\n- add regression coverage across all affected guardrail tools\n\n## Testing\n- cd mcp-server && npm run lint\n- cd mcp-server && npm test -- src/utils/__tests__/guardrail-repo-identity.test.ts src/tools/__tests__/issue-bootstrap.test.ts src/tools/__tests__/preflight.test.ts src/tools/__tests__/edit-guard.test.ts src/tools/__tests__/pr-scope-check.test.ts src/tools/__tests__/branch-bootstrap.test.ts\n\nCloses #268