### PR TITLE
feat: add workspace config audit command

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -14,6 +14,7 @@
       },
       "bin": {
         "agenticos-bootstrap": "build/bootstrap.js",
+        "agenticos-config": "build/config.js",
         "agenticos-edit-guard": "build/edit-guard.js",
         "agenticos-mcp": "build/index.js",
         "agenticos-record-reminder": "build/record-reminder.js"

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -6,6 +6,7 @@
   "bin": {
     "agenticos-mcp": "./build/index.js",
     "agenticos-bootstrap": "./build/bootstrap.js",
+    "agenticos-config": "./build/config.js",
     "agenticos-edit-guard": "./build/edit-guard.js",
     "agenticos-record-reminder": "./build/record-reminder.js"
   },

--- a/mcp-server/src/config.ts
+++ b/mcp-server/src/config.ts
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'child_process';
+import { existsSync, readFileSync } from 'fs';
+import { homedir } from 'os';
+import { runConfigCli } from './utils/config-cli.js';
+
+const exitCode = runConfigCli(process.argv.slice(2), {
+  env: process.env,
+  homeDir: homedir(),
+  platform: process.platform,
+  shellPath: process.env.SHELL,
+  nowIso() {
+    return new Date().toISOString();
+  },
+  commandExists(command: string) {
+    const result = spawnSync('which', [command], { stdio: 'ignore' });
+    return result.status === 0;
+  },
+  runCommand(command: string, args: string[], failOnError: boolean) {
+    const result = spawnSync(command, args, { encoding: 'utf-8' });
+    const output = `${result.stdout || ''}${result.stderr || ''}`.trim();
+    const detail = output || result.error?.message || `${command} exited with status ${result.status ?? 'unknown'}`;
+    if (result.status !== 0 && failOnError) {
+      return { ok: false, detail };
+    }
+    return { ok: result.status === 0, detail };
+  },
+  readFile(path: string) {
+    try {
+      return readFileSync(path, 'utf-8');
+    } catch {
+      return null;
+    }
+  },
+  pathExists(path: string) {
+    return existsSync(path);
+  },
+  stdout(line: string) {
+    console.log(line);
+  },
+  stderr(line: string) {
+    console.error(line);
+  },
+});
+
+process.exit(exitCode);

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -16,7 +16,7 @@ import {
   ListResourcesRequestSchema,
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { initProject, switchProject, listProjects, getStatus, saveState, recordSession, runPreflight, runIssueBootstrap, runBranchBootstrap, runPrScopeCheck, runHealth, runEditGuard, runEntrySurfaceRefresh, runStandardKitAdopt, runStandardKitUpgradeCheck, runStandardKitConformanceCheck, runNonCodeEvaluate, runArchiveImportEvaluate } from './tools/index.js';
+import { initProject, switchProject, listProjects, getStatus, saveState, recordSession, runPreflight, runIssueBootstrap, runBranchBootstrap, runPrScopeCheck, runHealth, runConfig, runEditGuard, runEntrySurfaceRefresh, runStandardKitAdopt, runStandardKitUpgradeCheck, runStandardKitConformanceCheck, runNonCodeEvaluate, runArchiveImportEvaluate } from './tools/index.js';
 import { getProjectContext } from './resources/index.js';
 import { isDirectExecution, resolveCliPrelude } from './utils/mcp-server-cli.js';
 
@@ -100,6 +100,17 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         properties: {
           project: { type: 'string', description: 'Optional project ID, name, or path. If omitted, uses the current session project.' },
           message: { type: 'string', description: 'Optional commit message' },
+        },
+      },
+    },
+    {
+      name: 'agenticos_config',
+      description: 'Audit AgenticOS workspace configuration sources and validate drift across runtime, MCP, and Homebrew-related surfaces.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          action: { type: 'string', enum: ['show', 'validate'], description: 'Show detected configuration sources or validate that they agree.' },
+          scope: { type: 'string', enum: ['all', 'runtime', 'mcp', 'homebrew'], description: 'Limit the audit to runtime env, MCP config surfaces, or Homebrew hints.' },
         },
       },
     },
@@ -367,6 +378,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       return { content: [{ type: 'text', text: await saveState(args) }] };
     case 'agenticos_status':
       return { content: [{ type: 'text', text: await getStatus(args ?? {}) }] };
+    case 'agenticos_config':
+      return { content: [{ type: 'text', text: await runConfig(args ?? {}) }] };
     case 'agenticos_preflight':
       return { content: [{ type: 'text', text: await runPreflight(args ?? {}) }] };
     case 'agenticos_issue_bootstrap':

