### PR TITLE
fix: harden #284 canonical checkout sync diagnostics and runtime write protection

### DIFF
--- a/mcp-server/src/tools/__tests__/record.test.ts
+++ b/mcp-server/src/tools/__tests__/record.test.ts
@@ -39,10 +39,15 @@ vi.mock('../../utils/distill.js', () => ({
   updateClaudeMdState: vi.fn().mockResolvedValue({ updated: true, created: false }),
 }));
 
+vi.mock('../../utils/canonical-main-guard.js', () => ({
+  detectCanonicalMainWriteProtection: vi.fn(),
+}));
+
 import { recordSession } from '../record.js';
 import * as fsPromises from 'fs/promises';
 import * as registry from '../../utils/registry.js';
 import { bindSessionProject, clearSessionProjectBinding } from '../../utils/session-context.js';
+import { detectCanonicalMainWriteProtection } from '../../utils/canonical-main-guard.js';
 
 const fsPromisesMock = fsPromises as typeof fsPromises & {
   readFile: ReturnType<typeof vi.fn>;
@@ -53,6 +58,7 @@ const registryMock = registry as typeof registry & {
   loadRegistry: ReturnType<typeof vi.fn>;
   patchProjectMetadata: ReturnType<typeof vi.fn>;
 };
+const canonicalMainGuardMock = detectCanonicalMainWriteProtection as unknown as ReturnType<typeof vi.fn>;
 
 function buildRegistry(overrides: Record<string, unknown> = {}) {
   return {
@@ -141,6 +147,7 @@ describe('recordSession', () => {
       projects: [],
     });
     registryMock.patchProjectMetadata.mockResolvedValue(undefined);
+    canonicalMainGuardMock.mockResolvedValue({ blocked: false });
     mockProjectFiles();
   });
 
@@ -181,6 +188,22 @@ describe('recordSession', () => {
 
     const result = await recordSession({ summary: 'test summary' });
     expect(result).toContain('No project provided and no session project is bound');
+  });
+
+  it('blocks canonical main runtime persistence before any file writes occur', async () => {
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry());
+    canonicalMainGuardMock.mockResolvedValue({
+      blocked: true,
+      reason: 'canonical main checkout is write-protected for runtime persistence: /test/path',
+    });
+
+    const result = await recordSession({ summary: 'blocked write' });
+
+    expect(result).toContain('agenticos_record blocked');
+    expect(result).toContain('canonical main checkout is write-protected for runtime persistence: /test/path');
+    expect(fsPromisesMock.mkdir).not.toHaveBeenCalled();
+    expect(fsPromisesMock.writeFile).not.toHaveBeenCalled();
+    expect(registryMock.patchProjectMetadata).not.toHaveBeenCalled();
   });
 
   it('creates conversation file with correct date-based filename', async () => {

--- a/mcp-server/src/tools/record.ts
+++ b/mcp-server/src/tools/record.ts
@@ -9,6 +9,7 @@ import {
   detectLegacyTrackedTranscriptStatus,
   resolveConversationRoutingPlan,
 } from '../utils/conversation-routing.js';
+import { detectCanonicalMainWriteProtection } from '../utils/canonical-main-guard.js';
 
 function parseArray(val: unknown): string[] {
   if (Array.isArray(val)) return val as string[];
@@ -42,6 +43,14 @@ export async function recordSession(args: any): Promise<string> {
   }
 
   const { project, projectPath, projectYaml, statePath, markerPath } = resolved;
+  const writeProtection = await detectCanonicalMainWriteProtection(projectPath);
+  if (writeProtection.blocked) {
+    return `❌ agenticos_record blocked for "${project.name}" because canonical main checkout runtime persistence is write-protected.\n\n` +
+      `- ${writeProtection.reason}\n` +
+      '- switch to an isolated issue worktree before recording operational state\n' +
+      '- keep runtime recording out of the canonical main checkout so future issue flow starts from a trusted baseline';
+  }
+
   const contextPolicyPlan = resolveContextPolicyPlan({
     projectName: project.name,
     projectPath,

--- a/mcp-server/src/utils/__tests__/canonical-checkout-sync.test.ts
+++ b/mcp-server/src/utils/__tests__/canonical-checkout-sync.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import { analyzeCanonicalRepoSync } from '../canonical-checkout-sync.js';
+
+describe('analyzeCanonicalRepoSync', () => {
+  it('returns PASS for a clean canonical checkout aligned to origin/main', () => {
+    const result = analyzeCanonicalRepoSync({
+      statusOutput: '## main...origin/main\n',
+      remoteBaseBranch: 'origin/main',
+      runtimeManagedEntries: ['standards/.context/state.yaml', 'standards/.context/conversations/', 'CLAUDE.md'],
+    });
+
+    expect(result.status).toBe('PASS');
+    expect(result.summary).toBe('Canonical checkout is clean and aligned with origin/main.');
+    expect(result.details).toEqual({
+      branch_line: '## main...origin/main',
+      branch_status: 'aligned',
+      dirty_paths: [],
+      runtime_dirty_paths: [],
+      source_dirty_paths: [],
+    });
+    expect(result.recovery_actions).toEqual([]);
+  });
+
+  it('classifies runtime-only drift and rename paths', () => {
+    const result = analyzeCanonicalRepoSync({
+      statusOutput: '## main...origin/main\n M standards/.context/state.yaml\nR  old/path.txt -> CLAUDE.md\n?? standards/.context/conversations/2026-04-14.md\n',
+      remoteBaseBranch: 'origin/main',
+      runtimeManagedEntries: ['standards/.context/state.yaml', 'standards/.context/conversations/', 'CLAUDE.md'],
+    });
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.summary).toContain('runtime-managed drift: 3 path(s)');
+    expect(result.details.runtime_dirty_paths).toEqual([
+      'standards/.context/state.yaml',
+      'CLAUDE.md',
+      'standards/.context/conversations/2026-04-14.md',
+    ]);
+    expect(result.details.source_dirty_paths).toEqual([]);
+    expect(result.recovery_actions[0]).toContain('discard or isolate runtime-managed drift');
+    expect(result.recovery_actions[1]).toContain('isolated issue worktrees');
+  });
+
+  it('classifies source-tree edits and behind canonical main separately', () => {
+    const result = analyzeCanonicalRepoSync({
+      statusOutput: '## main...origin/main [behind 6]\n M standards/.context/state.yaml\n M README.md\n',
+      remoteBaseBranch: 'origin/main',
+      runtimeManagedEntries: ['standards/.context/state.yaml', 'standards/.context/conversations/', 'CLAUDE.md'],
+    });
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.summary).toContain('branch misalignment: ## main...origin/main [behind 6]');
+    expect(result.summary).toContain('runtime-managed drift: 1 path(s)');
+    expect(result.summary).toContain('source-tree edits: 1 path(s)');
+    expect(result.details.branch_status).toBe('behind');
+    expect(result.details.runtime_dirty_paths).toEqual(['standards/.context/state.yaml']);
+    expect(result.details.source_dirty_paths).toEqual(['README.md']);
+    expect(result.recovery_actions).toEqual([
+      'fast-forward canonical main to origin/main before treating it as a trusted base checkout',
+      'discard or isolate runtime-managed drift from the canonical checkout: standards/.context/state.yaml',
+      'review, move, or revert source-tree edits before trusting the canonical checkout: README.md',
+      'keep new implementation work inside isolated issue worktrees rather than the canonical main checkout',
+    ]);
+  });
+
+  it('truncates long recovery path lists with a +N suffix', () => {
+    const result = analyzeCanonicalRepoSync({
+      statusOutput: '## main...origin/main\n M a\n M b\n M c\n M d\n M e\n M f\n',
+      remoteBaseBranch: 'origin/main',
+      runtimeManagedEntries: [],
+    });
+
+    expect(result.recovery_actions[0]).toContain('a, b, c, d, e (+1 more)');
+  });
+
+  it('covers ahead, diverged, non-main, and missing branch states', () => {
+    const ahead = analyzeCanonicalRepoSync({
+      statusOutput: '## main...origin/main [ahead 2]\n',
+      remoteBaseBranch: 'origin/main',
+    });
+    expect(ahead.details.branch_status).toBe('ahead');
+    expect(ahead.recovery_actions[0]).toContain('realign canonical main with origin/main');
+
+    const diverged = analyzeCanonicalRepoSync({
+      statusOutput: '## main...origin/main [ahead 1, behind 2]\n',
+      remoteBaseBranch: 'origin/main',
+    });
+    expect(diverged.details.branch_status).toBe('diverged');
+    expect(diverged.recovery_actions[0]).toContain('realign canonical main with origin/main');
+
+    const notOnMain = analyzeCanonicalRepoSync({
+      statusOutput: '## fix/284-canonical-checkout-sync-runtime-write-protection\n',
+      remoteBaseBranch: 'origin/main',
+    });
+    expect(notOnMain.details.branch_status).toBe('not_on_main');
+    expect(notOnMain.recovery_actions[0]).toContain('return the canonical checkout to main');
+
+    const unknownMain = analyzeCanonicalRepoSync({
+      statusOutput: '## main\n',
+      remoteBaseBranch: 'origin/main',
+    });
+    expect(unknownMain.details.branch_status).toBe('unknown');
+    expect(unknownMain.recovery_actions[0]).toContain('restore exact main...origin/main alignment');
+
+    const unknownDecoratedMain = analyzeCanonicalRepoSync({
+      statusOutput: '## main...origin/main [gone]\n',
+      remoteBaseBranch: 'origin/main',
+    });
+    expect(unknownDecoratedMain.details.branch_status).toBe('unknown');
+
+    const missing = analyzeCanonicalRepoSync({
+      statusOutput: '\n',
+      remoteBaseBranch: 'origin/main',
+    });
+    expect(missing.details.branch_status).toBe('unknown');
+    expect(missing.summary).toContain('missing branch status');
+    expect(missing.recovery_actions[0]).toContain('missing branch status');
+  });
+});

--- a/mcp-server/src/utils/__tests__/health.test.ts
+++ b/mcp-server/src/utils/__tests__/health.test.ts
@@ -22,10 +22,13 @@ vi.mock('../standard-kit.js', () => ({
 import { runHealthCheck } from '../health.js';
 import { runHealth } from '../../tools/health.js';
 
-async function setupProjectRoot(stateYaml: string): Promise<string> {
+async function setupProjectRoot(stateYaml: string, options?: { projectYaml?: string }): Promise<string> {
   const projectRoot = await mkdtemp(join(tmpdir(), 'agenticos-health-'));
   await mkdir(join(projectRoot, '.context'), { recursive: true });
-  await writeFile(join(projectRoot, '.context', 'state.yaml'), stateYaml, 'utf-8');
+  const projectYaml = options?.projectYaml || `meta:\n  id: "health-project"\n  name: "Health Project"\nsource_control:\n  topology: "github_versioned"\n  context_publication_policy: "public_distilled"\nagent_context:\n  quick_start: "standards/.context/quick-start.md"\n  current_state: "standards/.context/state.yaml"\n  conversations: "standards/.context/conversations/"\n  last_record_marker: "standards/.context/.last_record"\n`;
+  await mkdir(join(projectRoot, 'standards', '.context'), { recursive: true });
+  await writeFile(join(projectRoot, '.project.yaml'), projectYaml, 'utf-8');
+  await writeFile(join(projectRoot, 'standards', '.context', 'state.yaml'), stateYaml, 'utf-8');
   return projectRoot;
 }
 
@@ -56,6 +59,14 @@ describe('health command', () => {
       { gate: 'guardrail_evidence', status: 'PASS', summary: 'Latest guardrail evidence is present (agenticos_preflight).' },
       { gate: 'standard_kit', status: 'PASS', summary: 'Standard-kit files match the canonical kit.' },
     ]);
+    expect(result.repo_sync).toEqual({
+      branch_line: '## main...origin/main',
+      branch_status: 'aligned',
+      dirty_paths: [],
+      runtime_dirty_paths: [],
+      source_dirty_paths: [],
+    });
+    expect(result.recovery_actions).toEqual([]);
 
     const wrapped = JSON.parse(await runHealth({
       repo_path: '/repo',
@@ -65,9 +76,9 @@ describe('health command', () => {
     expect(wrapped.status).toBe('PASS');
   });
 
-  it('reports BLOCK and WARN gates for a behind or dirty canonical checkout with stale state surfaces', async () => {
+  it('reports branch misalignment separately from runtime drift and source edits', async () => {
     const projectRoot = await setupProjectRoot(`session:\n  id: "session-1"\n`);
-    childProcessMock.exec.mockImplementation((_: string, cb: Function) => cb(null, '## main...origin/main [behind 2]\n M README.md\n', ''));
+    childProcessMock.exec.mockImplementation((_: string, cb: Function) => cb(null, '## main...origin/main [behind 2]\n M standards/.context/state.yaml\n M README.md\n', ''));
 
     const result = await runHealthCheck({
       repo_path: '/repo',
@@ -79,7 +90,7 @@ describe('health command', () => {
       {
         gate: 'repo_sync',
         status: 'BLOCK',
-        summary: 'Canonical checkout is not aligned with origin/main: ## main...origin/main [behind 2]',
+        summary: 'Canonical checkout is blocked by branch misalignment: ## main...origin/main [behind 2]; runtime-managed drift: 1 path(s); source-tree edits: 1 path(s).',
       },
       {
         gate: 'entry_surface_refresh',
@@ -91,6 +102,19 @@ describe('health command', () => {
         status: 'WARN',
         summary: 'No persisted guardrail evidence is present yet.',
       },
+    ]);
+    expect(result.repo_sync).toEqual({
+      branch_line: '## main...origin/main [behind 2]',
+      branch_status: 'behind',
+      dirty_paths: ['standards/.context/state.yaml', 'README.md'],
+      runtime_dirty_paths: ['standards/.context/state.yaml'],
+      source_dirty_paths: ['README.md'],
+    });
+    expect(result.recovery_actions).toEqual([
+      'fast-forward canonical main to origin/main before treating it as a trusted base checkout',
+      'discard or isolate runtime-managed drift from the canonical checkout: standards/.context/state.yaml',
+      'review, move, or revert source-tree edits before trusting the canonical checkout: README.md',
+      'keep new implementation work inside isolated issue worktrees rather than the canonical main checkout',
     ]);
   });
 
@@ -129,9 +153,9 @@ describe('health command', () => {
     ]);
   });
 
-  it('blocks a canonical checkout that is on main but still dirty', async () => {
+  it('classifies runtime-only drift in a canonical checkout that is otherwise aligned', async () => {
     const projectRoot = await setupProjectRoot(`entry_surface_refresh:\n  refreshed_at: "2026-03-25T00:00:00.000Z"\n`);
-    childProcessMock.exec.mockImplementation((_: string, cb: Function) => cb(null, '## main...origin/main\n M README.md\n', ''));
+    childProcessMock.exec.mockImplementation((_: string, cb: Function) => cb(null, '## main...origin/main\n M standards/.context/state.yaml\n M CLAUDE.md\n', ''));
 
     const result = await runHealthCheck({
       repo_path: '/repo',
@@ -142,8 +166,10 @@ describe('health command', () => {
     expect(result.gates[0]).toEqual({
       gate: 'repo_sync',
       status: 'BLOCK',
-      summary: 'Canonical checkout is dirty and cannot be treated as a trusted starting point.',
+      summary: 'Canonical checkout is blocked by runtime-managed drift: 2 path(s).',
     });
+    expect(result.repo_sync?.runtime_dirty_paths).toEqual(['standards/.context/state.yaml', 'CLAUDE.md']);
+    expect(result.repo_sync?.source_dirty_paths).toEqual([]);
   });
 
   it('fails closed on missing repo_path, git command failure fallbacks, missing branch status, and missing project_path for standard-kit checks', async () => {
@@ -167,7 +193,7 @@ describe('health command', () => {
       {
         gate: 'repo_sync',
         status: 'BLOCK',
-        summary: 'Canonical checkout is not aligned with origin/main: missing branch status',
+        summary: 'Canonical checkout is blocked by branch misalignment: missing branch status.',
       },
       {
         gate: 'entry_surface_refresh',
@@ -179,6 +205,16 @@ describe('health command', () => {
         status: 'WARN',
         summary: 'No persisted guardrail evidence is present yet.',
       },
+    ]);
+    expect(missingBranchResult.repo_sync).toEqual({
+      branch_line: '',
+      branch_status: 'unknown',
+      dirty_paths: [],
+      runtime_dirty_paths: [],
+      source_dirty_paths: [],
+    });
+    expect(missingBranchResult.recovery_actions).toEqual([
+      'inspect canonical branch status "missing branch status" and restore exact main...origin/main alignment',
     ]);
 
     childProcessMock.exec.mockImplementation((_: string, cb: Function) => cb(null, '## main...origin/main\n', ''));

--- a/mcp-server/src/utils/canonical-checkout-sync.ts
+++ b/mcp-server/src/utils/canonical-checkout-sync.ts
@@ -1,0 +1,176 @@
+export type CanonicalBranchStatus =
+  | 'aligned'
+  | 'behind'
+  | 'ahead'
+  | 'diverged'
+  | 'not_on_main'
+  | 'unknown';
+
+export interface CanonicalRepoSyncDetails {
+  branch_line: string;
+  branch_status: CanonicalBranchStatus;
+  dirty_paths: string[];
+  runtime_dirty_paths: string[];
+  source_dirty_paths: string[];
+}
+
+export interface CanonicalRepoSyncAnalysis {
+  status: 'PASS' | 'BLOCK';
+  summary: string;
+  details: CanonicalRepoSyncDetails;
+  recovery_actions: string[];
+}
+
+function classifyBranchStatus(branchLine: string, remoteBaseBranch: string): CanonicalBranchStatus {
+  const expectedBranchLine = `## main...${remoteBaseBranch}`;
+  if (branchLine === expectedBranchLine) {
+    return 'aligned';
+  }
+
+  if (branchLine.startsWith(`${expectedBranchLine} `)) {
+    const normalized = branchLine.toLowerCase();
+    const hasAhead = normalized.includes('ahead');
+    const hasBehind = normalized.includes('behind');
+    if (hasAhead && hasBehind) return 'diverged';
+    if (hasBehind) return 'behind';
+    if (hasAhead) return 'ahead';
+    return 'unknown';
+  }
+
+  if (branchLine.startsWith('## main')) {
+    return 'unknown';
+  }
+
+  if (branchLine.startsWith('## ')) {
+    return 'not_on_main';
+  }
+
+  return 'unknown';
+}
+
+function parseDirtyPaths(statusOutput: string): string[] {
+  return statusOutput
+    .trimEnd()
+    .split('\n')
+    .slice(1)
+    .map((line) => line.trimEnd())
+    .filter((line) => line.length > 0)
+    .map((line) => line.slice(3).trim())
+    .map((path) => {
+      const renameParts = path.split(' -> ');
+      return renameParts[renameParts.length - 1].replace(/\\/g, '/');
+    });
+}
+
+function pathMatchesRuntimeEntry(path: string, runtimeManagedEntries: string[]): boolean {
+  return runtimeManagedEntries.some((entry) => {
+    if (entry.endsWith('/')) {
+      return path.startsWith(entry);
+    }
+    return path === entry;
+  });
+}
+
+function formatPathList(paths: string[], limit = 5): string {
+  const visible = paths.slice(0, limit);
+  const suffix = paths.length > limit ? ` (+${paths.length - limit} more)` : '';
+  return `${visible.join(', ')}${suffix}`;
+}
+
+function buildRecoveryActions(args: {
+  branchStatus: CanonicalBranchStatus;
+  branchLine: string;
+  remoteBaseBranch: string;
+  runtimeDirtyPaths: string[];
+  sourceDirtyPaths: string[];
+}): string[] {
+  const actions: string[] = [];
+  const { branchStatus, branchLine, remoteBaseBranch, runtimeDirtyPaths, sourceDirtyPaths } = args;
+
+  switch (branchStatus) {
+    case 'behind':
+      actions.push(`fast-forward canonical main to ${remoteBaseBranch} before treating it as a trusted base checkout`);
+      break;
+    case 'ahead':
+    case 'diverged':
+      actions.push(`realign canonical main with ${remoteBaseBranch}; do not cut new issue work from branch state "${branchLine}"`);
+      break;
+    case 'not_on_main':
+      actions.push(`return the canonical checkout to main tracking ${remoteBaseBranch} before using it as the trusted base`);
+      break;
+    case 'unknown':
+      actions.push(`inspect canonical branch status "${branchLine || 'missing branch status'}" and restore exact main...${remoteBaseBranch} alignment`);
+      break;
+    case 'aligned':
+      break;
+  }
+
+  if (runtimeDirtyPaths.length > 0) {
+    actions.push(`discard or isolate runtime-managed drift from the canonical checkout: ${formatPathList(runtimeDirtyPaths)}`);
+  }
+
+  if (sourceDirtyPaths.length > 0) {
+    actions.push(`review, move, or revert source-tree edits before trusting the canonical checkout: ${formatPathList(sourceDirtyPaths)}`);
+  }
+
+  if (runtimeDirtyPaths.length > 0 || sourceDirtyPaths.length > 0) {
+    actions.push('keep new implementation work inside isolated issue worktrees rather than the canonical main checkout');
+  }
+
+  return actions;
+}
+
+export function analyzeCanonicalRepoSync(args: {
+  statusOutput: string;
+  remoteBaseBranch: string;
+  runtimeManagedEntries?: string[];
+}): CanonicalRepoSyncAnalysis {
+  const lines = args.statusOutput.trimEnd().split('\n');
+  const branchLine = lines[0] || '';
+  const branchStatus = classifyBranchStatus(branchLine, args.remoteBaseBranch);
+  const dirtyPaths = parseDirtyPaths(args.statusOutput);
+  const runtimeManagedEntries = args.runtimeManagedEntries || [];
+  const runtimeDirtyPaths = dirtyPaths.filter((path) => pathMatchesRuntimeEntry(path, runtimeManagedEntries));
+  const sourceDirtyPaths = dirtyPaths.filter((path) => !pathMatchesRuntimeEntry(path, runtimeManagedEntries));
+
+  const details: CanonicalRepoSyncDetails = {
+    branch_line: branchLine,
+    branch_status: branchStatus,
+    dirty_paths: dirtyPaths,
+    runtime_dirty_paths: runtimeDirtyPaths,
+    source_dirty_paths: sourceDirtyPaths,
+  };
+
+  if (branchStatus === 'aligned' && dirtyPaths.length === 0) {
+    return {
+      status: 'PASS',
+      summary: `Canonical checkout is clean and aligned with ${args.remoteBaseBranch}.`,
+      details,
+      recovery_actions: [],
+    };
+  }
+
+  const summaryParts: string[] = [];
+  if (branchStatus !== 'aligned') {
+    summaryParts.push(`branch misalignment: ${branchLine || 'missing branch status'}`);
+  }
+  if (runtimeDirtyPaths.length > 0) {
+    summaryParts.push(`runtime-managed drift: ${runtimeDirtyPaths.length} path(s)`);
+  }
+  if (sourceDirtyPaths.length > 0) {
+    summaryParts.push(`source-tree edits: ${sourceDirtyPaths.length} path(s)`);
+  }
+
+  return {
+    status: 'BLOCK',
+    summary: `Canonical checkout is blocked by ${summaryParts.join('; ')}.`,
+    details,
+    recovery_actions: buildRecoveryActions({
+      branchStatus,
+      branchLine,
+      remoteBaseBranch: args.remoteBaseBranch,
+      runtimeDirtyPaths,
+      sourceDirtyPaths,
+    }),
+  };
+}

--- a/mcp-server/src/utils/health.ts
+++ b/mcp-server/src/utils/health.ts
@@ -3,6 +3,8 @@ import { readFile } from 'fs/promises';
 import { join } from 'path';
 import yaml from 'yaml';
 import { checkStandardKitUpgrade } from './standard-kit.js';
+import { analyzeCanonicalRepoSync, type CanonicalRepoSyncDetails } from './canonical-checkout-sync.js';
+import { resolveManagedProjectContextDisplayPaths, resolveManagedProjectContextPaths } from './agent-context-paths.js';
 
 export interface HealthArgs {
   repo_path: string;
@@ -27,6 +29,8 @@ export interface HealthResult {
   checkout_role: 'canonical';
   checked_at: string;
   gates: HealthGate[];
+  repo_sync?: CanonicalRepoSyncDetails;
+  recovery_actions?: string[];
 }
 
 function execCommand(command: string): Promise<string> {
@@ -47,40 +51,45 @@ function combineHealthStatus(gates: HealthGate[]): 'PASS' | 'WARN' | 'BLOCK' {
   return 'PASS';
 }
 
-function parseRepoSyncGate(statusOutput: string, remoteBaseBranch: string): HealthGate {
-  const lines = statusOutput.trimEnd().split('\n');
-  const branchLine = lines[0] || '';
-  const fileChanges = lines.slice(1).filter((line) => line.trim().length > 0);
-  const expectedBranchLine = `## main...${remoteBaseBranch}`;
-
-  if (branchLine !== expectedBranchLine) {
-    return {
-      gate: 'repo_sync',
-      status: 'BLOCK',
-      summary: `Canonical checkout is not aligned with ${remoteBaseBranch}: ${branchLine || 'missing branch status'}`,
-    };
-  }
-
-  if (fileChanges.length > 0) {
-    return {
-      gate: 'repo_sync',
-      status: 'BLOCK',
-      summary: 'Canonical checkout is dirty and cannot be treated as a trusted starting point.',
-    };
-  }
-
-  return {
-    gate: 'repo_sync',
-    status: 'PASS',
-    summary: `Canonical checkout is clean and aligned with ${remoteBaseBranch}.`,
-  };
-}
-
-async function readState(projectPath?: string): Promise<any | null> {
+async function readProjectYaml(projectPath?: string): Promise<any | null> {
   if (!projectPath) return null;
 
   try {
-    return yaml.parse(await readFile(join(projectPath, '.context', 'state.yaml'), 'utf-8')) || {};
+    return yaml.parse(await readFile(join(projectPath, '.project.yaml'), 'utf-8')) || {};
+  } catch {
+    return null;
+  }
+}
+
+function resolveRuntimeManagedEntries(projectYaml: any | null): string[] {
+  if (!projectYaml) {
+    return ['CLAUDE.md', 'AGENTS.md'];
+  }
+
+  const contextPaths = resolveManagedProjectContextDisplayPaths(projectYaml);
+  const toRelative = (path: string, options?: { directory?: boolean }): string => {
+    const normalized = path.replace(/\\/g, '/').replace(/^\.\/+/, '');
+    return options?.directory && !normalized.endsWith('/') ? `${normalized}/` : normalized;
+  };
+
+  return [
+    toRelative(contextPaths.quickStartPath),
+    toRelative(contextPaths.statePath),
+    toRelative(contextPaths.markerPath),
+    toRelative(contextPaths.conversationsDir, { directory: true }),
+    'CLAUDE.md',
+    'AGENTS.md',
+  ];
+}
+
+async function readState(projectPath?: string, projectYaml?: any | null): Promise<any | null> {
+  if (!projectPath) return null;
+
+  try {
+    const statePath = projectYaml
+      ? resolveManagedProjectContextPaths(projectPath, projectYaml).statePath
+      : join(projectPath, '.context', 'state.yaml');
+    return yaml.parse(await readFile(statePath, 'utf-8')) || {};
   } catch {
     return null;
   }
@@ -173,11 +182,21 @@ export async function runHealthCheck(args: HealthArgs): Promise<HealthResult> {
   const checkoutRole = args.checkout_role || 'canonical';
   const checkedAt = new Date().toISOString();
 
-  const repoStatus = await execCommand(`git -C "${args.repo_path}" status --short --branch`);
-  const state = await readState(args.project_path);
+  const repoStatus = await execCommand(`git -C "${args.repo_path}" status --short --branch --untracked-files=all`);
+  const projectYaml = await readProjectYaml(args.project_path);
+  const state = await readState(args.project_path, projectYaml);
+  const repoSync = analyzeCanonicalRepoSync({
+    statusOutput: repoStatus,
+    remoteBaseBranch,
+    runtimeManagedEntries: resolveRuntimeManagedEntries(projectYaml),
+  });
 
   const gates: HealthGate[] = [
-    parseRepoSyncGate(repoStatus, remoteBaseBranch),
+    {
+      gate: 'repo_sync',
+      status: repoSync.status,
+      summary: repoSync.summary,
+    },
     buildEntrySurfaceGate(state),
     buildGuardrailGate(state),
   ];
@@ -196,5 +215,7 @@ export async function runHealthCheck(args: HealthArgs): Promise<HealthResult> {
     checkout_role: checkoutRole,
     checked_at: checkedAt,
     gates,
+    repo_sync: repoSync.details,
+    recovery_actions: repoSync.recovery_actions,
   };
 }


### PR DESCRIPTION
## Summary
- block `agenticos_record` from writing runtime state into canonical `main` checkouts
- add structured canonical checkout sync analysis for branch misalignment, runtime-only drift, and source-tree edits
- upgrade `agenticos_health` to respect configured `agent_context.current_state` and return recovery actions

## Verification
- `npm run lint`
- `npm test`
- `npx vitest run src/utils/__tests__/canonical-checkout-sync.test.ts --coverage --coverage.include=src/utils/canonical-checkout-sync.ts`
  - `canonical-checkout-sync.ts`: 100% statements / 100% branches / 100% functions / 100% lines

Closes #284
