### PR TITLE
fix: correct agenticos-mcp help bootstrap guidance (#274)

### DIFF
--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -8,24 +8,6 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const VERSION = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8')).version;
 
-// Handle --version and --help before starting the MCP server
-if (process.argv.includes('--version') || process.argv.includes('-v')) {
-  console.log(VERSION);
-  process.exit(0);
-}
-if (process.argv.includes('--help') || process.argv.includes('-h')) {
-  console.log(`agenticos-mcp — AgenticOS MCP Server v${VERSION}`);
-  console.log('');
-  console.log('Usage: agenticos-mcp [--version] [--help]');
-  console.log('');
-  console.log('Runs as a stdio MCP server. Configure in your AI tool\'s mcp.json:');
-  console.log('  { "command": "agenticos-mcp", "args": [] }');
-  console.log('');
-  console.log('Environment:');
-  console.log('  AGENTICOS_HOME  Workspace root (required)');
-  process.exit(0);
-}
-
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import {
@@ -36,6 +18,7 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 import { initProject, switchProject, listProjects, getStatus, saveState, recordSession, runPreflight, runIssueBootstrap, runBranchBootstrap, runPrScopeCheck, runHealth, runEditGuard, runEntrySurfaceRefresh, runStandardKitAdopt, runStandardKitUpgradeCheck, runStandardKitConformanceCheck, runNonCodeEvaluate, runArchiveImportEvaluate } from './tools/index.js';
 import { getProjectContext } from './resources/index.js';
+import { isDirectExecution, resolveCliPrelude } from './utils/mcp-server-cli.js';
 
 const server = new Server(
   {
@@ -444,9 +427,31 @@ server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
   throw new Error(`Unknown resource: ${uri}`);
 });
 
-async function main() {
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
+export async function main(
+  argv: string[] = process.argv,
+  writeLine: (line: string) => void = console.log,
+  connect: () => Promise<void> = async () => {
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+  },
+): Promise<number> {
+  const prelude = resolveCliPrelude(argv, VERSION);
+  if (prelude) {
+    for (const line of prelude.lines) {
+      writeLine(line);
+    }
+    return prelude.exitCode;
+  }
+
+  await connect();
+  return 0;
 }
 
-main().catch(console.error);
+if (isDirectExecution(process.argv, import.meta.url)) {
+  main().then((exitCode) => {
+    process.exit(exitCode);
+  }).catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/mcp-server/src/utils/__tests__/mcp-server-cli.test.ts
+++ b/mcp-server/src/utils/__tests__/mcp-server-cli.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { buildHelpLines, isDirectExecution, resolveCliPrelude } from '../mcp-server-cli.js';
+
+describe('mcp server cli helpers', () => {
+  it('builds help text without generic mcp.json guidance', () => {
+    const lines = buildHelpLines('0.4.3');
+    const output = lines.join('\n');
+
+    expect(output).toContain('agenticos-mcp — AgenticOS MCP Server v0.4.3');
+    expect(output).toContain('AGENTICOS_HOME  Workspace root (required)');
+    expect(output).toContain('agenticos-bootstrap --help');
+    expect(output).toContain('Claude Code: claude mcp add --transport stdio --scope user');
+    expect(output).toContain('~/.cursor/mcp.json');
+    expect(output).not.toContain('Configure in your AI tool\'s mcp.json');
+  });
+
+  it('returns version output when --version is requested', () => {
+    expect(resolveCliPrelude(['node', 'agenticos-mcp', '--version'], '0.4.3')).toEqual({
+      exitCode: 0,
+      lines: ['0.4.3'],
+    });
+    expect(resolveCliPrelude(['node', 'agenticos-mcp', '-v'], '0.4.3')).toEqual({
+      exitCode: 0,
+      lines: ['0.4.3'],
+    });
+  });
+
+  it('returns help output when --help is requested', () => {
+    const prelude = resolveCliPrelude(['node', 'agenticos-mcp', '--help'], '0.4.3');
+
+    expect(prelude?.exitCode).toBe(0);
+    expect(prelude?.lines.join('\n')).toContain('Manual registration examples:');
+  });
+
+  it('returns null when startup should continue into the server', () => {
+    expect(resolveCliPrelude(['node', 'agenticos-mcp'], '0.4.3')).toBeNull();
+  });
+
+  it('detects direct execution only for the module entry path', () => {
+    expect(isDirectExecution(
+      ['node', '/tmp/index.js'],
+      'file:///tmp/index.js',
+    )).toBe(true);
+    expect(isDirectExecution(
+      ['node', '/tmp/other.js'],
+      'file:///tmp/index.js',
+    )).toBe(false);
+    expect(isDirectExecution([], 'file:///tmp/index.js')).toBe(false);
+  });
+});

--- a/mcp-server/src/utils/mcp-server-cli.ts
+++ b/mcp-server/src/utils/mcp-server-cli.ts
@@ -1,0 +1,49 @@
+import { pathToFileURL } from 'url';
+
+export function buildHelpLines(version: string): string[] {
+  return [
+    `agenticos-mcp — AgenticOS MCP Server v${version}`,
+    '',
+    'Usage: agenticos-mcp [--version] [--help]',
+    '',
+    'Runs as a stdio MCP server.',
+    '',
+    'Prerequisites:',
+    '  AGENTICOS_HOME  Workspace root (required)',
+    '',
+    'Recommended setup:',
+    '  agenticos-bootstrap --workspace "$AGENTICOS_HOME" --first-run',
+    '  agenticos-bootstrap --help',
+    '',
+    'Manual registration examples:',
+    '  Claude Code: claude mcp add --transport stdio --scope user -e AGENTICOS_HOME="$AGENTICOS_HOME" agenticos -- agenticos-mcp',
+    '  Codex:       codex mcp add --env AGENTICOS_HOME="$AGENTICOS_HOME" agenticos -- agenticos-mcp',
+    '  Cursor:      add `agenticos` to ~/.cursor/mcp.json with env.AGENTICOS_HOME',
+    '  Gemini CLI:  gemini mcp add -s user -e AGENTICOS_HOME="$AGENTICOS_HOME" agenticos agenticos-mcp',
+  ];
+}
+
+export function resolveCliPrelude(argv: string[], version: string): { exitCode: number; lines: string[] } | null {
+  if (argv.includes('--version') || argv.includes('-v')) {
+    return {
+      exitCode: 0,
+      lines: [version],
+    };
+  }
+  if (argv.includes('--help') || argv.includes('-h')) {
+    return {
+      exitCode: 0,
+      lines: buildHelpLines(version),
+    };
+  }
+  return null;
+}
+
+export function isDirectExecution(argv: string[] = process.argv, moduleUrl: string = import.meta.url): boolean {
+  const entry = argv[1];
+  if (!entry) {
+    return false;
+  }
+
+  return pathToFileURL(entry).href === moduleUrl;
+}


### PR DESCRIPTION
## Summary
- replace the misleading generic `mcp.json` help text with explicit multi-agent registration guidance
- make `AGENTICOS_HOME` a first-class prerequisite in `agenticos-mcp --help`
- extract CLI prelude logic into a small helper module with dedicated tests

## Verification
- npm run build
- npm test -- src/utils/__tests__/mcp-server-cli.test.ts --coverage --coverage.include=src/utils/mcp-server-cli.ts
- node build/index.js --help

## Coverage
- targeted coverage for changed CLI-help logic is 100% statements / branches / functions / lines

## Review note
- during review I found and fixed a direct-execution regression in the initial refactor (`isDirectExecution` needed the caller module URL from `index.ts`) before opening this PR