### PR TITLE
docs: document stop-hook migration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,21 @@ It must expose the same canonical policy as other agent adapters rather than def
 
 - If natural-language routing is weak, use explicit `agenticos_*` tool calls before treating the issue as transport failure.
 - Bootstrap differences are runtime concerns rather than policy changes.
+- Optional local stop-hook reminders should call `agenticos-record-reminder`, not a source-checkout `tools/record-reminder.sh` path.
+- If migrating from a legacy source-checkout hook, replace `bash /path/to/tools/record-reminder.sh` with the installed `agenticos-record-reminder` command.
+## Optional Stop-Hook Reminder
+
+If your runtime supports local stop hooks or command reminders, the preferred installed command is:
+
+```json
+{
+  "command": "agenticos-record-reminder",
+  "timeout": 5,
+  "type": "command"
+}
+```
+
+This remains an optional local reminder layer rather than a canonical guardrail.
 ## Task Intake Rule
 
 - At task intake, recover operator intent before treating named methods or workflow fragments as the full plan.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,21 @@ It must expose the same canonical policy as other agent adapters while allowing 
 
 - Claude CLI-managed user MCP config is the canonical Claude bootstrap surface.
 - Claude-specific stop hooks remain optional local stop-hook reminders rather than canonical guardrails.
+- Optional local stop-hook reminders should call `agenticos-record-reminder`, not a source-checkout `tools/record-reminder.sh` path.
+- If migrating from a legacy source-checkout hook, replace `bash /path/to/tools/record-reminder.sh` with the installed `agenticos-record-reminder` command.
+## Optional Stop-Hook Reminder
+
+If your runtime supports local stop hooks or command reminders, the preferred installed command is:
+
+```json
+{
+  "command": "agenticos-record-reminder",
+  "timeout": 5,
+  "type": "command"
+}
+```
+
+This remains an optional local reminder layer rather than a canonical guardrail.
 ## Task Intake Rule
 
 - At task intake, recover operator intent before treating named methods or workflow fragments as the full plan.

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -31,6 +31,29 @@ When the client supports a pre-edit hook or local command wrapper, point that la
 For stop-event reminders, prefer `agenticos-record-reminder`.
 The old root `tools/check-edit-boundary.sh` and `tools/record-reminder.sh` paths should now be treated as legacy compatibility shims.
 
+If you still have a legacy Claude Code stop hook that points at a source-checkout script under an old workspace checkout, migrate it to the installed command.
+For example, an older config may still contain:
+
+```json
+{
+  "command": "bash /path/to/tools/record-reminder.sh",
+  "timeout": 5,
+  "type": "command"
+}
+```
+
+Replace it with:
+
+```json
+{
+  "command": "agenticos-record-reminder",
+  "timeout": 5,
+  "type": "command"
+}
+```
+
+The stop hook remains an optional local reminder only. It should not be treated as a canonical guardrail or as a substitute for `agenticos_record`.
+
 ### Homebrew Post-Install Contract
 
 If the user installed AgenticOS with Homebrew:

--- a/mcp-server/src/utils/__tests__/distill.test.ts
+++ b/mcp-server/src/utils/__tests__/distill.test.ts
@@ -16,13 +16,14 @@ import {
   generateAgentsMd,
   generateClaudeMd,
 } from '../distill.js';