--- a/mcp-server/src/tools/config.ts
+++ b/mcp-server/src/tools/config.ts
@@ -1,0 +1,41 @@
+import { existsSync, readFileSync } from 'fs';
+import { homedir } from 'os';
+import { spawnSync } from 'child_process';
+import { renderConfigAuditResult, runConfigAudit } from '../utils/config-audit.js';
+
+export async function runConfig(args: any): Promise<string> {
+  const result = runConfigAudit(args ?? {}, {
+    env: process.env,
+    homeDir: homedir(),
+    platform: process.platform,
+    shellPath: process.env.SHELL,
+    nowIso() {
+      return new Date().toISOString();
+    },
+    commandExists(command: string) {
+      const probe = spawnSync('which', [command], { stdio: 'ignore' });
+      return probe.status === 0;
+    },
+    runCommand(command: string, args: string[], failOnError: boolean) {
+      const probe = spawnSync(command, args, { encoding: 'utf-8' });
+      const output = `${probe.stdout || ''}${probe.stderr || ''}`.trim();
+      const detail = output || probe.error?.message || `${command} exited with status ${probe.status ?? 'unknown'}`;
+      if (probe.status !== 0 && failOnError) {
+        return { ok: false, detail };
+      }
+      return { ok: probe.status === 0, detail };
+    },
+    readFile(path: string) {
+      try {
+        return readFileSync(path, 'utf-8');
+      } catch {
+        return null;
+      }
+    },
+    pathExists(path: string) {
+      return existsSync(path);
+    },
+  });
+
+  return renderConfigAuditResult(result);
+}

--- a/mcp-server/src/tools/index.ts
+++ b/mcp-server/src/tools/index.ts
@@ -7,6 +7,7 @@ export { runIssueBootstrap } from './issue-bootstrap.js';
 export { runBranchBootstrap } from './branch-bootstrap.js';
 export { runPrScopeCheck } from './pr-scope-check.js';
 export { runHealth } from './health.js';
+export { runConfig } from './config.js';
 export { runEditGuard } from './edit-guard.js';
 export { runEntrySurfaceRefresh } from './entry-surface-refresh.js';
 export { runStandardKitAdopt, runStandardKitUpgradeCheck, runStandardKitConformanceCheck } from './standard-kit.js';

