### PR TITLE
feat: add canonical checkout sync helper

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -384,6 +384,18 @@ Evaluate whether a canonical checkout and project context are fresh enough to tr
 
 **Returns**: JSON with overall `PASS`, `WARN`, or `BLOCK`
 
+### agenticos_canonical_sync
+Plan, snapshot, or prepare runtime-managed cleanup for a canonical checkout before manual branch resync.
+
+**Parameters**:
+- `repo_path` (required)
+- `action` (optional: `plan`, `snapshot`, or `prepare`; default `plan`)
+- `project_path` (optional)
+- `remote_base_branch` (optional, default `origin/main`)
+- `snapshot_label` (optional)
+
+**Returns**: JSON with current repo-sync status plus optional snapshot / cleanup details
+
 ### agenticos_refresh_entry_surfaces
 Deterministically refresh the configured quick-start and state paths from structured merged-work inputs, honoring `.project.yaml.agent_context` when present and defaulting to root `.context/*` otherwise.
 

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -16,7 +16,7 @@ import {
   ListResourcesRequestSchema,
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { initProject, switchProject, listProjects, getStatus, saveState, recordSession, runPreflight, runIssueBootstrap, runBranchBootstrap, runPrScopeCheck, runHealth, runConfig, runEditGuard, runEntrySurfaceRefresh, runStandardKitAdopt, runStandardKitUpgradeCheck, runStandardKitConformanceCheck, runNonCodeEvaluate, runArchiveImportEvaluate, runRecordCase, runListCases } from './tools/index.js';
+import { initProject, switchProject, listProjects, getStatus, saveState, recordSession, runPreflight, runIssueBootstrap, runBranchBootstrap, runPrScopeCheck, runHealth, runCanonicalSync, runConfig, runEditGuard, runEntrySurfaceRefresh, runStandardKitAdopt, runStandardKitUpgradeCheck, runStandardKitConformanceCheck, runNonCodeEvaluate, runArchiveImportEvaluate, runRecordCase, runListCases } from './tools/index.js';
 import { getProjectContext } from './resources/index.js';
 import { isDirectExecution, resolveCliPrelude } from './utils/mcp-server-cli.js';
 
@@ -301,6 +301,21 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
       },
     },
     {
+      name: 'agenticos_canonical_sync',
+      description: 'Plan, snapshot, or prepare runtime-managed cleanup for a canonical checkout before manual branch resync.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          action: { type: 'string', enum: ['plan', 'snapshot', 'prepare'], description: 'Whether to inspect, snapshot, or snapshot-and-clean runtime drift.' },
+          repo_path: { type: 'string', description: 'Absolute repository checkout path to evaluate.' },
+          project_path: { type: 'string', description: 'Optional absolute project path whose .project.yaml defines runtime-managed entries.' },
+          remote_base_branch: { type: 'string', description: 'Remote base branch expected for canonical checkout freshness (default: origin/main).' },
+          snapshot_label: { type: 'string', description: 'Optional label appended to the created snapshot directory.' },
+        },
+        required: ['repo_path'],
+      },
+    },
+    {
       name: 'agenticos_refresh_entry_surfaces',
       description: 'Deterministically refresh the configured quick-start and state paths from structured merged-work inputs, honoring .project.yaml agent_context when present.',
       inputSchema: {
@@ -429,6 +444,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       return { content: [{ type: 'text', text: await runPrScopeCheck(args ?? {}) }] };
     case 'agenticos_health':
       return { content: [{ type: 'text', text: await runHealth(args ?? {}) }] };
+    case 'agenticos_canonical_sync':
+      return { content: [{ type: 'text', text: await runCanonicalSync(args ?? {}) }] };
     case 'agenticos_refresh_entry_surfaces':
       return { content: [{ type: 'text', text: await runEntrySurfaceRefresh(args ?? {}) }] };
     case 'agenticos_standard_kit_adopt':

--- a/mcp-server/src/tools/__tests__/canonical-sync.test.ts
+++ b/mcp-server/src/tools/__tests__/canonical-sync.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const canonicalSyncMock = vi.hoisted(() => ({
+  runCanonicalSync: vi.fn(),
+}));
+
+vi.mock('../../utils/canonical-sync.js', () => ({
+  runCanonicalSync: canonicalSyncMock.runCanonicalSync,
+}));
+
+import { runCanonicalSync } from '../canonical-sync.js';
+
+describe('runCanonicalSync tool wrapper', () => {
+  it('serializes the utility result as formatted JSON', async () => {
+    canonicalSyncMock.runCanonicalSync.mockResolvedValue({
+      command: 'agenticos_canonical_sync',
+      action: 'plan',
+      status: 'PASS',
+    });
+
+    const result = await runCanonicalSync({ action: 'plan', repo_path: '/repo' });
+
+    expect(canonicalSyncMock.runCanonicalSync).toHaveBeenCalledWith({ action: 'plan', repo_path: '/repo' });
+    expect(JSON.parse(result)).toEqual({
+      command: 'agenticos_canonical_sync',
+      action: 'plan',
+      status: 'PASS',
+    });
+  });
+
+  it('normalizes missing args to an empty object', async () => {
+    canonicalSyncMock.runCanonicalSync.mockResolvedValue({
+      command: 'agenticos_canonical_sync',
+      action: 'plan',
+      status: 'PASS',
+    });
+
+    await runCanonicalSync(undefined);
+
+    expect(canonicalSyncMock.runCanonicalSync).toHaveBeenCalledWith({});
+  });
+});

--- a/mcp-server/src/tools/canonical-sync.ts
+++ b/mcp-server/src/tools/canonical-sync.ts
@@ -1,0 +1,6 @@
+import { runCanonicalSync as runCanonicalSyncOperation } from '../utils/canonical-sync.js';
+
+export async function runCanonicalSync(args: any): Promise<string> {
+  const result = await runCanonicalSyncOperation(args ?? {});
+  return JSON.stringify(result, null, 2);
+}

--- a/mcp-server/src/tools/index.ts
+++ b/mcp-server/src/tools/index.ts
@@ -7,6 +7,7 @@ export { runIssueBootstrap } from './issue-bootstrap.js';
 export { runBranchBootstrap } from './branch-bootstrap.js';
 export { runPrScopeCheck } from './pr-scope-check.js';
 export { runHealth } from './health.js';
+export { runCanonicalSync } from './canonical-sync.js';
 export { runConfig } from './config.js';
 export { runEditGuard } from './edit-guard.js';
 export { runEntrySurfaceRefresh } from './entry-surface-refresh.js';

--- a/mcp-server/src/utils/__tests__/canonical-sync.test.ts
+++ b/mcp-server/src/utils/__tests__/canonical-sync.test.ts
@@ -1,0 +1,460 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const childProcessMock = vi.hoisted(() => ({
+  execFile: vi.fn(),
+}));
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return {
+    ...actual,
+    execFile: childProcessMock.execFile,
+  };
+});
+
+import { resolveRuntimeManagedEntries, runCanonicalSync } from '../canonical-sync.js';
+
+function mockExecFileImplementation(handlers: Array<(args: string[]) => { stdout?: string; stderr?: string; error?: Error | null }>) {
+  childProcessMock.execFile.mockImplementation((_file: string, args: string[], _options: unknown, cb: Function) => {
+    const handler = handlers.shift();
+    if (!handler) {
+      cb(new Error(`unexpected execFile call: ${args.join(' ')}`));
+      return;
+    }
+    const result = handler(args);
+    if (result.error) {
+      cb(Object.assign(result.error, { stdout: result.stdout || '', stderr: result.stderr || '' }));
+      return;
+    }
+    cb(null, result.stdout || '', result.stderr || '');
+  });
+}
+
+async function setupProjectRoot(): Promise<{ home: string; projectRoot: string }> {
+  const home = await mkdtemp(join(tmpdir(), 'agenticos-canonical-sync-home-'));
+  const projectRoot = join(home, 'projects', 'agenticos');
+  await mkdir(join(projectRoot, 'standards', '.context', 'conversations'), { recursive: true });
+  await writeFile(join(projectRoot, '.project.yaml'), `meta:\n  id: "agenticos"\n  name: "AgenticOS"\nsource_control:\n  topology: "github_versioned"\n  context_publication_policy: "public_distilled"\nagent_context:\n  quick_start: "standards/.context/quick-start.md"\n  current_state: "standards/.context/state.yaml"\n  conversations: "standards/.context/conversations/"\n  last_record_marker: "standards/.context/.last_record"\n`, 'utf-8');
+  await writeFile(join(projectRoot, 'CLAUDE.md'), 'runtime note\n', 'utf-8');
+  await writeFile(join(projectRoot, 'README.md'), 'source file\n', 'utf-8');
+  await writeFile(join(projectRoot, 'standards', '.context', 'state.yaml'), 'state: dirty\n', 'utf-8');
+  await writeFile(join(projectRoot, 'standards', '.context', 'conversations', '2026-04-14.md'), 'conversation\n', 'utf-8');
+  return { home, projectRoot };
+}
+
+describe('runCanonicalSync', () => {
+  beforeEach(() => {
+    childProcessMock.execFile.mockReset();
+  });
+
+  afterEach(() => {
+    delete process.env.AGENTICOS_HOME;
+  });
+
+  it('resolves runtime-managed entries from configured agent context paths', () => {
+    expect(resolveRuntimeManagedEntries(null)).toEqual(['CLAUDE.md', 'AGENTS.md']);
+    expect(resolveRuntimeManagedEntries({
+      agent_context: {
+        quick_start: './standards/.context/quick-start.md',
+        current_state: './standards/.context/state.yaml',
+        conversations: './standards/.context/conversations',
+        last_record_marker: './standards/.context/.last_record',
+      },
+    })).toEqual([
+      'standards/.context/quick-start.md',
+      'standards/.context/state.yaml',
+      'standards/.context/.last_record',
+      'standards/.context/conversations/',
+      'CLAUDE.md',
+      'AGENTS.md',
+    ]);
+    expect(resolveRuntimeManagedEntries({
+      agent_context: {
+        conversations: 'standards/.context/conversations/',
+      },
+    })).toContain('standards/.context/conversations/');
+  });
+
+  it('returns a plan showing runtime drift and blocked prepare when source edits are present', async () => {
+    const { home, projectRoot } = await setupProjectRoot();
+    process.env.AGENTICOS_HOME = home;
+
+    mockExecFileImplementation([
+      () => ({
+        stdout: '## main...origin/main [behind 2]\n M standards/.context/state.yaml\n M README.md\n?? standards/.context/conversations/2026-04-14.md\n',
+      }),
+    ]);
+
+    const result = await runCanonicalSync({
+      action: 'plan',
+      repo_path: projectRoot,
+      project_path: projectRoot,
+    });
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.prepare_allowed).toBe(false);
+    expect(result.snapshot_recommended).toBe(true);
+    expect(result.repo_sync.runtime_dirty_paths).toEqual([
+      'standards/.context/state.yaml',
+      'standards/.context/conversations/2026-04-14.md',
+    ]);
+    expect(result.repo_sync.source_dirty_paths).toEqual(['README.md']);
+    expect(result.next_steps[0]).toContain('action "snapshot"');
+  });
+
+  it('defaults to a plan action and summarizes prepare-allowed runtime drift', async () => {
+    const { home, projectRoot } = await setupProjectRoot();
+    process.env.AGENTICOS_HOME = home;
+
+    mockExecFileImplementation([
+      () => ({
+        stdout: '## main...origin/main\n M standards/.context/state.yaml\n',
+      }),
+    ]);
+
+    const result = await runCanonicalSync({
+      repo_path: projectRoot,
+      project_path: projectRoot,
+    });
+
+    expect(result.action).toBe('plan');
+    expect(result.status).toBe('BLOCK');
+    expect(result.prepare_allowed).toBe(true);
+    expect(result.summary).toContain('can be cleaned safely');
+    expect(result.next_steps[0]).toContain('action "prepare"');
+  });
+
+  it('returns the underlying health summary for a clean plan with no runtime drift', async () => {
+    const { home, projectRoot } = await setupProjectRoot();
+    process.env.AGENTICOS_HOME = home;
+
+    mockExecFileImplementation([
+      () => ({
+        stdout: '## main...origin/main\n',
+      }),
+    ]);
+
+    const result = await runCanonicalSync({
+      action: 'plan',
+      repo_path: projectRoot,
+      project_path: projectRoot,
+    });
+
+    expect(result.status).toBe('PASS');
+    expect(result.summary).toBe('Canonical checkout is clean and aligned with origin/main.');
+    expect(result.next_steps).toEqual([]);
+  });
+
+  it('creates a runtime drift snapshot without mutating the checkout', async () => {
+    const { home, projectRoot } = await setupProjectRoot();
+    process.env.AGENTICOS_HOME = home;
+
+    mockExecFileImplementation([
+      () => ({
+        stdout: '## main...origin/main\n M standards/.context/state.yaml\n?? standards/.context/conversations/2026-04-14.md\n',
+      }),
+    ]);
+
+    const result = await runCanonicalSync({
+      action: 'snapshot',
+      repo_path: projectRoot,
+      project_path: projectRoot,
+      snapshot_label: 'Pre Pull',
+    });
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.summary).toContain('snapshot was created');
+    expect(result.snapshot?.preserved_paths).toEqual([
+      'standards/.context/state.yaml',
+      'standards/.context/conversations/2026-04-14.md',
+    ]);
+
+    const manifest = JSON.parse(await readFile(result.snapshot!.manifest_path, 'utf-8')) as { runtime_dirty_paths: string[] };
+    expect(manifest.runtime_dirty_paths).toEqual([
+      'standards/.context/state.yaml',
+      'standards/.context/conversations/2026-04-14.md',
+    ]);
+    expect(result.snapshot?.snapshot_root).toContain('pre-pull');
+  });
+
+  it('creates no snapshot when runtime drift is absent and falls back to repo basename metadata', async () => {
+    const { home, projectRoot } = await setupProjectRoot();
+    process.env.AGENTICOS_HOME = home;
+
+    mockExecFileImplementation([
+      () => ({
+        stdout: '## main...origin/main\n',
+      }),
+    ]);
+
+    const result = await runCanonicalSync({
+      action: 'snapshot',
+      repo_path: projectRoot,
+      project_path: join(projectRoot, 'missing-project-root'),
+    });
+
+    expect(result.status).toBe('PASS');
+    expect(result.summary).toContain('no snapshot was needed');
+    expect(result.snapshot).toBeUndefined();
+    expect(result.runtime_managed_entries).toEqual(['CLAUDE.md', 'AGENTS.md']);
+  });
+
+  it('succeeds without project_path and uses repo-path fallback metadata', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'agenticos-canonical-sync-bare-home-'));
+    const repoPath = join(home, 'bare-canonical-checkout');
+    await mkdir(repoPath, { recursive: true });
+    process.env.AGENTICOS_HOME = home;
+
+    mockExecFileImplementation([
+      () => ({
+        stdout: '## main...origin/main\n',
+      }),
+    ]);
+
+    const result = await runCanonicalSync({
+      action: 'snapshot',
+      repo_path: repoPath,
+      snapshot_label: undefined,
+    });
+
+    expect(result.project_path).toBeNull();
+    expect(result.status).toBe('PASS');
+    expect(result.runtime_managed_entries).toEqual(['CLAUDE.md', 'AGENTS.md']);
+    expect(result.summary).toContain('no snapshot was needed');
+  });
+
+  it('treats a null project yaml as an empty object and still completes planning', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'agenticos-canonical-sync-null-yaml-home-'));
+    const repoPath = join(home, 'null-yaml-project');
+    await mkdir(repoPath, { recursive: true });
+    await writeFile(join(repoPath, '.project.yaml'), 'null\n', 'utf-8');
+    process.env.AGENTICOS_HOME = home;
+
+    mockExecFileImplementation([
+      () => ({
+        stdout: '## main...origin/main\n',
+      }),
+    ]);
+
+    const result = await runCanonicalSync({
+      action: 'plan',
+      repo_path: repoPath,
+      project_path: repoPath,
+    });
+
+    expect(result.status).toBe('PASS');
+    expect(result.runtime_managed_entries).toContain('.context/conversations/');
+  });
+
+  it('records missing runtime paths in the snapshot manifest', async () => {
+    const { home, projectRoot } = await setupProjectRoot();
+    process.env.AGENTICOS_HOME = home;
+    await rm(join(projectRoot, 'standards', '.context', 'state.yaml'));
+
+    mockExecFileImplementation([
+      () => ({
+        stdout: '## main...origin/main\n D standards/.context/state.yaml\n',
+      }),
+    ]);
+
+    const result = await runCanonicalSync({
+      action: 'snapshot',
+      repo_path: projectRoot,
+      project_path: projectRoot,
+      snapshot_label: '   ',
+    });
+
+    expect(result.snapshot?.preserved_paths).toEqual([]);
+    expect(result.snapshot?.missing_paths).toEqual(['standards/.context/state.yaml']);
+    expect(result.snapshot?.snapshot_root).toContain('runtime-drift');
+  });
+
+  it('uses the default snapshot label when runtime drift exists and no label is provided', async () => {
+    const { home, projectRoot } = await setupProjectRoot();
+    process.env.AGENTICOS_HOME = home;
+
+    mockExecFileImplementation([
+      () => ({
+        stdout: '## main...origin/main\n M standards/.context/state.yaml\n',
+      }),
+    ]);
+
+    const result = await runCanonicalSync({
+      action: 'snapshot',
+      repo_path: projectRoot,
+      project_path: projectRoot,
+    });
+
+    expect(result.snapshot?.snapshot_root).toContain('runtime-drift');
+    expect(result.snapshot?.preserved_paths).toEqual(['standards/.context/state.yaml']);
+  });
+
+  it('blocks prepare when source-tree edits are still present', async () => {
+    const { home, projectRoot } = await setupProjectRoot();
+    process.env.AGENTICOS_HOME = home;
+
+    mockExecFileImplementation([
+      () => ({
+        stdout: '## main...origin/main\n M standards/.context/state.yaml\n M README.md\n',
+      }),
+    ]);
+
+    const result = await runCanonicalSync({
+      action: 'prepare',
+      repo_path: projectRoot,
+      project_path: projectRoot,
+    });
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.summary).toContain('blocked');
+    expect(result.cleanup).toBeUndefined();
+  });
+
+  it('snapshots and cleans runtime-only drift, then reports the remaining branch misalignment', async () => {
+    const { home, projectRoot } = await setupProjectRoot();
+    process.env.AGENTICOS_HOME = home;
+
+    mockExecFileImplementation([
+      () => ({
+        stdout: '## main...origin/main [behind 1]\n M standards/.context/state.yaml\n?? standards/.context/conversations/2026-04-14.md\n',
+      }),
+      (args) => {
+        expect(args).toEqual(['-C', projectRoot, 'ls-files', '--error-unmatch', '--', 'standards/.context/state.yaml']);
+        return { stdout: 'standards/.context/state.yaml\n' };
+      },
+      (args) => {
+        expect(args).toEqual(['-C', projectRoot, 'restore', '--source=HEAD', '--staged', '--worktree', '--', 'standards/.context/state.yaml']);
+        return { stdout: '' };
+      },
+      (args) => {
+        expect(args).toEqual(['-C', projectRoot, 'ls-files', '--error-unmatch', '--', 'standards/.context/conversations/2026-04-14.md']);
+        return { error: new Error('not tracked') };
+      },
+      () => ({
+        stdout: '## main...origin/main [behind 1]\n',
+      }),
+    ]);
+
+    const result = await runCanonicalSync({
+      action: 'prepare',
+      repo_path: projectRoot,
+      project_path: projectRoot,
+    });
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.cleanup?.cleaned_paths).toEqual([
+      'standards/.context/state.yaml',
+      'standards/.context/conversations/2026-04-14.md',
+    ]);
+    expect(result.repo_sync.runtime_dirty_paths).toEqual([]);
+    expect(result.next_steps[0]).toContain('fast-forward canonical main');
+  });
+
+  it('returns PASS after prepare when cleanup leaves a fully aligned checkout', async () => {
+    const { home, projectRoot } = await setupProjectRoot();
+    process.env.AGENTICOS_HOME = home;
+
+    mockExecFileImplementation([
+      () => ({
+        stdout: '## main...origin/main\n M standards/.context/state.yaml\n',
+      }),
+      () => ({
+        stdout: 'standards/.context/state.yaml\n',
+      }),
+      () => ({
+        stdout: '',
+      }),
+      () => ({
+        stdout: '## main...origin/main\n',
+      }),
+    ]);
+
+    const result = await runCanonicalSync({
+      action: 'prepare',
+      repo_path: projectRoot,
+      project_path: projectRoot,
+      snapshot_label: 'clean',
+    });
+
+    expect(result.status).toBe('PASS');
+    expect(result.summary).toContain('canonical checkout is now clean');
+    expect(result.cleanup?.cleaned_paths).toEqual(['standards/.context/state.yaml']);
+  });
+
+  it('returns PASS for prepare when no runtime drift exists and validates required args', async () => {
+    const { home, projectRoot } = await setupProjectRoot();
+    process.env.AGENTICOS_HOME = home;
+
+    mockExecFileImplementation([
+      () => ({
+        stdout: '## main...origin/main\n',
+      }),
+    ]);
+
+    const result = await runCanonicalSync({
+      action: 'prepare',
+      repo_path: projectRoot,
+      project_path: projectRoot,
+    });
+
+    expect(result.status).toBe('PASS');
+    expect(result.summary).toContain('no cleanup');
+    await expect(() => runCanonicalSync({ action: 'plan' })).rejects.toThrow('repo_path is required.');
+    await expect(() => runCanonicalSync({ action: 'bad' as any, repo_path: projectRoot })).rejects.toThrow('Unsupported action');
+  });
+
+  it('surfaces git failures when the initial status probe cannot run', async () => {
+    const { home, projectRoot } = await setupProjectRoot();
+    process.env.AGENTICOS_HOME = home;
+
+    mockExecFileImplementation([
+      () => ({
+        error: new Error('fatal: not a git repository'),
+        stderr: 'fatal: not a git repository',
+      }),
+    ]);
+
+    await expect(() => runCanonicalSync({
+      action: 'plan',
+      repo_path: projectRoot,
+      project_path: projectRoot,
+    })).rejects.toThrow('fatal: not a git repository');
+  });
+
+  it('surfaces message-only git failures when stderr and stdout are empty', async () => {
+    const { home, projectRoot } = await setupProjectRoot();
+    process.env.AGENTICOS_HOME = home;
+
+    mockExecFileImplementation([
+      () => ({
+        error: new Error('message only git failure'),
+      }),
+    ]);
+
+    await expect(() => runCanonicalSync({
+      action: 'plan',
+      repo_path: projectRoot,
+      project_path: projectRoot,
+    })).rejects.toThrow('message only git failure');
+  });
+
+  it('falls back to a synthesized git command error when no failure detail is available', async () => {
+    const { home, projectRoot } = await setupProjectRoot();
+    process.env.AGENTICOS_HOME = home;
+
+    mockExecFileImplementation([
+      () => ({
+        error: { message: '' } as Error,
+      }),
+    ]);
+
+    await expect(() => runCanonicalSync({
+      action: 'plan',
+      repo_path: projectRoot,
+      project_path: projectRoot,
+    })).rejects.toThrow('git status --short --branch --untracked-files=all failed');
+  });
+});

