### PR TITLE
feat: persist full private continuity surfaces on save

### DIFF
--- a/.meta/templates/.project.yaml
+++ b/.meta/templates/.project.yaml
@@ -14,7 +14,7 @@ source_control:
 agent_context:
   quick_start: ".context/quick-start.md"
   current_state: ".context/state.yaml"
-  conversations: ".context/conversations/"
+  conversations: ".context/conversations/"  # configured conversation-history contract path; raw transcript routing may still differ by publication policy
   knowledge: "knowledge/"
   tasks: "tasks/"
   artifacts: "artifacts/"
@@ -23,7 +23,7 @@ memory_contract:
   version: 1
   quick_start_role: "project_orientation"
   state_role: "operational_working_state"
-  conversations_role: "append_only_session_history"
+  conversations_role: "append_only_session_history"  # tracked continuity contract input; public policies may route raw transcripts elsewhere
   knowledge_role: "durable_synthesis"
   tasks_role: "execution_artifacts"
   artifacts_role: "deliverables"

--- a/.meta/templates/quick-start.md
+++ b/.meta/templates/quick-start.md
@@ -17,7 +17,7 @@
 
 ## Canonical Layers
 - Operational state: `.context/state.yaml`
-- Session history: `.context/conversations/`
+- Conversation history surface: `.context/conversations/` (tracked contract path; raw transcript routing may vary by publication policy)
 - Durable knowledge: `knowledge/`
 - Execution plans: `tasks/`
 - Deliverables: `artifacts/`

--- a/README.md
+++ b/README.md
@@ -145,3 +145,9 @@ Managed projects now distinguish three separate questions:
 The canonical field location is `source_control.context_publication_policy` in `.project.yaml`.
 
 The canonical rationale for context publication policy lives in [standards/knowledge/context-publication-policy-2026-04-10.md](standards/knowledge/context-publication-policy-2026-04-10.md).
+
+Current save/recovery contract:
+
+- `local_private`: Git is not the continuity recovery mechanism
+- `private_continuity`: `agenticos_save` is expected to persist the tracked continuity core for Git-backed restore
+- `public_distilled`: tracked recovery stays distilled; raw transcript isolation remains a separate contract

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -227,6 +227,11 @@ Create new project with standard structure.
 - `github_versioned + private_continuity` means full AI continuity surfaces may live in the repo because the repo is private
 - `github_versioned + public_distilled` means distilled context may ship, but raw session history and other non-publishable runtime surfaces must be isolated from the public source tree
 
+**Current recovery contract**:
+- `local_private`: Git is not the continuity recovery mechanism; `agenticos_save` keeps the existing narrow runtime-managed backup behavior
+- `private_continuity`: `agenticos_save` stages the tracked continuity core for Git-backed recovery, including `.project.yaml`, quick-start, state, conversations, `knowledge/`, `tasks/`, and mirrored guidance such as `CLAUDE.md` / `AGENTS.md` when present and repo-local
+- `public_distilled`: save behavior remains narrower in this issue; raw transcript isolation belongs to `#245`
+
 Publication policy is not the same as workflow topology or canonical source inclusion. A project can be `github_versioned` and still require `public_distilled`.
 
 **Upgrade path**:
@@ -261,6 +266,12 @@ Save state and backup to Git.
 - `message` (optional) - Commit message
 
 **Returns**: Backup confirmation with timestamp
+
+**Policy-aware behavior**:
+- `private_continuity` validates the tracked continuity plan before mutating `state.yaml` or staging files
+- if a required continuity path escapes the repo root, or no Git repo root can be proven, `agenticos_save` fails closed instead of writing a partial tracked state
+- successful `private_continuity` saves stage the tracked continuity core rather than only the legacy runtime review subset
+- other publication policies currently keep the narrower runtime-managed save surface until their dedicated follow-up issues land
 
 ### agenticos_status
 Show the status of the current session project, or an explicit project when provided.

