### PR TITLE
feat: implement #272 record case knowledge management

### DIFF
--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -16,7 +16,7 @@ import {
   ListResourcesRequestSchema,
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { initProject, switchProject, listProjects, getStatus, saveState, recordSession, runPreflight, runIssueBootstrap, runBranchBootstrap, runPrScopeCheck, runHealth, runConfig, runEditGuard, runEntrySurfaceRefresh, runStandardKitAdopt, runStandardKitUpgradeCheck, runStandardKitConformanceCheck, runNonCodeEvaluate, runArchiveImportEvaluate } from './tools/index.js';
+import { initProject, switchProject, listProjects, getStatus, saveState, recordSession, runPreflight, runIssueBootstrap, runBranchBootstrap, runPrScopeCheck, runHealth, runConfig, runEditGuard, runEntrySurfaceRefresh, runStandardKitAdopt, runStandardKitUpgradeCheck, runStandardKitConformanceCheck, runNonCodeEvaluate, runArchiveImportEvaluate, runRecordCase, runListCases } from './tools/index.js';
 import { getProjectContext } from './resources/index.js';
 import { isDirectExecution, resolveCliPrelude } from './utils/mcp-server-cli.js';
 
@@ -90,6 +90,39 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
           },
         },
         required: ['summary'],