--- a/mcp-server/src/utils/__tests__/config-audit.test.ts
+++ b/mcp-server/src/utils/__tests__/config-audit.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest';
+import { renderConfigAuditResult, runConfigAudit } from '../config-audit.js';
+
+function createDeps() {
+  const files = new Map<string, string>();
+  const paths = new Set<string>();
+  const commands = new Map<string, { ok: boolean; detail: string }>();
+
+  return {
+    files,
+    paths,
+    commands,
+    deps: {
+      env: {} as Record<string, string | undefined>,
+      homeDir: '/Users/tester',
+      platform: 'darwin',
+      shellPath: '/bin/zsh',
+      nowIso() {
+        return '2026-04-13T13:50:00.000Z';
+      },
+      commandExists(command: string): boolean {
+        return command === 'launchctl';
+      },
+      runCommand(command: string, args: string[]) {
+        return commands.get([command, ...args].join(' ')) || { ok: false, detail: 'unset' };
+      },
+      readFile(path: string) {
+        return files.get(path) ?? null;
+      },
+      pathExists(path: string) {
+        return paths.has(path);
+      },
+    },
+  };
+}
+
+describe('config audit', () => {
+  it('shows detected runtime and MCP configuration sources', () => {
+    const harness = createDeps();
+    harness.deps.env.AGENTICOS_HOME = '/runtime/home';
+    harness.files.set('/Users/tester/.zshrc', 'export AGENTICOS_HOME="/runtime/home"\n');
+    harness.files.set('/Users/tester/.claude/settings.json', JSON.stringify({ env: { AGENTICOS_HOME: '/runtime/home' } }));
+    harness.files.set('/Users/tester/.claude.json', JSON.stringify({ mcpServers: { agenticos: { env: { AGENTICOS_HOME: '/runtime/home' } } } }));
+    harness.files.set('/Users/tester/.codex/config.toml', '[mcp_servers.agenticos.env]\nAGENTICOS_HOME = "/runtime/home"\n');
+    harness.files.set('/Users/tester/.cursor/mcp.json', JSON.stringify({ mcpServers: { agenticos: { env: { AGENTICOS_HOME: '/runtime/home' } } } }));
+    harness.paths.add('/opt/homebrew/var/agenticos');
+    harness.commands.set('launchctl getenv AGENTICOS_HOME', { ok: true, detail: '/runtime/home' });
+
+    const result = runConfigAudit({ action: 'show', scope: 'all' }, harness.deps);
+    const rendered = renderConfigAuditResult(result);
+
+    expect(result.status).toBe('PASS');
+    expect(result.canonical_workspace).toBe('/runtime/home');
+    expect(rendered).toContain('process.env AGENTICOS_HOME');
+    expect(rendered).toContain('Claude Code settings env');
+    expect(rendered).toContain('Cursor MCP config');
+    expect(rendered).toContain('/opt/homebrew/var/agenticos');
+  });
+
+  it('fails validation when authoritative sources disagree', () => {
+    const harness = createDeps();
+    harness.deps.env.AGENTICOS_HOME = '/runtime/home';
+    harness.files.set('/Users/tester/.zshrc', 'export AGENTICOS_HOME="/other/home"\n');
+    harness.commands.set('launchctl getenv AGENTICOS_HOME', { ok: true, detail: '/runtime/home' });
+
+    const result = runConfigAudit({ action: 'validate', scope: 'runtime' }, harness.deps);
+    const rendered = renderConfigAuditResult(result);
+
+    expect(result.status).toBe('FAIL');
+    expect(result.discrepancies).toEqual([
+      {
+        label: 'shell profile export',
+        value: '/other/home',
+        fix_target: '/Users/tester/.zshrc',
+      },
+    ]);
+    expect(rendered).toContain('Configuration drift detected');
+    expect(rendered).toContain('/Users/tester/.zshrc');
+  });
+
+  it('shows drift without switching out of show mode', () => {
+    const harness = createDeps();
+    harness.deps.env.AGENTICOS_HOME = '/runtime/home';
+    harness.files.set('/Users/tester/.zshrc', 'export AGENTICOS_HOME="/other/home"\n');
+
+    const result = runConfigAudit({ action: 'show', scope: 'runtime' }, harness.deps);
+
+    expect(result.status).toBe('FAIL');
+    expect(result.summary).toContain('drift is present');
+  });
+
+  it('fails validation when no configured source exists', () => {
+    const harness = createDeps();
+    harness.files.set('/Users/tester/.zshrc', '# no export here\n');
+
+    const result = runConfigAudit({ action: 'validate', scope: 'runtime' }, harness.deps);
+    const rendered = renderConfigAuditResult(result);
+
+    expect(result.status).toBe('FAIL');
+    expect(result.canonical_workspace).toBeNull();
+    expect(rendered).toContain('No configured AGENTICOS_HOME source was detected');
+  });
+
+  it('filters sources by scope and handles unavailable launchctl/json parse failures', () => {
+    const harness = createDeps();
+    harness.deps.platform = 'linux';
+    harness.files.set('/Users/tester/.claude/settings.json', '{bad json');
+    harness.files.set('/Users/tester/.cursor/mcp.json', JSON.stringify([{ env: { AGENTICOS_HOME: '/cursor/home' } }]));
+    harness.paths.add('/usr/local/var/agenticos');
+
+    const result = runConfigAudit({ action: 'show', scope: 'mcp' }, harness.deps);
+
+    expect(result.sources.every((source) => source.scope === 'mcp')).toBe(true);
+    expect(result.sources.find((source) => source.id === 'claude_settings')?.status).toBe('unavailable');
+    expect(result.sources.find((source) => source.id === 'cursor_mcp')?.value).toBe('/cursor/home');
+
+    const homebrewOnly = runConfigAudit({ action: 'show', scope: 'homebrew' }, harness.deps);
+    expect(homebrewOnly.sources).toHaveLength(2);
+    expect(homebrewOnly.sources.find((source) => source.value === '/usr/local/var/agenticos')?.status).toBe('present');
+  });
+
+  it('treats missing Codex values and empty JSON arrays as unset', () => {
+    const harness = createDeps();
+    harness.files.set('/Users/tester/.codex/config.toml', '[mcp_servers.other]\nname = "other"\n');
+    harness.files.set('/Users/tester/.claude/settings.json', '[]');
+
+    const result = runConfigAudit({ action: 'show', scope: 'mcp' }, harness.deps);
+
+    expect(result.sources.find((source) => source.id === 'codex_config')?.status).toBe('unset');
+    expect(result.sources.find((source) => source.id === 'claude_settings')?.status).toBe('unset');
+  });
+
+  it('accepts generic Codex AGENTICOS_HOME entries outside a focused agent block', () => {
+    const harness = createDeps();
+    harness.files.set('/Users/tester/.codex/config.toml', 'AGENTICOS_HOME = "/generic/home"\n');
+
+    const result = runConfigAudit({ action: 'show', scope: 'mcp' }, harness.deps);
+
+    expect(result.sources.find((source) => source.id === 'codex_config')?.value).toBe('/generic/home');
+  });
+
+  it('uses default action and scope when omitted', () => {
+    const harness = createDeps();
+
+    const result = runConfigAudit({}, harness.deps);
+
+    expect(result.action).toBe('show');
+    expect(result.scope).toBe('all');
+  });
+
+  it('marks launchctl unavailable when the command is not present', () => {
+    const harness = createDeps();
+    harness.deps.commandExists = () => false;
+
+    const result = runConfigAudit({ action: 'show', scope: 'runtime' }, harness.deps);
+
+    expect(result.sources.find((source) => source.id === 'launchctl')?.detail).toContain('not available on PATH');
+  });
+
+  it('returns null when JSON config trees contain no AGENTICOS_HOME anywhere', () => {
+    const harness = createDeps();
+    harness.files.set('/Users/tester/.claude/settings.json', JSON.stringify({ mcpServers: { agenticos: { env: {} } } }));
+    harness.files.set('/Users/tester/.claude.json', JSON.stringify('plain-string'));
+
+    const result = runConfigAudit({ action: 'show', scope: 'mcp' }, harness.deps);
+
+    expect(result.sources.find((source) => source.id === 'claude_settings')?.status).toBe('unset');
+    expect(result.sources.find((source) => source.id === 'claude_legacy')?.status).toBe('unset');
+  });
+
+  it('passes validation when configured sources agree', () => {
+    const harness = createDeps();
+    harness.deps.env.AGENTICOS_HOME = '/runtime/home';
+    harness.files.set('/Users/tester/.zshrc', 'export AGENTICOS_HOME="/runtime/home"\n');
+    harness.commands.set('launchctl getenv AGENTICOS_HOME', { ok: true, detail: '/runtime/home' });
+
+    const result = runConfigAudit({ action: 'validate', scope: 'runtime' }, harness.deps);
+
+    expect(result.status).toBe('PASS');
+    expect(result.summary).toContain('agree on /runtime/home');
+  });
+
+  it('rejects unsupported action and scope values', () => {
+    const harness = createDeps();
+
+    expect(() => runConfigAudit({ action: 'fix' }, harness.deps)).toThrow('action must be one of: show, validate');
+    expect(() => runConfigAudit({ scope: 'cli' }, harness.deps)).toThrow('scope must be one of: all, runtime, mcp, homebrew');
+  });
+});