--- a/mcp-server/src/tools/__tests__/save.test.ts
+++ b/mcp-server/src/tools/__tests__/save.test.ts
@@ -631,6 +631,14 @@ describe('saveState', () => {
           cb(null, '/test/path\n', '');
           return;
         }
+        if (cmd.includes('rev-parse --git-common-dir')) {
+          cb(null, '.git\n', '');
+          return;
+        }
+        if (cmd.includes('remote get-url origin')) {
+          cb(null, 'git@github.com:example/test-project.git\n', '');
+          return;
+        }
         if (cmd.includes(' commit ')) {
           cb(new Error('nothing to commit'), '', 'nothing to commit');
           return;
@@ -643,14 +651,14 @@ describe('saveState', () => {
 
     const addCommand = commands.find((cmd) => cmd.includes(' add -A -- '));
     expect(addCommand).toBeDefined();
-    expect(addCommand).toContain('/test/path/.project.yaml');
-    expect(addCommand).toContain('/test/path/.context/quick-start.md');
-    expect(addCommand).toContain('/test/path/.context/state.yaml');
-    expect(addCommand).toContain('/test/path/.context/conversations');
-    expect(addCommand).toContain('/test/path/knowledge');
-    expect(addCommand).toContain('/test/path/tasks');
-    expect(addCommand).toContain('/test/path/CLAUDE.md');
-    expect(addCommand).not.toContain('/test/path/.context/.last_record');
+    expect(addCommand).toContain('".project.yaml"');
+    expect(addCommand).toContain('".context/quick-start.md"');
+    expect(addCommand).toContain('".context/state.yaml"');
+    expect(addCommand).toContain('".context/conversations/"');
+    expect(addCommand).toContain('"knowledge/"');
+    expect(addCommand).toContain('"tasks/"');
+    expect(addCommand).toContain('"CLAUDE.md"');
+    expect(addCommand).not.toContain('.context/.last_record');
     expect(result).toContain('Recovery: tracked continuity contract evaluated; no new continuity changes were committed');
   });
 
@@ -740,6 +748,10 @@ describe('saveState', () => {
           cb(null, '/test/repo\n', '');
           return;
         }
+        if (cmd.includes('rev-parse --git-common-dir')) {
+          cb(null, '.git\n', '');
+          return;
+        }
         cb(null, '', '');
       }
     );
@@ -779,6 +791,14 @@ describe('saveState', () => {
           cb(null, '/test/path\n', '');
           return;
         }
+        if (cmd.includes('rev-parse --git-common-dir')) {
+          cb(null, '.git\n', '');
+          return;
+        }
+        if (cmd.includes('remote get-url origin')) {
+          cb(null, 'git@github.com:example/test-project.git\n', '');
+          return;
+        }
         if (cmd.includes(' commit ')) {
           cb(null, '', '');
           return;
@@ -796,5 +816,276 @@ describe('saveState', () => {
     expect(result).toContain('Push failed');
     expect(result).toContain('tracked continuity committed locally; remote sync is still pending');
     expect(result).not.toContain('Git-backed restore');
+  });
+
+  it('fails closed when the discovered git repo root is not a declared source repo root', async () => {
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry({
+      projects: [
+        {
+          id: 'test-project',
+          name: 'Test Project',
+          path: '/test/runtime/project',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    }));
+    clearSessionProjectBinding();
+    bindSessionProject({
+      projectId: 'test-project',
+      projectName: 'Test Project',
+      projectPath: '/test/runtime/project',
+    });
+    fsPromisesMock.readFile.mockImplementation(async (path: string) => {
+      if (path === '/test/runtime/project/.project.yaml') {
+        return JSON.stringify({
+          meta: {
+            id: 'test-project',
+            name: 'Test Project',
+          },
+          source_control: {
+            topology: 'github_versioned',
+            context_publication_policy: 'private_continuity',
+            github_repo: 'example/test-project',
+            branch_strategy: 'github_flow',
+          },
+          execution: {
+            source_repo_roots: ['.'],
+          },
+        });
+      }
+      if (path === '/test/runtime/project/.context/state.yaml') {
+        return JSON.stringify({ session: {} });
+      }
+      throw new Error(`unexpected path: ${path}`);
+    });
+
+    childProcessMock.exec.mockImplementation(
+      (cmd: string, cb: (err: Error | null, stdout?: string, stderr?: string) => void) => {
+        if (cmd.includes('rev-parse --show-toplevel')) {
+          cb(null, '/test/runtime/project\n', '');
+          return;
+        }
+        if (cmd.includes('rev-parse --git-common-dir')) {
+          cb(null, '../.git\n', '');
+          return;
+        }
+        if (cmd.includes('remote get-url origin')) {
+          cb(null, 'git@github.com:example/test-project.git\n', '');
+          return;
+        }
+        cb(null, '', '');
+      }
+    );
+
+    const result = await saveState({ message: 'wrong repo root' });
+
+    expect(result).toContain('could not persist tracked continuity');
+    expect(result).toContain('git common repo root');
+    expect(fsPromisesMock.writeFile).not.toHaveBeenCalled();
+    expect(updateClaudeMdStateMock).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when git remote origin does not match the declared github repo', async () => {
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry());
+    mockProjectFiles({
+      projectYaml: {
+        meta: {
+          id: 'test-project',
+          name: 'Test Project',
+        },
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'private_continuity',
+          github_repo: 'example/test-project',
+          branch_strategy: 'github_flow',
+        },
+        execution: {
+          source_repo_roots: ['.'],
+        },
+      },
+      state: { session: {} },
+    });
+
+    childProcessMock.exec.mockImplementation(
+      (cmd: string, cb: (err: Error | null, stdout?: string, stderr?: string) => void) => {
+        if (cmd.includes('rev-parse --show-toplevel')) {
+          cb(null, '/test/path\n', '');
+          return;
+        }
+        if (cmd.includes('rev-parse --git-common-dir')) {
+          cb(null, '.git\n', '');
+          return;
+        }
+        if (cmd.includes('remote get-url origin')) {
+          cb(null, 'git@github.com:example/other-project.git\n', '');
+          return;
+        }
+        cb(null, '', '');
+      }
+    );
+
+    const result = await saveState({ message: 'wrong remote' });
+
+    expect(result).toContain('could not persist tracked continuity');
+    expect(result).toContain('does not match declared source_control.github_repo');
+    expect(fsPromisesMock.writeFile).not.toHaveBeenCalled();
+    expect(updateClaudeMdStateMock).not.toHaveBeenCalled();
+  });
+
+  it('allows private_continuity saves from a nested worktree when the declared source repo root matches the git common repo root', async () => {
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry({
+      projects: [
+        {
+          id: 'test-project',
+          name: 'Test Project',
+          path: '/repo/worktrees/issue-244',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    }));
+    clearSessionProjectBinding();
+    bindSessionProject({
+      projectId: 'test-project',
+      projectName: 'Test Project',
+      projectPath: '/repo/worktrees/issue-244',
+    });
+    fsPromisesMock.readFile.mockImplementation(async (path: string) => {
+      if (path === '/repo/worktrees/issue-244/.project.yaml') {
+        return JSON.stringify({
+          meta: {
+            id: 'test-project',
+            name: 'Test Project',
+          },
+          source_control: {
+            topology: 'github_versioned',
+            context_publication_policy: 'private_continuity',
+            github_repo: 'example/test-project',
+            branch_strategy: 'github_flow',
+          },
+          execution: {
+            source_repo_roots: ['../..'],
+          },
+        });
+      }
+      if (path === '/repo/worktrees/issue-244/.context/state.yaml') {
+        return JSON.stringify({ session: {} });
+      }
+      throw new Error(`unexpected path: ${path}`);
+    });
+
+    const commands: string[] = [];
+    childProcessMock.exec.mockImplementation(
+      (cmd: string, cb: (err: Error | null, stdout?: string, stderr?: string) => void) => {
+        commands.push(cmd);
+        if (cmd.includes('rev-parse --show-toplevel')) {
+          cb(null, '/repo/worktrees/issue-244\n', '');
+          return;
+        }
+        if (cmd.includes('rev-parse --git-common-dir')) {
+          cb(null, '/repo/.git\n', '');
+          return;
+        }
+        if (cmd.includes('remote get-url origin')) {
+          cb(null, 'git@github.com:example/test-project.git\n', '');
+          return;
+        }
+        if (cmd.includes(' commit ')) {
+          cb(new Error('nothing to commit'), '', 'nothing to commit');
+          return;
+        }
+        cb(null, '', '');
+      }
+    );
+
+    const result = await saveState({ message: 'nested worktree continuity save' });
+
+    const addCommand = commands.find((cmd) => cmd.includes(' add -A -- '));
+    expect(addCommand).toBeDefined();
+    expect(addCommand).toContain('git -C "/repo/worktrees/issue-244" add -A --');
+    expect(addCommand).toContain('".project.yaml"');
+    expect(addCommand).toContain('".context/state.yaml"');
+    expect(result).toContain('tracked continuity contract evaluated; no new continuity changes were committed');
+  });
+
+  it('stages worktree-relative continuity paths when the project lives under a repo subdirectory', async () => {
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry({
+      projects: [
+        {
+          id: 'test-project',
+          name: 'Test Project',
+          path: '/repo/projects/app',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    }));
+    clearSessionProjectBinding();
+    bindSessionProject({
+      projectId: 'test-project',
+      projectName: 'Test Project',
+      projectPath: '/repo/projects/app',
+    });
+    fsPromisesMock.readFile.mockImplementation(async (path: string) => {
+      if (path === '/repo/projects/app/.project.yaml') {
+        return JSON.stringify({
+          meta: {
+            id: 'test-project',
+            name: 'Test Project',
+          },
+          source_control: {
+            topology: 'github_versioned',
+            context_publication_policy: 'private_continuity',
+            github_repo: 'example/test-project',
+            branch_strategy: 'github_flow',
+          },
+          execution: {
+            source_repo_roots: ['../..'],
+          },
+        });
+      }
+      if (path === '/repo/projects/app/.context/state.yaml') {
+        return JSON.stringify({ session: {} });
+      }
+      throw new Error(`unexpected path: ${path}`);
+    });
+
+    const commands: string[] = [];
+    childProcessMock.exec.mockImplementation(
+      (cmd: string, cb: (err: Error | null, stdout?: string, stderr?: string) => void) => {
+        commands.push(cmd);
+        if (cmd.includes('rev-parse --show-toplevel')) {
+          cb(null, '/repo\n', '');
+          return;
+        }
+        if (cmd.includes('rev-parse --git-common-dir')) {
+          cb(null, '.git\n', '');
+          return;
+        }
+        if (cmd.includes('remote get-url origin')) {
+          cb(null, 'git@github.com:example/test-project.git\n', '');
+          return;
+        }
+        if (cmd.includes(' commit ')) {
+          cb(new Error('nothing to commit'), '', 'nothing to commit');
+          return;
+        }
+        cb(null, '', '');
+      }
+    );
+
+    const result = await saveState({ message: 'nested project continuity save' });
+
+    const addCommand = commands.find((cmd) => cmd.includes(' add -A -- '));
+    expect(addCommand).toBeDefined();
+    expect(addCommand).toContain('git -C "/repo" add -A --');
+    expect(addCommand).toContain('"projects/app/.project.yaml"');
+    expect(addCommand).toContain('"projects/app/.context/state.yaml"');
+    expect(addCommand).toContain('"projects/app/tasks/"');
+    expect(result).toContain('tracked continuity contract evaluated; no new continuity changes were committed');
   });
 });

--- a/mcp-server/src/tools/__tests__/save.test.ts
+++ b/mcp-server/src/tools/__tests__/save.test.ts
@@ -91,6 +91,7 @@ function mockProjectFiles(options?: {
     },
     source_control: {
       topology: 'local_directory_only',
+      context_publication_policy: 'local_private',
     },
   };
   const state = options?.state || { session: {}, working_memory: { pending: [], decisions: [], facts: [] } };
@@ -282,6 +283,7 @@ describe('saveState', () => {
           },
           source_control: {
             topology: 'local_directory_only',
+            context_publication_policy: 'local_private',
           },
         });
       }
