### PR TITLE
feat: isolate public raw transcripts from tracked continuity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ mcp-server/build/
 # Runtime-only state
 .runtime/
 .claude/worktrees/
+.private/
+.meta/transcripts/

--- a/.meta/standard-kit/README.md
+++ b/.meta/standard-kit/README.md
@@ -58,7 +58,7 @@ The downstream kit now carries a canonical contract for:
 - `.project.yaml`
 - `.context/quick-start.md`
 - `.context/state.yaml`
-- `.context/conversations/`
+- `.context/conversations/` (tracked/display conversation contract path)
 - `knowledge/`
 - `tasks/`
 - `artifacts/`
@@ -78,6 +78,12 @@ The contract distinguishes:
 - `public_distilled`
 
 That field determines whether raw session history is allowed in tracked source for the project class, rather than forcing later tools to guess from topology alone.
+
+For `public_distilled`, the downstream contract is split:
+
+- `.context/conversations/` remains the tracked/display conversation contract path
+- raw transcript writes should route to a private sidecar such as `.private/conversations/`
+- quick-start and generated adapter surfaces should describe that split truthfully
 
 The canonical rationale lives in:
 

--- a/.meta/standard-kit/inheritance-rules.md
+++ b/.meta/standard-kit/inheritance-rules.md
@@ -7,7 +7,7 @@ Downstream projects inherit not just files, but the role boundaries between:
 - `.project.yaml`
 - `.context/quick-start.md`
 - `.context/state.yaml`
-- `.context/conversations/`
+- `.context/conversations/` (tracked/display conversation surface)
 - `knowledge/`
 - `tasks/`
 - `artifacts/`
@@ -15,7 +15,7 @@ Downstream projects inherit not just files, but the role boundaries between:
 Implication:
 - quick-start stays concise and project-level
 - state stays mutable and operational
-- conversations stay append-only
+- the conversations field stays a tracked/display contract path, while raw transcript routing may still move to a private sidecar for public projects
 - knowledge stays synthesized
 - tasks stay future-facing
 - `.project.yaml` must also declare the context publication policy that governs whether raw conversation history is allowed in tracked source for the project class

--- a/.meta/standard-kit/manifest.yaml
+++ b/.meta/standard-kit/manifest.yaml
@@ -123,6 +123,7 @@ adoption:
     - operator_intent_resolution
     - memory_layer_contracts
     - context_publication_policy_contract
+    - public_transcript_isolation_contract
     - cross_agent_policy_contract
     - session_start_alignment
     - implementation_preflight

--- a/.meta/templates/quick-start.md
+++ b/.meta/templates/quick-start.md
@@ -17,7 +17,7 @@
 
 ## Canonical Layers
 - Operational state: `.context/state.yaml`
-- Conversation history surface: `.context/conversations/` (tracked contract path; raw transcript routing may vary by publication policy)
+- Conversation history surface: `.context/conversations/` (tracked/display contract path; raw transcript routing may vary by publication policy)
 - Durable knowledge: `knowledge/`
 - Execution plans: `tasks/`
 - Deliverables: `artifacts/`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ After recording, call `agenticos_save` to commit to Git.
 On session start, align the runtime before meaningful work:
 1. call `agenticos_status` to confirm the current session project, current task, pending work, and latest recorded state
 2. if no session project is bound or the bound project is not `AgenticOS`, call `agenticos_switch`
-3. read `.project.yaml`, `standards/.context/quick-start.md`, `standards/.context/state.yaml`, and `standards/.context/conversations/`
+3. read `.project.yaml`, `standards/.context/quick-start.md`, and `standards/.context/state.yaml`; use the conversation-history contract surface for recovery when needed (`standards/.context/conversations/` for tracked continuity, or the publication-policy raw sidecar such as `.private/conversations/` when applicable)
 4. review the latest guardrail evidence and latest `agenticos_issue_bootstrap` record before implementation-affecting work
 5. if implementation work is requested, follow the Guardrail Protocol above exactly before editing
 
@@ -79,7 +79,7 @@ Then greet the user with: project name, last progress, current pending items, su
 | `.project.yaml` | Project metadata |
 | `standards/.context/quick-start.md` | Quick project summary |
 | `standards/.context/state.yaml` | Session state and working memory |
-| `standards/.context/conversations/` | Session records (auto-generated) |
+| `standards/.context/conversations/` | Conversation-history contract surface; tracked continuity path, while raw transcript routing depends on publication policy |
 | `knowledge/` | Persistent knowledge documents |
 | `tasks/` | Task tracking |
 | `tasks/templates/agent-preflight-checklist.yaml` | Preflight checklist template |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ When you open this project in a new session, **immediately do the following**:
 
 1. Call `agenticos_status` to confirm the current session project, current task, pending work, and latest recorded state
 2. If no session project is bound or the bound project is not `AgenticOS`, call `agenticos_switch`
-3. Read `.project.yaml`, the "Current State" section below, `standards/.context/quick-start.md`, and `standards/.context/conversations/`
+3. Read `.project.yaml`, the "Current State" section below, `standards/.context/quick-start.md`, and `standards/.context/state.yaml`; use the conversation-history contract surface for recovery when needed (`standards/.context/conversations/` for tracked continuity, or the publication-policy raw sidecar such as `.private/conversations/` when applicable)
 4. Review the latest guardrail evidence and latest `agenticos_issue_bootstrap` record before implementation-affecting work
 5. Greet the user with a brief status report:
 
@@ -124,7 +124,7 @@ When you open this project in a new session, **immediately do the following**:
 | `.project.yaml` | 项目元信息 |
 | `standards/.context/quick-start.md` | 快速项目概览 |
 | `standards/.context/state.yaml` | 当前会话状态及工作记忆 |
-| `standards/.context/conversations/` | 会话记录（自动生成） |
+| `standards/.context/conversations/` | 会话历史契约层；tracked continuity surface，raw transcript 路径受 publication policy 约束 |
 | `knowledge/` | 持久化知识文档 |
 | `tasks/` | 任务追踪 |
 | `tasks/templates/agent-preflight-checklist.yaml` | preflight 模板 |

--- a/README.md
+++ b/README.md
@@ -150,4 +150,4 @@ Current save/recovery contract:
 
 - `local_private`: Git is not the continuity recovery mechanism
 - `private_continuity`: `agenticos_save` is expected to persist the tracked continuity core for Git-backed restore
-- `public_distilled`: tracked recovery stays distilled; raw transcript isolation remains a separate contract
+- `public_distilled`: `agenticos_save` persists a distilled tracked continuity core for Git-backed restore, while raw transcripts route to a private sidecar such as `.private/conversations/`

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -61,7 +61,9 @@ my-project/
 ├── .context/
 │   ├── quick-start.md     # Concise orientation for fast resume
 │   ├── state.yaml         # Mutable operational working state
-│   └── conversations/     # Append-only raw session history
+│   └── conversations/     # Tracked/display conversation contract surface
+├── .private/
+│   └── conversations/     # Raw transcript sidecar for public_distilled projects
 ├── knowledge/             # Durable synthesized insights, architecture, research
 ├── tasks/                 # Execution plans, briefs, and task decomposition
 └── artifacts/             # Deliverables and concrete outputs
@@ -230,7 +232,7 @@ Create new project with standard structure.
 **Current recovery contract**:
 - `local_private`: Git is not the continuity recovery mechanism; `agenticos_save` keeps the existing narrow runtime-managed backup behavior
 - `private_continuity`: `agenticos_save` stages the tracked continuity core for Git-backed recovery, including `.project.yaml`, quick-start, state, conversations, `knowledge/`, `tasks/`, and mirrored guidance such as `CLAUDE.md` / `AGENTS.md` when present and repo-local
-- `public_distilled`: save behavior remains narrower in this issue; raw transcript isolation belongs to `#245`
+- `public_distilled`: `agenticos_save` stages a distilled tracked continuity core for Git-backed recovery (`.project.yaml`, quick-start, state, `knowledge/`, `tasks/`, and mirrored guidance when present), while raw transcripts route to `.private/conversations/`
 
 Publication policy is not the same as workflow topology or canonical source inclusion. A project can be `github_versioned` and still require `public_distilled`.
 
@@ -252,7 +254,7 @@ Use this when `agenticos_status` shows that no session project is bound or the b
 The quick-start/state split is intentional:
 - `quick-start.md` is a concise entry surface
 - `state.yaml` is mutable operational state
-- `conversations/` is append-only history, not the default inline resume surface
+- `conversations/` is the tracked/display conversation contract surface, not the default inline resume surface
 
 ### agenticos_list
 List all projects with status.
@@ -271,7 +273,8 @@ Save state and backup to Git.
 - `private_continuity` validates the tracked continuity plan before mutating `state.yaml` or staging files
 - if a required continuity path escapes the repo root, or no Git repo root can be proven, `agenticos_save` fails closed instead of writing a partial tracked state
 - successful `private_continuity` saves stage the tracked continuity core rather than only the legacy runtime review subset
-- other publication policies currently keep the narrower runtime-managed save surface until their dedicated follow-up issues land
+- `public_distilled` stages the distilled tracked continuity core and keeps raw transcripts in `.private/conversations/`
+- if a `public_distilled` project has tracked raw transcript diffs under `.context/conversations/`, `agenticos_save` blocks instead of silently publishing them
 
 ### agenticos_status
 Show the status of the current session project, or an explicit project when provided.

--- a/mcp-server/src/tools/__tests__/init.test.ts
+++ b/mcp-server/src/tools/__tests__/init.test.ts
@@ -165,6 +165,19 @@ describe('initProject', () => {
     expect(parsed.execution.source_repo_roots).toEqual(['.']);
   });
 