+import { STOP_HOOK_MIGRATION_BULLETS } from '../stop-hook-guidance.js';
 
 describe('distill templates', () => {
   it('generates AGENTS.md with the current template marker, adapter role, and guardrail flow', () => {
     const content = generateAgentsMd('Demo Project', 'Guardrail test');
 
-    expect(CURRENT_TEMPLATE_VERSION).toBe(12);
-    expect(content).toContain('<!-- agenticos-template: v12 -->');
+    expect(CURRENT_TEMPLATE_VERSION).toBe(13);
+    expect(content).toContain('<!-- agenticos-template: v13 -->');
     expect(content).toContain('## Adapter Role');
     expect(content).toContain(AGENTS_ADAPTER_LINES[0]);
     expect(content).toContain(AGENTS_ADAPTER_LINES[1]);
@@ -38,6 +39,11 @@ describe('distill templates', () => {
     for (const bullet of AGENTS_RUNTIME_GUIDANCE_BULLETS) {
       expect(content).toContain(bullet);
     }
+    for (const bullet of STOP_HOOK_MIGRATION_BULLETS) {
+      expect(content).toContain(bullet);
+    }
+    expect(content).toContain('## Optional Stop-Hook Reminder');
+    expect(content).toContain('"command": "agenticos-record-reminder"');
     expect(content).toContain(`## ${TASK_INTAKE_RULE_TITLE}`);
     for (const bullet of TASK_INTAKE_RULE_BULLETS) {
       expect(content).toContain(bullet);
@@ -79,6 +85,11 @@ describe('distill templates', () => {
     for (const bullet of CLAUDE_RUNTIME_GUIDANCE_BULLETS) {
       expect(content).toContain(bullet);
     }
+    for (const bullet of STOP_HOOK_MIGRATION_BULLETS) {
+      expect(content).toContain(bullet);
+    }
+    expect(content).toContain('## Optional Stop-Hook Reminder');
+    expect(content).toContain('"command": "agenticos-record-reminder"');
     expect(content).toContain(`## ${TASK_INTAKE_RULE_TITLE}`);
     for (const bullet of TASK_INTAKE_RULE_BULLETS) {
       expect(content).toContain(bullet);

--- a/mcp-server/src/utils/__tests__/stop-hook-guidance.test.ts
+++ b/mcp-server/src/utils/__tests__/stop-hook-guidance.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import {
+  OPTIONAL_STOP_HOOK_SNIPPET,
+  renderOptionalStopHookSection,
+  renderStopHookSnippet,
+  STOP_HOOK_MIGRATION_BULLETS,
+} from '../stop-hook-guidance.js';
+
+describe('stop hook guidance', () => {
+  it('defines the installed stop-hook snippet', () => {
+    expect(OPTIONAL_STOP_HOOK_SNIPPET.join('\n')).toContain('"command": "agenticos-record-reminder"');
+    expect(OPTIONAL_STOP_HOOK_SNIPPET.join('\n')).toContain('"timeout": 5');
+    expect(OPTIONAL_STOP_HOOK_SNIPPET.join('\n')).not.toContain('record-reminder.sh');
+  });
+
+  it('defines migration bullets that replace the legacy script path', () => {
+    const combined = STOP_HOOK_MIGRATION_BULLETS.join('\n');
+
+    expect(combined).toContain('agenticos-record-reminder');
+    expect(combined).toContain('tools/record-reminder.sh');
+  });
+
+  it('renders the snippet without indentation by default', () => {
+    expect(renderStopHookSnippet()).toBe([
+      '{',
+      '  "command": "agenticos-record-reminder",',
+      '  "timeout": 5,',
+      '  "type": "command"',
+      '}',
+    ].join('\n'));
+  });
+
+  it('renders the snippet with caller-provided indentation', () => {
+    expect(renderStopHookSnippet('    ')).toBe([
+      '    {',
+      '      "command": "agenticos-record-reminder",',
+      '      "timeout": 5,',
+      '      "type": "command"',
+      '    }',
+    ].join('\n'));
+  });
+
+  it('renders the optional stop-hook section with the installed command snippet', () => {
+    const section = renderOptionalStopHookSection();
+
+    expect(section).toContain('## Optional Stop-Hook Reminder');
+    expect(section).toContain('preferred installed command');
+    expect(section).toContain('"command": "agenticos-record-reminder"');
+    expect(section).toContain('optional local reminder layer');
+  });
+});

--- a/mcp-server/src/utils/distill.ts
+++ b/mcp-server/src/utils/distill.ts
@@ -1,12 +1,13 @@
 import { readFile, writeFile } from 'fs/promises';
 import { readFileSync } from 'fs';
 import { joinDisplayPath, type ManagedProjectContextDisplayPaths } from './agent-context-paths.js';
+import { renderOptionalStopHookSection, STOP_HOOK_MIGRATION_BULLETS } from './stop-hook-guidance.js';
 
 /**
  * Current template version. Increment when templates change.
  * Used for auto-upgrade on project switch.
  */
-export const CURRENT_TEMPLATE_VERSION = 12;
+export const CURRENT_TEMPLATE_VERSION = 13;
 
 /** Version marker format in generated files */
 const VERSION_MARKER = `<!-- agenticos-template: v${CURRENT_TEMPLATE_VERSION} -->`;
@@ -50,6 +51,7 @@ export const AGENTS_RUNTIME_GUIDANCE_TITLE = 'Codex / Generic Runtime Notes';
 export const AGENTS_RUNTIME_GUIDANCE_BULLETS = [
   'If natural-language routing is weak, use explicit `agenticos_*` tool calls before treating the issue as transport failure.',
   'Bootstrap differences are runtime concerns rather than policy changes.',
+  ...STOP_HOOK_MIGRATION_BULLETS,
 ] as const;
 
 export const CLAUDE_ADAPTER_LINES = [
@@ -61,6 +63,7 @@ export const CLAUDE_RUNTIME_GUIDANCE_TITLE = 'Claude Runtime Notes';
 export const CLAUDE_RUNTIME_GUIDANCE_BULLETS = [
   'Claude CLI-managed user MCP config is the canonical Claude bootstrap surface.',
   'Claude-specific stop hooks remain optional local stop-hook reminders rather than canonical guardrails.',
+  ...STOP_HOOK_MIGRATION_BULLETS,
 ] as const;
 
 export const TASK_INTAKE_RULE_TITLE = 'Task Intake Rule';
@@ -137,7 +140,7 @@ export function generateAgentsMd(
 ${AGENTS_ADAPTER_LINES[0]}
 ${AGENTS_ADAPTER_LINES[1]}
 
-${renderSharedPolicySection()}${renderContinuityContractSection()}${renderRuntimeGuidanceSection(AGENTS_RUNTIME_GUIDANCE_TITLE, AGENTS_RUNTIME_GUIDANCE_BULLETS)}${renderRuntimeGuidanceSection(TASK_INTAKE_RULE_TITLE, TASK_INTAKE_RULE_BULLETS)}## Guardrail Protocol (MANDATORY)
+${renderSharedPolicySection()}${renderContinuityContractSection()}${renderRuntimeGuidanceSection(AGENTS_RUNTIME_GUIDANCE_TITLE, AGENTS_RUNTIME_GUIDANCE_BULLETS)}${renderOptionalStopHookSection()}${renderRuntimeGuidanceSection(TASK_INTAKE_RULE_TITLE, TASK_INTAKE_RULE_BULLETS)}## Guardrail Protocol (MANDATORY)
 
 Before implementation edits, confirm session/project alignment with \`agenticos_status\`; if no session project is bound or the bound project is not the intended one, call \`agenticos_switch\`.
 
@@ -292,7 +295,7 @@ function buildClaudeMdContent(
 ${CLAUDE_ADAPTER_LINES[0]}
 ${CLAUDE_ADAPTER_LINES[1]}
 
-${renderSharedPolicySection()}${renderContinuityContractSection()}${renderRuntimeGuidanceSection(CLAUDE_RUNTIME_GUIDANCE_TITLE, CLAUDE_RUNTIME_GUIDANCE_BULLETS)}${renderRuntimeGuidanceSection(TASK_INTAKE_RULE_TITLE, TASK_INTAKE_RULE_BULLETS)}## Guardrail Protocol (MANDATORY)
+${renderSharedPolicySection()}${renderContinuityContractSection()}${renderRuntimeGuidanceSection(CLAUDE_RUNTIME_GUIDANCE_TITLE, CLAUDE_RUNTIME_GUIDANCE_BULLETS)}${renderOptionalStopHookSection()}${renderRuntimeGuidanceSection(TASK_INTAKE_RULE_TITLE, TASK_INTAKE_RULE_BULLETS)}## Guardrail Protocol (MANDATORY)
 
 Before implementation edits, confirm session/project alignment with \`agenticos_status\`; if no session project is bound or the bound project is not the intended one, call \`agenticos_switch\`.
 

--- a/mcp-server/src/utils/stop-hook-guidance.ts
+++ b/mcp-server/src/utils/stop-hook-guidance.ts
@@ -1,0 +1,31 @@
+export const OPTIONAL_STOP_HOOK_SNIPPET = [
+  '{',
+  '  "command": "agenticos-record-reminder",',
+  '  "timeout": 5,',
+  '  "type": "command"',
+  '}',
+] as const;
+
+export const STOP_HOOK_MIGRATION_BULLETS = [
+  'Optional local stop-hook reminders should call `agenticos-record-reminder`, not a source-checkout `tools/record-reminder.sh` path.',
+  'If migrating from a legacy source-checkout hook, replace `bash /path/to/tools/record-reminder.sh` with the installed `agenticos-record-reminder` command.',
+] as const;
+
+export function renderStopHookSnippet(indent: string = ''): string {
+  return OPTIONAL_STOP_HOOK_SNIPPET.map((line) => `${indent}${line}`).join('\n');
+}
+
+export function renderOptionalStopHookSection(): string {
+  return [
+    '## Optional Stop-Hook Reminder',
+    '',
+    'If your runtime supports local stop hooks or command reminders, the preferred installed command is:',
+    '',
+    '```json',
+    renderStopHookSnippet(),
+    '```',
+    '',
+    'This remains an optional local reminder layer rather than a canonical guardrail.',
+    '',
+  ].join('\n');
+}


### PR DESCRIPTION
## Summary
- document how to migrate legacy Claude stop hooks from `tools/record-reminder.sh` to `agenticos-record-reminder`
- add reusable stop-hook guidance for generated AGENTS/CLAUDE templates
- update checked-in AGENTS.md and CLAUDE.md with only the stop-hook migration note/snippet

## Scope Notes
- no `agenticos-bootstrap stop-hook` subcommand
- no automatic settings mutation
- stop hooks remain optional local reminders, not canonical guardrails

## Verification
- `npm test -- src/utils/__tests__/stop-hook-guidance.test.ts --coverage --coverage.include=src/utils/stop-hook-guidance.ts`
- `npm test -- src/utils/__tests__/distill.test.ts`
- `npm run build`

## Coverage
- `src/utils/stop-hook-guidance.ts`: 100% statements / branches / functions / lines