@@ -500,7 +502,7 @@ describe('saveState', () => {
       if (path === '/other/path/.project.yaml') {
         return JSON.stringify({
           meta: { id: 'other-project', name: 'Other Project' },
-          source_control: { topology: 'local_directory_only' },
+          source_control: { topology: 'local_directory_only', context_publication_policy: 'local_private' },
         });
       }
       if (path === '/other/path/.context/state.yaml') {
@@ -509,7 +511,7 @@ describe('saveState', () => {
       if (path === '/test/path/.project.yaml') {
         return JSON.stringify({
           meta: { id: 'test-project', name: 'Test Project' },
-          source_control: { topology: 'local_directory_only' },
+          source_control: { topology: 'local_directory_only', context_publication_policy: 'local_private' },
         });
       }
       if (path === '/test/path/.context/state.yaml') {
@@ -556,7 +558,7 @@ describe('saveState', () => {
       if (path === '/other/path/.project.yaml') {
         return JSON.stringify({
           meta: { id: 'other-project', name: 'Other Project' },
-          source_control: { topology: 'local_directory_only' },
+          source_control: { topology: 'local_directory_only', context_publication_policy: 'local_private' },
         });
       }
       if (path === '/other/path/.context/state.yaml') {
@@ -589,6 +591,7 @@ describe('saveState', () => {
         },
         source_control: {
           topology: 'local_directory_only',
+          context_publication_policy: 'local_private',
         },
       },
     });
@@ -597,5 +600,92 @@ describe('saveState', () => {
 
     expect(result).toContain('does not match .project.yaml meta.id');
     expect(childProcessMock.exec).not.toHaveBeenCalled();
+  });
+
+  it('stages the full tracked continuity surface for private_continuity projects', async () => {
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry());
+    mockProjectFiles({
+      projectYaml: {
+        meta: {
+          id: 'test-project',
+          name: 'Test Project',
+        },
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'private_continuity',
+          github_repo: 'example/test-project',
+          branch_strategy: 'github_flow',
+        },
+        execution: {
+          source_repo_roots: ['.'],
+        },
+      },
+      state: { session: {} },
+    });
+
+    const commands: string[] = [];
+    childProcessMock.exec.mockImplementation(
+      (cmd: string, cb: (err: Error | null, stdout?: string, stderr?: string) => void) => {
+        commands.push(cmd);
+        if (cmd.includes('rev-parse --show-toplevel')) {
+          cb(null, '/test/path\n', '');
+          return;
+        }
+        if (cmd.includes(' commit ')) {
+          cb(new Error('nothing to commit'), '', 'nothing to commit');
+          return;
+        }
+        cb(null, '', '');
+      }
+    );
+
+    const result = await saveState({ message: 'full continuity save' });
+
+    const addCommand = commands.find((cmd) => cmd.includes(' add -A -- '));
+    expect(addCommand).toBeDefined();
+    expect(addCommand).toContain('/test/path/.project.yaml');
+    expect(addCommand).toContain('/test/path/.context/quick-start.md');
+    expect(addCommand).toContain('/test/path/.context/state.yaml');
+    expect(addCommand).toContain('/test/path/.context/conversations');
+    expect(addCommand).toContain('/test/path/knowledge');
+    expect(addCommand).toContain('/test/path/tasks');
+    expect(addCommand).toContain('/test/path/CLAUDE.md');
+    expect(addCommand).not.toContain('/test/path/.context/.last_record');
+    expect(result).toContain('Recovery: full tracked continuity staged for Git-backed restore');
+  });
+
+  it('fails closed before state mutation when private_continuity cannot prove a git repo', async () => {
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry());
+    mockProjectFiles({
+      projectYaml: {
+        meta: {
+          id: 'test-project',
+          name: 'Test Project',
+        },
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'private_continuity',
+          github_repo: 'example/test-project',
+          branch_strategy: 'github_flow',
+        },
+        execution: {
+          source_repo_roots: ['.'],
+        },
+      },
+      state: { session: {} },
+    });
+
+    childProcessMock.exec.mockImplementation(
+      (_cmd: string, cb: (err: Error | null, stdout?: string, stderr?: string) => void) => {
+        cb(new Error('not a git repo'), '', '');
+      }
+    );
+
+    const result = await saveState({ message: 'should fail closed' });
+
+    expect(result).toContain('could not persist tracked continuity');
+    expect(result).toContain('git repo root');
+    expect(fsPromisesMock.writeFile).not.toHaveBeenCalled();
+    expect(updateClaudeMdStateMock).not.toHaveBeenCalled();
   });
 });

--- a/mcp-server/src/tools/__tests__/save.test.ts
+++ b/mcp-server/src/tools/__tests__/save.test.ts
@@ -651,7 +651,7 @@ describe('saveState', () => {
     expect(addCommand).toContain('/test/path/tasks');
     expect(addCommand).toContain('/test/path/CLAUDE.md');
     expect(addCommand).not.toContain('/test/path/.context/.last_record');
-    expect(result).toContain('Recovery: full tracked continuity staged for Git-backed restore');
+    expect(result).toContain('Recovery: tracked continuity contract evaluated; no new continuity changes were committed');
   });
 
   it('fails closed before state mutation when private_continuity cannot prove a git repo', async () => {
@@ -687,5 +687,114 @@ describe('saveState', () => {
     expect(result).toContain('git repo root');
     expect(fsPromisesMock.writeFile).not.toHaveBeenCalled();
     expect(updateClaudeMdStateMock).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when private_continuity paths escape the project root even if they remain inside the repo', async () => {
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry({
+      projects: [
+        {
+          id: 'test-project',
+          name: 'Test Project',
+          path: '/test/repo/projects/app',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    }));
+    clearSessionProjectBinding();
+    bindSessionProject({
+      projectId: 'test-project',
+      projectName: 'Test Project',
+      projectPath: '/test/repo/projects/app',
+    });
+    fsPromisesMock.readFile.mockImplementation(async (path: string) => {
+      if (path === '/test/repo/projects/app/.project.yaml') {
+        return JSON.stringify({
+          meta: {
+            id: 'test-project',
+            name: 'Test Project',
+          },
+          source_control: {
+            topology: 'github_versioned',
+            context_publication_policy: 'private_continuity',
+            github_repo: 'example/test-project',
+            branch_strategy: 'github_flow',
+          },
+          execution: {
+            source_repo_roots: ['../..'],
+          },
+          agent_context: {
+            tasks: '../../shared-tasks/',
+          },
+        });
+      }
+      if (path === '/test/repo/projects/app/.context/state.yaml') {
+        return JSON.stringify({ session: {} });
+      }
+      throw new Error(`unexpected path: ${path}`);
+    });
+    childProcessMock.exec.mockImplementation(
+      (cmd: string, cb: (err: Error | null, stdout?: string, stderr?: string) => void) => {
+        if (cmd.includes('rev-parse --show-toplevel')) {
+          cb(null, '/test/repo\n', '');
+          return;
+        }
+        cb(null, '', '');
+      }
+    );
+
+    const result = await saveState({ message: 'should fail on project escape' });
+
+    expect(result).toContain('could not persist tracked continuity');
+    expect(result).toContain('tasks path escapes project root');
+    expect(fsPromisesMock.writeFile).not.toHaveBeenCalled();
+    expect(updateClaudeMdStateMock).not.toHaveBeenCalled();
+  });
+
+  it('does not claim git-backed restore sync when push fails for private_continuity', async () => {
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry());
+    mockProjectFiles({
+      projectYaml: {
+        meta: {
+          id: 'test-project',
+          name: 'Test Project',
+        },
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'private_continuity',
+          github_repo: 'example/test-project',
+          branch_strategy: 'github_flow',
+        },
+        execution: {
+          source_repo_roots: ['.'],
+        },
+      },
+      state: { session: {} },
+    });
+
+    childProcessMock.exec.mockImplementation(
+      (cmd: string, cb: (err: Error | null, stdout?: string, stderr?: string) => void) => {
+        if (cmd.includes('rev-parse --show-toplevel')) {
+          cb(null, '/test/path\n', '');
+          return;
+        }
+        if (cmd.includes(' commit ')) {
+          cb(null, '', '');
+          return;
+        }
+        if (cmd.includes(' push')) {
+          cb(new Error('push failed'), '', '');
+          return;
+        }
+        cb(null, '', '');
+      }
+    );
+
+    const result = await saveState({ message: 'pending remote sync' });
+
+    expect(result).toContain('Push failed');
+    expect(result).toContain('tracked continuity committed locally; remote sync is still pending');
+    expect(result).not.toContain('Git-backed restore');
   });
 });

--- a/mcp-server/src/tools/save.ts
+++ b/mcp-server/src/tools/save.ts
@@ -1,9 +1,13 @@
 import { exec } from 'child_process';
 import { updateClaudeMdState } from '../utils/distill.js';
 import { readFile, writeFile } from 'fs/promises';
+import { existsSync } from 'fs';
+import { join } from 'path';
 import yaml from 'yaml';
 import { resolveManagedProjectTarget } from '../utils/project-target.js';
 import { resolveRuntimeReviewSurfacePaths, toProjectAbsoluteRuntimePath } from '../utils/runtime-review-surface.js';