+  it('creates a private transcript sidecar directory for public_distilled github_versioned projects', async () => {
+    await initProject({
+      name: 'Public Project',
+      description: 'A public distilled project',
+      topology: 'github_versioned',
+      context_publication_policy: 'public_distilled',
+      github_repo: 'madlouse/public-project',
+    });
+
+    const mkdirCalls = fsPromisesMock.mkdir.mock.calls.map((c) => String(c[0]).replace(/\/$/, ''));
+    expect(mkdirCalls).toContain('/home/testuser/AgenticOS/projects/public-project/.private/conversations');
+  });
+
   it('writes state.yaml with correct structure', async () => {
     fsMock.existsSync.mockReturnValue(false);
     fsPromisesMock.access.mockRejectedValue(new Error('ENOENT'));

--- a/mcp-server/src/tools/__tests__/init.test.ts
+++ b/mcp-server/src/tools/__tests__/init.test.ts
@@ -178,6 +178,22 @@ describe('initProject', () => {
     expect(mkdirCalls).toContain('/home/testuser/AgenticOS/projects/public-project/.private/conversations');
   });
 
+  it('writes gitignore entries for public_distilled private transcript sidecars', async () => {
+    await initProject({
+      name: 'Public Project',
+      description: 'A public distilled project',
+      topology: 'github_versioned',
+      context_publication_policy: 'public_distilled',
+      github_repo: 'madlouse/public-project',
+    });
+
+    const writeCalls = fsPromisesMock.writeFile.mock.calls;
+    const gitignoreCall = writeCalls.find((c) => c[0].endsWith('/.gitignore'));
+    expect(gitignoreCall).toBeDefined();
+    expect(String(gitignoreCall![1])).toContain('.private/');
+    expect(String(gitignoreCall![1])).toContain('.meta/transcripts/');
+  });
+
   it('writes state.yaml with correct structure', async () => {
     fsMock.existsSync.mockReturnValue(false);
     fsPromisesMock.access.mockRejectedValue(new Error('ENOENT'));

--- a/mcp-server/src/tools/__tests__/pr-scope-check.test.ts
+++ b/mcp-server/src/tools/__tests__/pr-scope-check.test.ts
@@ -238,6 +238,41 @@ describe('runPrScopeCheck', () => {
     expect(result.block_reasons.join(' ')).toContain('runtime-managed files are mixed');
   });
 
+  it('returns BLOCK when private raw transcript paths appear in tracked review scope for public_distilled projects', async () => {
+    readFileMock.mockResolvedValue(JSON.stringify({
+      meta: { id: 'agenticos', name: 'AgenticOS' },
+      source_control: {
+        topology: 'github_versioned',
+        context_publication_policy: 'public_distilled',
+      },
+      agent_context: {
+        current_state: 'standards/.context/state.yaml',
+        conversations: 'standards/.context/conversations/',
+        last_record_marker: 'standards/.context/.last_record',
+      },
+    }));
+
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo/worktrees/issue-245\n',
+      'rev-parse --git-common-dir': '/repo/.git\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'log --format=%s origin/main..HEAD': 'feat(mcp-server): isolate public raw transcripts (#245)\n',
+      'diff --name-only origin/main...HEAD': '.private/conversations/2026-04-13.md\n',
+    });
+
+    const result = JSON.parse(await runPrScopeCheck({
+      issue_id: '245',
+      repo_path: '/repo/worktrees/issue-245',
+      declared_target_files: ['projects/agenticos/mcp-server/src/**'],
+      expected_issue_scope: 'public_distilled_transcript_isolation',
+    })) as { status: string; private_raw_transcript_files: string[]; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.private_raw_transcript_files).toEqual(['.private/conversations/2026-04-13.md']);
+    expect(result.block_reasons.join(' ')).toContain('private raw transcript paths appear in tracked review scope');
+  });
+
   it('returns BLOCK when the branch is not comparable to the intended remote base', async () => {
     execAsyncMock.mockRejectedValue(new Error('bad ref'));
 

--- a/mcp-server/src/tools/__tests__/pr-scope-check.test.ts
+++ b/mcp-server/src/tools/__tests__/pr-scope-check.test.ts
@@ -54,7 +54,13 @@ function mockGitResponses(responses: Record<string, string>): void {
 describe('runPrScopeCheck', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    readFileMock.mockResolvedValue('{"meta":{"id":"agenticos","name":"AgenticOS"}}');
+    readFileMock.mockResolvedValue(JSON.stringify({
+      meta: { id: 'agenticos', name: 'AgenticOS' },
+      source_control: {
+        topology: 'local_directory_only',
+        context_publication_policy: 'local_private',
+      },
+    }));
     yamlMock.parse.mockImplementation((content: string) => {
       try { return JSON.parse(content); } catch { return undefined; }
     });
@@ -71,9 +77,9 @@ describe('runPrScopeCheck', () => {
       targetProject: {
         id: 'agenticos',
         name: 'AgenticOS',
-        path: '/workspace/projects/agenticos/standards',
-        statePath: '/workspace/projects/agenticos/standards/.context/state.yaml',
-        projectYamlPath: '/workspace/projects/agenticos/standards/.project.yaml',
+        path: '/repo',
+        statePath: '/repo/.context/state.yaml',
+        projectYamlPath: '/repo/.project.yaml',
         sourceRepoRoots: ['/repo'],
         sourceRepoRootsDeclared: true,
       },
@@ -82,7 +88,7 @@ describe('runPrScopeCheck', () => {
 
   it('returns PASS when commits and files stay within the intended issue scope', async () => {
     mockGitResponses({
-      'rev-parse --show-toplevel': '/repo/worktrees/issue-36\n',
+      'rev-parse --show-toplevel': '/repo\n',
       'rev-parse --git-common-dir': '/repo/.git\n',
       'rev-parse origin/main': 'base999\n',
       'merge-base HEAD origin/main': 'base999\n',
@@ -107,7 +113,7 @@ describe('runPrScopeCheck', () => {
 
   it('returns PASS when declared exact file paths contain dots', async () => {
     mockGitResponses({
-      'rev-parse --show-toplevel': '/repo/worktrees/issue-114\n',
+      'rev-parse --show-toplevel': '/repo\n',
       'rev-parse --git-common-dir': '/repo/.git\n',
       'rev-parse origin/main': 'base999\n',
       'merge-base HEAD origin/main': 'base999\n',
@@ -131,7 +137,7 @@ describe('runPrScopeCheck', () => {
 
   it('returns BLOCK when commit subjects do not match the current issue', async () => {
     mockGitResponses({
-      'rev-parse --show-toplevel': '/repo/worktrees/issue-36\n',
+      'rev-parse --show-toplevel': '/repo\n',
       'rev-parse --git-common-dir': '/repo/.git\n',
       'rev-parse origin/main': 'base999\n',
       'merge-base HEAD origin/main': 'base999\n',
@@ -153,7 +159,7 @@ describe('runPrScopeCheck', () => {
 
   it('returns BLOCK when changed files escape the declared target scope', async () => {
     mockGitResponses({
-      'rev-parse --show-toplevel': '/repo/worktrees/issue-36\n',
+      'rev-parse --show-toplevel': '/repo\n',
       'rev-parse --git-common-dir': '/repo/.git\n',
       'rev-parse origin/main': 'base999\n',
       'merge-base HEAD origin/main': 'base999\n',
@@ -174,8 +180,26 @@ describe('runPrScopeCheck', () => {
   });
 
   it('returns PASS when the diff is runtime-managed only', async () => {
+    resolveGuardrailProjectTargetMock.mockResolvedValue({
+      activeProjectId: 'agenticos',
+      resolutionSource: 'repo_path_match',
+      resolutionErrors: [],
+      targetProject: {
+        id: 'agenticos',
+        name: 'AgenticOS',
+        path: '/repo/worktrees/issue-171',
+        statePath: '/repo/worktrees/issue-171/standards/.context/state.yaml',
+        projectYamlPath: '/repo/worktrees/issue-171/.project.yaml',
+        sourceRepoRoots: ['/repo'],
+        sourceRepoRootsDeclared: true,
+      },
+    });
     readFileMock.mockResolvedValue(JSON.stringify({
       meta: { id: 'agenticos', name: 'AgenticOS' },
+      source_control: {
+        topology: 'local_directory_only',
+        context_publication_policy: 'local_private',
+      },
       agent_context: {
         current_state: 'standards/.context/state.yaml',
         conversations: 'standards/.context/conversations/',
@@ -208,8 +232,26 @@ describe('runPrScopeCheck', () => {
   });
 
   it('returns BLOCK when runtime-managed files are mixed into a normal product review slice', async () => {
+    resolveGuardrailProjectTargetMock.mockResolvedValue({
+      activeProjectId: 'agenticos',
+      resolutionSource: 'repo_path_match',
+      resolutionErrors: [],
+      targetProject: {
+        id: 'agenticos',
+        name: 'AgenticOS',
+        path: '/repo/worktrees/issue-171',
+        statePath: '/repo/worktrees/issue-171/standards/.context/state.yaml',
+        projectYamlPath: '/repo/worktrees/issue-171/.project.yaml',
+        sourceRepoRoots: ['/repo'],
+        sourceRepoRootsDeclared: true,
+      },
+    });
     readFileMock.mockResolvedValue(JSON.stringify({
       meta: { id: 'agenticos', name: 'AgenticOS' },
+      source_control: {
+        topology: 'local_directory_only',
+        context_publication_policy: 'local_private',
+      },
       agent_context: {
         current_state: 'standards/.context/state.yaml',
         conversations: 'standards/.context/conversations/',
@@ -239,6 +281,20 @@ describe('runPrScopeCheck', () => {
   });
 
   it('returns BLOCK when private raw transcript paths appear in tracked review scope for public_distilled projects', async () => {
+    resolveGuardrailProjectTargetMock.mockResolvedValue({
+      activeProjectId: 'agenticos',
+      resolutionSource: 'repo_path_match',
+      resolutionErrors: [],
+      targetProject: {
+        id: 'agenticos',
+        name: 'AgenticOS',
+        path: '/repo/worktrees/issue-245',
+        statePath: '/repo/worktrees/issue-245/standards/.context/state.yaml',
+        projectYamlPath: '/repo/worktrees/issue-245/.project.yaml',
+        sourceRepoRoots: ['/repo/worktrees/issue-245'],
+        sourceRepoRootsDeclared: true,
+      },
+    });
     readFileMock.mockResolvedValue(JSON.stringify({
       meta: { id: 'agenticos', name: 'AgenticOS' },
       source_control: {
@@ -270,6 +326,55 @@ describe('runPrScopeCheck', () => {
 
     expect(result.status).toBe('BLOCK');
     expect(result.private_raw_transcript_files).toEqual(['.private/conversations/2026-04-13.md']);
+    expect(result.block_reasons.join(' ')).toContain('private raw transcript paths appear in tracked review scope');
+  });
+
+  it('blocks nested-project tracked transcript diffs using repo-relative review paths', async () => {
+    resolveGuardrailProjectTargetMock.mockResolvedValue({
+      activeProjectId: 'nested-public-project',
+      resolutionSource: 'repo_path_match',
+      resolutionErrors: [],
+      targetProject: {
+        id: 'nested-public-project',
+        name: 'Nested Public Project',
+        path: '/repo/projects/app',
+        statePath: '/repo/projects/app/runtime/state.yaml',
+        projectYamlPath: '/repo/projects/app/.project.yaml',
+        sourceRepoRoots: ['/repo'],
+        sourceRepoRootsDeclared: true,
+      },
+    });
+    readFileMock.mockResolvedValue(JSON.stringify({
+      meta: { id: 'nested-public-project', name: 'Nested Public Project' },
+      source_control: {
+        topology: 'github_versioned',
+        context_publication_policy: 'public_distilled',
+      },
+      agent_context: {
+        current_state: 'runtime/state.yaml',
+        conversations: 'runtime/conversations/',
+        last_record_marker: 'runtime/.last_record',
+      },
+    }));
+
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --git-common-dir': '/repo/.git\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'log --format=%s origin/main..HEAD': 'feat(mcp-server): isolate nested public raw transcripts (#245)\n',
+      'diff --name-only origin/main...HEAD': 'projects/app/runtime/conversations/2026-04-13.md\n',
+    });
+
+    const result = JSON.parse(await runPrScopeCheck({
+      issue_id: '245',
+      repo_path: '/repo',
+      declared_target_files: ['projects/app/mcp-server/src/**'],
+      expected_issue_scope: 'nested_public_distilled_transcript_isolation',
+    })) as { status: string; private_raw_transcript_files: string[]; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.private_raw_transcript_files).toEqual(['projects/app/runtime/conversations/2026-04-13.md']);
     expect(result.block_reasons.join(' ')).toContain('private raw transcript paths appear in tracked review scope');
   });
 

--- a/mcp-server/src/tools/__tests__/project.test.ts
+++ b/mcp-server/src/tools/__tests__/project.test.ts
@@ -492,6 +492,47 @@ describe('switchProject', () => {
     expect(result).toContain('📖 Project summary: Fallback project summary from quick-start.');
   });
 
+  it('surfaces the public_distilled transcript contract in switch output', async () => {
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: null,
+      projects: [
+        {
+          id: 'public-project',
+          name: 'Public Project',
+          path: '/test/path',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    fsPromisesMock.readFile
+      .mockResolvedValueOnce(JSON.stringify({
+        meta: { description: 'Public distilled project' },
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'public_distilled',
+          github_repo: 'example/public-project',
+          branch_strategy: 'github_flow',
+        },
+        execution: {
+          source_repo_roots: ['.'],
+        },
+      }))
+      .mockResolvedValueOnce(JSON.stringify({
+        working_memory: { pending: [], decisions: [] },
+      }))
+      .mockResolvedValueOnce('# Quick Start\n\nPublic distilled summary');
+
+    const result = await switchProject({ project: 'public-project' });
+
+    expect(result).toContain('🔒 Raw transcripts: `.private/conversations/`');
+    expect(result).toContain('Git recovery is distilled-only');
+  });
+
   it('refuses to switch into archived reference content', async () => {
     registryMock.loadRegistry.mockResolvedValue({
       version: '1.0.0',
@@ -991,6 +1032,54 @@ describe('getStatus', () => {
 
     expect(result).toContain('🧭 Latest issue bootstrap: #179 on feat/179-issue-start-bootstrap-evidence');
     expect(result).toContain('Title: Implement bootstrap evidence');
+  });
+
+  it('surfaces the public_distilled transcript contract in status output', async () => {
+    bindSessionProject({
+      projectId: 'public-project',
+      projectName: 'Public Project',
+      projectPath: '/test/path',
+    });
+
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: 'public-project',
+      projects: [
+        {
+          id: 'public-project',
+          name: 'Public Project',
+          path: '/test/path',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    mockStatusReads(
+      {
+        meta: { id: 'public-project', name: 'Public Project' },
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'public_distilled',
+          github_repo: 'example/public-project',
+          branch_strategy: 'github_flow',
+        },
+        execution: {
+          source_repo_roots: ['.'],
+        },
+      },
+      {
+        session: { last_backup: '2025-01-02T12:00:00.000Z' },
+        working_memory: { pending: [], decisions: [] },
+      }
+    );
+
+    const result = await getStatus();
+
+    expect(result).toContain('🔒 Raw transcripts: `.private/conversations/`');
+    expect(result).toContain('Git recovery is distilled-only');
   });
 
   it('shows the latest BLOCK guardrail summary and reason', async () => {

--- a/mcp-server/src/tools/__tests__/record.test.ts
+++ b/mcp-server/src/tools/__tests__/record.test.ts
@@ -86,6 +86,7 @@ function mockProjectFiles(options?: {
     },
     source_control: {
       topology: 'local_directory_only',
+      context_publication_policy: 'local_private',
     },
   };
   const state = options?.state || {
@@ -441,13 +442,40 @@ describe('recordSession', () => {
     expect(result).toContain('✅ Session recorded');
   });
 
+  it('routes raw transcripts to a private sidecar path for public_distilled projects', async () => {
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry());
+    mockProjectFiles({
+      projectYaml: {
+        meta: { id: 'test-project', name: 'Test Project' },
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'public_distilled',
+          github_repo: 'example/test-project',
+          branch_strategy: 'github_flow',
+        },
+        execution: {
+          source_repo_roots: ['.'],
+        },
+      },
+      state: { session: {}, working_memory: { decisions: [], facts: [], pending: [] } },
+    });
+
+    const result = await recordSession({ summary: 'test session' });
+
+    const writeCalls = fsPromisesMock.writeFile.mock.calls;
+    const convCall = writeCalls.find((c) => String(c[0]).includes('/.private/conversations/') && String(c[0]).endsWith('.md'));
+    expect(convCall).toBeDefined();
+    expect(result).toContain('Raw conversation: .private/conversations/');
+    expect(result).toContain('Git recovery is distilled-only');
+  });
+
   it('continues when quick-start.md is missing during enrichment', async () => {
     registryMock.loadRegistry.mockResolvedValue(buildRegistry());
     fsPromisesMock.readFile.mockImplementation(async (path: string) => {
       if (path.endsWith('/.project.yaml')) {
         return JSON.stringify({
           meta: { id: 'test-project', name: 'Test Project' },
-          source_control: { topology: 'local_directory_only' },
+          source_control: { topology: 'local_directory_only', context_publication_policy: 'local_private' },
         });
       }
       if (path.endsWith('/state.yaml')) {
@@ -480,7 +508,7 @@ describe('recordSession', () => {
       if (path.endsWith('/.project.yaml')) {
         return JSON.stringify({
           meta: { id: 'test-project', name: 'Test Project' },
-          source_control: { topology: 'local_directory_only' },
+          source_control: { topology: 'local_directory_only', context_publication_policy: 'local_private' },
         });
       }
       if (path.endsWith('/state.yaml')) {
@@ -519,7 +547,7 @@ describe('recordSession', () => {
       if (path.endsWith('/.project.yaml')) {
         return JSON.stringify({
           meta: { id: 'test-project', name: 'Test Project' },
-          source_control: { topology: 'local_directory_only' },
+          source_control: { topology: 'local_directory_only', context_publication_policy: 'local_private' },
         });
       }
       if (path.endsWith('/state.yaml')) {
@@ -550,7 +578,7 @@ describe('recordSession', () => {
       if (path.endsWith('/.project.yaml')) {
         return JSON.stringify({
           meta: { id: 'test-project', name: 'Test Project' },
-          source_control: { topology: 'local_directory_only' },
+          source_control: { topology: 'local_directory_only', context_publication_policy: 'local_private' },
         });
       }
       if (path.endsWith('/state.yaml')) {
@@ -618,7 +646,7 @@ describe('recordSession', () => {
       if (path === '/other/path/.project.yaml') {
         return JSON.stringify({
           meta: { id: 'other-project', name: 'Other Project' },
-          source_control: { topology: 'local_directory_only' },
+          source_control: { topology: 'local_directory_only', context_publication_policy: 'local_private' },
         });
       }
       if (path === '/other/path/.context/state.yaml') {
@@ -636,7 +664,7 @@ describe('recordSession', () => {
       if (path === '/test/path/.project.yaml') {
         return JSON.stringify({
           meta: { id: 'test-project', name: 'Test Project' },
-          source_control: { topology: 'local_directory_only' },
+          source_control: { topology: 'local_directory_only', context_publication_policy: 'local_private' },
         });
       }
       if (path === '/test/path/.context/state.yaml') {
@@ -692,7 +720,7 @@ describe('recordSession', () => {
       if (path === '/other/path/.project.yaml') {
         return JSON.stringify({
           meta: { id: 'other-project', name: 'Other Project' },
-          source_control: { topology: 'local_directory_only' },
+          source_control: { topology: 'local_directory_only', context_publication_policy: 'local_private' },
         });
       }
       if (path === '/other/path/.context/state.yaml') {
@@ -725,6 +753,7 @@ describe('recordSession', () => {
         },
         source_control: {
           topology: 'local_directory_only',
+          context_publication_policy: 'local_private',
         },
       },
     });

--- a/mcp-server/src/tools/__tests__/save.test.ts
+++ b/mcp-server/src/tools/__tests__/save.test.ts
@@ -1088,4 +1088,119 @@ describe('saveState', () => {
     expect(addCommand).toContain('"projects/app/tasks/"');
     expect(result).toContain('tracked continuity contract evaluated; no new continuity changes were committed');
   });
+
+  it('stages the distilled tracked continuity surface for public_distilled projects', async () => {
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry());
+    mockProjectFiles({
+      projectYaml: {
+        meta: {
+          id: 'test-project',
+          name: 'Test Project',
+        },
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'public_distilled',
+          github_repo: 'example/test-project',
+          branch_strategy: 'github_flow',
+        },
+        execution: {
+          source_repo_roots: ['.'],
+        },
+      },
+      state: { session: {} },
+    });
+
+    const commands: string[] = [];
+    childProcessMock.exec.mockImplementation(
+      (cmd: string, cb: (err: Error | null, stdout?: string, stderr?: string) => void) => {
+        commands.push(cmd);
+        if (cmd.includes('rev-parse --show-toplevel')) {
+          cb(null, '/test/path\n', '');
+          return;
+        }
+        if (cmd.includes('rev-parse --git-common-dir')) {
+          cb(null, '.git\n', '');
+          return;
+        }
+        if (cmd.includes('remote get-url origin')) {
+          cb(null, 'git@github.com:example/test-project.git\n', '');
+          return;
+        }
+        if (cmd.includes('status --porcelain')) {
+          cb(null, '', '');
+          return;
+        }
+        if (cmd.includes(' commit ')) {
+          cb(new Error('nothing to commit'), '', 'nothing to commit');
+          return;
+        }
+        cb(null, '', '');
+      }
+    );
+
+    const result = await saveState({ message: 'public continuity save' });
+
+    const addCommand = commands.find((cmd) => cmd.includes(' add -A -- '));
+    expect(addCommand).toBeDefined();
+    expect(addCommand).toContain('".project.yaml"');
+    expect(addCommand).toContain('".context/quick-start.md"');
+    expect(addCommand).toContain('".context/state.yaml"');
+    expect(addCommand).toContain('"knowledge/"');
+    expect(addCommand).toContain('"tasks/"');
+    expect(addCommand).toContain('"CLAUDE.md"');
+    expect(addCommand).not.toContain('.context/conversations');
+    expect(result).toContain('Recovery: distilled continuity contract evaluated; no new continuity changes were committed');
+    expect(result).toContain('.private/conversations/');
+  });
+
+  it('blocks save when a public_distilled project has tracked raw transcript diffs', async () => {
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry());
+    mockProjectFiles({
+      projectYaml: {
+        meta: {
+          id: 'test-project',
+          name: 'Test Project',
+        },
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'public_distilled',
+          github_repo: 'example/test-project',
+          branch_strategy: 'github_flow',
+        },
+        execution: {
+          source_repo_roots: ['.'],
+        },
+      },
+      state: { session: {} },
+    });
+
+    childProcessMock.exec.mockImplementation(
+      (cmd: string, cb: (err: Error | null, stdout?: string, stderr?: string) => void) => {
+        if (cmd.includes('rev-parse --show-toplevel')) {
+          cb(null, '/test/path\n', '');
+          return;
+        }
+        if (cmd.includes('rev-parse --git-common-dir')) {
+          cb(null, '.git\n', '');
+          return;
+        }
+        if (cmd.includes('remote get-url origin')) {
+          cb(null, 'git@github.com:example/test-project.git\n', '');
+          return;
+        }
+        if (cmd.includes('status --porcelain')) {
+          cb(null, ' M .context/conversations/2026-04-13.md\n', '');
+          return;
+        }
+        cb(null, '', '');
+      }
+    );
+
+    const result = await saveState({ message: 'should block' });
+
+    expect(result).toContain('agenticos_save blocked');
+    expect(result).toContain('.context/conversations/');
+    expect(fsPromisesMock.writeFile).not.toHaveBeenCalled();
+    expect(updateClaudeMdStateMock).not.toHaveBeenCalled();
+  });
 });

--- a/mcp-server/src/tools/__tests__/save.test.ts
+++ b/mcp-server/src/tools/__tests__/save.test.ts
@@ -1258,6 +1258,14 @@ describe('saveState', () => {
           cb(null, '/repo\n', '');
           return;
         }
+        if (cmd.includes('rev-parse --git-common-dir')) {
+          cb(null, '.git\n', '');
+          return;
+        }
+        if (cmd.includes('remote get-url origin')) {
+          cb(null, 'git@github.com:example/test-project.git\n', '');
+          return;
+        }
         if (cmd.includes('status --porcelain')) {
           cb(null, ' M projects/app/runtime/conversations/2026-04-13.md\n', '');
           return;

--- a/mcp-server/src/tools/__tests__/save.test.ts
+++ b/mcp-server/src/tools/__tests__/save.test.ts
@@ -1203,4 +1203,74 @@ describe('saveState', () => {
     expect(fsPromisesMock.writeFile).not.toHaveBeenCalled();
     expect(updateClaudeMdStateMock).not.toHaveBeenCalled();
   });
+
+  it('checks tracked public transcript diffs using repo-relative paths for nested projects', async () => {
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry({
+      projects: [
+        {
+          id: 'test-project',
+          name: 'Test Project',
+          path: '/repo/projects/app',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    }));
+    clearSessionProjectBinding();
+    bindSessionProject({
+      projectId: 'test-project',
+      projectName: 'Test Project',
+      projectPath: '/repo/projects/app',
+    });
+    fsPromisesMock.readFile.mockImplementation(async (path: string) => {
+      if (path === '/repo/projects/app/.project.yaml') {
+        return JSON.stringify({
+          meta: {
+            id: 'test-project',
+            name: 'Test Project',
+          },
+          source_control: {
+            topology: 'github_versioned',
+            context_publication_policy: 'public_distilled',
+            github_repo: 'example/test-project',
+            branch_strategy: 'github_flow',
+          },
+          execution: {
+            source_repo_roots: ['../..'],
+          },
+          agent_context: {
+            conversations: 'runtime/conversations/',
+          },
+        });
+      }
+      if (path === '/repo/projects/app/.context/state.yaml') {
+        return JSON.stringify({ session: {} });
+      }
+      throw new Error(`unexpected path: ${path}`);
+    });
+
+    const commands: string[] = [];
+    childProcessMock.exec.mockImplementation(
+      (cmd: string, cb: (err: Error | null, stdout?: string, stderr?: string) => void) => {
+        commands.push(cmd);
+        if (cmd.includes('rev-parse --show-toplevel')) {
+          cb(null, '/repo\n', '');
+          return;
+        }
+        if (cmd.includes('status --porcelain')) {
+          cb(null, ' M projects/app/runtime/conversations/2026-04-13.md\n', '');
+          return;
+        }
+        cb(null, '', '');
+      }
+    );
+
+    const result = await saveState({ message: 'should block nested project public transcript leak' });
+
+    const statusCommand = commands.find((cmd) => cmd.includes('status --porcelain'));
+    expect(statusCommand).toContain('"projects/app/runtime/conversations/"');
+    expect(result).toContain('agenticos_save blocked');
+    expect(result).toContain('runtime/conversations/');
+  });
 });

--- a/mcp-server/src/tools/__tests__/standard-kit.test.ts
+++ b/mcp-server/src/tools/__tests__/standard-kit.test.ts
@@ -75,6 +75,7 @@ async function setupKitHome(): Promise<{ home: string; projectRoot: string }> {
         'operator_intent_resolution',
         'memory_layer_contracts',
         'context_publication_policy_contract',
+        'public_transcript_isolation_contract',
         'cross_agent_policy_contract',
         'session_start_alignment',
         'implementation_preflight',
@@ -90,7 +91,7 @@ async function setupKitHome(): Promise<{ home: string; projectRoot: string }> {
 
   await writeFile(join(kitRoot, 'manifest.yaml'), yaml.stringify(manifest), 'utf-8');
   await writeFile(join(templateRoot, '.project.yaml'), `meta:\n  name: "Project Name"\n  id: "project-id"\n  version: "1.0.0"\n  created: "YYYY-MM-DD"\n  description: "Project description"\nsource_control:\n  topology: "local_directory_only"\n  context_publication_policy: "local_private"\nagent_context:\n  quick_start: ".context/quick-start.md"\n  current_state: ".context/state.yaml"\n  conversations: ".context/conversations/"\n  knowledge: "knowledge/"\n  tasks: "tasks/"\n  artifacts: "artifacts/"\nmemory_contract:\n  version: 1\n  quick_start_role: "project_orientation"\n  state_role: "operational_working_state"\n  conversations_role: "append_only_session_history"\n  knowledge_role: "durable_synthesis"\n  tasks_role: "execution_artifacts"\n  artifacts_role: "deliverables"\nstatus:\n  phase: "planning"\n  last_updated: "YYYY-MM-DD"\n`, 'utf-8');
-  await writeFile(join(templateRoot, 'quick-start.md'), '# Quick Start\n\n> Contract: concise project-level orientation for fast resume.\n> Do not store full session history, exhaustive decision logs, or issue-by-issue execution details here.\n\n## Project Snapshot\n- **Project**: [Project Name]\n- **Goal**: [Main objective]\n- **Status**: [Current phase]\n- **Last Action**: [What was done last]\n- **Current Focus**: [What to do next]\n- **Resume Here**: [What to do next]\n\n## Key Facts\n- [Important fact 1]\n- [Important fact 2]\n\n## Canonical Layers\n- Operational state: `.context/state.yaml`\n- Session history: `.context/conversations/`\n- Durable knowledge: `knowledge/`\n- Execution plans: `tasks/`\n- Deliverables: `artifacts/`\n', 'utf-8');
+  await writeFile(join(templateRoot, 'quick-start.md'), '# Quick Start\n\n> Contract: concise project-level orientation for fast resume.\n> Do not store full session history, exhaustive decision logs, or issue-by-issue execution details here.\n\n## Project Snapshot\n- **Project**: [Project Name]\n- **Goal**: [Main objective]\n- **Status**: [Current phase]\n- **Last Action**: [What was done last]\n- **Current Focus**: [What to do next]\n- **Resume Here**: [What to do next]\n\n## Key Facts\n- [Important fact 1]\n- [Important fact 2]\n\n## Canonical Layers\n- Operational state: `.context/state.yaml`\n- Conversation history surface: `.context/conversations/` (tracked/display contract path; raw transcript routing may vary by publication policy)\n- Durable knowledge: `knowledge/`\n- Execution plans: `tasks/`\n- Deliverables: `artifacts/`\n', 'utf-8');
   await writeFile(join(templateRoot, 'state.yaml'), '# Contract:\n# - Mutable operational working state only\n# - Keep current task, working memory, and latest guardrail evidence here\n# - Do not append raw conversation transcripts here\n# - Durable synthesis belongs in knowledge/\nsession:\n  id: "session-001"\n  started: "YYYY-MM-DDTHH:MM:SSZ"\n  agent: "claude-sonnet-4.6"\ncurrent_task:\n  id: null\n  title: null\n  status: "pending"\n  next_step: null\nworking_memory:\n  facts: []\n  decisions: []\n  pending: []\nmemory_contract:\n  version: 1\n  quick_start_role: "project_orientation"\n  state_role: "operational_working_state"\n  conversations_role: "append_only_session_history"\n  knowledge_role: "durable_synthesis"\n  tasks_role: "execution_artifacts"\nloaded_context:\n  - ".project.yaml"\n', 'utf-8');
   await writeFile(join(templateRoot, 'agent-preflight-checklist.yaml'), 'version: 0.2\n', 'utf-8');
   await writeFile(join(templateRoot, 'issue-design-brief.md'), '# Issue Design Brief\n\n## Objective Synthesis\n- User-stated request:\n- Inferred end goal:\n- Operator signals / partial methods:\n- Constraints:\n- Contradictions or weak assumptions to resolve:\n- Non-goals:\n', 'utf-8');
@@ -468,6 +469,60 @@ describe('standard kit commands', () => {
     expect(result.status).toBe('FAIL');
     expect(result.adapter_checks.find((item) => item.agent_id === 'claude-code')).toMatchObject({ status: 'FAIL' });
     expect(result.adapter_checks.find((item) => item.agent_id === 'codex')).toMatchObject({ status: 'PASS' });
+  });
+
+  it('conformance check passes the public transcript isolation contract for public_distilled projects', async () => {
+    const { home, projectRoot } = await setupKitHome();
+    process.env.AGENTICOS_HOME = home;
+
+    await writeFile(join(projectRoot, '.project.yaml'), yaml.stringify({
+      meta: {
+        name: 'Public Project',
+        id: 'public-project',
+        description: 'Public distilled project',
+      },
+      source_control: {
+        topology: 'github_versioned',
+        context_publication_policy: 'public_distilled',
+        github_repo: 'example/public-project',
+        branch_strategy: 'github_flow',
+      },
+      execution: {
+        source_repo_roots: ['.'],
+      },
+      agent_context: {
+        quick_start: '.context/quick-start.md',
+        current_state: '.context/state.yaml',
+        conversations: '.context/conversations/',
+        knowledge: 'knowledge/',
+        tasks: 'tasks/',
+        artifacts: 'artifacts/',
+      },
+      memory_contract: {
+        version: 1,
+      },
+    }), 'utf-8');
+    await runStandardKitAdopt({
+      project_path: projectRoot,
+      project_name: 'Public Project',
+      project_description: 'Public distilled project',
+    });
+    await writeFile(
+      join(projectRoot, '.context', 'quick-start.md'),
+      '# Quick Start\n\n## Canonical Layers\n- Conversation history contract: tracked surface `.context/conversations/`; raw transcripts route to `.private/conversations/`\n',
+      'utf-8',
+    );
+
+    const result = JSON.parse(await runStandardKitConformanceCheck({
+      project_path: projectRoot,
+      project_name: 'Public Project',
+    })) as {
+      status: string;
+      behavior_checks: Array<{ behavior: string; status: string }>;
+    };
+
+    expect(result.status).toBe('PASS');
+    expect(result.behavior_checks.find((item) => item.behavior === 'public_transcript_isolation_contract')).toMatchObject({ status: 'PASS' });
   });
 
   it('conformance check skips archived reference projects', async () => {

--- a/mcp-server/src/tools/init.ts
+++ b/mcp-server/src/tools/init.ts
@@ -194,6 +194,9 @@ export async function initProject(args: any): Promise<string> {
   const contextDisplayPaths = resolveManagedProjectContextDisplayPaths(projectYaml);
 
   await mkdir(contextPaths.conversationsDir, { recursive: true });
+  if (contextPublicationPolicy === 'public_distilled') {
+    await mkdir(join(projectPath, '.private', 'conversations'), { recursive: true });
+  }
   await mkdir(contextPaths.knowledgeDir, { recursive: true });
   await mkdir(contextPaths.tasksDir, { recursive: true });
   await mkdir(contextPaths.artifactsDir, { recursive: true });

--- a/mcp-server/src/tools/init.ts
+++ b/mcp-server/src/tools/init.ts
@@ -73,6 +73,27 @@ async function loadExistingProjectYaml(projectPath: string): Promise<any> {
   }
 }
 
+async function ensureIgnoreEntries(projectPath: string, entries: string[]): Promise<void> {
+  const gitignorePath = join(projectPath, '.gitignore');
+  let existing = '';
+  try {
+    existing = await readFile(gitignorePath, 'utf-8');
+  } catch {
+    existing = '';
+  }
+
+  const lines = existing.split('\n').map((line) => line.trim()).filter((line) => line.length > 0);
+  const missingEntries = entries.filter((entry) => !lines.includes(entry));
+  if (missingEntries.length === 0) {
+    return;
+  }
+
+  const prefix = existing.length > 0 && !existing.endsWith('\n') ? '\n' : '';
+  const separator = existing.trim().length > 0 ? '\n' : '';
+  const block = `${separator}# AgenticOS private runtime surfaces\n${missingEntries.join('\n')}\n`;
+  await writeFile(gitignorePath, `${existing}${prefix}${block}`, 'utf-8');
+}
+
 function buildProjectYaml(args: {
   name: string;
   id: string;
@@ -196,6 +217,7 @@ export async function initProject(args: any): Promise<string> {
   await mkdir(contextPaths.conversationsDir, { recursive: true });
   if (contextPublicationPolicy === 'public_distilled') {
     await mkdir(join(projectPath, '.private', 'conversations'), { recursive: true });
+    await ensureIgnoreEntries(projectPath, ['.private/', '.meta/transcripts/']);
   }
   await mkdir(contextPaths.knowledgeDir, { recursive: true });
   await mkdir(contextPaths.tasksDir, { recursive: true });

--- a/mcp-server/src/tools/pr-scope-check.ts
+++ b/mcp-server/src/tools/pr-scope-check.ts
@@ -25,6 +25,7 @@ interface PrScopeCheckResult {
   commit_count: number;
   changed_files: string[];
   runtime_managed_files: string[];
+  private_raw_transcript_files: string[];
   unexpected_files: string[];
   unrelated_commit_subjects: string[];
   branch_ancestry_verified: boolean;
@@ -99,6 +100,7 @@ function makeBaseResult(remoteBaseBranch: string, expectedIssueScope: string): P
     commit_count: 0,
     changed_files: [],
     runtime_managed_files: [],
+    private_raw_transcript_files: [],
     unexpected_files: [],
     unrelated_commit_subjects: [],
     branch_ancestry_verified: false,
@@ -157,6 +159,7 @@ export async function runPrScopeCheck(args: PrScopeCheckArgs): Promise<string> {
           commit_count: result.commit_count,
           changed_files: result.changed_files,
           runtime_managed_files: result.runtime_managed_files,
+          private_raw_transcript_files: result.private_raw_transcript_files,
           unexpected_files: result.unexpected_files,
           unrelated_commit_subjects: result.unrelated_commit_subjects,
           branch_ancestry_verified: result.branch_ancestry_verified,
@@ -218,6 +221,7 @@ export async function runPrScopeCheck(args: PrScopeCheckArgs): Promise<string> {
           commit_count: result.commit_count,
           changed_files: result.changed_files,
           runtime_managed_files: result.runtime_managed_files,
+          private_raw_transcript_files: result.private_raw_transcript_files,
           unexpected_files: result.unexpected_files,
           unrelated_commit_subjects: result.unrelated_commit_subjects,
           branch_ancestry_verified: result.branch_ancestry_verified,
@@ -238,17 +242,22 @@ export async function runPrScopeCheck(args: PrScopeCheckArgs): Promise<string> {
     await runGit(repo_path, `diff --name-only ${remote_base_branch}...HEAD`).catch(() => ''),
   );
   const projectYaml = await loadProjectYaml(projectResolution.targetProject!.projectYamlPath);
-  const runtimeTrackedPaths = resolveRuntimeReviewSurfacePaths(
+  const runtimeSurfacePaths = resolveRuntimeReviewSurfacePaths(
     projectResolution.targetProject!.path,
     projectYaml,
     { include_claude_state_mirror: true },
-  ).tracked_review_excluded_paths;
+  );
+  const runtimeTrackedPaths = runtimeSurfacePaths.tracked_review_excluded_paths;
+  const privateTranscriptPaths = runtimeSurfacePaths.private_transcript_blocked_paths;
 
   result.commit_count = subjects.length;
   result.changed_files = changedFiles;
   result.runtime_managed_files = changedFiles.filter((file) => matchesRuntimeReviewExcludedPath(file, runtimeTrackedPaths));
+  result.private_raw_transcript_files = changedFiles.filter((file) => matchesRuntimeReviewExcludedPath(file, privateTranscriptPaths));
   result.unrelated_commit_subjects = subjects.filter((subject) => !subject.includes(`#${issue_id}`));
-  const productReviewFiles = changedFiles.filter((file) => !matchesRuntimeReviewExcludedPath(file, runtimeTrackedPaths));
+  const productReviewFiles = changedFiles.filter((file) =>
+    !matchesRuntimeReviewExcludedPath(file, runtimeTrackedPaths)
+    && !matchesRuntimeReviewExcludedPath(file, privateTranscriptPaths));
   result.unexpected_files = productReviewFiles.filter((file) => !fileMatchesDeclaredScope(file, declared_target_files));
 
   if (result.unrelated_commit_subjects.length > 0) {
@@ -257,6 +266,10 @@ export async function runPrScopeCheck(args: PrScopeCheckArgs): Promise<string> {
 
   if (result.runtime_managed_files.length > 0 && productReviewFiles.length > 0) {
     result.block_reasons.push('runtime-managed files are mixed into a normal product review slice');
+  }
+
+  if (result.private_raw_transcript_files.length > 0) {
+    result.block_reasons.push('private raw transcript paths appear in tracked review scope');
   }
 
   if (result.unexpected_files.length > 0) {
@@ -285,6 +298,7 @@ export async function runPrScopeCheck(args: PrScopeCheckArgs): Promise<string> {
           commit_count: result.commit_count,
           changed_files: result.changed_files,
           runtime_managed_files: result.runtime_managed_files,
+          private_raw_transcript_files: result.private_raw_transcript_files,
           unexpected_files: result.unexpected_files,
           unrelated_commit_subjects: result.unrelated_commit_subjects,
           branch_ancestry_verified: result.branch_ancestry_verified,
@@ -319,6 +333,7 @@ export async function runPrScopeCheck(args: PrScopeCheckArgs): Promise<string> {
         commit_count: result.commit_count,
         changed_files: result.changed_files,
         runtime_managed_files: result.runtime_managed_files,
+        private_raw_transcript_files: result.private_raw_transcript_files,
         unexpected_files: result.unexpected_files,
         unrelated_commit_subjects: result.unrelated_commit_subjects,
         branch_ancestry_verified: result.branch_ancestry_verified,

--- a/mcp-server/src/tools/pr-scope-check.ts
+++ b/mcp-server/src/tools/pr-scope-check.ts
@@ -175,9 +175,10 @@ export async function runPrScopeCheck(args: PrScopeCheckArgs): Promise<string> {
 
   let gitCommonRepoRoot: string | null = null;
   let gitRemoteOrigin: string | null = null;
+  let gitWorktreeRoot: string | null = null;
 
   try {
-    const gitWorktreeRoot = await runGit(repo_path, 'rev-parse --show-toplevel');
+    gitWorktreeRoot = await runGit(repo_path, 'rev-parse --show-toplevel');
     const gitCommonDir = resolve(gitWorktreeRoot, await runGit(repo_path, 'rev-parse --git-common-dir'));
     gitCommonRepoRoot = dirname(gitCommonDir);
     gitRemoteOrigin = await runGit(repo_path, 'config --get remote.origin.url').catch(() => null);
@@ -242,11 +243,52 @@ export async function runPrScopeCheck(args: PrScopeCheckArgs): Promise<string> {
     await runGit(repo_path, `diff --name-only ${remote_base_branch}...HEAD`).catch(() => ''),
   );
   const projectYaml = await loadProjectYaml(projectResolution.targetProject!.projectYamlPath);
-  const runtimeSurfacePaths = resolveRuntimeReviewSurfacePaths(
-    projectResolution.targetProject!.path,
-    projectYaml,
-    { include_claude_state_mirror: true },
-  );
+  let runtimeSurfacePaths;
+  try {
+    runtimeSurfacePaths = resolveRuntimeReviewSurfacePaths(
+      projectResolution.targetProject!.path,
+      projectYaml,
+      {
+        include_claude_state_mirror: true,
+        repo_root: gitWorktreeRoot,
+        fail_closed_on_context_policy_error: true,
+      },
+    );
+  } catch (error: any) {
+    result.block_reasons.push(error?.message || 'failed to resolve runtime review surface paths');
+    result.summary = result.block_reasons.join('; ');
+    result.persistence = await persistGuardrailEvidence({
+      command: 'agenticos_pr_scope_check',
+      repo_path,
+      project_path: projectResolution.targetProject?.path || project_path,
+      payload: {
+        issue_id,
+        target_project_id: projectResolution.targetProject?.id || null,
+        active_project: projectResolution.activeProjectId,
+        git_common_repo_root: gitCommonRepoRoot,
+        git_remote_origin: gitRemoteOrigin,
+        remote_base_branch,
+        declared_target_files,
+        expected_issue_scope,
+        result: {
+          status: result.status,
+          summary: result.summary,
+          commit_count: result.commit_count,
+          changed_files: result.changed_files,
+          runtime_managed_files: result.runtime_managed_files,
+          private_raw_transcript_files: result.private_raw_transcript_files,
+          unexpected_files: result.unexpected_files,
+          unrelated_commit_subjects: result.unrelated_commit_subjects,
+          branch_ancestry_verified: result.branch_ancestry_verified,
+          remote_base_branch: result.remote_base_branch,
+          branch_fork_point: result.branch_fork_point,
+          expected_issue_scope: result.expected_issue_scope,
+          block_reasons: result.block_reasons,
+        },
+      },
+    });
+    return JSON.stringify(result, null, 2);
+  }
   const runtimeTrackedPaths = runtimeSurfacePaths.tracked_review_excluded_paths;
   const privateTranscriptPaths = runtimeSurfacePaths.private_transcript_blocked_paths;
 

--- a/mcp-server/src/tools/project.ts
+++ b/mcp-server/src/tools/project.ts
@@ -9,6 +9,12 @@ import { buildArchivedReferenceMessage, isArchivedReferenceProject, validateMana
 import { resolveManagedProjectContextPaths, resolveManagedProjectTarget } from '../utils/project-target.js';
 import { type IssueBootstrapRecord, type IssueBootstrapState } from '../utils/guardrail-evidence.js';
 import { resolveManagedProjectContextDisplayPaths } from '../utils/agent-context-paths.js';
+import { resolveContextPolicyPlan } from '../utils/context-policy-plan.js';
+import {
+  buildConversationRoutingStatusLines,
+  detectLegacyTrackedTranscriptStatus,
+  resolveConversationRoutingPlan,
+} from '../utils/conversation-routing.js';
 import { bindSessionProject, getSessionProjectBinding } from '../utils/session-context.js';
 
 type GuardrailCommand = 'agenticos_preflight' | 'agenticos_branch_bootstrap' | 'agenticos_pr_scope_check';
@@ -272,6 +278,18 @@ export async function switchProject(args: any): Promise<string> {
   try {
     quickStart = await readFile(contextPaths.quickStartPath, 'utf-8');
   } catch {}
+  let transcriptRoutingSummary: string[] = [];
+  try {
+    const contextPolicyPlan = resolveContextPolicyPlan({
+      projectName: found.name,
+      projectPath: found.path,
+      projectYaml,
+    });
+    transcriptRoutingSummary = buildConversationRoutingStatusLines(
+      resolveConversationRoutingPlan(contextPolicyPlan),
+      await detectLegacyTrackedTranscriptStatus(contextPolicyPlan),
+    );
+  } catch {}
 
   // CLAUDE.md: create if missing, upgrade if stale template version
   if (!existsSync(claudeMdPath)) {
@@ -311,7 +329,7 @@ export async function switchProject(args: any): Promise<string> {
     lastRecorded: found.last_recorded,
   });
 
-  return `✅ Switched to project "${found.name}"\n\nPath: ${found.path}\nStatus: ${found.status}\n\n${contextSummary.join('\n')}\n\nContext loaded from:\n- ${found.path}/.project.yaml\n- ${contextPaths.quickStartPath}\n- ${contextPaths.statePath}\n\n${guardrailSummary.join('\n')}\n${issueBootstrapSummary.join('\n')}${bootstrap}`;
+  return `✅ Switched to project "${found.name}"\n\nPath: ${found.path}\nStatus: ${found.status}\n\n${contextSummary.join('\n')}\n${transcriptRoutingSummary.length > 0 ? `\n${transcriptRoutingSummary.join('\n')}\n` : '\n'}Context loaded from:\n- ${found.path}/.project.yaml\n- ${contextPaths.quickStartPath}\n- ${contextPaths.statePath}\n\n${guardrailSummary.join('\n')}\n${issueBootstrapSummary.join('\n')}${bootstrap}`;
 }
 
 export async function listProjects(): Promise<string> {
@@ -375,6 +393,18 @@ export async function getStatus(args: any = {}): Promise<string> {
     const backupDate = new Date(state.session.last_backup).toLocaleString('zh-CN', { timeZone: 'Asia/Shanghai' });
     lines.push(`💾 Last saved: ${backupDate}`);
   }
+
+  try {
+    const contextPolicyPlan = resolveContextPolicyPlan({
+      projectName: project.name,
+      projectPath: resolved.projectPath,
+      projectYaml: resolved.projectYaml,
+    });
+    lines.push(...buildConversationRoutingStatusLines(
+      resolveConversationRoutingPlan(contextPolicyPlan),
+      await detectLegacyTrackedTranscriptStatus(contextPolicyPlan),
+    ));
+  } catch {}
 
   lines.push(...buildGuardrailSummaryLines(state.guardrail_evidence as GuardrailEvidenceState | undefined));
   lines.push(...buildIssueBootstrapSummaryLines({

--- a/mcp-server/src/tools/record.ts
+++ b/mcp-server/src/tools/record.ts
@@ -3,6 +3,12 @@ import yaml from 'yaml';
 import { patchProjectMetadata } from '../utils/registry.js';
 import { updateClaudeMdState } from '../utils/distill.js';
 import { resolveManagedProjectTarget } from '../utils/project-target.js';
+import { resolveContextPolicyPlan } from '../utils/context-policy-plan.js';
+import {
+  buildConversationRoutingStatusLines,
+  detectLegacyTrackedTranscriptStatus,
+  resolveConversationRoutingPlan,
+} from '../utils/conversation-routing.js';
 
 function parseArray(val: unknown): string[] {
   if (Array.isArray(val)) return val as string[];
@@ -35,7 +41,18 @@ export async function recordSession(args: any): Promise<string> {
     return `❌ ${error.message}`;
   }
 
-  const { project, projectPath, statePath, conversationsDir: convDir, markerPath } = resolved;
+  const { project, projectPath, projectYaml, statePath, markerPath } = resolved;
+  const contextPolicyPlan = resolveContextPolicyPlan({
+    projectName: project.name,
+    projectPath,
+    projectYaml,
+  });
+  const conversationRoutingPlan = resolveConversationRoutingPlan(contextPolicyPlan);
+  const legacyTranscriptStatus = await detectLegacyTrackedTranscriptStatus(contextPolicyPlan);
+  if (legacyTranscriptStatus === 'misconfigured_public_raw_target') {
+    return `❌ agenticos_record blocked for "${project.name}" because public transcript routing is misconfigured. Raw transcript destination must remain sidecar-only for public_distilled projects.`;
+  }
+  const convDir = conversationRoutingPlan.raw_conversations_dir;
   const now = new Date();
   const today = now.toISOString().split('T')[0];
   const time = now.toISOString().substring(11, 16);
@@ -119,8 +136,10 @@ export async function recordSession(args: any): Promise<string> {
     last_recorded: now.toISOString(),
   });
 
+  const routingNotes = buildConversationRoutingStatusLines(conversationRoutingPlan, legacyTranscriptStatus);
   return `✅ Session recorded for "${project.name}"\n\n` +
-    `📝 Conversation: .context/conversations/${today}.md\n` +
-    `📊 State: .context/state.yaml (updated)\n` +
-    `📋 CLAUDE.md: Current State synced\n`;
+    `📝 Raw conversation: ${conversationRoutingPlan.raw_conversations_display_dir}${today}.md\n` +
+    `📊 State: ${contextPolicyPlan.trackedContextDisplayPaths.state} (updated)\n` +
+    `📋 CLAUDE.md: Current State synced\n` +
+    (routingNotes.length > 0 ? `\n${routingNotes.join('\n')}\n` : '');
 }

--- a/mcp-server/src/tools/save.ts
+++ b/mcp-server/src/tools/save.ts
@@ -106,7 +106,7 @@ function extractGitHubRepoFromRemoteOrigin(value: string): string | null {
 
 async function validateGitBackedContinuityRepoBinding(args: {
   projectName: string;
-  policy: 'private_continuity' | 'public_distilled';
+  policy: 'private_continuity' | 'public_distilled' | 'local_private';
   projectPath: string;
   projectYaml: any;
   gitWorktreeRoot: string | null;

--- a/mcp-server/src/tools/save.ts
+++ b/mcp-server/src/tools/save.ts
@@ -8,6 +8,11 @@ import { resolveManagedProjectTarget } from '../utils/project-target.js';
 import { resolveRuntimeReviewSurfacePaths, toProjectAbsoluteRuntimePath } from '../utils/runtime-review-surface.js';
 import { resolveContextPolicyPlan } from '../utils/context-policy-plan.js';
 import { resolveContinuitySurfacePlan } from '../utils/continuity-surface.js';
+import {
+  buildConversationRoutingStatusLines,
+  detectLegacyTrackedTranscriptStatus,
+  resolveConversationRoutingPlan,
+} from '../utils/conversation-routing.js';
 
 async function execCommand(command: string): Promise<{ stdout: string; stderr: string }> {
   return await new Promise((resolve, reject) => {
@@ -99,18 +104,19 @@ function extractGitHubRepoFromRemoteOrigin(value: string): string | null {
   return null;
 }
 
-async function validatePrivateContinuityRepoBinding(args: {
+async function validateGitBackedContinuityRepoBinding(args: {
   projectName: string;
+  policy: 'private_continuity' | 'public_distilled';
   projectPath: string;
   projectYaml: any;
   gitWorktreeRoot: string | null;
   gitCommonRepoRoot: string | null;
 }): Promise<string[]> {
-  const { projectName, projectPath, projectYaml, gitWorktreeRoot, gitCommonRepoRoot } = args;
+  const { projectName, policy, projectPath, projectYaml, gitWorktreeRoot, gitCommonRepoRoot } = args;
   const reasons: string[] = [];
 
   if (!gitWorktreeRoot || !gitCommonRepoRoot) {
-    reasons.push('private_continuity requires a git repo root for tracked continuity persistence.');
+    reasons.push(`${policy} requires a git repo root for tracked continuity persistence.`);
     return reasons;
   }
 
@@ -151,6 +157,13 @@ async function validatePrivateContinuityRepoBinding(args: {
   return reasons;
 }
 
+async function hasTrackedPublicTranscriptDiffs(gitRoot: string, trackedConversationPath: string): Promise<boolean> {
+  const { stdout } = await execCommand(
+    `git -C "${gitRoot}" status --porcelain --untracked-files=all -- "${trackedConversationPath}"`,
+  );
+  return stdout.trim().length > 0;
+}
+
 export async function saveState(args: any): Promise<string> {
   const now = new Date();
   const timestamp = now.toISOString().replace('T', ' ').substring(0, 16);
@@ -186,7 +199,7 @@ export async function saveState(args: any): Promise<string> {
       return `❌ ${error.message}`;
     }
 
-    const continuityPlan = contextPolicyPlan.policy === 'private_continuity'
+    const continuityPlan = contextPolicyPlan.policy !== 'local_private'
       ? resolveContinuitySurfacePlan(contextPolicyPlan, {
         include_claude_state_mirror: true,
         include_agents_guidance: existsSync(`${projectPath}/AGENTS.md`),
@@ -194,8 +207,9 @@ export async function saveState(args: any): Promise<string> {
       : null;
 
     if (continuityPlan) {
-      const repoBindingReasons = await validatePrivateContinuityRepoBinding({
+      const repoBindingReasons = await validateGitBackedContinuityRepoBinding({
         projectName: project.name,
+        policy: continuityPlan.policy,
         projectPath,
         projectYaml,
         gitWorktreeRoot,
@@ -209,6 +223,30 @@ export async function saveState(args: any): Promise<string> {
       if (continuityFailureReasons.length > 0) {
         return buildContinuityFailureMessage(project.name, continuityFailureReasons);
       }
+    }
+
+    const conversationRoutingPlan = resolveConversationRoutingPlan(contextPolicyPlan);
+    const trackedConversationReviewPath = gitWorktreeRoot
+      ? toGitRelativePath(
+        gitWorktreeRoot,
+        join(projectPath, contextPolicyPlan.trackedContextDisplayPaths.conversations),
+        { directory: true },
+      )
+      : contextPolicyPlan.trackedContextDisplayPaths.conversations;
+    const legacyTranscriptStatus = contextPolicyPlan.policy === 'public_distilled' && gitWorktreeRoot
+      ? await detectLegacyTrackedTranscriptStatus(contextPolicyPlan, {
+        tracked_transcript_dirty: await hasTrackedPublicTranscriptDiffs(
+          gitWorktreeRoot,
+          trackedConversationReviewPath,
+        ),
+      })
+      : await detectLegacyTrackedTranscriptStatus(contextPolicyPlan);
+
+    if (legacyTranscriptStatus === 'tracked_legacy_dirty') {
+      return `❌ agenticos_save blocked for "${project.name}"\n\n- tracked raw transcript changes are present under ${contextPolicyPlan.trackedContextDisplayPaths.conversations}\n- public_distilled projects must not publish new raw transcript history from tracked paths`;
+    }
+    if (legacyTranscriptStatus === 'misconfigured_public_raw_target') {
+      return `❌ agenticos_save blocked for "${project.name}"\n\n- public transcript routing is misconfigured\n- raw transcript destination must remain sidecar-only for public_distilled projects`;
     }
 
     // Update state.yaml only after the continuity plan is known to be supported.
@@ -238,7 +276,9 @@ export async function saveState(args: any): Promise<string> {
         toGitRelativePath(gitWorktreeRoot, join(projectPath, contextPolicyPlan.trackedContextDisplayPaths.projectFile)),
         toGitRelativePath(gitWorktreeRoot, join(projectPath, contextPolicyPlan.trackedContextDisplayPaths.quickStart)),
         toGitRelativePath(gitWorktreeRoot, join(projectPath, contextPolicyPlan.trackedContextDisplayPaths.state)),
-        toGitRelativePath(gitWorktreeRoot, join(projectPath, contextPolicyPlan.trackedContextDisplayPaths.conversations), { directory: true }),
+        ...(continuityPlan.policy === 'private_continuity'
+          ? [toGitRelativePath(gitWorktreeRoot, join(projectPath, contextPolicyPlan.trackedContextDisplayPaths.conversations), { directory: true })]
+          : []),
         toGitRelativePath(gitWorktreeRoot, join(projectPath, contextPolicyPlan.trackedContextDisplayPaths.knowledge), { directory: true }),
         toGitRelativePath(gitWorktreeRoot, join(projectPath, contextPolicyPlan.trackedContextDisplayPaths.tasks), { directory: true }),
         toGitRelativePath(gitWorktreeRoot, join(projectPath, 'CLAUDE.md')),
@@ -288,14 +328,22 @@ export async function saveState(args: any): Promise<string> {
     else if (committed) phases.push('⚠️ Push failed (committed locally, not synced)');
 
     const recoveryNote = continuityPlan
-      ? pushed
-        ? '\nRecovery: full tracked continuity synced for Git-backed restore'
-        : committed
-          ? '\nRecovery: tracked continuity committed locally; remote sync is still pending'
-          : '\nRecovery: tracked continuity contract evaluated; no new continuity changes were committed'
+      ? continuityPlan.policy === 'private_continuity'
+        ? pushed
+          ? '\nRecovery: full tracked continuity synced for Git-backed restore'
+          : committed
+            ? '\nRecovery: tracked continuity committed locally; remote sync is still pending'
+            : '\nRecovery: tracked continuity contract evaluated; no new continuity changes were committed'
+        : pushed
+          ? `\nRecovery: distilled continuity synced for Git-backed restore; raw transcripts remain in ${conversationRoutingPlan.raw_conversations_display_dir}`
+          : committed
+            ? `\nRecovery: distilled continuity committed locally; remote sync is still pending; raw transcripts remain in ${conversationRoutingPlan.raw_conversations_display_dir}`
+            : `\nRecovery: distilled continuity contract evaluated; no new continuity changes were committed; raw transcripts remain in ${conversationRoutingPlan.raw_conversations_display_dir}`
       : '';
+    const routingNotes = buildConversationRoutingStatusLines(conversationRoutingPlan, legacyTranscriptStatus);
+    const routingSuffix = routingNotes.length > 0 ? `\n${routingNotes.join('\n')}` : '';
 
-    return `${phases.join('\n')}\n\nProject: "${project.name}"\nCommit: ${commitMessage}\nTimestamp: ${state.session.last_backup}${claudeMdNote}${recoveryNote}`;
+    return `${phases.join('\n')}\n\nProject: "${project.name}"\nCommit: ${commitMessage}\nTimestamp: ${state.session.last_backup}${claudeMdNote}${recoveryNote}${routingSuffix}`;
   } catch (error: any) {
     return `⚠️ Partial save completed\n\nError: ${error.message}`;
   }

--- a/mcp-server/src/utils/__tests__/continuity-surface.test.ts
+++ b/mcp-server/src/utils/__tests__/continuity-surface.test.ts
@@ -26,9 +26,9 @@ describe('resolveContinuitySurfacePlan', () => {
       '.project.yaml',
       '.context/quick-start.md',
       '.context/state.yaml',
-      '.context/conversations/',
       'knowledge/',
       'tasks/',
+      '.context/conversations/',
     ]);
     expect(plan.optional_guidance_paths).toEqual(['CLAUDE.md', 'AGENTS.md']);
     expect(plan.excluded_paths).toContain('.context/.last_record');
@@ -36,7 +36,7 @@ describe('resolveContinuitySurfacePlan', () => {
     expect(plan.unsupported_reasons).toEqual([]);
   });
 
-  it('does not widen public_distilled to full continuity', () => {
+  it('returns the distilled tracked continuity set for public_distilled', () => {
     const contextPlan = resolveContextPolicyPlan({
       projectName: 'Public Project',
       projectPath: '/workspace/public-project',
@@ -52,8 +52,15 @@ describe('resolveContinuitySurfacePlan', () => {
     const plan = resolveContinuitySurfacePlan(contextPlan);
 
     expect(plan.policy).toBe('public_distilled');
-    expect(plan.tracked_continuity_paths).toEqual([]);
-    expect(plan.optional_guidance_paths).toEqual([]);
+    expect(plan.tracked_continuity_paths).toEqual([
+      '.project.yaml',
+      '.context/quick-start.md',
+      '.context/state.yaml',
+      'knowledge/',
+      'tasks/',
+    ]);
+    expect(plan.optional_guidance_paths).toEqual(['CLAUDE.md']);
+    expect(plan.tracked_continuity_paths).not.toContain('.context/conversations/');
   });
 
   it('fails closed when a required tracked continuity path escapes the repo root', () => {

--- a/mcp-server/src/utils/__tests__/conversation-routing.test.ts
+++ b/mcp-server/src/utils/__tests__/conversation-routing.test.ts
@@ -1,0 +1,57 @@
+import { mkdir, mkdtemp, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { describe, expect, it } from 'vitest';
+import {
+  buildConversationRoutingStatusLines,
+  detectLegacyTrackedTranscriptStatus,
+  resolveConversationRoutingPlan,
+} from '../conversation-routing.js';
+import { resolveContextPolicyPlan } from '../context-policy-plan.js';
+
+describe('conversation routing', () => {
+  it('derives a sidecar raw transcript path for public_distilled', () => {
+    const contextPlan = resolveContextPolicyPlan({
+      projectName: 'Public Project',
+      projectPath: '/workspace/public-project',
+      repoRoot: '/workspace/public-project',
+      projectYaml: {
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'public_distilled',
+        },
+      },
+    });
+
+    const routing = resolveConversationRoutingPlan(contextPlan);
+
+    expect(routing.raw_conversations_display_dir).toBe('.private/conversations/');
+    expect(routing.tracked_conversations_display_dir).toBeNull();
+    expect(routing.tracked_recovery_contract).toBe('git_distilled');
+    expect(routing.is_sidecar).toBe(true);
+  });
+
+  it('detects tracked legacy transcript history for public_distilled projects', async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), 'agenticos-routing-'));
+    await mkdir(join(projectRoot, '.context', 'conversations'), { recursive: true });
+    await writeFile(join(projectRoot, '.context', 'conversations', '2026-04-13.md'), '# legacy\n', 'utf-8');
+
+    const contextPlan = resolveContextPolicyPlan({
+      projectName: 'Public Project',
+      projectPath: projectRoot,
+      repoRoot: projectRoot,
+      projectYaml: {
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'public_distilled',
+        },
+      },
+    });
+
+    const status = await detectLegacyTrackedTranscriptStatus(contextPlan);
+    const lines = buildConversationRoutingStatusLines(resolveConversationRoutingPlan(contextPlan), status);
+
+    expect(status).toBe('tracked_legacy_present');
+    expect(lines.join('\n')).toContain('historical tracked evidence');
+  });
+});

--- a/mcp-server/src/utils/__tests__/conversation-routing.test.ts
+++ b/mcp-server/src/utils/__tests__/conversation-routing.test.ts
@@ -26,9 +26,32 @@ describe('conversation routing', () => {
     const routing = resolveConversationRoutingPlan(contextPlan);
 
     expect(routing.raw_conversations_display_dir).toBe('.private/conversations/');
-    expect(routing.tracked_conversations_display_dir).toBeNull();
+    expect(routing.tracked_conversations_display_dir).toBe('.context/conversations/');
     expect(routing.tracked_recovery_contract).toBe('git_distilled');
     expect(routing.is_sidecar).toBe(true);
+  });
+
+  it('preserves the configured tracked conversation display path for public_distilled', () => {
+    const contextPlan = resolveContextPolicyPlan({
+      projectName: 'Public Project',
+      projectPath: '/workspace/public-project',
+      repoRoot: '/workspace/public-project',
+      projectYaml: {
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'public_distilled',
+        },
+        agent_context: {
+          conversations: 'runtime/conversations/',
+        },
+      },
+    });
+
+    const routing = resolveConversationRoutingPlan(contextPlan);
+    const lines = buildConversationRoutingStatusLines(routing, 'tracked_legacy_present');
+
+    expect(routing.tracked_conversations_display_dir).toBe('runtime/conversations/');
+    expect(lines.join('\n')).toContain('runtime/conversations/');
   });
 
   it('detects tracked legacy transcript history for public_distilled projects', async () => {

--- a/mcp-server/src/utils/__tests__/entry-surface-refresh.test.ts
+++ b/mcp-server/src/utils/__tests__/entry-surface-refresh.test.ts
@@ -212,6 +212,40 @@ describe('entry surface refresh', () => {
     expect(state.loaded_context).toEqual(['.project.yaml', 'standards/.context/quick-start.md']);
   });
 
+  it('describes tracked and raw transcript paths separately for public_distilled projects', async () => {
+    const projectRoot = await setupProjectRoot();
+    await writeFile(
+      join(projectRoot, '.project.yaml'),
+      yaml.stringify({
+        meta: {
+          name: 'Public Project',
+          description: 'Public distilled project.',
+        },
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'public_distilled',
+          github_repo: 'example/public-project',
+          branch_strategy: 'github_flow',
+        },
+        execution: {
+          source_repo_roots: ['.'],
+        },
+      }),
+      'utf-8',
+    );
+    await writeFile(join(projectRoot, '.context', 'state.yaml'), yaml.stringify({}), 'utf-8');
+
+    await refreshEntrySurfaces({
+      project_path: projectRoot,
+      summary: 'Refreshed public entry surfaces.',
+      status: 'active',
+      current_focus: 'Keep public continuity distilled',
+    });
+
+    const quickStart = await readFile(join(projectRoot, '.context', 'quick-start.md'), 'utf-8');
+    expect(quickStart).toContain('tracked surface `.context/conversations/`; raw transcripts route to `.private/conversations/`');
+  });
+
   it('falls back to basename inside the readable project-yaml path when metadata fields are empty', async () => {
     const projectRoot = await setupProjectRoot();
     await writeFile(join(projectRoot, '.project.yaml'), yaml.stringify({ meta: {} }), 'utf-8');

--- a/mcp-server/src/utils/__tests__/runtime-review-surface.test.ts
+++ b/mcp-server/src/utils/__tests__/runtime-review-surface.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { resolveRuntimeReviewSurfacePaths } from '../runtime-review-surface.js';
+
+describe('runtime review surface', () => {
+  it('keeps tracked conversations in runtime-managed paths for private continuity', () => {
+    const result = resolveRuntimeReviewSurfacePaths('/workspace/private-project', {
+      meta: { name: 'Private Project' },
+      source_control: {
+        topology: 'github_versioned',
+        context_publication_policy: 'private_continuity',
+      },
+    });
+
+    expect(result.tracked_review_excluded_paths).toContain('.context/conversations/');
+    expect(result.private_transcript_blocked_paths).toContain('.private/conversations/');
+  });
+
+  it('treats tracked conversations as blocked raw transcript paths for public_distilled', () => {
+    const result = resolveRuntimeReviewSurfacePaths('/workspace/public-project', {
+      meta: { name: 'Public Project' },
+      source_control: {
+        topology: 'github_versioned',
+        context_publication_policy: 'public_distilled',
+      },
+    });
+
+    expect(result.tracked_review_excluded_paths).not.toContain('.context/conversations/');
+    expect(result.private_transcript_blocked_paths).toContain('.context/conversations/');
+    expect(result.private_transcript_blocked_paths).toContain('.private/conversations/');
+  });
+});

--- a/mcp-server/src/utils/__tests__/runtime-review-surface.test.ts
+++ b/mcp-server/src/utils/__tests__/runtime-review-surface.test.ts
@@ -28,4 +28,33 @@ describe('runtime review surface', () => {
     expect(result.private_transcript_blocked_paths).toContain('.context/conversations/');
     expect(result.private_transcript_blocked_paths).toContain('.private/conversations/');
   });
+
+  it('resolves nested-project review paths relative to the git repo root when provided', () => {
+    const result = resolveRuntimeReviewSurfacePaths('/workspace/repo/projects/app', {
+      meta: { name: 'Nested Public Project' },
+      source_control: {
+        topology: 'github_versioned',
+        context_publication_policy: 'public_distilled',
+      },
+      agent_context: {
+        current_state: 'runtime/state.yaml',
+        conversations: 'runtime/conversations/',
+        last_record_marker: 'runtime/.last_record',
+      },
+    }, {
+      repo_root: '/workspace/repo',
+    });
+
+    expect(result.tracked_review_excluded_paths).toContain('projects/app/runtime/state.yaml');
+    expect(result.private_transcript_blocked_paths).toContain('projects/app/runtime/conversations/');
+    expect(result.private_transcript_blocked_paths).toContain('projects/app/.private/conversations/');
+  });
+
+  it('fails closed when strict context-policy resolution is requested', () => {
+    expect(() => resolveRuntimeReviewSurfacePaths('/workspace/project', {
+      meta: { name: 'Broken Project' },
+    }, {
+      fail_closed_on_context_policy_error: true,
+    })).toThrow();
+  });
 });

--- a/mcp-server/src/utils/continuity-surface.ts
+++ b/mcp-server/src/utils/continuity-surface.ts
@@ -58,7 +58,7 @@ export function resolveContinuitySurfacePlan(
 ): ContinuitySurfacePlan {
   const unsupportedReasons: string[] = [];
 
-  if (plan.policy !== 'private_continuity') {
+  if (plan.policy === 'local_private') {
     return {
       policy: plan.policy,
       tracked_continuity_paths: [],
@@ -70,7 +70,7 @@ export function resolveContinuitySurfacePlan(
   }
 
   if (!plan.repoRoot) {
-    unsupportedReasons.push('private_continuity requires a git repo root for tracked continuity persistence.');
+    unsupportedReasons.push(`${plan.policy} requires a git repo root for tracked continuity persistence.`);
   }
 
   const trackedContinuity = new Set<string>();
@@ -90,9 +90,11 @@ export function resolveContinuitySurfacePlan(
   addTrackedPath('.project.yaml', plan.trackedContextPaths.projectFile);
   addTrackedPath('quick-start', plan.trackedContextPaths.quickStart);
   addTrackedPath('state', plan.trackedContextPaths.state);
-  addTrackedPath('conversations', plan.trackedContextPaths.conversations, true);
   addTrackedPath('knowledge', plan.trackedContextPaths.knowledge, true);
   addTrackedPath('tasks', plan.trackedContextPaths.tasks, true);
+  if (plan.policy === 'private_continuity') {
+    addTrackedPath('conversations', plan.trackedContextPaths.conversations, true);
+  }
 
   if (options.include_claude_state_mirror !== false) {
     const claudePath = join(plan.projectRoot, 'CLAUDE.md');
@@ -124,10 +126,13 @@ export function resolveContinuitySurfacePlan(
     const isRequiredViolation = violation.startsWith('.project.yaml')
       || violation.startsWith('quick-start')
       || violation.startsWith('state')
-      || violation.startsWith('conversations')
       || violation.startsWith('knowledge')
       || violation.startsWith('tasks');
+    const isPrivateConversationViolation = plan.policy === 'private_continuity'
+      && violation.startsWith('conversations');
     if (isRequiredViolation) {
+      unsupportedReasons.push(violation);
+    } else if (isPrivateConversationViolation) {
       unsupportedReasons.push(violation);
     }
   }

--- a/mcp-server/src/utils/conversation-routing.ts
+++ b/mcp-server/src/utils/conversation-routing.ts
@@ -51,9 +51,7 @@ async function directoryContainsTranscriptFiles(path: string): Promise<boolean> 
 
 export function resolveConversationRoutingPlan(plan: ContextPolicyPlan): ConversationRoutingPlan {
   const rawDisplayDir = toProjectRelativePath(plan.projectRoot, plan.rawConversationsDir, true);
-  const trackedDisplayDir = plan.trackedConversationsDir
-    ? toProjectRelativePath(plan.projectRoot, plan.trackedConversationsDir, true)
-    : null;
+  const trackedDisplayDir = plan.trackedContextDisplayPaths.conversations;
   const trackedRecoveryContract: TrackedRecoveryContract = plan.policy === 'private_continuity'
     ? 'git_full'
     : plan.policy === 'public_distilled'
@@ -90,7 +88,6 @@ export async function detectLegacyTrackedTranscriptStatus(
 
   const rawRelative = relative(plan.projectRoot, plan.rawConversationsDir).replace(/\\/g, '/');
   if (!rawRelative || rawRelative.startsWith('..')
-    || plan.trackedConversationsDir !== null
     || plan.rawConversationsDir === plan.trackedContextPaths.conversations) {
     return 'misconfigured_public_raw_target';
   }

--- a/mcp-server/src/utils/conversation-routing.ts
+++ b/mcp-server/src/utils/conversation-routing.ts
@@ -1,0 +1,131 @@
+import { readdir } from 'fs/promises';
+import { relative } from 'path';
+import { type ContextPolicyPlan } from './context-policy-plan.js';
+
+export type TrackedRecoveryContract = 'local_only' | 'git_full' | 'git_distilled';
+export type LegacyTranscriptStatus =
+  | 'none'
+  | 'tracked_legacy_present'
+  | 'tracked_legacy_dirty'
+  | 'misconfigured_public_raw_target';
+
+export interface ConversationRoutingPlan {
+  policy: ContextPolicyPlan['policy'];
+  raw_conversations_dir: string;
+  raw_conversations_display_dir: string;
+  tracked_conversations_dir: string | null;
+  tracked_conversations_display_dir: string | null;
+  is_sidecar: boolean;
+  tracked_recovery_contract: TrackedRecoveryContract;
+  notes: string[];
+}
+
+interface DetectLegacyTrackedTranscriptStatusOptions {
+  tracked_transcript_dirty?: boolean;
+}
+
+function toProjectRelativePath(projectRoot: string, absolutePath: string, directory = false): string {
+  const relativePath = relative(projectRoot, absolutePath).replace(/\\/g, '/');
+  if (!relativePath || relativePath.startsWith('..')) {
+    throw new Error(`Path escapes project root: ${absolutePath}`);
+  }
+  return directory && !relativePath.endsWith('/') ? `${relativePath}/` : relativePath;
+}
+
+async function directoryContainsTranscriptFiles(path: string): Promise<boolean> {
+  try {
+    const entries = await readdir(path, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.isFile() && entry.name.endsWith('.md')) {
+        return true;
+      }
+      if (entry.isDirectory() && await directoryContainsTranscriptFiles(`${path}/${entry.name}`)) {
+        return true;
+      }
+    }
+  } catch {
+    return false;
+  }
+  return false;
+}
+
+export function resolveConversationRoutingPlan(plan: ContextPolicyPlan): ConversationRoutingPlan {
+  const rawDisplayDir = toProjectRelativePath(plan.projectRoot, plan.rawConversationsDir, true);
+  const trackedDisplayDir = plan.trackedConversationsDir
+    ? toProjectRelativePath(plan.projectRoot, plan.trackedConversationsDir, true)
+    : null;
+  const trackedRecoveryContract: TrackedRecoveryContract = plan.policy === 'private_continuity'
+    ? 'git_full'
+    : plan.policy === 'public_distilled'
+      ? 'git_distilled'
+      : 'local_only';
+
+  const notes: string[] = [];
+  if (plan.policy === 'public_distilled') {
+    notes.push(`Raw transcript writes route to \`${rawDisplayDir}\` and stay outside the tracked public tree.`);
+    if (trackedDisplayDir) {
+      notes.push(`Configured tracked/display transcript surface remains \`${trackedDisplayDir}\`.`);
+    }
+  }
+
+  return {
+    policy: plan.policy,
+    raw_conversations_dir: plan.rawConversationsDir,
+    raw_conversations_display_dir: rawDisplayDir,
+    tracked_conversations_dir: plan.trackedConversationsDir,
+    tracked_conversations_display_dir: trackedDisplayDir,
+    is_sidecar: plan.rawConversationsDir !== plan.trackedContextPaths.conversations,
+    tracked_recovery_contract: trackedRecoveryContract,
+    notes,
+  };
+}
+
+export async function detectLegacyTrackedTranscriptStatus(
+  plan: ContextPolicyPlan,
+  options: DetectLegacyTrackedTranscriptStatusOptions = {},
+): Promise<LegacyTranscriptStatus> {
+  if (plan.policy !== 'public_distilled') {
+    return 'none';
+  }
+
+  const rawRelative = relative(plan.projectRoot, plan.rawConversationsDir).replace(/\\/g, '/');
+  if (!rawRelative || rawRelative.startsWith('..')
+    || plan.trackedConversationsDir !== null
+    || plan.rawConversationsDir === plan.trackedContextPaths.conversations) {
+    return 'misconfigured_public_raw_target';
+  }
+
+  if (options.tracked_transcript_dirty) {
+    return 'tracked_legacy_dirty';
+  }
+
+  const hasTrackedLegacy = await directoryContainsTranscriptFiles(plan.trackedContextPaths.conversations);
+  return hasTrackedLegacy ? 'tracked_legacy_present' : 'none';
+}
+
+export function buildConversationRoutingStatusLines(
+  routingPlan: ConversationRoutingPlan,
+  legacyTranscriptStatus: LegacyTranscriptStatus,
+): string[] {
+  if (routingPlan.policy !== 'public_distilled') {
+    return [];
+  }
+
+  const lines = [
+    `🔒 Raw transcripts: \`${routingPlan.raw_conversations_display_dir}\` (private sidecar; Git recovery is distilled-only)`,
+  ];
+
+  if (legacyTranscriptStatus === 'tracked_legacy_present') {
+    lines.push(
+      `⚠️ Legacy public transcripts remain under \`${routingPlan.tracked_conversations_display_dir || '.context/conversations/'}\` as historical tracked evidence; new raw writes should not continue there.`,
+    );
+  } else if (legacyTranscriptStatus === 'tracked_legacy_dirty') {
+    lines.push(
+      `❌ Tracked raw transcript changes are present under \`${routingPlan.tracked_conversations_display_dir || '.context/conversations/'}\`; publishing them would leak new private history.`,
+    );
+  } else if (legacyTranscriptStatus === 'misconfigured_public_raw_target') {
+    lines.push('❌ Public transcript routing is misconfigured; raw transcript destination is not isolated from the tracked project tree.');
+  }
+
+  return lines;
+}

--- a/mcp-server/src/utils/entry-surface-refresh.ts
+++ b/mcp-server/src/utils/entry-surface-refresh.ts
@@ -5,6 +5,8 @@ import {
   resolveManagedProjectContextDisplayPaths,
   resolveManagedProjectContextPaths,
 } from './agent-context-paths.js';
+import { resolveConversationRoutingPlan } from './conversation-routing.js';
+import { resolveContextPolicyPlan } from './context-policy-plan.js';
 
 export interface EntrySurfaceRefreshArgs {
   project_path: string;
@@ -92,6 +94,7 @@ function buildQuickStart(
   args: EntrySurfaceRefreshArgs,
   identity: ResolvedProjectIdentity,
   refreshedAt: string,
+  projectPath: string,
   contextPaths: ReturnType<typeof resolveManagedProjectContextDisplayPaths>,
 ): string {
   const pending = normalizeList(args.pending);
@@ -144,11 +147,23 @@ function buildQuickStart(
     });
   }
 
+  let conversationLayerLine = `- Conversation history surface: \`${contextPaths.conversationsDir}\``;
+  try {
+    const routingPlan = resolveConversationRoutingPlan(resolveContextPolicyPlan({
+      projectName: identity.projectName,
+      projectPath,
+      projectYaml: identity.projectYaml,
+    }));
+    if (routingPlan.policy === 'public_distilled') {
+      conversationLayerLine = `- Conversation history contract: tracked surface \`${contextPaths.conversationsDir}\`; raw transcripts route to \`${routingPlan.raw_conversations_display_dir}\``;
+    }
+  } catch {}
+
   lines.push(
     '',
     '## Canonical Layers',
     `- Operational state: \`${contextPaths.statePath}\``,
-    `- Session history: \`${contextPaths.conversationsDir}\``,
+    conversationLayerLine,
     `- Durable knowledge: \`${contextPaths.knowledgeDir}\``,
     `- Execution plans: \`${contextPaths.tasksDir}\``,
     `- Deliverables: \`${contextPaths.artifactsDir}\``,
@@ -243,7 +258,7 @@ export async function refreshEntrySurfaces(args: EntrySurfaceRefreshArgs): Promi
 
   const existingState = await readState(statePath);
   const nextState = buildState(args, existingState, refreshedAt, displayPaths);
-  const nextQuickStart = buildQuickStart(args, identity, refreshedAt, displayPaths);
+  const nextQuickStart = buildQuickStart(args, identity, refreshedAt, projectPath, displayPaths);
 
   await writeFile(quickStartPath, nextQuickStart, 'utf-8');
   await writeFile(statePath, yaml.stringify(nextState), 'utf-8');

--- a/mcp-server/src/utils/runtime-review-surface.ts
+++ b/mcp-server/src/utils/runtime-review-surface.ts
@@ -1,9 +1,11 @@
-import { join, relative } from 'path';
+import { basename, join, relative } from 'path';
+import { resolveContextPolicyPlan } from './context-policy-plan.js';
 import { resolveManagedProjectContextPaths } from './project-target.js';
 
 export interface RuntimeReviewSurfacePaths {
   tracked_review_excluded_paths: string[];
   sidecar_only_paths: string[];
+  private_transcript_blocked_paths: string[];
 }
 
 interface ResolveRuntimeReviewSurfaceOptions {
@@ -27,12 +29,53 @@ export function resolveRuntimeReviewSurfacePaths(
   projectYaml: any,
   options: ResolveRuntimeReviewSurfaceOptions = {},
 ): RuntimeReviewSurfacePaths {
-  const contextPaths = resolveManagedProjectContextPaths(projectPath, projectYaml);
+  let contextPolicyPlan;
+  try {
+    contextPolicyPlan = resolveContextPolicyPlan({
+      projectName: projectYaml?.meta?.name || basename(projectPath),
+      projectPath,
+      projectYaml,
+    });
+  } catch {
+    const contextPaths = resolveManagedProjectContextPaths(projectPath, projectYaml);
+    const tracked = new Set<string>([
+      normalizeRepoRelativePath(projectPath, contextPaths.statePath),
+      normalizeRepoRelativePath(projectPath, contextPaths.markerPath),
+      normalizeRepoRelativePath(projectPath, contextPaths.conversationsDir, true),
+    ]);
+
+    if (options.include_claude_state_mirror) {
+      tracked.add('CLAUDE.md');
+    }
+
+    return {
+      tracked_review_excluded_paths: Array.from(tracked),
+      sidecar_only_paths: [
+        '.private/conversations/',
+        '.meta/transcripts/',
+      ],
+      private_transcript_blocked_paths: [
+        '.private/conversations/',
+        '.meta/transcripts/',
+      ],
+    };
+  }
   const tracked = new Set<string>([
-    normalizeRepoRelativePath(projectPath, contextPaths.statePath),
-    normalizeRepoRelativePath(projectPath, contextPaths.markerPath),
-    normalizeRepoRelativePath(projectPath, contextPaths.conversationsDir, true),
+    normalizeRepoRelativePath(projectPath, contextPolicyPlan.trackedContextPaths.state),
+    normalizeRepoRelativePath(projectPath, contextPolicyPlan.trackedContextPaths.lastRecord),
   ]);
+  const sidecarOnlyPaths = contextPolicyPlan.sidecarOnlyPaths.map((path) =>
+    normalizeRepoRelativePath(projectPath, path, true),
+  );
+  const privateTranscriptBlockedPaths = new Set<string>(sidecarOnlyPaths);
+
+  if (contextPolicyPlan.policy === 'private_continuity' || contextPolicyPlan.policy === 'local_private') {
+    tracked.add(normalizeRepoRelativePath(projectPath, contextPolicyPlan.trackedContextPaths.conversations, true));
+  } else {
+    privateTranscriptBlockedPaths.add(
+      normalizeRepoRelativePath(projectPath, contextPolicyPlan.trackedContextPaths.conversations, true),
+    );
+  }
 
   if (options.include_claude_state_mirror) {
     tracked.add('CLAUDE.md');
@@ -40,10 +83,8 @@ export function resolveRuntimeReviewSurfacePaths(
 
   return {
     tracked_review_excluded_paths: Array.from(tracked),
-    sidecar_only_paths: [
-      '.private/conversations/',
-      '.meta/transcripts/',
-    ],
+    sidecar_only_paths: sidecarOnlyPaths,
+    private_transcript_blocked_paths: Array.from(privateTranscriptBlockedPaths),
   };
 }
 

--- a/mcp-server/src/utils/runtime-review-surface.ts
+++ b/mcp-server/src/utils/runtime-review-surface.ts
@@ -10,12 +10,14 @@ export interface RuntimeReviewSurfacePaths {
 
 interface ResolveRuntimeReviewSurfaceOptions {
   include_claude_state_mirror?: boolean;
+  repo_root?: string | null;
+  fail_closed_on_context_policy_error?: boolean;
 }
 
-function normalizeRepoRelativePath(projectPath: string, absolutePath: string, treatAsDirectory = false): string {
-  const relativePath = relative(projectPath, absolutePath).replace(/\\/g, '/');
+function normalizeRelativePathFromBase(basePath: string, absolutePath: string, treatAsDirectory = false): string {
+  const relativePath = relative(basePath, absolutePath).replace(/\\/g, '/');
   if (!relativePath || relativePath.startsWith('..')) {
-    throw new Error(`Runtime review surface path escapes project root: ${absolutePath}`);
+    throw new Error(`Runtime review surface path escapes comparison root: ${absolutePath}`);
   }
   return treatAsDirectory && !relativePath.endsWith('/') ? `${relativePath}/` : relativePath;
 }
@@ -29,19 +31,24 @@ export function resolveRuntimeReviewSurfacePaths(
   projectYaml: any,
   options: ResolveRuntimeReviewSurfaceOptions = {},
 ): RuntimeReviewSurfacePaths {
+  const comparisonRoot = options.repo_root || projectPath;
   let contextPolicyPlan;
   try {
     contextPolicyPlan = resolveContextPolicyPlan({
       projectName: projectYaml?.meta?.name || basename(projectPath),
       projectPath,
       projectYaml,
+      repoRoot: options.repo_root || null,
     });
-  } catch {
+  } catch (error) {
+    if (options.fail_closed_on_context_policy_error) {
+      throw error;
+    }
     const contextPaths = resolveManagedProjectContextPaths(projectPath, projectYaml);
     const tracked = new Set<string>([
-      normalizeRepoRelativePath(projectPath, contextPaths.statePath),
-      normalizeRepoRelativePath(projectPath, contextPaths.markerPath),
-      normalizeRepoRelativePath(projectPath, contextPaths.conversationsDir, true),
+      normalizeRelativePathFromBase(comparisonRoot, contextPaths.statePath),
+      normalizeRelativePathFromBase(comparisonRoot, contextPaths.markerPath),
+      normalizeRelativePathFromBase(comparisonRoot, contextPaths.conversationsDir, true),
     ]);
 
     if (options.include_claude_state_mirror) {
@@ -61,19 +68,19 @@ export function resolveRuntimeReviewSurfacePaths(
     };
   }
   const tracked = new Set<string>([
-    normalizeRepoRelativePath(projectPath, contextPolicyPlan.trackedContextPaths.state),
-    normalizeRepoRelativePath(projectPath, contextPolicyPlan.trackedContextPaths.lastRecord),
+    normalizeRelativePathFromBase(comparisonRoot, contextPolicyPlan.trackedContextPaths.state),
+    normalizeRelativePathFromBase(comparisonRoot, contextPolicyPlan.trackedContextPaths.lastRecord),
   ]);
   const sidecarOnlyPaths = contextPolicyPlan.sidecarOnlyPaths.map((path) =>
-    normalizeRepoRelativePath(projectPath, path, true),
+    normalizeRelativePathFromBase(comparisonRoot, path, true),
   );
   const privateTranscriptBlockedPaths = new Set<string>(sidecarOnlyPaths);
 
   if (contextPolicyPlan.policy === 'private_continuity' || contextPolicyPlan.policy === 'local_private') {
-    tracked.add(normalizeRepoRelativePath(projectPath, contextPolicyPlan.trackedContextPaths.conversations, true));
+    tracked.add(normalizeRelativePathFromBase(comparisonRoot, contextPolicyPlan.trackedContextPaths.conversations, true));
   } else {
     privateTranscriptBlockedPaths.add(
-      normalizeRepoRelativePath(projectPath, contextPolicyPlan.trackedContextPaths.conversations, true),
+      normalizeRelativePathFromBase(comparisonRoot, contextPolicyPlan.trackedContextPaths.conversations, true),
     );
   }
 

--- a/mcp-server/src/utils/standard-kit.ts
+++ b/mcp-server/src/utils/standard-kit.ts
@@ -10,6 +10,8 @@ import { validateContextPublicationPolicy } from './project-contract.js';
 import { resolveAgenticOSProductPath, resolveAgenticOSProductRoot, toCanonicalProductRelativePath } from './product-source-root.js';
 import { resolveManagedProjectContextDisplayPaths, resolveManagedProjectContextPaths, type ManagedProjectContextDisplayPaths } from './agent-context-paths.js';
 import { getSessionProjectBinding } from './session-context.js';
+import { resolveConversationRoutingPlan } from './conversation-routing.js';
+import { resolveContextPolicyPlan } from './context-policy-plan.js';
 
 interface StandardKitEntry {
   path: string;
@@ -232,6 +234,9 @@ async function ensureParentDir(path: string): Promise<void> {
 async function ensureStandardDirectories(project: ResolvedProjectTarget): Promise<void> {
   const contextPaths = resolveManagedProjectContextPaths(project.projectPath, project.projectYaml);
   await mkdir(contextPaths.conversationsDir, { recursive: true });
+  if (project.projectYaml?.source_control?.context_publication_policy === 'public_distilled') {
+    await mkdir(join(project.projectPath, '.private', 'conversations'), { recursive: true });
+  }
   await mkdir(contextPaths.knowledgeDir, { recursive: true });
   await mkdir(join(contextPaths.tasksDir, 'templates'), { recursive: true });
   await mkdir(contextPaths.artifactsDir, { recursive: true });
@@ -553,6 +558,44 @@ export async function checkStandardKitConformance(args: { project_path?: string;
               ? 'The managed project is missing source_control.context_publication_policy in .project.yaml.'
               : publicationValidation.message,
           evidence_paths: ['.project.yaml'],
+        });
+        break;
+      }
+      case 'public_transcript_isolation_contract': {
+        const publicationValidation = validateContextPublicationPolicy(project.projectName, projectYaml);
+        let pass = publicationValidation.ok
+          && fileContainsAll(agentsMd, ['Configured conversation history surface (tracked or policy-routed)'])
+          && fileContainsAll(claudeMd, ['会话历史入口（tracked 或按 policy 路由）']);
+
+        if (pass && publicationValidation.ok && publicationValidation.policy === 'public_distilled') {
+          const quickStartPath = resolveManagedProjectContextPaths(project.projectPath, projectYaml).quickStartPath;
+          let quickStart = '';
+          try {
+            quickStart = readFileSync(quickStartPath, 'utf-8');
+          } catch {}
+          let routingPlan;
+          try {
+            routingPlan = resolveConversationRoutingPlan(resolveContextPolicyPlan({
+              projectName: project.projectName,
+              projectPath: project.projectPath,
+              projectYaml,
+            }));
+          } catch {
+            routingPlan = null;
+          }
+          pass = pass
+            && !!routingPlan
+            && quickStart.includes('raw transcripts route to')
+            && quickStart.includes(routingPlan.raw_conversations_display_dir);
+        }
+
+        behaviorChecks.push({
+          behavior,
+          status: pass ? 'PASS' : 'FAIL',
+          summary: pass
+            ? 'Generated adapter surfaces and quick-start guidance preserve the public transcript isolation contract.'
+            : 'Public transcript isolation truth is missing from generated adapter surfaces or quick-start guidance.',
+          evidence_paths: ['AGENTS.md', 'CLAUDE.md', '.context/quick-start.md'],
         });
         break;
       }

--- a/standards/knowledge/context-publication-policy-2026-04-10.md
+++ b/standards/knowledge/context-publication-policy-2026-04-10.md
@@ -49,7 +49,7 @@ Meaning:
 
 - distilled context may be tracked in source
 - raw session history and other non-publishable runtime surfaces must be isolated from the public source tree
-- `.context/conversations/` must not remain a tracked public-tree path once enforcement work lands
+- `.context/conversations/` remains the tracked/display continuity contract path, while raw transcripts route to a private sidecar such as `.private/conversations/`
 
 ## Interaction With Other Contracts
 
@@ -74,15 +74,14 @@ Examples:
 
 ## Current Enforcement Boundary
 
-This issue defines the contract and pushes it into templates, initialization flow, and conformance checks.
+This issue defined the contract and pushed it into templates, initialization flow, and conformance checks.
 
-It does not yet implement all publication-aware routing behavior.
+Implementation now exists across the managed-project lifecycle:
 
-Follow-up work:
-
-- `#244` private continuity persistence behavior
-- `#245` raw conversation isolation for public `github_versioned` projects
+- `#244` completed private continuity persistence behavior
+- `#245` completed raw conversation isolation for public `github_versioned` projects
+- `record`, `save`, runtime review surfaces, and conformance checks now resolve transcript behavior from the explicit publication-policy contract
 
 ## Outcome
 
-After this policy lands, later implementation issues can route `save`, `record`, and runtime sidecars against one explicit contract instead of inventing topology-based heuristics.
+`save`, `record`, and runtime sidecars now route against one explicit contract instead of inventing topology-based heuristics.

--- a/standards/knowledge/memory-layer-contract-spec-2026-03-25.md
+++ b/standards/knowledge/memory-layer-contract-spec-2026-03-25.md
@@ -49,7 +49,7 @@ That question is handled separately by the context publication policy contract.
 | `.project.yaml` | stable project identity and layer map | canonical | rare change | project id, name, description, path roles | session logs, pending items, derived summaries |
 | `.context/quick-start.md` | concise entry orientation | canonical | mutable | project goal, current focus, resume pointer, key facts | full conversation history, detailed task decomposition, exhaustive decision logs |
 | `.context/state.yaml` | mutable operational working state | canonical | mutable | current task, working memory, loaded context, latest guardrail evidence | append-only transcripts, long-form research, durable architecture docs |
-| `.context/conversations/` | raw session history | canonical | append-only | timestamped session records | synthesized architecture, canonical project overview |
+| `.context/conversations/` | conversation-history contract surface | canonical | append-only or tracked-display depending on publication policy | timestamped session records for raw/tracked-continuity projects, or the tracked continuity contract path for `public_distilled` projects | synthesized architecture, canonical project overview, public raw transcript dumps for `public_distilled` |
 | `knowledge/` | durable synthesized understanding | canonical | mutable but review-oriented | architecture, product judgments, research, decision syntheses | raw transcript dumps, scratch task checklists |
 | `tasks/` | future-facing execution artifacts | canonical | mutable | issue briefs, plans, checklists, templates | session narrative, long-term architecture rationale |
 | `artifacts/` | concrete outputs and deliverables | canonical for outputs | mutable | generated outputs, deliverables, exported files | memory/state/history by default |
@@ -68,6 +68,8 @@ Default session-entry read order is:
 `conversations/` is not a first-pass entry surface.
 
 It is a recovery and audit layer.
+
+For `public_distilled` projects, the tracked contract path may remain `.context/conversations/` while raw recovery records live in a private sidecar such as `.private/conversations/`.
 
 ## Write Rules
 
@@ -94,8 +96,9 @@ It is a recovery and audit layer.
 
 ### `.context/conversations/`
 
-- Append-only session history
-- One session record may be appended or created, but earlier entries should not be silently rewritten as summary
+- Conversation-history contract surface
+- For raw/tracked-continuity projects, one session record may be appended or created, but earlier entries should not be silently rewritten as summary
+- For `public_distilled` projects, this path remains the tracked continuity contract surface and must not receive public raw transcript dumps; raw session history belongs in the private sidecar path selected by publication policy
 
 ### `knowledge/`
 


### PR DESCRIPTION
## Summary
- route public_distilled raw transcripts to private sidecars while keeping tracked/display transcript surfaces explicit
- block save and review flows when tracked raw transcript diffs would leak from public_distilled projects
- align standard-kit, templates, status/switch output, and tests with the public transcript isolation contract

## Validation
- npm run lint
- npm test -- src/tools/__tests__/init.test.ts src/tools/__tests__/pr-scope-check.test.ts src/tools/__tests__/project.test.ts src/tools/__tests__/record.test.ts src/tools/__tests__/save.test.ts src/tools/__tests__/standard-kit.test.ts src/utils/__tests__/conversation-routing.test.ts src/utils/__tests__/runtime-review-surface.test.ts

Supersedes closed PR #271 after rebasing onto main.