### PR TITLE
docs: align runtime-home readme guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,17 @@ This directory is the canonical product-source project for AgenticOS. If you
 are changing AgenticOS itself, start here instead of treating the enclosing
 workspace root as the authoritative product repository.
 
+## Source Checkout vs Runtime Home
+
+AgenticOS now distinguishes two different paths:
+
+- `projects/agenticos/` is the canonical product-source checkout for developing AgenticOS itself
+- `AGENTICOS_HOME` is the runtime home used by installed binaries and managed projects
+
+Do not treat the runtime home as the product-source root.
+In the standard layout, the runtime home contains a `projects/` directory, and
+the AgenticOS source project lives at `"$AGENTICOS_HOME/projects/agenticos"`.
+
 ## Scope
 
 `projects/agenticos/` owns:
@@ -83,6 +94,17 @@ working.
 `AGENTICOS_HOME` may be any valid workspace home, including a long-term
 self-hosting AgenticOS workspace, as long as it is not the repo root of a
 project such as `projects/agenticos`.
+
+If you installed via Homebrew on Apple Silicon macOS, the default runtime-home
+example is:
+
+```bash
+export AGENTICOS_HOME=/opt/homebrew/var/agenticos
+```
+
+That path is a runtime home example, not the canonical product-source checkout.
+If you are developing AgenticOS itself, work in `projects/agenticos/` under the
+selected runtime home.
 
 Requires: Node.js >= 20.0.0 for local build and packaged runtime workflows.
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -66,6 +66,10 @@ If the user installed AgenticOS with Homebrew:
 
 So post-install success only means the package landed. It does not mean the agent is already bootstrapped.
 
+On Apple Silicon macOS, Homebrew caveats commonly use `/opt/homebrew/var/agenticos`
+as the default runtime-home example for `AGENTICOS_HOME`.
+That is a runtime home, not a source checkout path.
+
 ### When to Use
 
 AgenticOS is ideal for:
@@ -110,6 +114,7 @@ Transport bootstrap and project-intent routing are different concerns.
 ### Claude Code
 
 - canonical bootstrap: `claude mcp add --transport stdio --scope user -e AGENTICOS_HOME="$AGENTICOS_HOME" agenticos -- agenticos-mcp`
+- canonical config location: `~/.claude/settings.json`
 - verify:
   - `claude mcp list`
   - `/mcp`
@@ -159,7 +164,7 @@ These are currently experimental. Do not describe them as first-class supported 
 ### Repairing Stale Registrations
 
 The supported runtime entrypoint is `agenticos-mcp`.
-Do not keep legacy source-checkout registrations such as `node /Users/jeking/dev/AgenticOS/mcp-server/build/index.js`.
+Do not keep legacy source-checkout registrations such as `node /path/to/mcp-server/build/index.js`.
 
 Claude Code repair flow:
 


### PR DESCRIPTION
## Summary
- clarify the boundary between the AgenticOS product-source checkout and the runtime home selected via `AGENTICOS_HOME`
- document `/opt/homebrew/var/agenticos` as the Apple Silicon Homebrew default runtime-home example
- replace the remaining machine-specific stale registration example with a generic placeholder path
- document Claude Code's canonical config location as `~/.claude/settings.json`

## Scope Notes
- docs-only change
- no bootstrap automation changes
- no runtime semantic changes

## Verification
- `./scripts/readme-lint.sh README.md mcp-server/README.md`
- `git diff --check`

## Coverage
- docs-only change; no executable code changed