+      },
+    },
+    {
+      name: 'agenticos_record_case',
+      description: 'Record a structured corner case or bad case under the current project knowledge surface.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          project: { type: 'string', description: 'Optional project ID, name, or path. If omitted, uses the current session project.' },
+          type: { type: 'string', enum: ['corner', 'bad'], description: 'Case type.' },
+          title: { type: 'string', description: 'Short case title.' },
+          trigger: { type: 'string', description: 'What action or input triggered this case.' },
+          behavior: { type: 'string', description: 'What the agent or system did incorrectly.' },
+          rootCause: { type: 'string', description: 'Optional root cause analysis.' },
+          impact: { type: 'string', description: 'Optional impact summary.' },
+          workaround: { type: 'string', description: 'Optional workaround or fix.' },
+          prevention: { type: 'string', description: 'Optional prevention guidance.' },
+          tags: { type: 'array', items: { type: 'string' }, description: 'Optional domain tags.' },
+          timestamp: { type: 'string', description: 'Optional ISO-8601 timestamp override.' },
+        },
+        required: ['type', 'title', 'trigger', 'behavior'],
+      },
+    },
+    {
+      name: 'agenticos_list_cases',
+      description: 'List recorded corner cases and bad cases for the current project or across all managed projects.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          project: { type: 'string', description: 'Optional project ID, name, or path. Use "all" to search all active managed projects.' },
+          type: { type: 'string', enum: ['corner', 'bad', 'all'], description: 'Optional case type filter.' },
+          tags: { type: 'array', items: { type: 'string' }, description: 'Optional tag filter. All supplied tags must match.' },
+        },
       },
     },
     {
@@ -374,6 +407,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       return { content: [{ type: 'text', text: await listProjects() }] };
     case 'agenticos_record':
       return { content: [{ type: 'text', text: await recordSession(args) }] };
+    case 'agenticos_record_case':
+      return { content: [{ type: 'text', text: await runRecordCase(args ?? {}) }] };
+    case 'agenticos_list_cases':
+      return { content: [{ type: 'text', text: await runListCases(args ?? {}) }] };
     case 'agenticos_save':
       return { content: [{ type: 'text', text: await saveState(args) }] };
     case 'agenticos_status':

--- a/mcp-server/src/resources/__tests__/context.test.ts
+++ b/mcp-server/src/resources/__tests__/context.test.ts
@@ -16,17 +16,24 @@ vi.mock('../../utils/project-target.js', () => ({
   resolveManagedProjectTarget: vi.fn(),
 }));
 
+vi.mock('../../utils/case-knowledge.js', () => ({
+  buildCaseContextSection: vi.fn(),
+}));
+
 import { readFile } from 'fs/promises';
 import { getProjectContext } from '../context.js';
 import { resolveManagedProjectTarget } from '../../utils/project-target.js';
+import { buildCaseContextSection } from '../../utils/case-knowledge.js';
 
 const readFileMock = readFile as unknown as ReturnType<typeof vi.fn>;
 const resolveManagedProjectTargetMock = resolveManagedProjectTarget as unknown as ReturnType<typeof vi.fn>;
+const buildCaseContextSectionMock = buildCaseContextSection as unknown as ReturnType<typeof vi.fn>;
 
 describe('getProjectContext', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     yamlMock.parse.mockImplementation((content: string) => JSON.parse(content));
+    buildCaseContextSectionMock.mockResolvedValue('## Relevant Cases\n\n### bad-case: Retry loop\n- Trigger: bad input\n');
   });
 
   afterEach(() => {
@@ -67,6 +74,7 @@ describe('getProjectContext', () => {
     expect(result).toContain('Project Path: /workspace/alpha');
     expect(result).toContain('## Quick Start');
     expect(result).toContain('## Latest Issue Bootstrap');
+    expect(result).toContain('## Relevant Cases');
     expect(result).toContain('Issue: #179');
     expect(result).toContain('## Current State');
   });

--- a/mcp-server/src/resources/context.ts
+++ b/mcp-server/src/resources/context.ts
@@ -2,6 +2,7 @@ import { readFile } from 'fs/promises';
 import yaml from 'yaml';
 import { resolveManagedProjectTarget } from '../utils/project-target.js';
 import { extractLatestIssueBootstrap } from '../utils/guardrail-evidence.js';
+import { buildCaseContextSection } from '../utils/case-knowledge.js';
 
 export async function getProjectContext(): Promise<string> {
   let resolved;
@@ -19,11 +20,17 @@ export async function getProjectContext(): Promise<string> {
     const state = await readFile(resolved.statePath, 'utf-8');
     const parsedState = (yaml.parse(state) || {}) as Record<string, unknown>;
     const latestBootstrap = extractLatestIssueBootstrap(parsedState as any);
+    const caseSection = await buildCaseContextSection({
+      projectId: resolved.projectId,
+      projectName: resolved.projectName,
+      projectPath: resolved.projectPath,
+      projectYaml: resolved.projectYaml,
+    }, parsedState);
     const bootstrapSection = latestBootstrap
       ? `## Latest Issue Bootstrap\n- Issue: #${latestBootstrap.issue_id || 'unknown'}\n- Title: ${latestBootstrap.issue_title || 'Untitled issue'}\n- Recorded: ${latestBootstrap.recorded_at || 'unknown'}\n- Branch: ${latestBootstrap.current_branch || 'unknown'}\n- Startup surfaces: ${(latestBootstrap.startup_context_paths || []).length}\n- Additional context: ${(latestBootstrap.additional_context || []).length}\n\n`
       : '## Latest Issue Bootstrap\nNo issue bootstrap evidence recorded.\n\n';
 
-    return `# ${resolved.projectName}\n\nProject ID: ${resolved.projectId}\nProject Path: ${resolved.projectPath}\n\n## Project Configuration\n\`\`\`yaml\n${projectYaml}\`\`\`\n\n## Quick Start\n${quickStart}\n\n${bootstrapSection}## Current State\n\`\`\`yaml\n${state}\`\`\``;
+    return `# ${resolved.projectName}\n\nProject ID: ${resolved.projectId}\nProject Path: ${resolved.projectPath}\n\n## Project Configuration\n\`\`\`yaml\n${projectYaml}\`\`\`\n\n## Quick Start\n${quickStart}\n\n${bootstrapSection}${caseSection}\n## Current State\n\`\`\`yaml\n${state}\`\`\``;
   } catch (error: any) {
     return `# Error Loading Context\n\n${error.message}`;
   }

--- a/mcp-server/src/tools/__tests__/init.test.ts
+++ b/mcp-server/src/tools/__tests__/init.test.ts
@@ -111,6 +111,8 @@ describe('initProject', () => {
     const expectedDirs = [
       `${base}/.context/conversations`,
       `${base}/knowledge`,
+      `${base}/knowledge/corner-cases`,
+      `${base}/knowledge/bad-cases`,
       `${base}/tasks`,
       `${base}/artifacts`,
     ];

--- a/mcp-server/src/tools/__tests__/standard-kit.test.ts
+++ b/mcp-server/src/tools/__tests__/standard-kit.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { mkdtemp, mkdir, readFile, writeFile } from 'fs/promises';
+import { mkdtemp, mkdir, readFile, readdir, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import yaml from 'yaml';
@@ -265,6 +265,9 @@ describe('standard kit commands', () => {
     const stateYaml = yaml.parse(await readFile(join(projectRoot, '.context', 'state.yaml'), 'utf-8')) as any;
     expect(stateYaml.memory_contract.version).toBe(1);
     expect(stateYaml.loaded_context).toContain('.context/quick-start.md');
+    expect(await readdir(join(projectRoot, 'knowledge'))).toEqual(
+      expect.arrayContaining(['bad-cases', 'corner-cases']),
+    );
 
     const agentsMd = await readFile(join(projectRoot, 'AGENTS.md'), 'utf-8');
     const claudeMd = await readFile(join(projectRoot, 'CLAUDE.md'), 'utf-8');

--- a/mcp-server/src/tools/case.ts
+++ b/mcp-server/src/tools/case.ts
@@ -1,0 +1,115 @@
+import { readFile } from 'fs/promises';
+import yaml from 'yaml';
+import { listCasesAcrossProjects, listCasesForProject, normalizeCaseFilterType, normalizeCaseType, parseCaseTags, recordCaseKnowledge, renderCaseListMarkdown, type CaseProjectTarget } from '../utils/case-knowledge.js';
+import { loadRegistry } from '../utils/registry.js';
+import { resolveManagedProjectTarget } from '../utils/project-target.js';
+import { validateManagedProjectTopology } from '../utils/project-contract.js';
+
+function toCaseProjectTarget(resolved: Awaited<ReturnType<typeof resolveManagedProjectTarget>>): CaseProjectTarget {
+  return {
+    projectId: resolved.projectId,
+    projectName: resolved.projectName,
+    projectPath: resolved.projectPath,
+    projectYaml: resolved.projectYaml,
+  };
+}
+
+async function resolveAllProjectTargets(): Promise<CaseProjectTarget[]> {
+  const registry = await loadRegistry();
+  const targets: CaseProjectTarget[] = [];
+
+  for (const project of registry.projects) {
+    if (project.status !== 'active') {
+      continue;
+    }
+
+    try {
+      const projectYaml = yaml.parse(await readFile(`${project.path}/.project.yaml`, 'utf-8')) || {};
+      const topologyValidation = validateManagedProjectTopology(project.name, projectYaml);
+      if (!topologyValidation.ok) {
+        continue;
+      }
+
+      targets.push({
+        projectId: project.id,
+        projectName: project.name,
+        projectPath: project.path,
+        projectYaml,
+      });
+    } catch {
+      continue;
+    }
+  }
+
+  return targets;
+}
+
+export async function runRecordCase(args: any): Promise<string> {
+  if (args?.project === 'all') {
+    return '❌ agenticos_record_case does not support project="all". Pass a specific project or bind the session first.';
+  }
+
+  let resolved;
+  try {
+    resolved = await resolveManagedProjectTarget({
+      project: args?.project,
+      commandName: 'agenticos_record_case',
+    });
+  } catch (error: any) {
+    return `❌ ${error.message}`;
+  }
+
+  const entry = await recordCaseKnowledge(toCaseProjectTarget(resolved), {
+    type: normalizeCaseType(args?.type),
+    title: args?.title,
+    trigger: args?.trigger,
+    behavior: args?.behavior,
+    rootCause: args?.rootCause ?? args?.root_cause,
+    impact: args?.impact,
+    workaround: args?.workaround,
+    prevention: args?.prevention,
+    tags: parseCaseTags(args?.tags),
+    timestamp: args?.timestamp,
+  });
+
+  return JSON.stringify({
+    command: 'agenticos_record_case',
+    status: 'RECORDED',
+    project_id: entry.projectId,
+    project_name: entry.projectName,
+    project_path: entry.projectPath,
+    case: {
+      type: entry.type,
+      title: entry.title,
+      timestamp: entry.timestamp,
+      tags: entry.tags,
+      file_path: entry.filePath,
+      relative_path: entry.relativePath,
+    },
+  }, null, 2);
+}
+
+export async function runListCases(args: any): Promise<string> {
+  const type = normalizeCaseFilterType(args?.type);
+  const tags = parseCaseTags(args?.tags);
+
+  if (args?.project === 'all') {
+    const targets = await resolveAllProjectTargets();
+    const entries = await listCasesAcrossProjects(targets, { type, tags });
+    return renderCaseListMarkdown(entries, 'Matching Cases Across Projects');
+  }
+
+  let resolved;
+  try {
+    resolved = await resolveManagedProjectTarget({
+      project: args?.project,
+      commandName: 'agenticos_list_cases',
+    });
+  } catch (error: any) {
+    return `# Error\n\n${error.message}`;
+  }
+
+  const project = toCaseProjectTarget(resolved);
+  const entries = await listCasesForProject(project, { type, tags });
+  return renderCaseListMarkdown(entries, `Matching Cases for ${project.projectName}`);
+}

--- a/mcp-server/src/tools/index.ts
+++ b/mcp-server/src/tools/index.ts
@@ -13,3 +13,4 @@ export { runEntrySurfaceRefresh } from './entry-surface-refresh.js';
 export { runStandardKitAdopt, runStandardKitUpgradeCheck, runStandardKitConformanceCheck } from './standard-kit.js';
 export { runNonCodeEvaluate } from './non-code-evaluate.js';
 export { runArchiveImportEvaluate } from './archive-import-evaluate.js';
+export { runRecordCase, runListCases } from './case.js';

--- a/mcp-server/src/tools/init.ts
+++ b/mcp-server/src/tools/init.ts
@@ -5,6 +5,7 @@ import { loadRegistry, patchRegistry, getAgenticOSHome } from '../utils/registry
 import { generateClaudeMd, generateAgentsMd } from '../utils/distill.js';
 import { buildProjectTopologyInitializationMessage, validateContextPublicationPolicy, type ContextPublicationPolicy, type ProjectTopology } from '../utils/project-contract.js';
 import { resolveManagedProjectContextDisplayPaths, resolveManagedProjectContextPaths } from '../utils/agent-context-paths.js';
+import { ensureCaseKnowledgeDirectories } from '../utils/case-knowledge.js';
 
 function isValidGithubRepo(value: string): boolean {
   return /^[^/\s]+\/[^/\s]+$/.test(value);
@@ -219,7 +220,7 @@ export async function initProject(args: any): Promise<string> {
     await mkdir(join(projectPath, '.private', 'conversations'), { recursive: true });
     await ensureIgnoreEntries(projectPath, ['.private/', '.meta/transcripts/']);
   }
-  await mkdir(contextPaths.knowledgeDir, { recursive: true });
+  await ensureCaseKnowledgeDirectories(projectPath, projectYaml);
   await mkdir(contextPaths.tasksDir, { recursive: true });
   await mkdir(contextPaths.artifactsDir, { recursive: true });
 

--- a/mcp-server/src/utils/__tests__/case-knowledge.test.ts
+++ b/mcp-server/src/utils/__tests__/case-knowledge.test.ts
@@ -1,0 +1,276 @@
+import { mkdtemp, mkdir, readFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { describe, expect, it } from 'vitest';
+import {
+  buildCaseContextSection,
+  ensureCaseKnowledgeDirectories,
+  getCaseDirectoryName,
+  getCaseTypeLabel,
+  listCasesAcrossProjects,
+  listCasesForProject,
+  normalizeCaseFilterType,
+  normalizeCaseType,
+  parseCaseDocument,
+  parseCaseTags,
+  recordCaseKnowledge,
+  renderCaseDocument,
+  renderCaseListMarkdown,
+  type CaseProjectTarget,
+} from '../case-knowledge.js';
+
+async function createProject(name: string, id: string): Promise<CaseProjectTarget> {
+  const projectPath = await mkdtemp(join(tmpdir(), `agenticos-case-${id}-`));
+  await mkdir(projectPath, { recursive: true });
+  return {
+    projectId: id,
+    projectName: name,
+    projectPath,
+    projectYaml: {
+      agent_context: {
+        knowledge: 'knowledge/',
+      },
+    },
+  };
+}
+
+describe('case-knowledge', () => {
+  it('creates case directories and records collision-safe case files', async () => {
+    const project = await createProject('Alpha Project', 'alpha');
+
+    await ensureCaseKnowledgeDirectories(project.projectPath, project.projectYaml);
+
+    const first = await recordCaseKnowledge(project, {
+      type: 'corner',
+      title: 'Retry Loop',
+      trigger: 'Repeated git bootstrap',
+      behavior: 'The agent retried the same failing command',
+      tags: ['Git', 'Retry'],
+      timestamp: '2026-04-14T10:00:00.000Z',
+    });
+    const second = await recordCaseKnowledge(project, {
+      type: 'corner',
+      title: 'Retry Loop',
+      trigger: 'Repeated git bootstrap',
+      behavior: 'The agent retried the same failing command',
+      tags: ['Git', 'Retry'],
+      timestamp: '2026-04-14T10:05:00.000Z',
+    });
+    const third = await recordCaseKnowledge(project, {
+      type: 'corner',
+      title: 'Retry Loop',
+      trigger: 'Repeated git bootstrap',
+      behavior: 'The agent retried the same failing command',
+      tags: ['Git', 'Retry'],
+      timestamp: '2026-04-14T10:10:00.000Z',
+    });
+
+    expect(first.relativePath).toBe('knowledge/corner-cases/2026-04-14-retry-loop.md');
+    expect(second.relativePath).toBe('knowledge/corner-cases/2026-04-14-retry-loop-2.md');
+    expect(third.relativePath).toBe('knowledge/corner-cases/2026-04-14-retry-loop-3.md');
+    expect(getCaseTypeLabel('corner')).toBe('corner-case');
+    expect(getCaseDirectoryName('bad')).toBe('bad-cases');
+
+    const content = await readFile(first.filePath, 'utf-8');
+    expect(content).toContain('# corner-case: Retry Loop');
+    expect(content).toContain('## Root Cause\n(not provided)');
+    expect(content).toContain('## Tags\ncorner-case, git, retry');
+
+    const parsed = parseCaseDocument(content, project, first.filePath);
+    expect(parsed.tags).toEqual(['corner-case', 'git', 'retry']);
+    expect(parsed.rootCause).toBeNull();
+    expect(parsed.behavior).toContain('retried the same failing command');
+  });
+
+  it('validates types, filters, tags, timestamps, and malformed case documents', async () => {
+    const project = await createProject('Beta Project', 'beta');
+    const validTimestamp = '2026-04-14T12:00:00.000Z';
+
+    expect(normalizeCaseType('corner')).toBe('corner');
+    expect(normalizeCaseType('bad')).toBe('bad');
+    expect(() => normalizeCaseType('weird')).toThrow('type is required and must be "corner" or "bad".');
+    expect(normalizeCaseFilterType(undefined)).toBe('all');
+    expect(normalizeCaseFilterType('all')).toBe('all');
+    expect(normalizeCaseFilterType('bad')).toBe('bad');
+    expect(parseCaseTags(' Guardrail,\nGuardrail, Runtime ', 'bad')).toEqual(['bad-case', 'guardrail', 'runtime']);
+
+    expect(() => renderCaseDocument({
+      type: 'bad',
+      title: '',
+      trigger: 'x',
+      behavior: 'y',
+    })).toThrow('title is required.');
+    expect(() => renderCaseDocument({
+      type: 'bad',
+      title: 'Missing Trigger',
+      trigger: '',
+      behavior: 'y',
+    })).toThrow('trigger is required.');
+    expect(() => renderCaseDocument({
+      type: 'bad',
+      title: 'Missing Behavior',
+      trigger: 'x',
+      behavior: '',
+    })).toThrow('behavior is required.');
+    expect(() => renderCaseDocument({
+      type: 'bad',
+      title: 'Invalid Timestamp',
+      trigger: 'x',
+      behavior: 'y',
+      timestamp: 'not-an-iso-date',
+    })).toThrow('timestamp must be a valid ISO-8601 string when provided.');
+
+    expect(() => parseCaseDocument('## Timestamp\n2026-04-14T12:00:00.000Z\n', project, join(project.projectPath, 'broken.md')))
+      .toThrow(`Case document ${join(project.projectPath, 'broken.md')} is missing the title heading.`);
+
+    const unknownTypeDoc = `# strange-case: Mystery\n\n## Timestamp\n${validTimestamp}\n\n## Trigger\nx\n\n## Observed Behavior\ny\n`;
+    expect(() => parseCaseDocument(unknownTypeDoc, project, join(project.projectPath, 'unknown.md')))
+      .toThrow('has an unknown type heading "strange-case"');
+
+    const missingTriggerDoc = `# bad-case: Missing Trigger\n\n## Timestamp\n${validTimestamp}\n\n## Observed Behavior\ny\n`;
+    expect(() => parseCaseDocument(missingTriggerDoc, project, join(project.projectPath, 'missing-trigger.md')))
+      .toThrow('Case document is missing required section "Trigger".');
+  });
+
+  it('lists, filters, and aggregates cases across projects', async () => {
+    const alpha = await createProject('Alpha Project', 'alpha');
+    const beta = await createProject('Beta Project', 'beta');
+    const empty = await createProject('Empty Project', 'empty');
+
+    await recordCaseKnowledge(alpha, {
+      type: 'bad',
+      title: 'Guardrail Drift',
+      trigger: 'Switching between projects',
+      behavior: 'The runtime surfaced stale guardrail evidence',
+      rootCause: 'Global binding leaked across sessions',
+      workaround: 'Rebind the session before reading state',
+      prevention: 'Use session-local binding only',
+      tags: ['guardrail', 'runtime'],
+      timestamp: '2026-04-13T10:00:00.000Z',
+    });
+    await recordCaseKnowledge(alpha, {
+      type: 'corner',
+      title: 'Sparse Bootstrap',
+      trigger: 'Bootstrap without linked docs',
+      behavior: 'The agent started with minimal context',
+      tags: ['bootstrap'],
+      timestamp: '2026-04-12T09:00:00.000Z',
+    });
+    await recordCaseKnowledge(alpha, {
+      type: 'bad',
+      title: 'Alpha Tie',
+      trigger: 'Same timestamp ordering',
+      behavior: 'Order depends on relative path',
+      tags: ['guardrail', 'runtime'],
+      timestamp: '2026-04-13T10:00:00.000Z',
+    });
+    await recordCaseKnowledge(beta, {
+      type: 'bad',
+      title: 'Registry Race',
+      trigger: 'Concurrent saves',
+      behavior: 'Registry writes overlapped',
+      tags: ['guardrail', 'registry'],
+      timestamp: '2026-04-14T08:00:00.000Z',
+    });
+
+    expect(await listCasesForProject(empty, { type: 'all' })).toEqual([]);
+
+    const alphaBadCases = await listCasesForProject(alpha, { type: 'bad', tags: ['guardrail'] });
+    expect(alphaBadCases).toHaveLength(2);
+    expect(alphaBadCases.map((entry) => entry.title)).toEqual(['Alpha Tie', 'Guardrail Drift']);
+
+    const strictTagFilter = await listCasesForProject(alpha, { type: 'bad', tags: ['guardrail', 'registry'] });
+    expect(strictTagFilter).toEqual([]);
+
+    const acrossProjects = await listCasesAcrossProjects([alpha, beta], { type: 'all', tags: ['guardrail'] });
+    expect(acrossProjects.map((entry) => entry.title)).toEqual(['Registry Race', 'Alpha Tie', 'Guardrail Drift']);
+
+    const markdown = renderCaseListMarkdown(acrossProjects, 'Workspace Cases');
+    expect(markdown).toContain('# Workspace Cases');
+    expect(markdown).toContain('## Beta Project · bad-case: Registry Race');
+    expect(markdown).toContain('### Root Cause');
+    expect(markdown).toContain('(not provided)');
+    expect(renderCaseListMarkdown([], 'Workspace Cases')).toContain('No matching cases found.');
+  });
+
+  it('builds recent and relevant case context sections', async () => {
+    const project = await createProject('Gamma Project', 'gamma');
+
+    await recordCaseKnowledge(project, {
+      type: 'bad',
+      title: 'Guardrail Failure',
+      trigger: 'Running status after project switch',
+      behavior: 'Old issue evidence was shown',
+      workaround: 'Re-run switch and refresh state',
+      tags: ['guardrail', 'switch'],
+      timestamp: '2026-04-10T09:00:00.000Z',
+    });
+    await recordCaseKnowledge(project, {
+      type: 'corner',
+      title: 'Context Refresh Gap',
+      trigger: 'Reading quick start before state refresh',
+      behavior: 'The summary was stale',
+      workaround: 'Call refresh_entry_surfaces first',
+      tags: ['context'],
+      timestamp: '2026-04-14T09:00:00.000Z',
+    });
+    await recordCaseKnowledge(project, {
+      type: 'bad',
+      title: 'Switch Guardrail Drift',
+      trigger: 'Switching projects before status refresh',
+      behavior: 'The previous project guardrail remained visible',
+      workaround: 'Refresh guardrail state after each switch',
+      tags: ['guardrail'],
+      timestamp: '2026-04-12T09:00:00.000Z',
+    });
+    await recordCaseKnowledge(project, {
+      type: 'bad',
+      title: 'Aged Session State',
+      trigger: 'Reusing an older state snapshot',
+      behavior: 'A stale runtime decision was reused',
+      tags: ['router'],
+      timestamp: '2026-04-11T09:00:00.000Z',
+    });
+    await recordCaseKnowledge(project, {
+      type: 'corner',
+      title: 'Deferred Context Load',
+      trigger: 'Loading state after the first command',
+      behavior: 'The first response lacked refreshed context',
+      tags: ['router'],
+      timestamp: '2026-04-13T09:00:00.000Z',
+    });
+
+    const noCasesProject = await createProject('No Cases', 'nocases');
+    expect(await buildCaseContextSection(noCasesProject, {})).toContain('No recorded corner or bad cases.');
+
+    const recentSection = await buildCaseContextSection(project, {}, 1);
+    expect(recentSection).toContain('## Recent Cases');
+    expect(recentSection).toContain('Context Refresh Gap');
+    expect(recentSection).not.toContain('Guardrail Failure');
+
+    const fallbackRecentSection = await buildCaseContextSection(project, {
+      current_task: { title: 'Polish docs', next_step: 'update readme' },
+      working_memory: { pending: ['clean release notes'] },
+    }, 1);
+    expect(fallbackRecentSection).toContain('## Recent Cases');
+    expect(fallbackRecentSection).toContain('Context Refresh Gap');
+
+    const relevantSection = await buildCaseContextSection(project, {
+      current_task: { title: 'Fix guardrail switch issue', next_step: 'stabilize guardrail output' },
+      working_memory: { pending: ['refresh guardrail state'] },
+    }, 2);
+    expect(relevantSection).toContain('## Relevant Cases');
+    expect(relevantSection).toContain('Guardrail Failure');
+    expect(relevantSection).toContain('Switch Guardrail Drift');
+    expect(relevantSection).toContain('Re-run switch and refresh state');
+
+    const tiedRelevantSection = await buildCaseContextSection(project, {
+      current_task: { title: 'Router audit' },
+      working_memory: { pending: [] },
+    }, 2);
+    expect(tiedRelevantSection).toContain('## Relevant Cases');
+    expect(tiedRelevantSection.indexOf('Deferred Context Load')).toBeLessThan(
+      tiedRelevantSection.indexOf('Aged Session State'),
+    );
+  });
+});

--- a/mcp-server/src/utils/case-knowledge.ts
+++ b/mcp-server/src/utils/case-knowledge.ts
@@ -1,0 +1,487 @@
+import { mkdir, readdir, readFile, writeFile } from 'fs/promises';
+import { join, relative } from 'path';
+import { resolveManagedProjectContextPaths } from './agent-context-paths.js';
+
+export type CaseType = 'corner' | 'bad';
+export type CaseFilterType = CaseType | 'all';
+
+const CASE_TYPE_LABEL: Record<CaseType, string> = {
+  corner: 'corner-case',
+  bad: 'bad-case',
+};
+
+const CASE_TYPE_DIRECTORY: Record<CaseType, string> = {
+  corner: 'corner-cases',
+  bad: 'bad-cases',
+};
+
+const SECTION_LABELS = {
+  timestamp: 'Timestamp',
+  trigger: 'Trigger',
+  behavior: 'Observed Behavior',
+  rootCause: 'Root Cause',
+  impact: 'Impact',
+  workaround: 'Workaround / Fix',
+  prevention: 'Prevention',
+  tags: 'Tags',
+} as const;
+
+const OPTIONAL_PLACEHOLDER = '(not provided)';
+
+export interface CaseRecordInput {
+  type: CaseType;
+  title: string;
+  trigger: string;
+  behavior: string;
+  rootCause?: string;
+  impact?: string;
+  workaround?: string;
+  prevention?: string;
+  tags?: string[];
+  timestamp?: string;
+}
+
+export interface CaseProjectTarget {
+  projectId: string;
+  projectName: string;
+  projectPath: string;
+  projectYaml: any;
+}
+
+export interface CaseEntry extends CaseProjectTarget {
+  type: CaseType;
+  title: string;
+  timestamp: string;
+  trigger: string;
+  behavior: string;
+  rootCause: string | null;
+  impact: string | null;
+  workaround: string | null;
+  prevention: string | null;
+  tags: string[];
+  filePath: string;
+  relativePath: string;
+}
+
+interface ListCasesOptions {
+  type?: CaseFilterType;
+  tags?: string[];
+}
+
+interface ContextCaseSelection {
+  heading: 'Relevant Cases' | 'Recent Cases';
+  entries: CaseEntry[];
+}
+
+function normalizeText(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeOptionalText(value: unknown): string | null {
+  const normalized = normalizeText(value);
+  return normalized.length > 0 ? normalized : null;
+}
+
+export function normalizeCaseType(value: unknown): CaseType {
+  if (value === 'corner' || value === 'bad') {
+    return value;
+  }
+  throw new Error('type is required and must be "corner" or "bad".');
+}
+
+export function normalizeCaseFilterType(value: unknown): CaseFilterType {
+  if (value === undefined || value === null || value === '' || value === 'all') {
+    return 'all';
+  }
+  return normalizeCaseType(value);
+}
+
+export function getCaseTypeLabel(type: CaseType): string {
+  return CASE_TYPE_LABEL[type];
+}
+
+export function getCaseDirectoryName(type: CaseType): string {
+  return CASE_TYPE_DIRECTORY[type];
+}
+
+export function parseCaseTags(value: unknown, type?: CaseType): string[] {
+  const source = Array.isArray(value)
+    ? value
+    : typeof value === 'string'
+      ? value.split(/[,\n]/g)
+      : [];
+
+  const normalized = source
+    .map((entry) => normalizeText(entry).toLowerCase())
+    .filter((entry) => entry.length > 0);
+
+  if (type) {
+    normalized.unshift(getCaseTypeLabel(type));
+  }
+
+  return [...new Set(normalized)];
+}
+
+function slugifyTitle(title: string): string {
+  const slug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+/g, '')
+    .replace(/-+$/g, '');
+  return slug || 'untitled-case';
+}
+
+function validateTimestamp(value: unknown): string {
+  const candidate = normalizeText(value);
+  const timestamp = candidate.length > 0 ? candidate : new Date().toISOString();
+  const parsed = new Date(timestamp);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error('timestamp must be a valid ISO-8601 string when provided.');
+  }
+  return parsed.toISOString();
+}
+
+function renderSection(label: string, value: string | null): string {
+  return `## ${label}\n${value ?? OPTIONAL_PLACEHOLDER}\n`;
+}
+
+function buildRelativeCasePath(projectPath: string, filePath: string): string {
+  return relative(projectPath, filePath).replace(/\\/g, '/');
+}
+
+function sortCasesDescending(entries: CaseEntry[]): CaseEntry[] {
+  return [...entries].sort((left, right) => {
+    const timestampOrder = right.timestamp.localeCompare(left.timestamp);
+    if (timestampOrder !== 0) return timestampOrder;
+    return left.relativePath.localeCompare(right.relativePath);
+  });
+}
+
+function extractSectionMap(content: string): Map<string, string> {
+  const normalized = content.replace(/\r\n/g, '\n');
+  const lines = normalized.split('\n');
+  const sections = new Map<string, string>();
+  let currentLabel: string | null = null;
+  let currentLines: string[] = [];
+
+  const flush = (): void => {
+    if (currentLabel) {
+      sections.set(currentLabel, currentLines.join('\n').trim());
+    }
+  };
+
+  for (const line of lines) {
+    if (line.startsWith('## ')) {
+      flush();
+      currentLabel = line.slice(3).trim();
+      currentLines = [];
+      continue;
+    }
+
+    if (currentLabel) {
+      currentLines.push(line);
+    }
+  }
+
+  flush();
+  return sections;
+}
+
+function parseOptionalSection(value: string | undefined): string | null {
+  if (!value || value === OPTIONAL_PLACEHOLDER) {
+    return null;
+  }
+  return value;
+}
+
+function parseRequiredSection(value: string | undefined, label: string): string {
+  const normalized = parseOptionalSection(value);
+  if (!normalized) {
+    throw new Error(`Case document is missing required section "${label}".`);
+  }
+  return normalized;
+}
+
+function scoreCaseAgainstKeywords(entry: CaseEntry, keywords: string[]): number {
+  if (keywords.length === 0) return 0;
+
+  let score = 0;
+  for (const keyword of keywords) {
+    if (entry.tags.some((tag) => tag.includes(keyword))) score += 3;
+    if (entry.title.toLowerCase().includes(keyword)) score += 2;
+    if (entry.trigger.toLowerCase().includes(keyword)) score += 1;
+    if (entry.behavior.toLowerCase().includes(keyword)) score += 1;
+    if ((entry.rootCause || '').toLowerCase().includes(keyword)) score += 1;
+    if ((entry.workaround || '').toLowerCase().includes(keyword)) score += 1;
+    if ((entry.prevention || '').toLowerCase().includes(keyword)) score += 1;
+  }
+  return score;
+}
+
+function extractRelevanceKeywords(state: any): string[] {
+  const candidates = [
+    normalizeText(state?.current_task?.title),
+    normalizeText(state?.current_task?.next_step),
+    ...(Array.isArray(state?.working_memory?.pending) ? state.working_memory.pending : []),
+  ];
+
+  const tokens = candidates
+    .flatMap((value) => value.toLowerCase().split(/[^a-z0-9]+/g))
+    .map((token) => token.trim())
+    .filter((token) => token.length >= 3);
+
+  return [...new Set(tokens)];
+}
+
+function selectContextCases(entries: CaseEntry[], state: any, limit: number): ContextCaseSelection {
+  const keywords = extractRelevanceKeywords(state);
+  if (keywords.length === 0) {
+    return {
+      heading: 'Recent Cases',
+      entries: sortCasesDescending(entries).slice(0, limit),
+    };
+  }
+
+  const scored = entries
+    .map((entry) => ({ entry, score: scoreCaseAgainstKeywords(entry, keywords) }))
+    .filter((entry) => entry.score > 0)
+    .sort((left, right) => {
+      const scoreOrder = right.score - left.score;
+      if (scoreOrder !== 0) return scoreOrder;
+      return right.entry.timestamp.localeCompare(left.entry.timestamp);
+    });
+
+  if (scored.length === 0) {
+    return {
+      heading: 'Recent Cases',
+      entries: sortCasesDescending(entries).slice(0, limit),
+    };
+  }
+
+  return {
+    heading: 'Relevant Cases',
+    entries: scored.slice(0, limit).map((entry) => entry.entry),
+  };
+}
+
+async function allocateCaseFilePath(caseDir: string, baseName: string): Promise<string> {
+  const existingFiles = new Set(
+    (await readdir(caseDir, { withFileTypes: true }))
+      .filter((entry) => entry.isFile())
+      .map((entry) => entry.name),
+  );
+
+  const primaryName = `${baseName}.md`;
+  if (!existingFiles.has(primaryName)) {
+    return join(caseDir, primaryName);
+  }
+
+  let suffix = 2;
+  while (existingFiles.has(`${baseName}-${suffix}.md`)) {
+    suffix += 1;
+  }
+  return join(caseDir, `${baseName}-${suffix}.md`);
+}
+
+export async function ensureCaseKnowledgeDirectories(projectPath: string, projectYaml: any): Promise<void> {
+  const { knowledgeDir } = resolveManagedProjectContextPaths(projectPath, projectYaml);
+  await mkdir(knowledgeDir, { recursive: true });
+  await mkdir(join(knowledgeDir, getCaseDirectoryName('corner')), { recursive: true });
+  await mkdir(join(knowledgeDir, getCaseDirectoryName('bad')), { recursive: true });
+}
+
+export function renderCaseDocument(input: CaseRecordInput): string {
+  const type = normalizeCaseType(input.type);
+  const title = normalizeText(input.title);
+  const trigger = normalizeText(input.trigger);
+  const behavior = normalizeText(input.behavior);
+
+  if (!title) {
+    throw new Error('title is required.');
+  }
+  if (!trigger) {
+    throw new Error('trigger is required.');
+  }
+  if (!behavior) {
+    throw new Error('behavior is required.');
+  }
+
+  const timestamp = validateTimestamp(input.timestamp);
+  const tags = parseCaseTags(input.tags, type);
+
+  return [
+    `# ${getCaseTypeLabel(type)}: ${title}`,
+    '',
+    renderSection(SECTION_LABELS.timestamp, timestamp).trimEnd(),
+    '',
+    renderSection(SECTION_LABELS.trigger, trigger).trimEnd(),
+    '',
+    renderSection(SECTION_LABELS.behavior, behavior).trimEnd(),
+    '',
+    renderSection(SECTION_LABELS.rootCause, normalizeOptionalText(input.rootCause)).trimEnd(),
+    '',
+    renderSection(SECTION_LABELS.impact, normalizeOptionalText(input.impact)).trimEnd(),
+    '',
+    renderSection(SECTION_LABELS.workaround, normalizeOptionalText(input.workaround)).trimEnd(),
+    '',
+    renderSection(SECTION_LABELS.prevention, normalizeOptionalText(input.prevention)).trimEnd(),
+    '',
+    renderSection(SECTION_LABELS.tags, tags.join(', ')).trimEnd(),
+    '',
+  ].join('\n');
+}
+
+export function parseCaseDocument(
+  content: string,
+  project: CaseProjectTarget,
+  filePath: string,
+): CaseEntry {
+  const normalized = content.replace(/\r\n/g, '\n');
+  const headingMatch = normalized.match(/^# ([^:]+): (.+)$/m);
+  if (!headingMatch) {
+    throw new Error(`Case document ${filePath} is missing the title heading.`);
+  }
+
+  const rawTypeLabel = headingMatch[1].trim().toLowerCase();
+  const type = rawTypeLabel === 'corner-case'
+    ? 'corner'
+    : rawTypeLabel === 'bad-case'
+      ? 'bad'
+      : (() => {
+          throw new Error(`Case document ${filePath} has an unknown type heading "${headingMatch[1].trim()}".`);
+        })();
+
+  const sections = extractSectionMap(normalized);
+
+  const entry: CaseEntry = {
+    ...project,
+    type,
+    title: headingMatch[2].trim(),
+    timestamp: validateTimestamp(parseRequiredSection(sections.get(SECTION_LABELS.timestamp), SECTION_LABELS.timestamp)),
+    trigger: parseRequiredSection(sections.get(SECTION_LABELS.trigger), SECTION_LABELS.trigger),
+    behavior: parseRequiredSection(sections.get(SECTION_LABELS.behavior), SECTION_LABELS.behavior),
+    rootCause: parseOptionalSection(sections.get(SECTION_LABELS.rootCause)),
+    impact: parseOptionalSection(sections.get(SECTION_LABELS.impact)),
+    workaround: parseOptionalSection(sections.get(SECTION_LABELS.workaround)),
+    prevention: parseOptionalSection(sections.get(SECTION_LABELS.prevention)),
+    tags: parseCaseTags(sections.get(SECTION_LABELS.tags), type),
+    filePath,
+    relativePath: buildRelativeCasePath(project.projectPath, filePath),
+  };
+
+  return entry;
+}
+
+export async function recordCaseKnowledge(
+  project: CaseProjectTarget,
+  input: CaseRecordInput,
+): Promise<CaseEntry> {
+  const type = normalizeCaseType(input.type);
+  await ensureCaseKnowledgeDirectories(project.projectPath, project.projectYaml);
+
+  const content = renderCaseDocument({ ...input, type });
+  const { knowledgeDir } = resolveManagedProjectContextPaths(project.projectPath, project.projectYaml);
+  const caseDir = join(knowledgeDir, getCaseDirectoryName(type));
+  const timestamp = validateTimestamp(input.timestamp);
+  const datePrefix = timestamp.slice(0, 10);
+  const filePath = await allocateCaseFilePath(caseDir, `${datePrefix}-${slugifyTitle(normalizeText(input.title))}`);
+
+  await writeFile(filePath, content, 'utf-8');
+  return parseCaseDocument(content, project, filePath);
+}
+
+export async function listCasesForProject(
+  project: CaseProjectTarget,
+  options: ListCasesOptions = {},
+): Promise<CaseEntry[]> {
+  const type = normalizeCaseFilterType(options.type);
+  const tags = parseCaseTags(options.tags);
+  const { knowledgeDir } = resolveManagedProjectContextPaths(project.projectPath, project.projectYaml);
+  const types: CaseType[] = type === 'all' ? ['corner', 'bad'] : [type];
+
+  const entries: CaseEntry[] = [];
+  for (const caseType of types) {
+    const caseDir = join(knowledgeDir, getCaseDirectoryName(caseType));
+    let files: string[] = [];
+    try {
+      files = (await readdir(caseDir))
+        .filter((entry) => entry.endsWith('.md'))
+        .sort();
+    } catch {
+      files = [];
+    }
+
+    for (const fileName of files) {
+      const filePath = join(caseDir, fileName);
+      const parsed = parseCaseDocument(await readFile(filePath, 'utf-8'), project, filePath);
+      if (tags.length > 0 && !tags.every((tag) => parsed.tags.includes(tag))) {
+        continue;
+      }
+      entries.push(parsed);
+    }
+  }
+
+  return sortCasesDescending(entries);
+}
+
+export async function listCasesAcrossProjects(
+  projects: CaseProjectTarget[],
+  options: ListCasesOptions = {},
+): Promise<CaseEntry[]> {
+  const nested = await Promise.all(projects.map((project) => listCasesForProject(project, options)));
+  return sortCasesDescending(nested.flat());
+}
+
+export function renderCaseListMarkdown(entries: CaseEntry[], heading = 'Matching Cases'): string {
+  if (entries.length === 0) {
+    return `# ${heading}\n\nNo matching cases found.`;
+  }
+
+  const sections = entries.map((entry) => [
+    `## ${entry.projectName} · ${getCaseTypeLabel(entry.type)}: ${entry.title}`,
+    `- Timestamp: ${entry.timestamp}`,
+    `- Project ID: ${entry.projectId}`,
+    `- Tags: ${entry.tags.join(', ')}`,
+    `- File: ${entry.relativePath}`,
+    '',
+    '### Trigger',
+    entry.trigger,
+    '',
+    '### Observed Behavior',
+    entry.behavior,
+    '',
+    '### Root Cause',
+    entry.rootCause ?? OPTIONAL_PLACEHOLDER,
+    '',
+    '### Workaround / Fix',
+    entry.workaround ?? OPTIONAL_PLACEHOLDER,
+    '',
+    '### Prevention',
+    entry.prevention ?? OPTIONAL_PLACEHOLDER,
+  ].join('\n'));
+
+  return `# ${heading}\n\n${sections.join('\n\n')}`;
+}
+
+export async function buildCaseContextSection(
+  project: CaseProjectTarget,
+  state: any,
+  limit = 3,
+): Promise<string> {
+  const entries = await listCasesForProject(project, { type: 'all' });
+  if (entries.length === 0) {
+    return '## Recent Cases\nNo recorded corner or bad cases.\n';
+  }
+
+  const selection = selectContextCases(entries, state, limit);
+  const body = selection.entries.map((entry) => [
+    `### ${getCaseTypeLabel(entry.type)}: ${entry.title}`,
+    `- Timestamp: ${entry.timestamp}`,
+    `- Tags: ${entry.tags.join(', ')}`,
+    `- File: ${entry.relativePath}`,
+    `- Trigger: ${entry.trigger}`,
+    `- Workaround / Fix: ${entry.workaround ?? OPTIONAL_PLACEHOLDER}`,
+  ].join('\n'));
+
+  return `## ${selection.heading}\n\n${body.join('\n\n')}\n`;
+}

--- a/mcp-server/src/utils/standard-kit.ts
+++ b/mcp-server/src/utils/standard-kit.ts
@@ -12,6 +12,7 @@ import { resolveManagedProjectContextDisplayPaths, resolveManagedProjectContextP
 import { getSessionProjectBinding } from './session-context.js';
 import { resolveConversationRoutingPlan } from './conversation-routing.js';
 import { resolveContextPolicyPlan } from './context-policy-plan.js';
+import { ensureCaseKnowledgeDirectories } from './case-knowledge.js';
 
 interface StandardKitEntry {
   path: string;
@@ -237,7 +238,7 @@ async function ensureStandardDirectories(project: ResolvedProjectTarget): Promis
   if (project.projectYaml?.source_control?.context_publication_policy === 'public_distilled') {
     await mkdir(join(project.projectPath, '.private', 'conversations'), { recursive: true });
   }
-  await mkdir(contextPaths.knowledgeDir, { recursive: true });
+  await ensureCaseKnowledgeDirectories(project.projectPath, project.projectYaml);
   await mkdir(join(contextPaths.tasksDir, 'templates'), { recursive: true });
   await mkdir(contextPaths.artifactsDir, { recursive: true });
 }


### PR DESCRIPTION
## Summary
- add `agenticos_record_case` and `agenticos_list_cases` MCP tools for structured corner/bad case knowledge
- create `knowledge/corner-cases/` and `knowledge/bad-cases/` during project init and standard-kit adoption
- include bounded recent/relevant case summaries in `agenticos://context/current`

## Verification
- `npm run lint`
- `npm test`
- `npx vitest run src/utils/__tests__/case-knowledge.test.ts --coverage --coverage.include=src/utils/case-knowledge.ts`
  - `case-knowledge.ts`: 100% statements / 100% functions / 100% lines

Closes #272