--- a/mcp-server/src/utils/__tests__/config-cli.test.ts
+++ b/mcp-server/src/utils/__tests__/config-cli.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+import { buildHelpLines, runConfigCli } from '../config-cli.js';
+
+function createDeps() {
+  const files = new Map<string, string>();
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+
+  return {
+    stdout,
+    stderr,
+    deps: {
+      env: {} as Record<string, string | undefined>,
+      homeDir: '/Users/tester',
+      platform: 'darwin',
+      shellPath: '/bin/zsh',
+      nowIso() {
+        return '2026-04-13T13:50:00.000Z';
+      },
+      commandExists(command: string) {
+        return command === 'launchctl';
+      },
+      runCommand() {
+        return { ok: true, detail: '/tmp/workspace' };
+      },
+      readFile(path: string) {
+        return files.get(path) ?? null;
+      },
+      pathExists() {
+        return false;
+      },
+      stdout(line: string) {
+        stdout.push(line);
+      },
+      stderr(line: string) {
+        stderr.push(line);
+      },
+    },
+  };
+}
+
+describe('config cli', () => {
+  it('prints help output', () => {
+    const lines = buildHelpLines();
+
+    expect(lines[0]).toContain('agenticos-config');
+    expect(lines.join('\n')).toContain('--validate');
+    expect(lines.join('\n')).toContain('--scope <all|runtime|mcp|homebrew>');
+  });
+
+  it('prints help output through the cli runner', () => {
+    const harness = createDeps();
+
+    const exitCode = runConfigCli(['-h'], harness.deps);
+
+    expect(exitCode).toBe(0);
+    expect(harness.stdout.join('\n')).toContain('agenticos-config');
+  });
+
+  it('accepts the long help flag as well', () => {
+    const harness = createDeps();
+
+    const exitCode = runConfigCli(['--help'], harness.deps);
+
+    expect(exitCode).toBe(0);
+    expect(harness.stdout.join('\n')).toContain('Usage:');
+  });
+
+  it('returns success for aligned configuration in show mode', () => {
+    const harness = createDeps();
+    harness.deps.env.AGENTICOS_HOME = '/tmp/workspace';
+    harness.deps.readFile = (path: string) => path === '/Users/tester/.zshrc'
+      ? 'export AGENTICOS_HOME="/tmp/workspace"\n'
+      : null;
+
+    const exitCode = runConfigCli(['--show', '--scope', 'runtime'], harness.deps);
+
+    expect(exitCode).toBe(0);
+    expect(harness.stdout.join('\n')).toContain('Status: PASS');
+    expect(harness.stderr).toHaveLength(0);
+  });
+
+  it('returns failure for drift in validate mode', () => {
+    const harness = createDeps();
+    harness.deps.env.AGENTICOS_HOME = '/tmp/workspace';
+    harness.deps.readFile = (path: string) => path === '/Users/tester/.zshrc'
+      ? 'export AGENTICOS_HOME="/tmp/other"\n'
+      : null;
+
+    const exitCode = runConfigCli(['--validate', '--scope', 'runtime'], harness.deps);
+
+    expect(exitCode).toBe(1);
+    expect(harness.stdout.join('\n')).toContain('Discrepancies:');
+    expect(harness.stdout.join('\n')).toContain('/Users/tester/.zshrc');
+  });
+
+  it('returns failure for unknown arguments', () => {
+    const harness = createDeps();
+
+    const exitCode = runConfigCli(['--nope'], harness.deps);
+
+    expect(exitCode).toBe(1);
+    expect(harness.stderr.join('\n')).toContain('Unknown argument');
+  });
+
+  it('returns failure when scope is missing a value', () => {
+    const harness = createDeps();
+
+    const exitCode = runConfigCli(['--scope'], harness.deps);
+
+    expect(exitCode).toBe(1);
+    expect(harness.stderr.join('\n')).toContain('--scope requires a value.');
+  });
+
+  it('stringifies non-Error exceptions from output handlers', () => {
+    const harness = createDeps();
+    harness.deps.env.AGENTICOS_HOME = '/tmp/workspace';
+    harness.deps.readFile = (path: string) => path === '/Users/tester/.zshrc'
+      ? 'export AGENTICOS_HOME="/tmp/workspace"\n'
+      : null;
+    harness.deps.stdout = () => {
+      throw 'boom';
+    };
+
+    const exitCode = runConfigCli(['--show', '--scope', 'runtime'], harness.deps);
+
+    expect(exitCode).toBe(1);
+    expect(harness.stderr.join('\n')).toContain('boom');
+  });
+});