--- a/mcp-server/src/utils/canonical-sync.ts
+++ b/mcp-server/src/utils/canonical-sync.ts
@@ -1,0 +1,436 @@
+import { execFile } from 'child_process';
+import { access, cp, mkdir, readFile, rm, writeFile } from 'fs/promises';
+import { basename, dirname, join } from 'path';
+import yaml from 'yaml';
+import { resolveManagedProjectContextDisplayPaths } from './agent-context-paths.js';
+import { analyzeCanonicalRepoSync, type CanonicalRepoSyncAnalysis, type CanonicalRepoSyncDetails } from './canonical-checkout-sync.js';
+import { getAgenticOSHome } from './registry.js';
+
+export type CanonicalSyncAction = 'plan' | 'snapshot' | 'prepare';
+
+export interface CanonicalSyncArgs {
+  action?: CanonicalSyncAction;
+  repo_path?: string;
+  project_path?: string;
+  remote_base_branch?: string;
+  snapshot_label?: string;
+}
+
+export interface CanonicalSyncSnapshot {
+  snapshot_root: string;
+  manifest_path: string;
+  preserved_paths: string[];
+  missing_paths: string[];
+}
+
+export interface CanonicalSyncCleanup {
+  cleaned_paths: string[];
+}
+
+export interface CanonicalSyncResult {
+  command: 'agenticos_canonical_sync';
+  action: CanonicalSyncAction;
+  status: 'PASS' | 'BLOCK';
+  summary: string;
+  repo_path: string;
+  project_path: string | null;
+  remote_base_branch: string;
+  checked_at: string;
+  prepare_allowed: boolean;
+  snapshot_recommended: boolean;
+  runtime_managed_entries: string[];
+  repo_sync: CanonicalRepoSyncDetails;
+  recovery_actions: string[];
+  next_steps: string[];
+  snapshot?: CanonicalSyncSnapshot;
+  cleanup?: CanonicalSyncCleanup;
+}
+
+interface ExecFileResult {
+  stdout: string;
+  stderr: string;
+}
+
+async function execGit(repoPath: string, args: string[], options?: { allowFailure?: boolean }): Promise<ExecFileResult & { ok: boolean }> {
+  try {
+    const result = await new Promise<ExecFileResult>((resolve, reject) => {
+      execFile('git', ['-C', repoPath, ...args], { encoding: 'utf-8' }, (error, stdout, stderr) => {
+        if (error) {
+          reject(Object.assign(error, { stdout, stderr }));
+          return;
+        }
+        resolve({
+          stdout: String(stdout || ''),
+          stderr: String(stderr || ''),
+        });
+      });
+    });
+    return {
+      ok: true,
+      stdout: result.stdout.trimEnd(),
+      stderr: result.stderr.trimEnd(),
+    };
+  } catch (error: any) {
+    const failure = {
+      ok: false,
+      stdout: String(error?.stdout || '').trimEnd(),
+      stderr: String(error?.stderr || '').trimEnd(),
+    };
+    if (options?.allowFailure) {
+      return failure;
+    }
+    throw new Error(failure.stderr || failure.stdout || error?.message || `git ${args.join(' ')} failed`);
+  }
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readProjectYaml(projectPath?: string): Promise<any | null> {
+  if (!projectPath) return null;
+
+  try {
+    return yaml.parse(await readFile(join(projectPath, '.project.yaml'), 'utf-8')) || {};
+  } catch {
+    return null;
+  }
+}
+
+export function resolveRuntimeManagedEntries(projectYaml: any | null): string[] {
+  if (!projectYaml) {
+    return ['CLAUDE.md', 'AGENTS.md'];
+  }
+
+  const contextPaths = resolveManagedProjectContextDisplayPaths(projectYaml);
+  const normalize = (path: string, options?: { directory?: boolean }): string => {
+    const normalized = path.replace(/\\/g, '/').replace(/^\.\/+/, '');
+    return options?.directory ? `${normalized.replace(/\/+$/, '')}/` : normalized;
+  };
+
+  return [
+    normalize(contextPaths.quickStartPath),
+    normalize(contextPaths.statePath),
+    normalize(contextPaths.markerPath),
+    normalize(contextPaths.conversationsDir, { directory: true }),
+    'CLAUDE.md',
+    'AGENTS.md',
+  ];
+}
+
+function resolveProjectId(projectYaml: any | null, projectPath: string | undefined, repoPath: string): string {
+  const configuredId = projectYaml?.meta?.id;
+  if (typeof configuredId === 'string' && configuredId.trim().length > 0) {
+    return configuredId.trim();
+  }
+  return basename(projectPath || repoPath);
+}
+
+async function inspectCanonicalCheckout(args: {
+  repoPath: string;
+  projectPath?: string;
+  remoteBaseBranch: string;
+}): Promise<{
+  projectYaml: any | null;
+  runtimeManagedEntries: string[];
+  analysis: CanonicalRepoSyncAnalysis;
+}> {
+  const statusResult = await execGit(args.repoPath, ['status', '--short', '--branch', '--untracked-files=all']);
+  const projectYaml = await readProjectYaml(args.projectPath);
+  const runtimeManagedEntries = resolveRuntimeManagedEntries(projectYaml);
+  const analysis = analyzeCanonicalRepoSync({
+    statusOutput: statusResult.stdout,
+    remoteBaseBranch: args.remoteBaseBranch,
+    runtimeManagedEntries,
+  });
+
+  return {
+    projectYaml,
+    runtimeManagedEntries,
+    analysis,
+  };
+}
+
+function sanitizeSnapshotLabel(label?: string): string {
+  const fallback = 'runtime-drift';
+  const normalized = String(label || fallback)
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return normalized || fallback;
+}
+
+function buildSnapshotRoot(projectId: string, checkedAt: string, snapshotLabel?: string): string {
+  const home = getAgenticOSHome();
+  const stamp = checkedAt.replace(/[:.]/g, '-');
+  return join(
+    home,
+    '.agent-workspace',
+    'canonical-sync-snapshots',
+    projectId,
+    `${stamp}-${sanitizeSnapshotLabel(snapshotLabel)}`,
+  );
+}
+
+async function createSnapshot(args: {
+  repoPath: string;
+  projectId: string;
+  runtimeDirtyPaths: string[];
+  analysis: CanonicalRepoSyncAnalysis;
+  checkedAt: string;
+  snapshotLabel?: string;
+}): Promise<CanonicalSyncSnapshot> {
+  const snapshotRoot = buildSnapshotRoot(args.projectId, args.checkedAt, args.snapshotLabel);
+  const filesRoot = join(snapshotRoot, 'files');
+  const preservedPaths: string[] = [];
+  const missingPaths: string[] = [];
+
+  await mkdir(filesRoot, { recursive: true });
+
+  for (const relativePath of args.runtimeDirtyPaths) {
+    const sourcePath = join(args.repoPath, relativePath);
+    if (!(await pathExists(sourcePath))) {
+      missingPaths.push(relativePath);
+      continue;
+    }
+
+    const targetPath = join(filesRoot, relativePath);
+    await mkdir(dirname(targetPath), { recursive: true });
+    await cp(sourcePath, targetPath, { recursive: true });
+    preservedPaths.push(relativePath);
+  }
+
+  const manifestPath = join(snapshotRoot, 'manifest.json');
+  await writeFile(
+    manifestPath,
+    JSON.stringify({
+      captured_at: args.checkedAt,
+      repo_path: args.repoPath,
+      branch_line: args.analysis.details.branch_line,
+      branch_status: args.analysis.details.branch_status,
+      dirty_paths: args.analysis.details.dirty_paths,
+      runtime_dirty_paths: args.analysis.details.runtime_dirty_paths,
+      source_dirty_paths: args.analysis.details.source_dirty_paths,
+      preserved_paths: preservedPaths,
+      missing_paths: missingPaths,
+    }, null, 2),
+    'utf-8',
+  );
+
+  return {
+    snapshot_root: snapshotRoot,
+    manifest_path: manifestPath,
+    preserved_paths: preservedPaths,
+    missing_paths: missingPaths,
+  };
+}
+
+async function cleanupRuntimeDrift(repoPath: string, runtimeDirtyPaths: string[]): Promise<CanonicalSyncCleanup> {
+  const cleanedPaths: string[] = [];
+
+  for (const relativePath of runtimeDirtyPaths) {
+    const trackedProbe = await execGit(repoPath, ['ls-files', '--error-unmatch', '--', relativePath], { allowFailure: true });
+    if (trackedProbe.ok) {
+      await execGit(repoPath, ['restore', '--source=HEAD', '--staged', '--worktree', '--', relativePath]);
+    } else {
+      await rm(join(repoPath, relativePath), { recursive: true, force: true });
+    }
+    cleanedPaths.push(relativePath);
+  }
+
+  return {
+    cleaned_paths: cleanedPaths,
+  };
+}
+
+function canPrepare(analysis: CanonicalRepoSyncAnalysis): boolean {
+  return analysis.details.source_dirty_paths.length === 0 && analysis.details.branch_status !== 'not_on_main';
+}
+
+function buildNextSteps(args: {
+  action: CanonicalSyncAction;
+  analysis: CanonicalRepoSyncAnalysis;
+  prepareAllowed: boolean;
+  runtimeDirtyPaths: string[];
+}): string[] {
+  const nextSteps = [...args.analysis.recovery_actions];
+
+  if (args.runtimeDirtyPaths.length === 0) {
+    return nextSteps;
+  }
+
+  if (args.action === 'plan' || args.action === 'snapshot') {
+    if (args.prepareAllowed) {
+      nextSteps.unshift('run agenticos_canonical_sync with action "prepare" to snapshot and clean runtime-managed drift');
+    } else {
+      nextSteps.unshift('run agenticos_canonical_sync with action "snapshot" to preserve runtime-managed drift before manual cleanup');
+    }
+  }
+
+  return Array.from(new Set(nextSteps));
+}
+
+function summarizePlan(analysis: CanonicalRepoSyncAnalysis, prepareAllowed: boolean): string {
+  if (analysis.details.runtime_dirty_paths.length === 0) {
+    return analysis.summary;
+  }
+
+  if (prepareAllowed) {
+    return 'Runtime-managed drift is present and can be cleaned safely after a preserved snapshot.';
+  }
+
+  return 'Runtime-managed drift is present, but automatic prepare is blocked until source edits are resolved or the checkout returns to main.';
+}
+
+export async function runCanonicalSync(args: CanonicalSyncArgs): Promise<CanonicalSyncResult> {
+  const action = args.action || 'plan';
+  if (!args.repo_path) {
+    throw new Error('repo_path is required.');
+  }
+
+  if (!['plan', 'snapshot', 'prepare'].includes(action)) {
+    throw new Error(`Unsupported action "${String(action)}".`);
+  }
+
+  const repoPath = args.repo_path;
+  const projectPath = args.project_path;
+  const remoteBaseBranch = args.remote_base_branch || 'origin/main';
+  const checkedAt = new Date().toISOString();
+
+  const initial = await inspectCanonicalCheckout({
+    repoPath,
+    projectPath,
+    remoteBaseBranch,
+  });
+  const prepareAllowed = canPrepare(initial.analysis);
+  const projectId = resolveProjectId(initial.projectYaml, projectPath, repoPath);
+
+  const baseResult = {
+    command: 'agenticos_canonical_sync' as const,
+    action,
+    repo_path: repoPath,
+    project_path: projectPath || null,
+    remote_base_branch: remoteBaseBranch,
+    checked_at: checkedAt,
+    prepare_allowed: prepareAllowed,
+    snapshot_recommended: initial.analysis.details.runtime_dirty_paths.length > 0,
+    runtime_managed_entries: initial.runtimeManagedEntries,
+  };
+
+  if (action === 'plan') {
+    return {
+      ...baseResult,
+      status: initial.analysis.status,
+      summary: summarizePlan(initial.analysis, prepareAllowed),
+      repo_sync: initial.analysis.details,
+      recovery_actions: initial.analysis.recovery_actions,
+      next_steps: buildNextSteps({
+        action,
+        analysis: initial.analysis,
+        prepareAllowed,
+        runtimeDirtyPaths: initial.analysis.details.runtime_dirty_paths,
+      }),
+    };
+  }
+
+  if (action === 'snapshot') {
+    const snapshot = initial.analysis.details.runtime_dirty_paths.length > 0
+      ? await createSnapshot({
+          repoPath,
+          projectId,
+          runtimeDirtyPaths: initial.analysis.details.runtime_dirty_paths,
+          analysis: initial.analysis,
+          checkedAt,
+          snapshotLabel: args.snapshot_label,
+        })
+      : undefined;
+
+    return {
+      ...baseResult,
+      status: initial.analysis.status,
+      summary: snapshot
+        ? 'Runtime-managed drift snapshot was created without mutating the checkout.'
+        : 'No runtime-managed drift was present, so no snapshot was needed.',
+      repo_sync: initial.analysis.details,
+      recovery_actions: initial.analysis.recovery_actions,
+      next_steps: buildNextSteps({
+        action,
+        analysis: initial.analysis,
+        prepareAllowed,
+        runtimeDirtyPaths: initial.analysis.details.runtime_dirty_paths,
+      }),
+      snapshot,
+    };
+  }
+
+  if (!prepareAllowed) {
+    return {
+      ...baseResult,
+      status: 'BLOCK',
+      summary: 'Automatic prepare is blocked because the checkout still has source-tree edits or is not on main.',
+      repo_sync: initial.analysis.details,
+      recovery_actions: initial.analysis.recovery_actions,
+      next_steps: buildNextSteps({
+        action,
+        analysis: initial.analysis,
+        prepareAllowed,
+        runtimeDirtyPaths: initial.analysis.details.runtime_dirty_paths,
+      }),
+    };
+  }
+
+  if (initial.analysis.details.runtime_dirty_paths.length === 0) {
+    return {
+      ...baseResult,
+      status: initial.analysis.status,
+      summary: 'No runtime-managed drift was present, so prepare performed no cleanup.',
+      repo_sync: initial.analysis.details,
+      recovery_actions: initial.analysis.recovery_actions,
+      next_steps: buildNextSteps({
+        action,
+        analysis: initial.analysis,
+        prepareAllowed,
+        runtimeDirtyPaths: initial.analysis.details.runtime_dirty_paths,
+      }),
+    };
+  }
+
+  const snapshot = await createSnapshot({
+    repoPath,
+    projectId,
+    runtimeDirtyPaths: initial.analysis.details.runtime_dirty_paths,
+    analysis: initial.analysis,
+    checkedAt,
+    snapshotLabel: args.snapshot_label || 'prepare',
+  });
+  const cleanup = await cleanupRuntimeDrift(repoPath, initial.analysis.details.runtime_dirty_paths);
+  const postCleanup = await inspectCanonicalCheckout({
+    repoPath,
+    projectPath,
+    remoteBaseBranch,
+  });
+
+  return {
+    ...baseResult,
+    status: postCleanup.analysis.status,
+    summary: postCleanup.analysis.status === 'PASS'
+      ? `Runtime-managed drift was snapshot to ${snapshot.snapshot_root} and the canonical checkout is now clean.`
+      : 'Runtime-managed drift was snapshot and cleaned, but the canonical checkout still needs manual branch resync.',
+    repo_sync: postCleanup.analysis.details,
+    recovery_actions: postCleanup.analysis.recovery_actions,
+    next_steps: buildNextSteps({
+      action,
+      analysis: postCleanup.analysis,
+      prepareAllowed: canPrepare(postCleanup.analysis),
+      runtimeDirtyPaths: postCleanup.analysis.details.runtime_dirty_paths,
+    }),
+    snapshot,
+    cleanup,
+  };
+}


### PR DESCRIPTION
## Summary
- add `agenticos_canonical_sync` with `plan`, `snapshot`, and `prepare` actions for canonical checkout runtime drift cleanup
- preserve runtime-managed drift under `AGENTICOS_HOME/.agent-workspace/canonical-sync-snapshots/...` before any cleanup
- register the tool in MCP, document it in the README, and add focused tests with 100% coverage for the new tool/util surfaces

## Verification
- `npm run lint`
- `npm test`
- `npx vitest run src/utils/__tests__/canonical-sync.test.ts src/tools/__tests__/canonical-sync.test.ts --coverage --coverage.include=src/utils/canonical-sync.ts --coverage.include=src/tools/canonical-sync.ts`