+import { resolveContextPolicyPlan } from '../utils/context-policy-plan.js';
+import { resolveContinuitySurfacePlan } from '../utils/continuity-surface.js';
 
 async function execCommand(command: string): Promise<{ stdout: string; stderr: string }> {
   return await new Promise((resolve, reject) => {
@@ -31,6 +35,14 @@ async function findGitRoot(fromDir: string): Promise<string | null> {
   }
 }
 
+function toRepoAbsolutePath(repoRoot: string, trackedPath: string): string {
+  return join(repoRoot, trackedPath.replace(/\/$/, ''));
+}
+
+function buildContinuityFailureMessage(projectName: string, reasons: string[]): string {
+  return `❌ agenticos_save could not persist tracked continuity for "${projectName}"\n\n${reasons.map((reason) => `- ${reason}`).join('\n')}`;
+}
+
 export async function saveState(args: any): Promise<string> {
   const now = new Date();
   const timestamp = now.toISOString().replace('T', ' ').substring(0, 16);
@@ -49,7 +61,33 @@ export async function saveState(args: any): Promise<string> {
   const { project, projectPath, projectYaml, statePath } = resolved;
 
   try {
-    // Update state.yaml with backup timestamp
+    // Find git root from the project path (works regardless of AGENTICOS_HOME)
+    const gitRoot = await findGitRoot(projectPath);
+
+    let contextPolicyPlan;
+    try {
+      contextPolicyPlan = resolveContextPolicyPlan({
+        projectName: project.name,
+        projectPath,
+        projectYaml,
+        repoRoot: gitRoot,
+      });
+    } catch (error: any) {
+      return `❌ ${error.message}`;
+    }
+
+    const continuityPlan = contextPolicyPlan.policy === 'private_continuity'
+      ? resolveContinuitySurfacePlan(contextPolicyPlan, {
+        include_claude_state_mirror: true,
+        include_agents_guidance: existsSync(`${projectPath}/AGENTS.md`),
+      })
+      : null;
+
+    if (continuityPlan && continuityPlan.unsupported_reasons.length > 0) {
+      return buildContinuityFailureMessage(project.name, continuityPlan.unsupported_reasons);
+    }
+
+    // Update state.yaml only after the continuity plan is known to be supported.
     const stateContent = await readFile(statePath, 'utf-8');
     const state = yaml.parse(stateContent);
 
@@ -65,19 +103,24 @@ export async function saveState(args: any): Promise<string> {
       ? '\n📝 CLAUDE.md was auto-generated (Project DNA section needs manual enrichment)'
       : '';
 
-    // Find git root from the project path (works regardless of AGENTICOS_HOME)
-    const gitRoot = await findGitRoot(projectPath);
     if (!gitRoot) {
       return `⚠️ State saved but no git repo found at ${projectPath}\n\nTimestamp: ${state.session.last_backup}${claudeMdNote}`;
     }
 
-    // Project-scoped git: stage only runtime-managed paths plus the CLAUDE state mirror.
+    // Project-scoped git: stage policy-aware continuity paths for private repos, otherwise keep runtime-managed paths.
     const gitCmd = `git -C "${gitRoot}"`;
-    const runtimePaths = resolveRuntimeReviewSurfacePaths(projectPath, projectYaml, {
-      include_claude_state_mirror: true,
-    }).tracked_review_excluded_paths;
-    const stageTargets = runtimePaths
-      .map((trackedPath) => `"${toProjectAbsoluteRuntimePath(projectPath, trackedPath)}"`)
+    const stagePaths = continuityPlan
+      ? [
+        ...continuityPlan.tracked_continuity_paths,
+        ...continuityPlan.optional_guidance_paths,
+      ]
+      : resolveRuntimeReviewSurfacePaths(projectPath, projectYaml, {
+        include_claude_state_mirror: true,
+      }).tracked_review_excluded_paths;
+    const stageTargets = stagePaths
+      .map((trackedPath) => continuityPlan
+        ? `"${toRepoAbsolutePath(gitRoot, trackedPath)}"`
+        : `"${toProjectAbsoluteRuntimePath(projectPath, trackedPath)}"`)
       .join(' ');
 
     // Phase 1: git add
@@ -114,7 +157,11 @@ export async function saveState(args: any): Promise<string> {
     if (pushed) phases.push('☁️ Pushed to remote');
     else if (committed) phases.push('⚠️ Push failed (committed locally, not synced)');
 
-    return `${phases.join('\n')}\n\nProject: "${project.name}"\nCommit: ${commitMessage}\nTimestamp: ${state.session.last_backup}${claudeMdNote}`;
+    const recoveryNote = continuityPlan
+      ? '\nRecovery: full tracked continuity staged for Git-backed restore'
+      : '';
+
+    return `${phases.join('\n')}\n\nProject: "${project.name}"\nCommit: ${commitMessage}\nTimestamp: ${state.session.last_backup}${claudeMdNote}${recoveryNote}`;
   } catch (error: any) {
     return `⚠️ Partial save completed\n\nError: ${error.message}`;
   }

--- a/mcp-server/src/tools/save.ts
+++ b/mcp-server/src/tools/save.ts
@@ -2,7 +2,7 @@ import { exec } from 'child_process';
 import { updateClaudeMdState } from '../utils/distill.js';
 import { readFile, writeFile } from 'fs/promises';
 import { existsSync } from 'fs';
-import { join } from 'path';
+import { dirname, isAbsolute, join, relative, resolve } from 'path';
 import yaml from 'yaml';
 import { resolveManagedProjectTarget } from '../utils/project-target.js';
 import { resolveRuntimeReviewSurfacePaths, toProjectAbsoluteRuntimePath } from '../utils/runtime-review-surface.js';
@@ -25,22 +25,130 @@ async function execCommand(command: string): Promise<{ stdout: string; stderr: s
   });
 }
 
-/** Detect git root from a directory path */
-async function findGitRoot(fromDir: string): Promise<string | null> {
+/** Detect git worktree/common repo identity from a directory path */
+async function findGitIdentity(fromDir: string): Promise<{ worktreeRoot: string; commonRepoRoot: string } | null> {
   try {
-    const { stdout } = await execCommand(`git -C "${fromDir}" rev-parse --show-toplevel`);
-    return stdout.trim();
+    const { stdout: worktreeStdout } = await execCommand(`git -C "${fromDir}" rev-parse --show-toplevel`);
+    const worktreeRoot = worktreeStdout.trim();
+    const { stdout: commonDirStdout } = await execCommand(`git -C "${fromDir}" rev-parse --git-common-dir`);
+    const commonDir = resolve(worktreeRoot, commonDirStdout.trim());
+    return {
+      worktreeRoot,
+      commonRepoRoot: dirname(commonDir),
+    };
   } catch {
     return null;
   }
 }
 
-function toRepoAbsolutePath(repoRoot: string, trackedPath: string): string {
-  return join(repoRoot, trackedPath.replace(/\/$/, ''));
-}
-
 function buildContinuityFailureMessage(projectName: string, reasons: string[]): string {
   return `❌ agenticos_save could not persist tracked continuity for "${projectName}"\n\n${reasons.map((reason) => `- ${reason}`).join('\n')}`;
+}
+
+function normalizePath(value: string): string {
+  return resolve(value);
+}
+
+function toGitRelativePath(gitWorktreeRoot: string, absolutePath: string, options?: { directory?: boolean }): string {
+  const relativePath = relative(normalizePath(gitWorktreeRoot), normalizePath(absolutePath)).replace(/\\/g, '/');
+  if (!relativePath || relativePath.startsWith('..')) {
+    throw new Error(`Path escapes git worktree root: ${absolutePath}`);
+  }
+  return options?.directory && !relativePath.endsWith('/') ? `${relativePath}/` : relativePath;
+}
+
+function resolveDeclaredSourceRepoRoots(projectPath: string, projectYaml: any): string[] {
+  if (!Array.isArray(projectYaml?.execution?.source_repo_roots)) {
+    return [];
+  }
+
+  return Array.from(new Set(
+    projectYaml.execution.source_repo_roots
+      .filter((value: unknown): value is string => typeof value === 'string')
+      .map((value: string) => value.trim())
+      .filter((value: string) => value.length > 0)
+      .map((value: string) => normalizePath(isAbsolute(value) ? value : join(projectPath, value))),
+  ));
+}
+
+function normalizeGitHubRepo(value: string): string {
+  return value.trim().replace(/\.git$/i, '').replace(/^\/+|\/+$/g, '').toLowerCase();
+}
+
+function extractGitHubRepoFromRemoteOrigin(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const sshMatch = trimmed.match(/^git@github\.com:([^/]+\/[^/]+?)(?:\.git)?$/i);
+  if (sshMatch) {
+    return normalizeGitHubRepo(sshMatch[1]);
+  }
+
+  const httpsMatch = trimmed.match(/^https?:\/\/github\.com\/([^/]+\/[^/]+?)(?:\.git)?$/i);
+  if (httpsMatch) {
+    return normalizeGitHubRepo(httpsMatch[1]);
+  }
+
+  const sshUrlMatch = trimmed.match(/^ssh:\/\/git@github\.com\/([^/]+\/[^/]+?)(?:\.git)?$/i);
+  if (sshUrlMatch) {
+    return normalizeGitHubRepo(sshUrlMatch[1]);
+  }
+
+  return null;
+}
+
+async function validatePrivateContinuityRepoBinding(args: {
+  projectName: string;
+  projectPath: string;
+  projectYaml: any;
+  gitWorktreeRoot: string | null;
+  gitCommonRepoRoot: string | null;
+}): Promise<string[]> {
+  const { projectName, projectPath, projectYaml, gitWorktreeRoot, gitCommonRepoRoot } = args;
+  const reasons: string[] = [];
+
+  if (!gitWorktreeRoot || !gitCommonRepoRoot) {
+    reasons.push('private_continuity requires a git repo root for tracked continuity persistence.');
+    return reasons;
+  }
+
+  const declaredSourceRepoRoots = resolveDeclaredSourceRepoRoots(projectPath, projectYaml);
+  if (declaredSourceRepoRoots.length === 0) {
+    reasons.push(`Project "${projectName}" is marked github_versioned but missing execution.source_repo_roots.`);
+    return reasons;
+  }
+
+  const normalizedCommonRepoRoot = normalizePath(gitCommonRepoRoot);
+  if (!declaredSourceRepoRoots.includes(normalizedCommonRepoRoot)) {
+    reasons.push(
+      `git common repo root "${gitCommonRepoRoot}" is not one of declared execution.source_repo_roots for "${projectName}": ${declaredSourceRepoRoots.join(', ')}`,
+    );
+  }
+
+  const declaredGithubRepo = typeof projectYaml?.source_control?.github_repo === 'string'
+    ? projectYaml.source_control.github_repo.trim()
+    : '';
+  if (declaredGithubRepo.length > 0) {
+    try {
+      const { stdout } = await execCommand(`git -C "${gitWorktreeRoot}" remote get-url origin`);
+      const actualGithubRepo = extractGitHubRepoFromRemoteOrigin(stdout);
+      const expectedGithubRepo = normalizeGitHubRepo(declaredGithubRepo);
+      if (actualGithubRepo !== expectedGithubRepo) {
+        reasons.push(
+          `git remote origin "${stdout.trim() || 'missing'}" does not match declared source_control.github_repo "${declaredGithubRepo}" for "${projectName}"`,
+        );
+      }
+    } catch (error: any) {
+      const detail = (error?.stderr || error?.stdout || error?.message || '').toString().trim() || 'missing';
+      reasons.push(
+        `git remote origin "${detail}" does not match declared source_control.github_repo "${declaredGithubRepo}" for "${projectName}"`,
+      );
+    }
+  }
+
+  return reasons;
 }
 
 export async function saveState(args: any): Promise<string> {
@@ -62,7 +170,9 @@ export async function saveState(args: any): Promise<string> {
 
   try {
     // Find git root from the project path (works regardless of AGENTICOS_HOME)
-    const gitRoot = await findGitRoot(projectPath);
+    const gitIdentity = await findGitIdentity(projectPath);
+    const gitWorktreeRoot = gitIdentity?.worktreeRoot || null;
+    const gitCommonRepoRoot = gitIdentity?.commonRepoRoot || null;
 
     let contextPolicyPlan;
     try {
@@ -70,7 +180,7 @@ export async function saveState(args: any): Promise<string> {
         projectName: project.name,
         projectPath,
         projectYaml,
-        repoRoot: gitRoot,
+        repoRoot: gitCommonRepoRoot,
       });
     } catch (error: any) {
       return `❌ ${error.message}`;
@@ -83,8 +193,22 @@ export async function saveState(args: any): Promise<string> {
       })
       : null;
 
-    if (continuityPlan && continuityPlan.unsupported_reasons.length > 0) {
-      return buildContinuityFailureMessage(project.name, continuityPlan.unsupported_reasons);
+    if (continuityPlan) {
+      const repoBindingReasons = await validatePrivateContinuityRepoBinding({
+        projectName: project.name,
+        projectPath,
+        projectYaml,
+        gitWorktreeRoot,
+        gitCommonRepoRoot,
+      });
+      const continuityFailureReasons = [
+        ...continuityPlan.unsupported_reasons,
+        ...repoBindingReasons,
+      ];
+
+      if (continuityFailureReasons.length > 0) {
+        return buildContinuityFailureMessage(project.name, continuityFailureReasons);
+      }
     }
 
     // Update state.yaml only after the continuity plan is known to be supported.
@@ -103,23 +227,29 @@ export async function saveState(args: any): Promise<string> {
       ? '\n📝 CLAUDE.md was auto-generated (Project DNA section needs manual enrichment)'
       : '';
 
-    if (!gitRoot) {
+    if (!gitWorktreeRoot) {
       return `⚠️ State saved but no git repo found at ${projectPath}\n\nTimestamp: ${state.session.last_backup}${claudeMdNote}`;
     }
 
     // Project-scoped git: stage policy-aware continuity paths for private repos, otherwise keep runtime-managed paths.
-    const gitCmd = `git -C "${gitRoot}"`;
+    const gitCmd = `git -C "${gitWorktreeRoot}"`;
     const stagePaths = continuityPlan
       ? [
-        ...continuityPlan.tracked_continuity_paths,
-        ...continuityPlan.optional_guidance_paths,
+        toGitRelativePath(gitWorktreeRoot, join(projectPath, contextPolicyPlan.trackedContextDisplayPaths.projectFile)),
+        toGitRelativePath(gitWorktreeRoot, join(projectPath, contextPolicyPlan.trackedContextDisplayPaths.quickStart)),
+        toGitRelativePath(gitWorktreeRoot, join(projectPath, contextPolicyPlan.trackedContextDisplayPaths.state)),
+        toGitRelativePath(gitWorktreeRoot, join(projectPath, contextPolicyPlan.trackedContextDisplayPaths.conversations), { directory: true }),
+        toGitRelativePath(gitWorktreeRoot, join(projectPath, contextPolicyPlan.trackedContextDisplayPaths.knowledge), { directory: true }),
+        toGitRelativePath(gitWorktreeRoot, join(projectPath, contextPolicyPlan.trackedContextDisplayPaths.tasks), { directory: true }),
+        toGitRelativePath(gitWorktreeRoot, join(projectPath, 'CLAUDE.md')),
+        ...(existsSync(`${projectPath}/AGENTS.md`) ? [toGitRelativePath(gitWorktreeRoot, join(projectPath, 'AGENTS.md'))] : []),
       ]
       : resolveRuntimeReviewSurfacePaths(projectPath, projectYaml, {
         include_claude_state_mirror: true,
       }).tracked_review_excluded_paths;
     const stageTargets = stagePaths
       .map((trackedPath) => continuityPlan
-        ? `"${toRepoAbsolutePath(gitRoot, trackedPath)}"`
+        ? `"${trackedPath}"`
         : `"${toProjectAbsoluteRuntimePath(projectPath, trackedPath)}"`)
       .join(' ');
 

--- a/mcp-server/src/tools/save.ts
+++ b/mcp-server/src/tools/save.ts
@@ -158,7 +158,11 @@ export async function saveState(args: any): Promise<string> {
     else if (committed) phases.push('⚠️ Push failed (committed locally, not synced)');
 
     const recoveryNote = continuityPlan
-      ? '\nRecovery: full tracked continuity staged for Git-backed restore'
+      ? pushed
+        ? '\nRecovery: full tracked continuity synced for Git-backed restore'
+        : committed
+          ? '\nRecovery: tracked continuity committed locally; remote sync is still pending'
+          : '\nRecovery: tracked continuity contract evaluated; no new continuity changes were committed'
       : '';
 
     return `${phases.join('\n')}\n\nProject: "${project.name}"\nCommit: ${commitMessage}\nTimestamp: ${state.session.last_backup}${claudeMdNote}${recoveryNote}`;

--- a/mcp-server/src/utils/__tests__/context-policy-plan.test.ts
+++ b/mcp-server/src/utils/__tests__/context-policy-plan.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { resolveContextPolicyPlan, toRepoRelativePath } from '../context-policy-plan.js';
+
+describe('resolveContextPolicyPlan', () => {
+  it('resolves private_continuity tracked paths inside the repo root', () => {
+    const plan = resolveContextPolicyPlan({
+      projectName: 'Private Project',
+      projectPath: '/workspace/private-project',
+      repoRoot: '/workspace/private-project',
+      projectYaml: {
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'private_continuity',
+        },
+        agent_context: {
+          quick_start: '.context/quick-start.md',
+          current_state: '.context/state.yaml',
+          conversations: '.context/conversations/',
+          last_record_marker: '.context/.last_record',
+          knowledge: 'knowledge/',
+          tasks: 'tasks/',
+          artifacts: 'artifacts/',
+        },
+      },
+    });
+
+    expect(plan.policy).toBe('private_continuity');
+    expect(plan.rawConversationsDir).toBe('/workspace/private-project/.context/conversations/');
+    expect(plan.trackedConversationsDir).toBe('/workspace/private-project/.context/conversations/');
+    expect(plan.repoBoundaryViolations).toEqual([]);
+  });
+
+  it('routes public_distilled raw conversations to the private sidecar path', () => {
+    const plan = resolveContextPolicyPlan({
+      projectName: 'Public Project',
+      projectPath: '/workspace/public-project',
+      repoRoot: '/workspace/public-project',
+      projectYaml: {
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'public_distilled',
+        },
+      },
+    });
+
+    expect(plan.policy).toBe('public_distilled');
+    expect(plan.rawConversationsDir).toBe('/workspace/public-project/.private/conversations');
+    expect(plan.trackedConversationsDir).toBeNull();
+    expect(plan.sidecarOnlyPaths).toContain('/workspace/public-project/.private/conversations');
+  });
+
+  it('records repo-boundary violations for configured paths outside the repo root', () => {
+    const plan = resolveContextPolicyPlan({
+      projectName: 'Escaping Project',
+      projectPath: '/workspace/project',
+      repoRoot: '/workspace/project',
+      projectYaml: {
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'private_continuity',
+        },
+        agent_context: {
+          knowledge: '../shared-knowledge/',
+        },
+      },
+    });
+
+    expect(plan.repoBoundaryViolations).toContain('knowledge path escapes repo root: /workspace/shared-knowledge/');
+  });
+});
+
+describe('toRepoRelativePath', () => {
+  it('returns repo-relative directory paths', () => {
+    expect(toRepoRelativePath('/workspace/project', '/workspace/project/tasks', { directory: true })).toBe('tasks/');
+  });
+
+  it('throws when the candidate escapes the repo root', () => {
+    expect(() => toRepoRelativePath('/workspace/project', '/workspace/elsewhere/state.yaml')).toThrow('Path escapes repo root');
+  });
+});

--- a/mcp-server/src/utils/__tests__/context-policy-plan.test.ts
+++ b/mcp-server/src/utils/__tests__/context-policy-plan.test.ts
@@ -67,6 +67,28 @@ describe('resolveContextPolicyPlan', () => {
 
     expect(plan.repoBoundaryViolations).toContain('knowledge path escapes repo root: /workspace/shared-knowledge/');
   });
+
+  it('records project-boundary violations for configured paths outside the project root but still inside the repo', () => {
+    const plan = resolveContextPolicyPlan({
+      projectName: 'Nested Project',
+      projectPath: '/workspace/repo/projects/app',
+      repoRoot: '/workspace/repo',
+      projectYaml: {
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'private_continuity',
+        },
+        agent_context: {
+          tasks: '../../shared-tasks/',
+        },
+      },
+    });
+
+    expect(plan.projectBoundaryViolations).toContain(
+      'tasks path escapes project root: /workspace/repo/shared-tasks/',
+    );
+    expect(plan.repoBoundaryViolations).toEqual([]);
+  });
 });
 
 describe('toRepoRelativePath', () => {

--- a/mcp-server/src/utils/__tests__/continuity-surface.test.ts
+++ b/mcp-server/src/utils/__tests__/continuity-surface.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { resolveContextPolicyPlan } from '../context-policy-plan.js';
+import { resolveContinuitySurfacePlan } from '../continuity-surface.js';
+
+describe('resolveContinuitySurfacePlan', () => {
+  it('returns the full tracked continuity set for private_continuity', () => {
+    const contextPlan = resolveContextPolicyPlan({
+      projectName: 'Private Project',
+      projectPath: '/workspace/private-project',
+      repoRoot: '/workspace/private-project',
+      projectYaml: {
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'private_continuity',
+        },
+      },
+    });
+
+    const plan = resolveContinuitySurfacePlan(contextPlan, {
+      include_claude_state_mirror: true,
+      include_agents_guidance: true,
+    });
+
+    expect(plan.policy).toBe('private_continuity');
+    expect(plan.tracked_continuity_paths).toEqual([
+      '.project.yaml',
+      '.context/quick-start.md',
+      '.context/state.yaml',
+      '.context/conversations/',
+      'knowledge/',
+      'tasks/',
+    ]);
+    expect(plan.optional_guidance_paths).toEqual(['CLAUDE.md', 'AGENTS.md']);
+    expect(plan.excluded_paths).toContain('.context/.last_record');
+    expect(plan.excluded_paths).toContain('.private/conversations/');
+    expect(plan.unsupported_reasons).toEqual([]);
+  });
+
+  it('does not widen public_distilled to full continuity', () => {
+    const contextPlan = resolveContextPolicyPlan({
+      projectName: 'Public Project',
+      projectPath: '/workspace/public-project',
+      repoRoot: '/workspace/public-project',
+      projectYaml: {
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'public_distilled',
+        },
+      },
+    });
+
+    const plan = resolveContinuitySurfacePlan(contextPlan);
+
+    expect(plan.policy).toBe('public_distilled');
+    expect(plan.tracked_continuity_paths).toEqual([]);
+    expect(plan.optional_guidance_paths).toEqual([]);
+  });
+
+  it('fails closed when a required tracked continuity path escapes the repo root', () => {
+    const contextPlan = resolveContextPolicyPlan({
+      projectName: 'Escaping Project',
+      projectPath: '/workspace/project',
+      repoRoot: '/workspace/project',
+      projectYaml: {
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'private_continuity',
+        },
+        agent_context: {
+          tasks: '../shared-tasks/',
+        },
+      },
+    });
+
+    const plan = resolveContinuitySurfacePlan(contextPlan);
+
+    expect(plan.unsupported_reasons).toContain('tasks path escapes repo root: /workspace/shared-tasks/');
+  });
+});

--- a/mcp-server/src/utils/__tests__/continuity-surface.test.ts
+++ b/mcp-server/src/utils/__tests__/continuity-surface.test.ts
@@ -76,4 +76,25 @@ describe('resolveContinuitySurfacePlan', () => {
 
     expect(plan.unsupported_reasons).toContain('tasks path escapes repo root: /workspace/shared-tasks/');
   });
+
+  it('fails closed when a required tracked continuity path escapes the project root but remains inside the repo', () => {
+    const contextPlan = resolveContextPolicyPlan({
+      projectName: 'Nested Project',
+      projectPath: '/workspace/repo/projects/app',
+      repoRoot: '/workspace/repo',
+      projectYaml: {
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'private_continuity',
+        },
+        agent_context: {
+          tasks: '../../shared-tasks/',
+        },
+      },
+    });
+
+    const plan = resolveContinuitySurfacePlan(contextPlan);
+
+    expect(plan.unsupported_reasons).toContain('tasks path escapes project root: /workspace/repo/shared-tasks/');
+  });
 });

--- a/mcp-server/src/utils/__tests__/distill.test.ts
+++ b/mcp-server/src/utils/__tests__/distill.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
   AGENTS_ADAPTER_LINES,
+  CONTINUITY_CONTRACT_BULLETS,
+  CONTINUITY_CONTRACT_TITLE,
   AGENTS_RUNTIME_GUIDANCE_BULLETS,
   AGENTS_RUNTIME_GUIDANCE_TITLE,
   CLAUDE_ADAPTER_LINES,
@@ -19,13 +21,17 @@ describe('distill templates', () => {
   it('generates AGENTS.md with the current template marker, adapter role, and guardrail flow', () => {
     const content = generateAgentsMd('Demo Project', 'Guardrail test');
 
-    expect(CURRENT_TEMPLATE_VERSION).toBe(11);
-    expect(content).toContain('<!-- agenticos-template: v11 -->');
+    expect(CURRENT_TEMPLATE_VERSION).toBe(12);
+    expect(content).toContain('<!-- agenticos-template: v12 -->');
     expect(content).toContain('## Adapter Role');
     expect(content).toContain(AGENTS_ADAPTER_LINES[0]);
     expect(content).toContain(AGENTS_ADAPTER_LINES[1]);
     expect(content).toContain(`## ${SHARED_POLICY_TITLE}`);
     for (const bullet of SHARED_POLICY_BULLETS) {
+      expect(content).toContain(bullet);
+    }
+    expect(content).toContain(`## ${CONTINUITY_CONTRACT_TITLE}`);
+    for (const bullet of CONTINUITY_CONTRACT_BULLETS) {
       expect(content).toContain(bullet);
     }
     expect(content).toContain(`## ${AGENTS_RUNTIME_GUIDANCE_TITLE}`);
@@ -49,6 +55,8 @@ describe('distill templates', () => {
     expect(content).toContain('agenticos_branch_bootstrap');
     expect(content).toContain('agenticos_pr_scope_check');
     expect(content).toContain('.context/quick-start.md');
+    expect(content).toContain('review the configured conversation history surface when relevant');
+    expect(content).toContain('Configured conversation history surface (tracked or policy-routed)');
     expect(content).toContain('tasks/templates/agent-preflight-checklist.yaml');
     expect(content).toContain('tasks/templates/non-code-evaluation-rubric.yaml');
   });
@@ -61,6 +69,10 @@ describe('distill templates', () => {
     expect(content).toContain(CLAUDE_ADAPTER_LINES[1]);
     expect(content).toContain(`## ${SHARED_POLICY_TITLE}`);
     for (const bullet of SHARED_POLICY_BULLETS) {
+      expect(content).toContain(bullet);
+    }
+    expect(content).toContain(`## ${CONTINUITY_CONTRACT_TITLE}`);
+    for (const bullet of CONTINUITY_CONTRACT_BULLETS) {
       expect(content).toContain(bullet);
     }
     expect(content).toContain(`## ${CLAUDE_RUNTIME_GUIDANCE_TITLE}`);
@@ -84,6 +96,8 @@ describe('distill templates', () => {
     expect(content).toContain('agenticos_branch_bootstrap');
     expect(content).toContain('agenticos_pr_scope_check');
     expect(content).toContain('.context/quick-start.md');
+    expect(content).toContain('review the configured conversation history surface when relevant');
+    expect(content).toContain('会话历史入口（tracked 或按 policy 路由）');
     expect(content).toContain('tasks/templates/submission-evidence.md');
     expect(content).toContain('tasks/templates/non-code-evaluation-rubric.yaml');
   });

--- a/mcp-server/src/utils/context-policy-plan.ts
+++ b/mcp-server/src/utils/context-policy-plan.ts
@@ -1,0 +1,161 @@
+import { join, relative, resolve } from 'path';
+import {
+  resolveManagedProjectContextDisplayPaths,
+  resolveManagedProjectContextPaths,
+  type ManagedProjectContextDisplayPaths,
+  type ManagedProjectContextPaths,
+} from './agent-context-paths.js';
+import {
+  type ContextPublicationPolicy,
+  validateContextPublicationPolicy,
+} from './project-contract.js';
+
+export interface ContextPolicyPlan {
+  policy: ContextPublicationPolicy;
+  projectRoot: string;
+  repoRoot: string | null;
+  trackedContextPaths: {
+    projectFile: string;
+    quickStart: string;
+    state: string;
+    conversations: string;
+    knowledge: string;
+    tasks: string;
+    lastRecord: string;
+    artifacts: string;
+  };
+  trackedContextDisplayPaths: {
+    projectFile: string;
+    quickStart: string;
+    state: string;
+    conversations: string;
+    knowledge: string;
+    tasks: string;
+    lastRecord: string;
+    artifacts: string;
+  };
+  rawConversationsDir: string;
+  trackedConversationsDir: string | null;
+  sidecarOnlyPaths: string[];
+  repoBoundaryViolations: string[];
+}
+
+interface ResolveContextPolicyPlanArgs {
+  projectName: string;
+  projectPath: string;
+  projectYaml: any;
+  repoRoot?: string | null;
+}
+
+function normalizePath(value: string): string {
+  return resolve(value);
+}
+
+function isWithinRoot(rootPath: string, candidatePath: string): boolean {
+  const normalizedRoot = normalizePath(rootPath);
+  const normalizedCandidate = normalizePath(candidatePath);
+  return normalizedCandidate === normalizedRoot || normalizedCandidate.startsWith(`${normalizedRoot}/`);
+}
+
+function collectRepoBoundaryViolations(
+  repoRoot: string | null,
+  trackedContextPaths: ContextPolicyPlan['trackedContextPaths'],
+  rawConversationsDir: string,
+  trackedConversationsDir: string | null,
+): string[] {
+  if (!repoRoot) {
+    return [];
+  }
+
+  const candidates: Array<[string, string | null]> = [
+    ['.project.yaml', trackedContextPaths.projectFile],
+    ['quick-start', trackedContextPaths.quickStart],
+    ['state', trackedContextPaths.state],
+    ['conversations', trackedContextPaths.conversations],
+    ['knowledge', trackedContextPaths.knowledge],
+    ['tasks', trackedContextPaths.tasks],
+    ['last_record', trackedContextPaths.lastRecord],
+    ['artifacts', trackedContextPaths.artifacts],
+    ['raw_conversations', rawConversationsDir],
+    ['tracked_conversations', trackedConversationsDir],
+  ];
+
+  return candidates
+    .filter(([, candidatePath]) => candidatePath && !isWithinRoot(repoRoot, candidatePath))
+    .map(([label, candidatePath]) => `${label} path escapes repo root: ${candidatePath}`);
+}
+
+export function toRepoRelativePath(repoRoot: string, absolutePath: string, options?: { directory?: boolean }): string {
+  const normalizedRoot = normalizePath(repoRoot);
+  const normalizedAbsolute = normalizePath(absolutePath);
+  const relativePath = relative(normalizedRoot, normalizedAbsolute).replace(/\\/g, '/');
+
+  if (!relativePath || relativePath.startsWith('..')) {
+    throw new Error(`Path escapes repo root: ${absolutePath}`);
+  }
+
+  return options?.directory && !relativePath.endsWith('/') ? `${relativePath}/` : relativePath;
+}
+
+export function resolveContextPolicyPlan(args: ResolveContextPolicyPlanArgs): ContextPolicyPlan {
+  const { projectName, projectPath, projectYaml } = args;
+  const validation = validateContextPublicationPolicy(projectName, projectYaml);
+  if (!validation.ok) {
+    throw new Error(validation.message);
+  }
+
+  const projectRoot = normalizePath(projectPath);
+  const repoRoot = args.repoRoot ? normalizePath(args.repoRoot) : null;
+  const displayPaths: ManagedProjectContextDisplayPaths = resolveManagedProjectContextDisplayPaths(projectYaml);
+  const absolutePaths: ManagedProjectContextPaths = resolveManagedProjectContextPaths(projectRoot, projectYaml);
+  const projectFile = join(projectRoot, '.project.yaml');
+
+  const rawConversationsDir = validation.policy === 'public_distilled'
+    ? join(projectRoot, '.private', 'conversations')
+    : absolutePaths.conversationsDir;
+  const trackedConversationsDir = validation.policy === 'public_distilled'
+    ? null
+    : absolutePaths.conversationsDir;
+
+  const trackedContextPaths = {
+    projectFile,
+    quickStart: absolutePaths.quickStartPath,
+    state: absolutePaths.statePath,
+    conversations: absolutePaths.conversationsDir,
+    knowledge: absolutePaths.knowledgeDir,
+    tasks: absolutePaths.tasksDir,
+    lastRecord: absolutePaths.markerPath,
+    artifacts: absolutePaths.artifactsDir,
+  };
+
+  const trackedContextDisplayPaths = {
+    projectFile: '.project.yaml',
+    quickStart: displayPaths.quickStartPath,
+    state: displayPaths.statePath,
+    conversations: displayPaths.conversationsDir,
+    knowledge: displayPaths.knowledgeDir,
+    tasks: displayPaths.tasksDir,
+    lastRecord: displayPaths.markerPath,
+    artifacts: displayPaths.artifactsDir,
+  };
+
+  return {
+    policy: validation.policy,
+    projectRoot,
+    repoRoot,
+    trackedContextPaths,
+    trackedContextDisplayPaths,
+    rawConversationsDir,
+    trackedConversationsDir,
+    sidecarOnlyPaths: [
+      join(projectRoot, '.private', 'conversations'),
+      join(projectRoot, '.meta', 'transcripts'),
+    ],
+    repoBoundaryViolations: collectRepoBoundaryViolations(
+      repoRoot,
+      trackedContextPaths,
+      rawConversationsDir,
+      trackedConversationsDir,
+    ),
+  };
+}

--- a/mcp-server/src/utils/context-policy-plan.ts
+++ b/mcp-server/src/utils/context-policy-plan.ts
@@ -37,6 +37,7 @@ export interface ContextPolicyPlan {
   rawConversationsDir: string;
   trackedConversationsDir: string | null;
   sidecarOnlyPaths: string[];
+  projectBoundaryViolations: string[];
   repoBoundaryViolations: string[];
 }
 
@@ -83,6 +84,30 @@ function collectRepoBoundaryViolations(
   return candidates
     .filter(([, candidatePath]) => candidatePath && !isWithinRoot(repoRoot, candidatePath))
     .map(([label, candidatePath]) => `${label} path escapes repo root: ${candidatePath}`);
+}
+
+function collectProjectBoundaryViolations(
+  projectRoot: string,
+  trackedContextPaths: ContextPolicyPlan['trackedContextPaths'],
+  rawConversationsDir: string,
+  trackedConversationsDir: string | null,
+): string[] {
+  const candidates: Array<[string, string | null]> = [
+    ['.project.yaml', trackedContextPaths.projectFile],
+    ['quick-start', trackedContextPaths.quickStart],
+    ['state', trackedContextPaths.state],
+    ['conversations', trackedContextPaths.conversations],
+    ['knowledge', trackedContextPaths.knowledge],
+    ['tasks', trackedContextPaths.tasks],
+    ['last_record', trackedContextPaths.lastRecord],
+    ['artifacts', trackedContextPaths.artifacts],
+    ['raw_conversations', rawConversationsDir],
+    ['tracked_conversations', trackedConversationsDir],
+  ];
+
+  return candidates
+    .filter(([, candidatePath]) => candidatePath && !isWithinRoot(projectRoot, candidatePath))
+    .map(([label, candidatePath]) => `${label} path escapes project root: ${candidatePath}`);
 }
 
 export function toRepoRelativePath(repoRoot: string, absolutePath: string, options?: { directory?: boolean }): string {
@@ -151,6 +176,12 @@ export function resolveContextPolicyPlan(args: ResolveContextPolicyPlanArgs): Co
       join(projectRoot, '.private', 'conversations'),
       join(projectRoot, '.meta', 'transcripts'),
     ],
+    projectBoundaryViolations: collectProjectBoundaryViolations(
+      projectRoot,
+      trackedContextPaths,
+      rawConversationsDir,
+      trackedConversationsDir,
+    ),
     repoBoundaryViolations: collectRepoBoundaryViolations(
       repoRoot,
       trackedContextPaths,

--- a/mcp-server/src/utils/continuity-surface.ts
+++ b/mcp-server/src/utils/continuity-surface.ts
@@ -132,6 +132,18 @@ export function resolveContinuitySurfacePlan(
     }
   }
 
+  for (const violation of plan.projectBoundaryViolations) {
+    const isRequiredViolation = violation.startsWith('.project.yaml')
+      || violation.startsWith('quick-start')
+      || violation.startsWith('state')
+      || violation.startsWith('conversations')
+      || violation.startsWith('knowledge')
+      || violation.startsWith('tasks');
+    if (isRequiredViolation) {
+      unsupportedReasons.push(violation);
+    }
+  }
+
   return {
     policy: plan.policy,
     tracked_continuity_paths: uniq(Array.from(trackedContinuity)),

--- a/mcp-server/src/utils/continuity-surface.ts
+++ b/mcp-server/src/utils/continuity-surface.ts
@@ -1,0 +1,143 @@
+import { join } from 'path';
+import { type ContextPolicyPlan, toRepoRelativePath } from './context-policy-plan.js';
+
+export interface ContinuitySurfacePlan {
+  policy: ContextPolicyPlan['policy'];
+  tracked_continuity_paths: string[];
+  excluded_paths: string[];
+  required_guidance_paths: string[];
+  optional_guidance_paths: string[];
+  unsupported_reasons: string[];
+}
+
+interface ResolveContinuitySurfaceOptions {
+  include_claude_state_mirror?: boolean;
+  include_agents_guidance?: boolean;
+}
+
+function uniq(values: string[]): string[] {
+  return Array.from(new Set(values));
+}
+
+function toProjectRelativePath(projectRoot: string, absolutePath: string, directory = false): string {
+  const repoRelative = absolutePath
+    .replace(projectRoot.replace(/\\/g, '/'), '')
+    .replace(/^\/+/, '')
+    .replace(/\\/g, '/');
+
+  if (!repoRelative) {
+    throw new Error(`Path escapes project root: ${absolutePath}`);
+  }
+
+  return directory && !repoRelative.endsWith('/') ? `${repoRelative}/` : repoRelative;
+}
+
+function resolveExcludedPaths(plan: ContextPolicyPlan): string[] {
+  const excluded = [
+    plan.trackedContextDisplayPaths.lastRecord,
+    '.private/conversations/',
+    '.meta/transcripts/',
+    'node_modules/',
+    'coverage/',
+  ];
+
+  if (plan.repoRoot) {
+    try {
+      excluded[0] = toRepoRelativePath(plan.repoRoot, plan.trackedContextPaths.lastRecord);
+    } catch {
+      excluded[0] = plan.trackedContextDisplayPaths.lastRecord;
+    }
+  }
+
+  return uniq(excluded);
+}
+
+export function resolveContinuitySurfacePlan(
+  plan: ContextPolicyPlan,
+  options: ResolveContinuitySurfaceOptions = {},
+): ContinuitySurfacePlan {
+  const unsupportedReasons: string[] = [];
+
+  if (plan.policy !== 'private_continuity') {
+    return {
+      policy: plan.policy,
+      tracked_continuity_paths: [],
+      excluded_paths: resolveExcludedPaths(plan),
+      required_guidance_paths: [],
+      optional_guidance_paths: [],
+      unsupported_reasons: unsupportedReasons,
+    };
+  }
+
+  if (!plan.repoRoot) {
+    unsupportedReasons.push('private_continuity requires a git repo root for tracked continuity persistence.');
+  }
+
+  const trackedContinuity = new Set<string>();
+  const optionalGuidance = new Set<string>();
+
+  const addTrackedPath = (label: string, absolutePath: string, directory = false) => {
+    if (!plan.repoRoot) {
+      return;
+    }
+    try {
+      trackedContinuity.add(toRepoRelativePath(plan.repoRoot, absolutePath, { directory }));
+    } catch {
+      unsupportedReasons.push(`${label} path escapes repo root: ${absolutePath}`);
+    }
+  };
+
+  addTrackedPath('.project.yaml', plan.trackedContextPaths.projectFile);
+  addTrackedPath('quick-start', plan.trackedContextPaths.quickStart);
+  addTrackedPath('state', plan.trackedContextPaths.state);
+  addTrackedPath('conversations', plan.trackedContextPaths.conversations, true);
+  addTrackedPath('knowledge', plan.trackedContextPaths.knowledge, true);
+  addTrackedPath('tasks', plan.trackedContextPaths.tasks, true);
+
+  if (options.include_claude_state_mirror !== false) {
+    const claudePath = join(plan.projectRoot, 'CLAUDE.md');
+    if (plan.repoRoot) {
+      try {
+        optionalGuidance.add(toRepoRelativePath(plan.repoRoot, claudePath));
+      } catch {
+        unsupportedReasons.push(`CLAUDE.md path escapes repo root: ${claudePath}`);
+      }
+    } else {
+      optionalGuidance.add(toProjectRelativePath(plan.projectRoot, claudePath));
+    }
+  }
+
+  if (options.include_agents_guidance) {
+    const agentsPath = join(plan.projectRoot, 'AGENTS.md');
+    if (plan.repoRoot) {
+      try {
+        optionalGuidance.add(toRepoRelativePath(plan.repoRoot, agentsPath));
+      } catch {
+        unsupportedReasons.push(`AGENTS.md path escapes repo root: ${agentsPath}`);
+      }
+    } else {
+      optionalGuidance.add(toProjectRelativePath(plan.projectRoot, agentsPath));
+    }
+  }
+
+  for (const violation of plan.repoBoundaryViolations) {
+    const isRequiredViolation = violation.startsWith('.project.yaml')
+      || violation.startsWith('quick-start')
+      || violation.startsWith('state')
+      || violation.startsWith('conversations')
+      || violation.startsWith('knowledge')
+      || violation.startsWith('tasks');
+    if (isRequiredViolation) {
+      unsupportedReasons.push(violation);
+    }
+  }
+
+  return {
+    policy: plan.policy,
+    tracked_continuity_paths: uniq(Array.from(trackedContinuity)),
+    excluded_paths: resolveExcludedPaths(plan),
+    required_guidance_paths: [],
+    optional_guidance_paths: uniq(Array.from(optionalGuidance)),
+    unsupported_reasons: uniq(unsupportedReasons),
+  };
+}

--- a/mcp-server/src/utils/distill.ts
+++ b/mcp-server/src/utils/distill.ts
@@ -6,7 +6,7 @@ import { joinDisplayPath, type ManagedProjectContextDisplayPaths } from './agent
  * Current template version. Increment when templates change.
  * Used for auto-upgrade on project switch.
  */
-export const CURRENT_TEMPLATE_VERSION = 11;
+export const CURRENT_TEMPLATE_VERSION = 12;
 
 /** Version marker format in generated files */
 const VERSION_MARKER = `<!-- agenticos-template: v${CURRENT_TEMPLATE_VERSION} -->`;
@@ -70,6 +70,13 @@ export const TASK_INTAKE_RULE_BULLETS = [
   'Once intent is resolved, collapse it into a clean execution objective instead of carrying the full intake rubric through every later step.',
 ] as const;
 
+export const CONTINUITY_CONTRACT_TITLE = 'Continuity Contract';
+export const CONTINUITY_CONTRACT_BULLETS = [
+  'The tracked continuity contract is publication-policy aware: local_private stays runtime-local, private_continuity persists the tracked continuity core, and public_distilled keeps a narrower tracked surface.',
+  'The configured conversations path is a context contract input, but raw transcript routing may differ by publication policy.',
+  '`CLAUDE.md` and `AGENTS.md` are mirrored adapter surfaces. They should stay aligned with project policy, but continuity correctness must not depend on them existing.',
+] as const;
+
 /** Extract template version from an existing file. Returns 0 if no marker found (v1 or earlier). */
 export function extractTemplateVersion(content: string): number {
   const match = content.match(/<!--\s*agenticos-template:\s*v(\d+)\s*-->/);
@@ -101,6 +108,15 @@ function renderRuntimeGuidanceSection(title: string, bullets: readonly string[])
   ].join('\n');
 }
 
+function renderContinuityContractSection(): string {
+  return [
+    `## ${CONTINUITY_CONTRACT_TITLE}`,
+    '',
+    ...CONTINUITY_CONTRACT_BULLETS.map((line) => `- ${line}`),
+    '',
+  ].join('\n');
+}
+
 // ---------------------------------------------------------------------------
 // AGENTS.md template
 // ---------------------------------------------------------------------------
@@ -121,7 +137,7 @@ export function generateAgentsMd(
 ${AGENTS_ADAPTER_LINES[0]}
 ${AGENTS_ADAPTER_LINES[1]}
 
-${renderSharedPolicySection()}${renderRuntimeGuidanceSection(AGENTS_RUNTIME_GUIDANCE_TITLE, AGENTS_RUNTIME_GUIDANCE_BULLETS)}${renderRuntimeGuidanceSection(TASK_INTAKE_RULE_TITLE, TASK_INTAKE_RULE_BULLETS)}## Guardrail Protocol (MANDATORY)
+${renderSharedPolicySection()}${renderContinuityContractSection()}${renderRuntimeGuidanceSection(AGENTS_RUNTIME_GUIDANCE_TITLE, AGENTS_RUNTIME_GUIDANCE_BULLETS)}${renderRuntimeGuidanceSection(TASK_INTAKE_RULE_TITLE, TASK_INTAKE_RULE_BULLETS)}## Guardrail Protocol (MANDATORY)
 
 Before implementation edits, confirm session/project alignment with \`agenticos_status\`; if no session project is bound or the bound project is not the intended one, call \`agenticos_switch\`.
 
@@ -161,7 +177,7 @@ After recording, call \`agenticos_save\` to commit to Git.
 On session start, align the runtime before meaningful work:
 1. call \`agenticos_status\` to confirm the current session project, current task, pending work, and latest recorded state
 2. if no session project is bound or the bound project is not \`${name}\`, call \`agenticos_switch\`
-3. read \`.project.yaml\`, \`${contextPaths.quickStartPath}\`, \`${contextPaths.statePath}\`, and \`${contextPaths.conversationsDir}\`
+3. read \`.project.yaml\`, \`${contextPaths.quickStartPath}\`, \`${contextPaths.statePath}\`, and review the configured conversation history surface when relevant
 4. review the latest guardrail evidence and latest \`agenticos_issue_bootstrap\` record before implementation-affecting work
 5. if implementation work is requested, follow the Guardrail Protocol above exactly before editing
 
@@ -179,7 +195,7 @@ Then greet the user with: project name, last progress, current pending items, su
 | \`.project.yaml\` | Project metadata |
 | \`${contextPaths.quickStartPath}\` | Quick project summary |
 | \`${contextPaths.statePath}\` | Session state and working memory |
-| \`${contextPaths.conversationsDir}\` | Session records (auto-generated) |
+| \`${contextPaths.conversationsDir}\` | Configured conversation history surface (tracked or policy-routed) |
 | \`${contextPaths.knowledgeDir}\` | Persistent knowledge documents |
 | \`${contextPaths.tasksDir}\` | Task tracking |
 | \`${joinDisplayPath(taskTemplatesDir, 'agent-preflight-checklist.yaml')}\` | Preflight checklist template |
@@ -266,7 +282,7 @@ function buildClaudeMdContent(
 
   const nav = userContent?.navigation
     ? `## Navigation\n\n${userContent.navigation}\n`
-    : `## Navigation\n\n| 目录/文件 | 用途 |\n|-----------|------|\n| \`.project.yaml\` | 项目元信息 |\n| \`${contextPaths.quickStartPath}\` | 快速项目概览 |\n| \`${contextPaths.statePath}\` | 当前会话状态及工作记忆 |\n| \`${contextPaths.conversationsDir}\` | 会话记录（自动生成） |\n| \`${contextPaths.knowledgeDir}\` | 持久化知识文档 |\n| \`${contextPaths.tasksDir}\` | 任务追踪 |\n| \`${joinDisplayPath(taskTemplatesDir, 'agent-preflight-checklist.yaml')}\` | preflight 模板 |\n| \`${joinDisplayPath(taskTemplatesDir, 'issue-design-brief.md')}\` | 设计循环模板 |\n| \`${joinDisplayPath(taskTemplatesDir, 'non-code-evaluation-rubric.yaml')}\` | 非代码评估模板 |\n| \`${joinDisplayPath(taskTemplatesDir, 'submission-evidence.md')}\` | 提交证据模板 |\n| \`${contextPaths.artifactsDir}\` | 产出物 |\n`;
+    : `## Navigation\n\n| 目录/文件 | 用途 |\n|-----------|------|\n| \`.project.yaml\` | 项目元信息 |\n| \`${contextPaths.quickStartPath}\` | 快速项目概览 |\n| \`${contextPaths.statePath}\` | 当前会话状态及工作记忆 |\n| \`${contextPaths.conversationsDir}\` | 会话历史入口（tracked 或按 policy 路由） |\n| \`${contextPaths.knowledgeDir}\` | 持久化知识文档 |\n| \`${contextPaths.tasksDir}\` | 任务追踪 |\n| \`${joinDisplayPath(taskTemplatesDir, 'agent-preflight-checklist.yaml')}\` | preflight 模板 |\n| \`${joinDisplayPath(taskTemplatesDir, 'issue-design-brief.md')}\` | 设计循环模板 |\n| \`${joinDisplayPath(taskTemplatesDir, 'non-code-evaluation-rubric.yaml')}\` | 非代码评估模板 |\n| \`${joinDisplayPath(taskTemplatesDir, 'submission-evidence.md')}\` | 提交证据模板 |\n| \`${contextPaths.artifactsDir}\` | 产出物 |\n`;
 
   return `${VERSION_MARKER}
 # CLAUDE.md — ${name}
@@ -276,7 +292,7 @@ function buildClaudeMdContent(
 ${CLAUDE_ADAPTER_LINES[0]}
 ${CLAUDE_ADAPTER_LINES[1]}
 
-${renderSharedPolicySection()}${renderRuntimeGuidanceSection(CLAUDE_RUNTIME_GUIDANCE_TITLE, CLAUDE_RUNTIME_GUIDANCE_BULLETS)}${renderRuntimeGuidanceSection(TASK_INTAKE_RULE_TITLE, TASK_INTAKE_RULE_BULLETS)}## Guardrail Protocol (MANDATORY)
+${renderSharedPolicySection()}${renderContinuityContractSection()}${renderRuntimeGuidanceSection(CLAUDE_RUNTIME_GUIDANCE_TITLE, CLAUDE_RUNTIME_GUIDANCE_BULLETS)}${renderRuntimeGuidanceSection(TASK_INTAKE_RULE_TITLE, TASK_INTAKE_RULE_BULLETS)}## Guardrail Protocol (MANDATORY)
 
 Before implementation edits, confirm session/project alignment with \`agenticos_status\`; if no session project is bound or the bound project is not the intended one, call \`agenticos_switch\`.
 
@@ -326,7 +342,7 @@ When you open this project in a new session, **immediately do the following**:
 
 1. Call \`agenticos_status\` to confirm the current session project, current task, pending work, and latest recorded state
 2. If no session project is bound or the bound project is not \`${name}\`, call \`agenticos_switch\`
-3. Read \`.project.yaml\`, the "Current State" section below, \`${contextPaths.quickStartPath}\`, and \`${contextPaths.conversationsDir}\`
+3. Read \`.project.yaml\`, the "Current State" section below, \`${contextPaths.quickStartPath}\`, and review the configured conversation history surface when relevant
 4. Review the latest guardrail evidence and latest \`agenticos_issue_bootstrap\` record before implementation-affecting work
 5. Greet the user with a brief status report:
 


### PR DESCRIPTION
## Summary
- add a shared validated context policy/path planner for github_versioned projects
- make agenticos_save fail closed and stage the full tracked continuity surface for private_continuity projects
- align generated guidance, templates, and recovery docs with the new private continuity contract

## Testing
- cd mcp-server && npm run lint
- cd mcp-server && npm test -- src/utils/__tests__/distill.test.ts src/utils/__tests__/context-policy-plan.test.ts src/utils/__tests__/continuity-surface.test.ts src/tools/__tests__/save.test.ts

Closes #244