--- a/mcp-server/src/utils/config-audit.ts
+++ b/mcp-server/src/utils/config-audit.ts
@@ -1,0 +1,454 @@
+import { join } from 'path';
+import { detectDefaultShellProfile } from './bootstrap-helper.js';
+
+export type ConfigAuditAction = 'show' | 'validate';
+export type ConfigAuditScope = 'all' | 'runtime' | 'mcp' | 'homebrew';
+export type ConfigSourceStatus = 'configured' | 'unset' | 'missing' | 'unavailable' | 'present';
+
+export interface CommandResult {
+  ok: boolean;
+  detail: string;
+}
+
+export interface ConfigAuditDeps {
+  env: Record<string, string | undefined>;
+  homeDir: string;
+  platform: string;
+  shellPath?: string;
+  commandExists(command: string): boolean;
+  runCommand(command: string, args: string[], failOnError: boolean): CommandResult;
+  readFile(path: string): string | null;
+  pathExists(path: string): boolean;
+  nowIso(): string;
+}
+
+export interface ConfigSourceRecord {
+  id: string;
+  label: string;
+  scope: Exclude<ConfigAuditScope, 'all'>;
+  status: ConfigSourceStatus;
+  value: string | null;
+  location: string;
+  fix_target: string;
+  detail: string;
+}
+
+export interface ConfigAuditResult {
+  command: 'agenticos_config';
+  action: ConfigAuditAction;
+  scope: ConfigAuditScope;
+  status: 'PASS' | 'FAIL';
+  checked_at: string;
+  canonical_workspace: string | null;
+  summary: string;
+  sources: ConfigSourceRecord[];
+  discrepancies: Array<{
+    label: string;
+    value: string;
+    fix_target: string;
+  }>;
+}
+
+export function normalizeAction(value: unknown): ConfigAuditAction {
+  if (value === undefined || value === null || value === '') return 'show';
+  if (value === 'show' || value === 'validate') return value;
+  throw new Error('action must be one of: show, validate');
+}
+
+export function normalizeScope(value: unknown): ConfigAuditScope {
+  if (value === undefined || value === null || value === '') return 'all';
+  if (value === 'all' || value === 'runtime' || value === 'mcp' || value === 'homebrew') return value;
+  throw new Error('scope must be one of: all, runtime, mcp, homebrew');
+}
+
+export function runConfigAudit(
+  args: { action?: unknown; scope?: unknown } | null | undefined,
+  deps: ConfigAuditDeps,
+): ConfigAuditResult {
+  const action = normalizeAction(args?.action);
+  const scope = normalizeScope(args?.scope);
+  const checkedAt = deps.nowIso();
+  const allSources = collectConfigSources(deps);
+  const sources = scope === 'all'
+    ? allSources
+    : allSources.filter((source) => source.scope === scope);
+  const configuredSources = sources.filter((source) => source.status === 'configured' && source.value);
+  const canonicalWorkspace = configuredSources.find((source) => source.id === 'process_env')?.value
+    || configuredSources[0]?.value
+    || null;
+  const discrepancies = canonicalWorkspace
+    ? configuredSources
+      .filter((source) => source.value !== canonicalWorkspace)
+      .map((source) => ({
+        label: source.label,
+        value: source.value as string,
+        fix_target: source.fix_target,
+      }))
+    : [];
+
+  if (action === 'show') {
+    return {
+      command: 'agenticos_config',
+      action,
+      scope,
+      status: discrepancies.length > 0 ? 'FAIL' : 'PASS',
+      checked_at: checkedAt,
+      canonical_workspace: canonicalWorkspace,
+      summary: canonicalWorkspace
+        ? discrepancies.length > 0
+          ? 'Configuration drift is present across detected sources.'
+          : 'Detected configuration sources are aligned.'
+        : 'No configured AGENTICOS_HOME source was detected in the selected scope.',
+      sources,
+      discrepancies,
+    };
+  }
+
+  if (!canonicalWorkspace) {
+    return {
+      command: 'agenticos_config',
+      action,
+      scope,
+      status: 'FAIL',
+      checked_at: checkedAt,
+      canonical_workspace: null,
+      summary: 'No configured AGENTICOS_HOME source was detected in the selected scope.',
+      sources,
+      discrepancies: [],
+    };
+  }
+
+  if (discrepancies.length > 0) {
+    return {
+      command: 'agenticos_config',
+      action,
+      scope,
+      status: 'FAIL',
+      checked_at: checkedAt,
+      canonical_workspace: canonicalWorkspace,
+      summary: 'Configuration drift detected. Update the mismatched source(s) listed below.',
+      sources,
+      discrepancies,
+    };
+  }
+
+  return {
+    command: 'agenticos_config',
+    action,
+    scope,
+    status: 'PASS',
+    checked_at: checkedAt,
+    canonical_workspace: canonicalWorkspace,
+    summary: `All detected configuration sources agree on ${canonicalWorkspace}.`,
+    sources,
+    discrepancies: [],
+  };
+}
+
+export function renderConfigAuditResult(result: ConfigAuditResult): string {
+  const lines = [
+    'AgenticOS configuration audit',
+    `Action: ${result.action}`,
+    `Scope: ${result.scope}`,
+    `Status: ${result.status}`,
+    `Checked at: ${result.checked_at}`,
+    `Canonical workspace: ${result.canonical_workspace || 'UNSET'}`,
+    '',
+    result.summary,
+    '',
+    'Sources:',
+  ];
+
+  for (const source of result.sources) {
+    lines.push(`- ${source.label}`);
+    lines.push(`  status: ${source.status}`);
+    lines.push(`  value: ${source.value || 'UNSET'}`);
+    lines.push(`  location: ${source.location}`);
+    lines.push(`  fix: ${source.fix_target}`);
+    lines.push(`  detail: ${source.detail}`);
+  }
+
+  if (result.action === 'validate' && result.status === 'FAIL') {
+    lines.push('');
+    lines.push('Discrepancies:');
+    if (result.discrepancies.length === 0) {
+      lines.push('- No authoritative source is configured. Set AGENTICOS_HOME in your shell or rerun bootstrap for the target agent.');
+    } else {
+      for (const mismatch of result.discrepancies) {
+        lines.push(`- ${mismatch.label}: ${mismatch.value} -> update ${mismatch.fix_target}`);
+      }
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function collectConfigSources(deps: ConfigAuditDeps): ConfigSourceRecord[] {
+  return [
+    readProcessEnvSource(deps),
+    readShellProfileSource(deps),
+    readLaunchctlSource(deps),
+    readClaudeSettingsSource(deps),
+    readClaudeLegacySource(deps),
+    readCodexConfigSource(deps),
+    readCursorConfigSource(deps),
+    ...readHomebrewSources(deps),
+  ];
+}
+
+function readProcessEnvSource(deps: ConfigAuditDeps): ConfigSourceRecord {
+  const value = normalizeValue(deps.env.AGENTICOS_HOME);
+  return {
+    id: 'process_env',
+    label: 'process.env AGENTICOS_HOME',
+    scope: 'runtime',
+    status: value ? 'configured' : 'unset',
+    value,
+    location: 'current process environment',
+    fix_target: 'export AGENTICOS_HOME=... before starting the client',
+    detail: value ? 'Active runtime environment value.' : 'AGENTICOS_HOME is not set in the current process.',
+  };
+}
+
+function readShellProfileSource(deps: ConfigAuditDeps): ConfigSourceRecord {
+  const profilePath = detectDefaultShellProfile(deps.shellPath, deps.homeDir);
+  const content = deps.readFile(profilePath);
+  if (content === null) {
+    return {
+      id: 'shell_profile',
+      label: 'shell profile export',
+      scope: 'runtime',
+      status: 'missing',
+      value: null,
+      location: profilePath,
+      fix_target: profilePath,
+      detail: 'Detected shell profile file is missing.',
+    };
+  }
+
+  const value = extractShellExportValue(content);
+  return {
+    id: 'shell_profile',
+    label: 'shell profile export',
+    scope: 'runtime',
+    status: value ? 'configured' : 'unset',
+    value,
+    location: profilePath,
+    fix_target: profilePath,
+    detail: value
+      ? 'Detected export AGENTICOS_HOME entry in the shell profile.'
+      : 'No export AGENTICOS_HOME entry found in the detected shell profile.',
+  };
+}
+
+function readLaunchctlSource(deps: ConfigAuditDeps): ConfigSourceRecord {
+  if (deps.platform !== 'darwin') {
+    return {
+      id: 'launchctl',
+      label: 'launchctl session env',
+      scope: 'runtime',
+      status: 'unavailable',
+      value: null,
+      location: 'launchctl getenv AGENTICOS_HOME',
+      fix_target: 'launchctl setenv AGENTICOS_HOME ...',
+      detail: 'launchctl is only applicable on macOS.',
+    };
+  }
+
+  if (!deps.commandExists('launchctl')) {
+    return {
+      id: 'launchctl',
+      label: 'launchctl session env',
+      scope: 'runtime',
+      status: 'unavailable',
+      value: null,
+      location: 'launchctl getenv AGENTICOS_HOME',
+      fix_target: 'launchctl setenv AGENTICOS_HOME ...',
+      detail: 'launchctl is not available on PATH.',
+    };
+  }
+
+  const result = deps.runCommand('launchctl', ['getenv', 'AGENTICOS_HOME'], true);
+  const value = result.ok ? normalizeValue(result.detail) : null;
+  return {
+    id: 'launchctl',
+    label: 'launchctl session env',
+    scope: 'runtime',
+    status: value ? 'configured' : 'unset',
+    value,
+    location: 'launchctl getenv AGENTICOS_HOME',
+    fix_target: 'launchctl setenv AGENTICOS_HOME ...',
+    detail: value
+      ? 'launchctl reports an inherited GUI/session workspace.'
+      : 'launchctl did not report AGENTICOS_HOME.',
+  };
+}
+
+function readClaudeSettingsSource(deps: ConfigAuditDeps): ConfigSourceRecord {
+  return readJsonEnvSource(
+    deps,
+    'claude_settings',
+    'Claude Code settings env',
+    join(deps.homeDir, '.claude', 'settings.json'),
+  );
+}
+
+function readClaudeLegacySource(deps: ConfigAuditDeps): ConfigSourceRecord {
+  return readJsonEnvSource(
+    deps,
+    'claude_legacy',
+    'Claude legacy MCP env',
+    join(deps.homeDir, '.claude.json'),
+  );
+}
+
+function readCursorConfigSource(deps: ConfigAuditDeps): ConfigSourceRecord {
+  return readJsonEnvSource(
+    deps,
+    'cursor_mcp',
+    'Cursor MCP config',
+    join(deps.homeDir, '.cursor', 'mcp.json'),
+  );
+}
+
+function readJsonEnvSource(
+  deps: ConfigAuditDeps,
+  id: string,
+  label: string,
+  filePath: string,
+): ConfigSourceRecord {
+  const content = deps.readFile(filePath);
+  if (content === null) {
+    return {
+      id,
+      label,
+      scope: 'mcp',
+      status: 'missing',
+      value: null,
+      location: filePath,
+      fix_target: filePath,
+      detail: 'Config file is missing.',
+    };
+  }
+
+  try {
+    const parsed = JSON.parse(content) as unknown;
+    const value = findEnvValueInJson(parsed);
+    return {
+      id,
+      label,
+      scope: 'mcp',
+      status: value ? 'configured' : 'unset',
+      value,
+      location: filePath,
+      fix_target: filePath,
+      detail: value
+        ? 'Detected AGENTICOS_HOME in the config file.'
+        : 'Config file exists but does not contain AGENTICOS_HOME for AgenticOS.',
+    };
+  } catch {
+    return {
+      id,
+      label,
+      scope: 'mcp',
+      status: 'unavailable',
+      value: null,
+      location: filePath,
+      fix_target: filePath,
+      detail: 'Config file could not be parsed as JSON.',
+    };
+  }
+}
+
+function readCodexConfigSource(deps: ConfigAuditDeps): ConfigSourceRecord {
+  const filePath = join(deps.homeDir, '.codex', 'config.toml');
+  const content = deps.readFile(filePath);
+  if (content === null) {
+    return {
+      id: 'codex_config',
+      label: 'Codex MCP config',
+      scope: 'mcp',
+      status: 'missing',
+      value: null,
+      location: filePath,
+      fix_target: filePath,
+      detail: 'Config file is missing.',
+    };
+  }
+
+  const value = extractCodexValue(content);
+  return {
+    id: 'codex_config',
+    label: 'Codex MCP config',
+    scope: 'mcp',
+    status: value ? 'configured' : 'unset',
+    value,
+    location: filePath,
+    fix_target: filePath,
+    detail: value
+      ? 'Detected AGENTICOS_HOME in Codex config.'
+      : 'Config file exists but no AGENTICOS_HOME entry was detected for AgenticOS.',
+  };
+}
+
+function readHomebrewSources(deps: ConfigAuditDeps): ConfigSourceRecord[] {
+  const candidates = ['/opt/homebrew/var/agenticos', '/usr/local/var/agenticos'];
+  return candidates.map((candidate) => ({
+    id: `homebrew:${candidate}`,
+    label: `Homebrew runtime-home hint (${candidate})`,
+    scope: 'homebrew' as const,
+    status: deps.pathExists(candidate) ? 'present' : 'missing',
+    value: deps.pathExists(candidate) ? candidate : null,
+    location: candidate,
+    fix_target: candidate,
+    detail: deps.pathExists(candidate)
+      ? 'Default Homebrew runtime-home path exists on this machine.'
+      : 'Default Homebrew runtime-home path does not exist on this machine.',
+  }));
+}
+
+function normalizeValue(value: string | undefined | null): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function extractShellExportValue(content: string): string | null {
+  const match = content.match(/^\s*export\s+AGENTICOS_HOME=(['"]?)(.+?)\1\s*$/m);
+  return match ? normalizeValue(match[2]) : null;
+}
+
+function extractCodexValue(content: string): string | null {
+  const focusedMatch = content.match(/agenticos[\s\S]{0,400}?AGENTICOS_HOME\s*=\s*["']([^"']+)["']/i);
+  if (focusedMatch) {
+    return normalizeValue(focusedMatch[1]);
+  }
+  const genericMatch = content.match(/AGENTICOS_HOME\s*=\s*["']([^"']+)["']/);
+  return genericMatch ? normalizeValue(genericMatch[1]) : null;
+}
+
+function findEnvValueInJson(value: unknown): string | null {
+  if (!value || typeof value !== 'object') return null;
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const nested = findEnvValueInJson(item);
+      if (nested) return nested;
+    }
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  if (record.env && typeof record.env === 'object' && !Array.isArray(record.env)) {
+    const envRecord = record.env as Record<string, unknown>;
+    if (typeof envRecord.AGENTICOS_HOME === 'string') {
+      return normalizeValue(envRecord.AGENTICOS_HOME);
+    }
+  }
+
+  for (const nestedValue of Object.values(record)) {
+    const nested = findEnvValueInJson(nestedValue);
+    if (nested) return nested;
+  }
+
+  return null;
+}

--- a/mcp-server/src/utils/config-cli.ts
+++ b/mcp-server/src/utils/config-cli.ts
@@ -1,0 +1,81 @@
+import {
+  renderConfigAuditResult,
+  runConfigAudit,
+  type ConfigAuditDeps,
+} from './config-audit.js';
+
+export interface ConfigCliDeps extends ConfigAuditDeps {
+  stdout(line: string): void;
+  stderr(line: string): void;
+}
+
+export function buildHelpLines(): string[] {
+  return [
+    'agenticos-config — audit AgenticOS workspace configuration',
+    '',
+    'Usage:',
+    '  agenticos-config [--show|--validate] [--scope <all|runtime|mcp|homebrew>] [--help]',
+    '',
+    'Behavior:',
+    '  --show      Print detected configuration sources and values (default).',
+    '  --validate  Fail when detected sources disagree on AGENTICOS_HOME.',
+    '  --scope     Limit the audit to runtime, MCP config, or Homebrew hints.',
+  ];
+}
+
+export function parseCliArgs(argv: string[]): { help: boolean; action?: 'show' | 'validate'; scope?: string } {
+  const parsed: { help: boolean; action?: 'show' | 'validate'; scope?: string } = { help: false };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    switch (arg) {
+      case '--help':
+      case '-h':
+        parsed.help = true;
+        break;
+      case '--show':
+        parsed.action = 'show';
+        break;
+      case '--validate':
+        parsed.action = 'validate';
+        break;
+      case '--scope': {
+        const value = argv[index + 1];
+        if (!value) throw new Error('--scope requires a value.');
+        parsed.scope = value;
+        index += 1;
+        break;
+      }
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return parsed;
+}
+
+export function runConfigCli(argv: string[], deps: ConfigCliDeps): number {
+  try {
+    const parsed = parseCliArgs(argv);
+    if (parsed.help) {
+      for (const line of buildHelpLines()) deps.stdout(line);
+      return 0;
+    }
+
+    const result = runConfigAudit(
+      {
+        action: parsed.action,
+        scope: parsed.scope,
+      },
+      deps,
+    );
+
+    for (const line of renderConfigAuditResult(result).split('\n')) {
+      deps.stdout(line);
+    }
+    return result.status === 'PASS' ? 0 : 1;
+  } catch (error) {
+    deps.stderr(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+}

--- a/mcp-server/src/utils/mcp-server-cli.ts
+++ b/mcp-server/src/utils/mcp-server-cli.ts
@@ -13,6 +13,7 @@ export function buildHelpLines(version: string): string[] {
     '',
     'Recommended setup:',
     '  agenticos-bootstrap --workspace "$AGENTICOS_HOME" --first-run',
+    '  agenticos-config --validate',
     '  agenticos-bootstrap --help',
     '',
     'Manual registration examples:',


### PR DESCRIPTION
## Summary
- add a read-only `agenticos_config` MCP tool for workspace configuration audit
- add an `agenticos-config` CLI wrapper for show/validate flows
- audit runtime env, shell profile, launchctl, Claude/Codex/Cursor config files, and Homebrew default runtime-home hints
- report drift with specific file/command remediation targets

## Scope Notes
- v1 supports `show` and `validate`
- no automatic `fix` mutations
- no automatic user-config rewrites

## Verification
- `npm test -- src/utils/__tests__/config-audit.test.ts --coverage --coverage.include=src/utils/config-audit.ts`
- `npm test -- src/utils/__tests__/config-cli.test.ts --coverage --coverage.include=src/utils/config-cli.ts`
- `npm test -- src/utils/__tests__/mcp-server-cli.test.ts`
- `npm run build`
- `node build/config.js --help`
- `node build/index.js --help`

## Coverage
- `src/utils/config-audit.ts`: 100% statements / branches / functions / lines
- `src/utils/config-cli.ts`: 100% statements / branches / functions / lines
