### PR TITLE
fix(#288): surface stale versioned entry-state freshness

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -384,6 +384,9 @@ Evaluate whether a canonical checkout and project context are fresh enough to tr
 
 **Returns**: JSON with overall `PASS`, `WARN`, or `BLOCK`
 
+For `github_versioned` projects, the health result also distinguishes stale
+committed entry-surface state from canonical checkout runtime drift.
+
 ### agenticos_canonical_sync
 Plan, snapshot, or prepare runtime-managed cleanup for a canonical checkout before manual branch resync.
 

--- a/mcp-server/src/tools/__tests__/project.test.ts
+++ b/mcp-server/src/tools/__tests__/project.test.ts
@@ -47,6 +47,7 @@ vi.mock('../../utils/distill.js', () => ({
 import { switchProject, listProjects, getStatus } from '../project.js';
 import * as fsPromises from 'fs/promises';
 import * as registry from '../../utils/registry.js';
+import * as distill from '../../utils/distill.js';
 import * as fs from 'fs';
 import { bindSessionProject, clearSessionProjectBinding } from '../../utils/session-context.js';
 
@@ -57,6 +58,9 @@ const fsPromisesMock = fsPromises as typeof fsPromises & {
 const registryMock = registry as typeof registry & {
   loadRegistry: ReturnType<typeof vi.fn>;
   patchProjectMetadata: ReturnType<typeof vi.fn>;
+};
+const distillMock = distill as typeof distill & {
+  extractTemplateVersion: ReturnType<typeof vi.fn>;
 };
 const fsMock = fs as typeof fs & { existsSync: ReturnType<typeof vi.fn> };
 
@@ -245,6 +249,65 @@ describe('switchProject', () => {
     const writeCalls = fsPromisesMock.writeFile.mock.calls;
     const claudeMdCall = writeCalls.find((c) => c[0].endsWith('CLAUDE.md'));
     expect(claudeMdCall).toBeDefined();
+  });
+
+  it('upgrades stale CLAUDE.md and AGENTS.md templates when both files already exist', async () => {
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: null,
+      projects: [
+        {
+          id: 'my-project',
+          name: 'My Project',
+          path: '/test/path',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    fsMock.existsSync.mockReturnValue(true);
+    distillMock.extractTemplateVersion.mockReturnValue(1);
+    fsPromisesMock.readFile.mockImplementation(async (path: string) => {
+      if (path.endsWith('/.project.yaml')) {
+        return JSON.stringify({
+          meta: { description: '' },
+          source_control: { topology: 'local_directory_only' },
+        });
+      }
+      if (path.endsWith('/.context/state.yaml')) {
+        return JSON.stringify({
+          working_memory: { pending: [], decisions: [] },
+        });
+      }
+      if (path.endsWith('/.context/quick-start.md')) {
+        return '# Quick Start\n\nProject summary';
+      }
+      if (path.endsWith('/CLAUDE.md')) {
+        return '# CLAUDE.md\n\nOld';
+      }
+      if (path.endsWith('/AGENTS.md')) {
+        return '# AGENTS.md\n\nOld';
+      }
+      return '';
+    });
+
+    const result = await switchProject({ project: 'my-project' });
+
+    expect(result).toContain('📝 CLAUDE.md upgraded: v1 → v2 (user content preserved)');
+    expect(result).toContain('📝 AGENTS.md upgraded: v1 → v2');
+    expect(fsPromisesMock.writeFile).toHaveBeenCalledWith(
+      '/test/path/CLAUDE.md',
+      expect.any(String),
+      'utf-8',
+    );
+    expect(fsPromisesMock.writeFile).toHaveBeenCalledWith(
+      '/test/path/AGENTS.md',
+      expect.any(String),
+      'utf-8',
+    );
   });
 
   it('shows a friendly guardrail placeholder in switch output when no evidence exists', async () => {
@@ -453,6 +516,63 @@ describe('switchProject', () => {
     expect(fsPromisesMock.readFile).toHaveBeenCalledWith('/workspace/projects/agenticos/standards/.context/quick-start.md', 'utf-8');
     expect(result).toContain('/workspace/projects/agenticos/standards/.context/quick-start.md');
     expect(result).toContain('/workspace/projects/agenticos/standards/.context/state.yaml');
+  });
+
+  it('marks stale committed github-versioned switch context explicitly', async () => {
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: null,
+      projects: [
+        {
+          id: 'agenticos',
+          name: 'AgenticOS',
+          path: '/workspace/projects/agenticos',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    fsPromisesMock.readFile
+      .mockResolvedValueOnce(JSON.stringify({
+        meta: { description: 'Self-hosting product' },
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'public_distilled',
+          github_repo: 'madlouse/AgenticOS',
+          branch_strategy: 'github_flow',
+        },
+        execution: {
+          source_repo_roots: ['.'],
+        },
+        agent_context: {
+          quick_start: 'standards/.context/quick-start.md',
+          current_state: 'standards/.context/state.yaml',
+        },
+      }))
+      .mockResolvedValueOnce(JSON.stringify({
+        current_task: { title: 'Implement #262 concurrent runtime project resolution', status: 'in_progress' },
+        working_memory: { pending: [], decisions: [] },
+        entry_surface_refresh: { refreshed_at: '2025-01-02T12:00:00.000Z', status: 'in_progress' },
+        issue_bootstrap: {
+          latest: {
+            issue_id: '260',
+            current_branch: 'fix/260-stop-active-project-drift-and-main-state-pollution',
+            workspace_type: 'isolated_worktree',
+            repo_path: '/tmp/worktrees/issue-260',
+          },
+        },
+      }))
+      .mockResolvedValueOnce('# Quick Start\n\nCanonical quick start');
+
+    const result = await switchProject({ project: 'agenticos' });
+
+    expect(result).toContain('⚠️ Committed snapshot: stale for canonical mainline use');
+    expect(result).toContain('🛡️ Latest committed guardrail snapshot: freshness not proven');
+    expect(result).toContain('🧭 Latest committed issue bootstrap snapshot: #260 on fix/260-stop-active-project-drift-and-main-state-pollution');
+    expect(result).toContain('🎯 Current committed task snapshot: Implement #262 concurrent runtime project resolution (in_progress)');
   });
 
   it('falls back to quick-start summary when project description is missing', async () => {
@@ -1032,6 +1152,67 @@ describe('getStatus', () => {
 
     expect(result).toContain('🧭 Latest issue bootstrap: #179 on feat/179-issue-start-bootstrap-evidence');
     expect(result).toContain('Title: Implement bootstrap evidence');
+  });
+
+  it('marks stale committed github-versioned status explicitly', async () => {
+    bindSessionProject({
+      projectId: 'agenticos',
+      projectName: 'AgenticOS',
+      projectPath: '/workspace/projects/agenticos',
+    });
+
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: 'agenticos',
+      projects: [
+        {
+          id: 'agenticos',
+          name: 'AgenticOS',
+          path: '/workspace/projects/agenticos',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    mockStatusReads(
+      {
+        meta: { id: 'agenticos', name: 'AgenticOS' },
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'public_distilled',
+          github_repo: 'madlouse/AgenticOS',
+          branch_strategy: 'github_flow',
+        },
+        execution: {
+          source_repo_roots: ['.'],
+        },
+      },
+      {
+        session: { last_backup: '2025-01-02T12:00:00.000Z', last_entry_surface_refresh: '2025-01-02T12:00:00.000Z' },
+        current_task: { title: 'Implement #262 concurrent runtime project resolution', status: 'in_progress' },
+        working_memory: { pending: [], decisions: [] },
+        entry_surface_refresh: { refreshed_at: '2025-01-02T12:00:00.000Z', status: 'in_progress' },
+        issue_bootstrap: {
+          latest: {
+            issue_id: '260',
+            issue_title: 'Stop active-project drift',
+            current_branch: 'fix/260-stop-active-project-drift-and-main-state-pollution',
+            workspace_type: 'isolated_worktree',
+            repo_path: '/tmp/worktrees/issue-260',
+          },
+        },
+      }
+    );
+
+    const result = await getStatus();
+
+    expect(result).toContain('⚠️ Committed snapshot: stale for canonical mainline use');
+    expect(result).toContain('🛡️ Latest committed guardrail snapshot: freshness not proven');
+    expect(result).toContain('🧭 Latest committed issue bootstrap snapshot: #260 on fix/260-stop-active-project-drift-and-main-state-pollution');
+    expect(result).toContain('🎯 Current committed task snapshot: Implement #262 concurrent runtime project resolution (in_progress)');
   });
 
   it('surfaces the public_distilled transcript contract in status output', async () => {

--- a/mcp-server/src/tools/project.ts
+++ b/mcp-server/src/tools/project.ts
@@ -16,6 +16,10 @@ import {
   resolveConversationRoutingPlan,
 } from '../utils/conversation-routing.js';
 import { bindSessionProject, getSessionProjectBinding } from '../utils/session-context.js';
+import {
+  assessVersionedEntrySurfaceState,
+  type VersionedEntrySurfaceAssessment,
+} from '../utils/versioned-entry-surface-state.js';
 
 type GuardrailCommand = 'agenticos_preflight' | 'agenticos_branch_bootstrap' | 'agenticos_pr_scope_check';
 
@@ -44,6 +48,7 @@ interface GuardrailEvidenceState {
 
 interface IssueBootstrapSummaryInput {
   issueBootstrap?: IssueBootstrapState;
+  committedSnapshotAssessment?: VersionedEntrySurfaceAssessment;
 }
 
 interface SwitchContextSummaryInput {
@@ -51,6 +56,7 @@ interface SwitchContextSummaryInput {
   quickStart?: string;
   state?: any;
   lastRecorded?: string;
+  committedSnapshotAssessment?: VersionedEntrySurfaceAssessment;
 }
 
 function formatTimestamp(value?: string): string | null {
@@ -101,10 +107,38 @@ function summarizeGuardrailDetail(entry: GuardrailEvidenceEntry): string | null 
   return null;
 }
 
-function buildGuardrailSummaryLines(guardrailEvidence?: GuardrailEvidenceState): string[] {
+function usesCommittedSnapshotLabels(assessment?: VersionedEntrySurfaceAssessment): boolean {
+  return Boolean(assessment?.applies && assessment.freshness !== 'fresh');
+}
+
+function buildCommittedSnapshotSummaryLines(assessment?: VersionedEntrySurfaceAssessment): string[] {
+  if (!assessment?.applies || assessment.freshness === 'fresh') {
+    return [];
+  }
+
+  const lines = [
+    assessment.freshness === 'stale'
+      ? '⚠️ Committed snapshot: stale for canonical mainline use'
+      : '⚠️ Committed snapshot: freshness is not proven for canonical mainline use',
+  ];
+
+  for (const reason of assessment.reasons.slice(0, 3)) {
+    lines.push(`   Reason: ${reason}`);
+  }
+
+  return lines;
+}
+
+function buildGuardrailSummaryLines(
+  guardrailEvidence?: GuardrailEvidenceState,
+  committedSnapshotAssessment?: VersionedEntrySurfaceAssessment,
+): string[] {
+  const label = usesCommittedSnapshotLabels(committedSnapshotAssessment)
+    ? '🛡️ Latest committed guardrail snapshot'
+    : '🛡️ Latest guardrail';
   const latestGuardrail = getLatestGuardrailEntry(guardrailEvidence);
   if (!latestGuardrail?.command) {
-    return ['🛡️ Latest guardrail: None recorded'];
+    return [`${label}: ${usesCommittedSnapshotLabels(committedSnapshotAssessment) ? 'freshness not proven' : 'None recorded'}`];
   }
 
   const status = latestGuardrail.result?.status || 'UNKNOWN';
@@ -113,7 +147,7 @@ function buildGuardrailSummaryLines(guardrailEvidence?: GuardrailEvidenceState):
     formatTimestamp(guardrailEvidence?.updated_at) ||
     'Unknown time';
 
-  const lines = [`🛡️ Latest guardrail: ${latestGuardrail.command} -> ${status} (${recordedAt})`];
+  const lines = [`${label}: ${latestGuardrail.command} -> ${status} (${recordedAt})`];
 
   if (latestGuardrail.issue_id) {
     lines.push(`   Issue: #${latestGuardrail.issue_id}`);
@@ -139,9 +173,12 @@ function summarizeIssueBootstrapDetail(entry: IssueBootstrapRecord): string | nu
 }
 
 function buildIssueBootstrapSummaryLines(input: IssueBootstrapSummaryInput): string[] {
+  const label = usesCommittedSnapshotLabels(input.committedSnapshotAssessment)
+    ? '🧭 Latest committed issue bootstrap snapshot'
+    : '🧭 Latest issue bootstrap';
   const latestBootstrap = input.issueBootstrap?.latest;
   if (!latestBootstrap) {
-    return ['🧭 Latest issue bootstrap: None recorded'];
+    return [`${label}: ${usesCommittedSnapshotLabels(input.committedSnapshotAssessment) ? 'freshness not proven' : 'None recorded'}`];
   }
 
   const recordedAt =
@@ -150,7 +187,7 @@ function buildIssueBootstrapSummaryLines(input: IssueBootstrapSummaryInput): str
     'Unknown time';
   const issueLabel = latestBootstrap.issue_id ? `#${latestBootstrap.issue_id}` : 'unknown issue';
   const branchDetail = latestBootstrap.current_branch ? ` on ${latestBootstrap.current_branch}` : '';
-  const lines = [`🧭 Latest issue bootstrap: ${issueLabel}${branchDetail} (${recordedAt})`];
+  const lines = [`${label}: ${issueLabel}${branchDetail} (${recordedAt})`];
 
   if (latestBootstrap.issue_title) {
     lines.push(`   Title: ${latestBootstrap.issue_title}`);
@@ -182,6 +219,9 @@ function buildSwitchContextSummaryLines(input: SwitchContextSummaryInput): strin
   const decisions = Array.isArray(state.working_memory?.decisions) ? state.working_memory.decisions : [];
   const task = state.current_task;
   const description = input.description || extractQuickStartSummary(input.quickStart);
+  const taskLabel = usesCommittedSnapshotLabels(input.committedSnapshotAssessment)
+    ? '🎯 Current committed task snapshot'
+    : '🎯 Current task';
 
   if (input.lastRecorded) {
     const recordedAt = formatTimestamp(input.lastRecorded);
@@ -191,7 +231,7 @@ function buildSwitchContextSummaryLines(input: SwitchContextSummaryInput): strin
   }
 
   if (task?.title) {
-    lines.push(`🎯 Current task: ${task.title} (${task.status || 'unknown'})`);
+    lines.push(`${taskLabel}: ${task.title} (${task.status || 'unknown'})`);
   }
 
   if (pending.length > 0) {
@@ -318,18 +358,29 @@ export async function switchProject(args: any): Promise<string> {
   }
 
   const bootstrap = bootstrapNotes.length > 0 ? '\n\n' + bootstrapNotes.join('\n') : '';
-  const guardrailSummary = buildGuardrailSummaryLines(state?.guardrail_evidence as GuardrailEvidenceState | undefined);
+  const committedSnapshotAssessment = assessVersionedEntrySurfaceState({
+    projectYaml,
+    state,
+    projectPath: found.path,
+  });
+  const committedSnapshotSummary = buildCommittedSnapshotSummaryLines(committedSnapshotAssessment);
+  const guardrailSummary = buildGuardrailSummaryLines(
+    state?.guardrail_evidence as GuardrailEvidenceState | undefined,
+    committedSnapshotAssessment,
+  );
   const issueBootstrapSummary = buildIssueBootstrapSummaryLines({
     issueBootstrap: state?.issue_bootstrap as IssueBootstrapState | undefined,
+    committedSnapshotAssessment,
   });
   const contextSummary = buildSwitchContextSummaryLines({
     description,
     quickStart,
     state,
     lastRecorded: found.last_recorded,
+    committedSnapshotAssessment,
   });
 
-  return `✅ Switched to project "${found.name}"\n\nPath: ${found.path}\nStatus: ${found.status}\n\n${contextSummary.join('\n')}\n${transcriptRoutingSummary.length > 0 ? `\n${transcriptRoutingSummary.join('\n')}\n` : '\n'}Context loaded from:\n- ${found.path}/.project.yaml\n- ${contextPaths.quickStartPath}\n- ${contextPaths.statePath}\n\n${guardrailSummary.join('\n')}\n${issueBootstrapSummary.join('\n')}${bootstrap}`;
+  return `✅ Switched to project "${found.name}"\n\nPath: ${found.path}\nStatus: ${found.status}\n\n${contextSummary.join('\n')}${committedSnapshotSummary.length > 0 ? `\n${committedSnapshotSummary.join('\n')}` : ''}\n${transcriptRoutingSummary.length > 0 ? `\n${transcriptRoutingSummary.join('\n')}\n` : '\n'}Context loaded from:\n- ${found.path}/.project.yaml\n- ${contextPaths.quickStartPath}\n- ${contextPaths.statePath}\n\n${guardrailSummary.join('\n')}\n${issueBootstrapSummary.join('\n')}${bootstrap}`;
 }
 
 export async function listProjects(): Promise<string> {
@@ -406,16 +457,30 @@ export async function getStatus(args: any = {}): Promise<string> {
     ));
   } catch {}
 
-  lines.push(...buildGuardrailSummaryLines(state.guardrail_evidence as GuardrailEvidenceState | undefined));
+  const committedSnapshotAssessment = assessVersionedEntrySurfaceState({
+    projectYaml: resolved.projectYaml,
+    state,
+    projectPath: resolved.projectPath,
+  });
+
+  lines.push(...buildCommittedSnapshotSummaryLines(committedSnapshotAssessment));
+  lines.push(...buildGuardrailSummaryLines(
+    state.guardrail_evidence as GuardrailEvidenceState | undefined,
+    committedSnapshotAssessment,
+  ));
   lines.push(...buildIssueBootstrapSummaryLines({
     issueBootstrap: state.issue_bootstrap as IssueBootstrapState | undefined,
+    committedSnapshotAssessment,
   }));
 
   lines.push('');
+  const taskLabel = usesCommittedSnapshotLabels(committedSnapshotAssessment)
+    ? '🎯 Current committed task snapshot'
+    : '🎯 Current task';
   if (state.current_task) {
-    lines.push(`🎯 Current task: ${state.current_task.title || 'Untitled'} (${state.current_task.status || 'unknown'})`);
+    lines.push(`${taskLabel}: ${state.current_task.title || 'Untitled'} (${state.current_task.status || 'unknown'})`);
   } else {
-    lines.push(`🎯 Current task: None`);
+    lines.push(`${taskLabel}: None`);
   }
 
   const pending = state.working_memory?.pending || [];

--- a/mcp-server/src/utils/__tests__/health.test.ts
+++ b/mcp-server/src/utils/__tests__/health.test.ts
@@ -25,7 +25,7 @@ import { runHealth } from '../../tools/health.js';
 async function setupProjectRoot(stateYaml: string, options?: { projectYaml?: string }): Promise<string> {
   const projectRoot = await mkdtemp(join(tmpdir(), 'agenticos-health-'));
   await mkdir(join(projectRoot, '.context'), { recursive: true });
-  const projectYaml = options?.projectYaml || `meta:\n  id: "health-project"\n  name: "Health Project"\nsource_control:\n  topology: "github_versioned"\n  context_publication_policy: "public_distilled"\nagent_context:\n  quick_start: "standards/.context/quick-start.md"\n  current_state: "standards/.context/state.yaml"\n  conversations: "standards/.context/conversations/"\n  last_record_marker: "standards/.context/.last_record"\n`;
+  const projectYaml = options?.projectYaml || `meta:\n  id: "health-project"\n  name: "Health Project"\nsource_control:\n  topology: "github_versioned"\n  context_publication_policy: "public_distilled"\n  branch_strategy: "github_flow"\nagent_context:\n  quick_start: "standards/.context/quick-start.md"\n  current_state: "standards/.context/state.yaml"\n  conversations: "standards/.context/conversations/"\n  last_record_marker: "standards/.context/.last_record"\n`;
   await mkdir(join(projectRoot, 'standards', '.context'), { recursive: true });
   await writeFile(join(projectRoot, '.project.yaml'), projectYaml, 'utf-8');
   await writeFile(join(projectRoot, 'standards', '.context', 'state.yaml'), stateYaml, 'utf-8');
@@ -56,6 +56,7 @@ describe('health command', () => {
     expect(result.gates).toEqual([
       { gate: 'repo_sync', status: 'PASS', summary: 'Canonical checkout is clean and aligned with origin/main.' },
       { gate: 'entry_surface_refresh', status: 'PASS', summary: 'Entry surfaces have explicit refresh metadata.' },
+      { gate: 'versioned_entry_surface_state', status: 'PASS', summary: 'Committed versioned entry surfaces look fresh for canonical mainline use.' },
       { gate: 'guardrail_evidence', status: 'PASS', summary: 'Latest guardrail evidence is present (agenticos_preflight).' },
       { gate: 'standard_kit', status: 'PASS', summary: 'Standard-kit files match the canonical kit.' },
     ]);
@@ -96,6 +97,11 @@ describe('health command', () => {
         gate: 'entry_surface_refresh',
         status: 'WARN',
         summary: 'Entry surfaces do not yet have explicit refresh metadata.',
+      },
+      {
+        gate: 'versioned_entry_surface_state',
+        status: 'WARN',
+        summary: 'Committed versioned entry surface freshness is not proven.',
       },
       {
         gate: 'guardrail_evidence',
@@ -172,6 +178,73 @@ describe('health command', () => {
     expect(result.repo_sync?.source_dirty_paths).toEqual([]);
   });
 
+  it('warns separately when committed github-versioned entry surfaces look stale', async () => {
+    const projectRoot = await setupProjectRoot(`session:\n  last_entry_surface_refresh: "2026-03-25T00:00:00.000Z"\ncurrent_task:\n  title: "Implement #262 concurrent runtime project resolution"\n  status: "in_progress"\nentry_surface_refresh:\n  refreshed_at: "2026-03-25T00:00:00.000Z"\n  status: "in_progress"\nissue_bootstrap:\n  latest:\n    issue_id: "260"\n    current_branch: "fix/260-stop-active-project-drift-and-main-state-pollution"\n    workspace_type: "isolated_worktree"\n    repo_path: "/tmp/worktrees/issue-260"\n`);
+    childProcessMock.exec.mockImplementation((_: string, cb: Function) => cb(null, '## main...origin/main\n', ''));
+
+    const result = await runHealthCheck({
+      repo_path: '/repo',
+      project_path: projectRoot,
+    });
+
+    expect(result.status).toBe('WARN');
+    expect(result.gates).toEqual([
+      { gate: 'repo_sync', status: 'PASS', summary: 'Canonical checkout is clean and aligned with origin/main.' },
+      { gate: 'entry_surface_refresh', status: 'PASS', summary: 'Entry surfaces have explicit refresh metadata.' },
+      { gate: 'versioned_entry_surface_state', status: 'WARN', summary: 'Committed versioned entry surfaces look stale for canonical mainline use.' },
+      { gate: 'guardrail_evidence', status: 'WARN', summary: 'No persisted guardrail evidence is present yet.' },
+    ]);
+  });
+
+  it('normalizes managed runtime paths when agent_context uses dot-prefixed and slashless directory paths', async () => {
+    const projectRoot = await setupProjectRoot(`entry_surface_refresh:\n  refreshed_at: "2026-03-25T00:00:00.000Z"\n`, {
+      projectYaml: `meta:\n  id: "health-project"\n  name: "Health Project"\nsource_control:\n  topology: "github_versioned"\n  context_publication_policy: "public_distilled"\n  branch_strategy: "github_flow"\nagent_context:\n  quick_start: "./standards/.context/quick-start.md"\n  current_state: "./standards/.context/state.yaml"\n  conversations: "./standards/.context/conversations"\n  last_record_marker: "./standards/.context/.last_record"\n`,
+    });
+    childProcessMock.exec.mockImplementation((_: string, cb: Function) => cb(null, '## main...origin/main\n M standards/.context/conversations/logs/session-1.md\n', ''));
+
+    const result = await runHealthCheck({
+      repo_path: '/repo',
+      project_path: projectRoot,
+    });
+
+    expect(result.repo_sync?.runtime_dirty_paths).toEqual(['standards/.context/conversations/logs/session-1.md']);
+    expect(result.repo_sync?.source_dirty_paths).toEqual([]);
+  });
+
+  it('preserves runtime-managed conversation directory paths that already end with a slash', async () => {
+    const projectRoot = await setupProjectRoot(`entry_surface_refresh:\n  refreshed_at: "2026-03-25T00:00:00.000Z"\n`, {
+      projectYaml: `meta:\n  id: "health-project"\n  name: "Health Project"\nsource_control:\n  topology: "github_versioned"\n  context_publication_policy: "public_distilled"\n  branch_strategy: "github_flow"\nagent_context:\n  quick_start: "standards/.context/quick-start.md"\n  current_state: "standards/.context/state.yaml"\n  conversations: "standards/.context/conversations/"\n  last_record_marker: "standards/.context/.last_record"\n`,
+    });
+    childProcessMock.exec.mockImplementation((_: string, cb: Function) => cb(null, '## main...origin/main\n M standards/.context/conversations/logs/session-2.md\n', ''));
+
+    const result = await runHealthCheck({
+      repo_path: '/repo',
+      project_path: projectRoot,
+    });
+
+    expect(result.repo_sync?.runtime_dirty_paths).toEqual(['standards/.context/conversations/logs/session-2.md']);
+    expect(result.repo_sync?.source_dirty_paths).toEqual([]);
+  });
+
+  it('treats a null project yaml parse as an empty managed config instead of failing closed', async () => {
+    const projectRoot = await setupProjectRoot(`entry_surface_refresh:\n  refreshed_at: "2026-03-25T00:00:00.000Z"\n`, {
+      projectYaml: 'null\n',
+    });
+    childProcessMock.exec.mockImplementation((_: string, cb: Function) => cb(null, '## main...origin/main\n', ''));
+
+    const result = await runHealthCheck({
+      repo_path: '/repo',
+      project_path: projectRoot,
+    });
+
+    expect(result.status).toBe('WARN');
+    expect(result.gates).toEqual([
+      { gate: 'repo_sync', status: 'PASS', summary: 'Canonical checkout is clean and aligned with origin/main.' },
+      { gate: 'entry_surface_refresh', status: 'WARN', summary: 'Project state could not be read, so entry-surface freshness was not proven.' },
+      { gate: 'guardrail_evidence', status: 'WARN', summary: 'Project state could not be read, so guardrail visibility was not proven.' },
+    ]);
+  });
+
   it('fails closed on missing repo_path, git command failure fallbacks, missing branch status, and missing project_path for standard-kit checks', async () => {
     await expect(() => runHealth(undefined)).rejects.toThrow('repo_path is required.');
 
@@ -199,6 +272,11 @@ describe('health command', () => {
         gate: 'entry_surface_refresh',
         status: 'WARN',
         summary: 'Entry surfaces do not yet have explicit refresh metadata.',
+      },
+      {
+        gate: 'versioned_entry_surface_state',
+        status: 'WARN',
+        summary: 'Committed versioned entry surface freshness is not proven.',
       },
       {
         gate: 'guardrail_evidence',

--- a/mcp-server/src/utils/__tests__/versioned-entry-surface-state.test.ts
+++ b/mcp-server/src/utils/__tests__/versioned-entry-surface-state.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+import { assessVersionedEntrySurfaceState } from '../versioned-entry-surface-state.js';
+
+describe('assessVersionedEntrySurfaceState', () => {
+  it('is not applicable for non-github-versioned projects', () => {
+    const result = assessVersionedEntrySurfaceState({
+      projectYaml: {
+        source_control: {
+          topology: 'local_directory_only',
+        },
+      },
+      state: {},
+      projectPath: '/project',
+    });
+
+    expect(result.applies).toBe(false);
+    expect(result.freshness).toBe('not_applicable');
+    expect(result.status).toBe('PASS');
+  });
+
+  it('marks github-versioned state stale when committed snapshot still points at issue-branch work', () => {
+    const result = assessVersionedEntrySurfaceState({
+      projectYaml: {
+        source_control: {
+          topology: 'github_versioned',
+        },
+      },
+      state: {
+        current_task: { status: 'in_progress' },
+        entry_surface_refresh: { status: 'in_progress', refreshed_at: '2026-04-10T10:58:11.098Z' },
+        issue_bootstrap: {
+          latest: {
+            current_branch: 'fix/260-stop-active-project-drift-and-main-state-pollution',
+            workspace_type: 'isolated_worktree',
+            repo_path: '/tmp/worktrees/issue-260',
+          },
+        },
+      },
+      projectPath: '/project',
+    });
+
+    expect(result.applies).toBe(true);
+    expect(result.freshness).toBe('stale');
+    expect(result.status).toBe('WARN');
+    expect(result.reasons).toEqual([
+      'current_task is still marked in_progress in committed state',
+      'entry_surface_refresh still reports in_progress in committed state',
+      'issue bootstrap still points at non-main branch "fix/260-stop-active-project-drift-and-main-state-pollution"',
+      'issue bootstrap still points at an isolated worktree snapshot',
+      'issue bootstrap repo_path still points at "/tmp/worktrees/issue-260" instead of the canonical project root',
+    ]);
+  });
+
+  it('marks github-versioned state unproven when no explicit refresh metadata exists', () => {
+    const result = assessVersionedEntrySurfaceState({
+      projectYaml: {
+        source_control: {
+          topology: 'github_versioned',
+        },
+      },
+      state: {},
+      projectPath: '/project',
+    });
+
+    expect(result.applies).toBe(true);
+    expect(result.freshness).toBe('unproven');
+    expect(result.status).toBe('WARN');
+    expect(result.reasons).toEqual(['entry surfaces do not yet have explicit refresh metadata']);
+  });
+
+  it('marks github-versioned state fresh when refresh metadata exists and no stale signals are present', () => {
+    const result = assessVersionedEntrySurfaceState({
+      projectYaml: {
+        source_control: {
+          topology: 'github_versioned',
+        },
+      },
+      state: {
+        session: {
+          last_entry_surface_refresh: '2026-04-15T00:00:00.000Z',
+        },
+        current_task: {
+          status: 'completed',
+        },
+        entry_surface_refresh: {
+          status: 'completed',
+          refreshed_at: '2026-04-15T00:00:00.000Z',
+        },
+        issue_bootstrap: {
+          latest: {
+            current_branch: 'main',
+            workspace_type: 'main',
+            repo_path: '/project',
+          },
+        },
+      },
+      projectPath: '/project',
+    });
+
+    expect(result.applies).toBe(true);
+    expect(result.freshness).toBe('fresh');
+    expect(result.status).toBe('PASS');
+    expect(result.reasons).toEqual([]);
+  });
+
+  it('normalizes blank string fields to null and keeps freshness unproven without metadata', () => {
+    const result = assessVersionedEntrySurfaceState({
+      projectYaml: {
+        source_control: {
+          topology: 'github_versioned',
+        },
+      },
+      state: {
+        current_task: {
+          status: '   ',
+        },
+        entry_surface_refresh: {
+          status: '   ',
+          refreshed_at: '   ',
+        },
+        issue_bootstrap: {
+          latest: {
+            current_branch: '   ',
+            workspace_type: '   ',
+            repo_path: '   ',
+          },
+        },
+        session: {
+          last_entry_surface_refresh: '   ',
+        },
+      },
+      projectPath: '/project',
+    });
+
+    expect(result.freshness).toBe('unproven');
+    expect(result.reasons).toEqual(['entry surfaces do not yet have explicit refresh metadata']);
+    expect(result.details).toEqual({
+      topology: 'github_versioned',
+      refresh_status: null,
+      has_refresh_metadata: false,
+      current_task_status: null,
+      issue_bootstrap_branch: null,
+      issue_bootstrap_workspace_type: null,
+      issue_bootstrap_repo_path: null,
+    });
+  });
+});

--- a/mcp-server/src/utils/health.ts
+++ b/mcp-server/src/utils/health.ts
@@ -5,6 +5,7 @@ import yaml from 'yaml';
 import { checkStandardKitUpgrade } from './standard-kit.js';
 import { analyzeCanonicalRepoSync, type CanonicalRepoSyncDetails } from './canonical-checkout-sync.js';
 import { resolveManagedProjectContextDisplayPaths, resolveManagedProjectContextPaths } from './agent-context-paths.js';
+import { assessVersionedEntrySurfaceState } from './versioned-entry-surface-state.js';
 
 export interface HealthArgs {
   repo_path: string;
@@ -15,7 +16,7 @@ export interface HealthArgs {
 }
 
 export interface HealthGate {
-  gate: 'repo_sync' | 'entry_surface_refresh' | 'guardrail_evidence' | 'standard_kit';
+  gate: 'repo_sync' | 'entry_surface_refresh' | 'versioned_entry_surface_state' | 'guardrail_evidence' | 'standard_kit';
   status: 'PASS' | 'WARN' | 'BLOCK';
   summary: string;
 }
@@ -67,16 +68,13 @@ function resolveRuntimeManagedEntries(projectYaml: any | null): string[] {
   }
 
   const contextPaths = resolveManagedProjectContextDisplayPaths(projectYaml);
-  const toRelative = (path: string, options?: { directory?: boolean }): string => {
-    const normalized = path.replace(/\\/g, '/').replace(/^\.\/+/, '');
-    return options?.directory && !normalized.endsWith('/') ? `${normalized}/` : normalized;
-  };
+  const toRelative = (path: string): string => path.replace(/\\/g, '/').replace(/^\.\/+/, '');
 
   return [
     toRelative(contextPaths.quickStartPath),
     toRelative(contextPaths.statePath),
     toRelative(contextPaths.markerPath),
-    toRelative(contextPaths.conversationsDir, { directory: true }),
+    toRelative(contextPaths.conversationsDir),
     'CLAUDE.md',
     'AGENTS.md',
   ];
@@ -190,6 +188,11 @@ export async function runHealthCheck(args: HealthArgs): Promise<HealthResult> {
     remoteBaseBranch,
     runtimeManagedEntries: resolveRuntimeManagedEntries(projectYaml),
   });
+  const versionedEntrySurfaceState = assessVersionedEntrySurfaceState({
+    projectYaml,
+    state,
+    projectPath: args.project_path,
+  });
 
   const gates: HealthGate[] = [
     {
@@ -198,8 +201,19 @@ export async function runHealthCheck(args: HealthArgs): Promise<HealthResult> {
       summary: repoSync.summary,
     },
     buildEntrySurfaceGate(state),
-    buildGuardrailGate(state),
   ];
+
+  if (versionedEntrySurfaceState.applies) {
+    gates.push({
+      gate: 'versioned_entry_surface_state',
+      status: versionedEntrySurfaceState.status,
+      summary: versionedEntrySurfaceState.summary,
+    });
+  }
+
+  gates.push(
+    buildGuardrailGate(state),
+  );
 
   const standardKitGate = await buildStandardKitGate(args);
   if (standardKitGate) {

--- a/mcp-server/src/utils/versioned-entry-surface-state.ts
+++ b/mcp-server/src/utils/versioned-entry-surface-state.ts
@@ -1,0 +1,118 @@
+import { resolve } from 'path';
+
+export type VersionedEntrySurfaceFreshness = 'fresh' | 'stale' | 'unproven' | 'not_applicable';
+
+export interface VersionedEntrySurfaceAssessment {
+  applies: boolean;
+  freshness: VersionedEntrySurfaceFreshness;
+  status: 'PASS' | 'WARN';
+  summary: string;
+  reasons: string[];
+  details: {
+    topology: string | null;
+    refresh_status: string | null;
+    has_refresh_metadata: boolean;
+    current_task_status: string | null;
+    issue_bootstrap_branch: string | null;
+    issue_bootstrap_workspace_type: string | null;
+    issue_bootstrap_repo_path: string | null;
+  };
+}
+
+function normalizedString(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function assessVersionedEntrySurfaceState(args: {
+  projectYaml?: any;
+  state?: any;
+  projectPath?: string;
+}): VersionedEntrySurfaceAssessment {
+  const topology = normalizedString(args.projectYaml?.source_control?.topology);
+  const state = args.state && typeof args.state === 'object' ? args.state : {};
+  const refreshStatus = normalizedString(state.entry_surface_refresh?.status);
+  const currentTaskStatus = normalizedString(state.current_task?.status);
+  const issueBootstrapBranch = normalizedString(state.issue_bootstrap?.latest?.current_branch);
+  const issueBootstrapWorkspaceType = normalizedString(state.issue_bootstrap?.latest?.workspace_type);
+  const issueBootstrapRepoPath = normalizedString(state.issue_bootstrap?.latest?.repo_path);
+  const hasRefreshMetadata = Boolean(
+    normalizedString(state.entry_surface_refresh?.refreshed_at) ||
+    normalizedString(state.session?.last_entry_surface_refresh),
+  );
+
+  const details = {
+    topology,
+    refresh_status: refreshStatus,
+    has_refresh_metadata: hasRefreshMetadata,
+    current_task_status: currentTaskStatus,
+    issue_bootstrap_branch: issueBootstrapBranch,
+    issue_bootstrap_workspace_type: issueBootstrapWorkspaceType,
+    issue_bootstrap_repo_path: issueBootstrapRepoPath,
+  };
+
+  if (topology !== 'github_versioned') {
+    return {
+      applies: false,
+      freshness: 'not_applicable',
+      status: 'PASS',
+      summary: 'Committed versioned snapshot freshness is only evaluated for github_versioned projects.',
+      reasons: [],
+      details,
+    };
+  }
+
+  const reasons: string[] = [];
+
+  if (currentTaskStatus === 'in_progress') {
+    reasons.push('current_task is still marked in_progress in committed state');
+  }
+
+  if (refreshStatus === 'in_progress') {
+    reasons.push('entry_surface_refresh still reports in_progress in committed state');
+  }
+
+  if (issueBootstrapBranch && issueBootstrapBranch !== 'main') {
+    reasons.push(`issue bootstrap still points at non-main branch "${issueBootstrapBranch}"`);
+  }
+
+  if (issueBootstrapWorkspaceType === 'isolated_worktree') {
+    reasons.push('issue bootstrap still points at an isolated worktree snapshot');
+  }
+
+  if (args.projectPath && issueBootstrapRepoPath && resolve(issueBootstrapRepoPath) !== resolve(args.projectPath)) {
+    reasons.push(`issue bootstrap repo_path still points at "${issueBootstrapRepoPath}" instead of the canonical project root`);
+  }
+
+  if (reasons.length > 0) {
+    return {
+      applies: true,
+      freshness: 'stale',
+      status: 'WARN',
+      summary: 'Committed versioned entry surfaces look stale for canonical mainline use.',
+      reasons,
+      details,
+    };
+  }
+
+  if (!hasRefreshMetadata) {
+    return {
+      applies: true,
+      freshness: 'unproven',
+      status: 'WARN',
+      summary: 'Committed versioned entry surface freshness is not proven.',
+      reasons: ['entry surfaces do not yet have explicit refresh metadata'],
+      details,
+    };
+  }
+
+  return {
+    applies: true,
+    freshness: 'fresh',
+    status: 'PASS',
+    summary: 'Committed versioned entry surfaces look fresh for canonical mainline use.',
+    reasons: [],
+    details,
+  };
+}

--- a/tasks/issue-288-versioned-entry-surface-refresh.md
+++ b/tasks/issue-288-versioned-entry-surface-refresh.md
@@ -1,0 +1,356 @@
+# Issue #288 Design Review: Versioned Entry Surface Refresh After Merged Mainline Work
+
+## Summary
+
+After `#286` cleaned canonical checkout runtime drift and restored canonical
+`main` to a trusted baseline, the remaining stale status-page behavior is no
+longer caused by Git drift.
+
+The problem is that the versioned entry surfaces under
+`standards/.context/{quick-start.md,state.yaml}` still reflect an older project
+snapshot around `#260` / `#262`, while the canonical checkout itself is already
+up to date with `origin/main`.
+
+So `#288` is a semantics and workflow issue:
+
+1. What do versioned entry surfaces mean for a `github_versioned` project?
+2. When should those surfaces be refreshed after merged mainline work?
+3. How should `status` and related summary commands represent stale versioned
+   state without confusing it with runtime drift?
+
+## Current Evidence
+
+As of `2026-04-14`, canonical project status still reports old work even though
+the canonical checkout is clean and aligned:
+
+- `agenticos_status` still shows:
+  - `Latest guardrail: None recorded`
+  - `Latest issue bootstrap: #260`
+  - `Current task: Implement #262 concurrent runtime project resolution`
+- `standards/.context/state.yaml` still includes:
+  - `issue_bootstrap.latest.issue_id: "260"`
+  - `current_task.title: "Implement #262 concurrent runtime project resolution"`
+- `standards/.context/quick-start.md` still says the current focus is to finish
+  `#262`
+
+Meanwhile:
+
+- canonical checkout is now `main...origin/main`
+- runtime-managed drift has been snapshot and cleaned
+- no source-tree drift remains in the canonical checkout
+- during this review round, `issue_bootstrap` / `preflight` persistence also
+  demonstrated that some execution-time evidence still targets the committed
+  project state surface and can re-dirty canonical `main` if not handled
+  carefully
+
+## Current Semantics In Code
+
+### `agenticos_status`
+
+`agenticos_status` currently builds its summary directly from the project's
+versioned quick-start and state surfaces. It treats:
+
+- `current_task`
+- `working_memory.pending`
+- `issue_bootstrap.latest`
+- `guardrail_evidence.last_command`
+
+as the primary visible truth for the status page.
+
+This means stale versioned state is rendered as if it were current truth.
+
+### `agenticos_health`
+
+`agenticos_health` currently checks:
+
+- repo sync / runtime drift
+- whether entry-surface refresh metadata exists
+- whether guardrail evidence exists
+
+But it does **not** check whether the versioned entry surfaces are stale relative
+to merged mainline work. So a project can pass repo sync while still presenting
+historically stale task/guardrail summaries.
+
+### `agenticos_refresh_entry_surfaces`
+
+`agenticos_refresh_entry_surfaces` already exists as a deterministic writer for
+versioned entry surfaces, but the system does not yet define a complete
+post-merge contract for when this must happen for `github_versioned` projects.
+
+## Problem Breakdown
+
+There are actually two different state classes here:
+
+### 1. Runtime Drift
+
+This is when the canonical checkout gets dirtied by local runtime-managed files.
+
+Examples:
+
+- `CLAUDE.md`
+- `standards/.context/state.yaml`
+- `standards/.context/.last_record`
+- conversation files
+
+This class is now handled by `#286` / `agenticos_canonical_sync`.
+
+### 2. Stale Versioned Entry Surfaces
+
+This is when the committed source of truth under `standards/.context/*` is
+internally consistent but no longer represents the intended current project
+snapshot after later merged work.
+
+This class is **not** handled by canonical sync and should not be treated as
+runtime drift.
+
+## Non-Goals
+
+- Reintroduce runtime writes into canonical `main`
+- Make status pages depend on legacy global `active_project`
+- Mix per-session runtime memory back into committed project state without an
+  explicit contract
+- Hide stale versioned state by silently switching to unrelated runtime state
+
+## Candidate Design Directions
+
+## Option A: Manual Refresh Only, Better Warnings
+
+Keep `agenticos_refresh_entry_surfaces` as the only refresh path.
+
+Add stale-state diagnostics to `status` / `health`, but require operators to
+refresh versioned entry surfaces manually when needed.
+
+Pros:
+
+- smallest implementation
+- keeps writes explicit
+- no new automation complexity
+
+Cons:
+
+- stale status pages remain common if humans forget
+- still weak as an operational default
+- does not define when refresh becomes required
+
+## Option B: Explicit Post-Merge Refresh Contract
+
+Keep refresh explicit, but define a required workflow:
+
+1. merged mainline work that changes project-facing status must also refresh
+   versioned entry surfaces in the issue branch before merge, or in a dedicated
+   follow-up refresh issue
+2. `status` and `health` must detect and surface stale versioned entry surfaces
+   as a distinct condition
+3. operators must not confuse stale versioned state with runtime drift
+
+Pros:
+
+- preserves explicit source control semantics
+- keeps canonical main read-only outside normal Git flow
+- gives one normative workflow instead of tribal knowledge
+
+Cons:
+
+- requires stronger stale-state detection heuristics / contracts
+- still depends on workflow discipline
+
+## Option C: Automatic Refresh Derived From Merge History
+
+Introduce a helper that tries to infer the latest merged issue and rewrite
+versioned entry surfaces automatically after merge.
+
+Pros:
+
+- reduces manual maintenance
+
+Cons:
+
+- highest hallucination / mis-summary risk
+- unclear source of truth across multiple merged issues
+- easy to produce wrong “current task” narratives
+- conflicts with the existing deterministic refresh philosophy
+
+## Initial Recommendation
+
+Recommend **Option B**.
+
+The intended model should be:
+
+1. For `github_versioned` projects, versioned entry surfaces are a committed
+   project-level summary surface, not a live per-session runtime ledger.
+2. They must be refreshed explicitly through deterministic inputs.
+3. `status` and `health` must distinguish:
+   - repo clean vs dirty
+   - runtime drift vs versioned-state staleness
+   - missing guardrail evidence vs stale versioned guardrail summary
+4. The system should fail clearer when the visible status page is stale, instead
+   of confidently rendering old task/guardrail data as if it were current.
+
+This keeps source control semantics clean and avoids heuristic auto-rewriters.
+
+## Refined Review Conclusions
+
+After local review of the current implementation and historical `#99` refresh
+design, the following refinements look necessary:
+
+1. The stale-state problem is not only “missing refresh.”
+   It is specifically that `status` currently renders the last committed
+   `current_task`, `issue_bootstrap`, and guardrail summary as if freshness were
+   already proven.
+
+2. `entry_surface_refresh.refreshed_at` by itself is not enough.
+   It proves that a refresh happened at some time, but not that the committed
+   snapshot still matches the intended current mainline narrative.
+
+3. `#288` should not introduce automatic merge-history summarization.
+   That would directly conflict with the original deterministic refresh contract
+   from `#99`.
+
+4. The first implementation should separate:
+   - detection of stale versioned entry surfaces
+   - presentation of stale status
+   - operator workflow for explicit refresh
+
+5. The first implementation does **not** need a heavy auto-refresh mechanism.
+   It needs one explicit contract and one machine-checkable stale-state model.
+
+6. There is an adjacent write-boundary risk:
+   if review/bootstrap/guardrail persistence still writes execution-time evidence
+   into committed project state during worktree execution, canonical `main` can
+   become dirty again even when runtime drift handling is otherwise correct.
+   `#288` should at minimum account for this boundary explicitly, even if some
+   write-target refactoring lands in a follow-up issue.
+
+## Proposed Semantic Contract
+
+### Versioned Entry Surfaces
+
+For `github_versioned` projects:
+
+- `standards/.context/quick-start.md`
+- `standards/.context/state.yaml`
+
+are **committed summary surfaces** for project resume and orientation.
+
+They are not guaranteed to represent the latest local session.
+They are only authoritative to the extent that they were explicitly refreshed
+for the intended current project snapshot.
+
+### Runtime State
+
+Per-session runtime evidence belongs in runtime-managed or append-only surfaces,
+not in ad hoc canonical-main writes.
+
+### Status Semantics
+
+`agenticos_status` should not present stale versioned state as if it were known
+fresh truth.
+
+Possible status behavior:
+
+- if versioned entry surfaces are stale, show the stale marker first
+- keep showing the last committed summary, but clearly mark it as historical
+- avoid “Latest guardrail: None recorded” when the deeper reality is “current
+  committed snapshot freshness is not proven”
+- distinguish:
+  - `Latest committed snapshot`
+  - `Latest committed issue bootstrap snapshot`
+  - `Latest committed guardrail snapshot`
+  from fresh live/runtime truth
+
+### Health Semantics
+
+`agenticos_health` should gain an explicit gate for versioned entry-surface
+freshness relative to the intended committed project snapshot, distinct from repo
+sync/runtime drift.
+
+Recommended initial behavior:
+
+- `repo_sync`: checkout cleanliness and canonical branch alignment
+- `entry_surface_refresh`: refresh metadata exists
+- `entry_surface_staleness`: whether the committed snapshot is still fresh enough
+  to trust
+- `guardrail_evidence`: committed guardrail snapshot visibility is present and
+  not misleadingly absent
+
+The stale-state gate should be independent from runtime drift.
+
+## Implementation Shape To Evaluate
+
+This review round should specifically decide whether the likely implementation
+should include:
+
+1. a new stale-state classifier for versioned entry surfaces
+2. `status` wording changes to avoid false freshness
+3. `health` gate changes so stale versioned state is machine-checkable
+4. an explicit documented/operator workflow for post-merge entry-surface refresh
+5. optionally, a report-only helper to explain why the current versioned state is
+   considered stale
+
+## Recommended V1 Scope
+
+The first landing should likely be limited to four bounded changes:
+
+1. Add a machine-checkable stale committed-snapshot classifier.
+2. Update `agenticos_status` and switch/status summaries to mark stale committed
+   state explicitly instead of rendering it as current truth.
+3. Extend `agenticos_health` with a distinct stale-versioned-state gate.
+4. Document the one supported post-merge refresh workflow for
+   `github_versioned` projects.
+
+This is enough to fix the misleading status semantics without jumping straight
+to auto-refresh automation.
+
+## Recommended Workflow Contract
+
+For `github_versioned` projects, the supported workflow should be:
+
+1. If an issue intentionally changes the project-facing current narrative, the
+   issue branch should refresh committed entry surfaces before merge.
+2. If multiple issues merge without a clean single-issue narrative, a dedicated
+   follow-up refresh issue is allowed and should be explicit.
+3. Until refresh is completed, canonical status surfaces must say the committed
+   snapshot is stale rather than pretending the old snapshot is current.
+4. No runtime-only command may silently rewrite canonical `main` to “fix” this.
+
+## Hard Questions For Review
+
+1. What is the minimum machine-checkable signal that versioned entry surfaces are
+   stale without inventing heuristics from arbitrary commit history?
+2. Should stale detection be based on:
+   - explicit refresh metadata only
+   - explicit issue linkage
+   - mismatch against newer merged task/report artifacts
+   - some bounded combination of the above
+3. What should `Latest guardrail` mean on a canonical status page:
+   - latest committed guardrail snapshot in versioned state
+   - latest persisted runtime guardrail evidence
+   - or “unknown / stale” when freshness is not proven
+4. Should the refresh workflow be:
+   - mandatory inside issue branches before merge
+   - allowed as a follow-up issue
+   - or both, with clear rules
+
+## Review Goal
+
+Before implementation, review should converge on:
+
+- one clear semantic model
+- one supported refresh workflow
+- one status/health representation for stale versioned state
+- one bounded implementation slice for the first landing
+
+## Missing Acceptance Criteria To Add
+
+- [ ] `agenticos_status` marks stale committed snapshots explicitly instead of
+      presenting their `current_task` / bootstrap / guardrail summary as fresh
+      truth
+- [ ] `agenticos_health` distinguishes runtime drift from stale committed entry
+      surfaces
+- [ ] the supported post-merge refresh workflow for `github_versioned` projects
+      is explicit about “refresh in branch” vs “refresh in follow-up issue”
+- [ ] the first implementation does not depend on heuristic merge-history
+      summarization
+- [ ] review/bootstrap/guardrail persistence semantics are at least explicitly
+      bounded so #288 does not accidentally reintroduce canonical-main write
+      pollution while addressing stale committed snapshots


### PR DESCRIPTION
# Issue #288 Design Review: Versioned Entry Surface Refresh After Merged Mainline Work

## Summary

After `#286` cleaned canonical checkout runtime drift and restored canonical
`main` to a trusted baseline, the remaining stale status-page behavior is no
longer caused by Git drift.

The problem is that the versioned entry surfaces under
`standards/.context/{quick-start.md,state.yaml}` still reflect an older project
snapshot around `#260` / `#262`, while the canonical checkout itself is already
up to date with `origin/main`.

So `#288` is a semantics and workflow issue:

1. What do versioned entry surfaces mean for a `github_versioned` project?
2. When should those surfaces be refreshed after merged mainline work?
3. How should `status` and related summary commands represent stale versioned
   state without confusing it with runtime drift?

## Current Evidence

As of `2026-04-14`, canonical project status still reports old work even though
the canonical checkout is clean and aligned:

- `agenticos_status` still shows:
  - `Latest guardrail: None recorded`
  - `Latest issue bootstrap: #260`
  - `Current task: Implement #262 concurrent runtime project resolution`
- `standards/.context/state.yaml` still includes:
  - `issue_bootstrap.latest.issue_id: "260"`
  - `current_task.title: "Implement #262 concurrent runtime project resolution"`
- `standards/.context/quick-start.md` still says the current focus is to finish
  `#262`

Meanwhile:

- canonical checkout is now `main...origin/main`
- runtime-managed drift has been snapshot and cleaned
- no source-tree drift remains in the canonical checkout
- during this review round, `issue_bootstrap` / `preflight` persistence also
  demonstrated that some execution-time evidence still targets the committed
  project state surface and can re-dirty canonical `main` if not handled
  carefully

## Current Semantics In Code

### `agenticos_status`

`agenticos_status` currently builds its summary directly from the project's
versioned quick-start and state surfaces. It treats:

- `current_task`
- `working_memory.pending`
- `issue_bootstrap.latest`
- `guardrail_evidence.last_command`

as the primary visible truth for the status page.

This means stale versioned state is rendered as if it were current truth.

### `agenticos_health`

`agenticos_health` currently checks:

- repo sync / runtime drift
- whether entry-surface refresh metadata exists
- whether guardrail evidence exists

But it does **not** check whether the versioned entry surfaces are stale relative
to merged mainline work. So a project can pass repo sync while still presenting
historically stale task/guardrail summaries.

### `agenticos_refresh_entry_surfaces`

`agenticos_refresh_entry_surfaces` already exists as a deterministic writer for
versioned entry surfaces, but the system does not yet define a complete
post-merge contract for when this must happen for `github_versioned` projects.

## Problem Breakdown

There are actually two different state classes here:

### 1. Runtime Drift

This is when the canonical checkout gets dirtied by local runtime-managed files.

Examples:

- `CLAUDE.md`
- `standards/.context/state.yaml`
- `standards/.context/.last_record`
- conversation files

This class is now handled by `#286` / `agenticos_canonical_sync`.

### 2. Stale Versioned Entry Surfaces

This is when the committed source of truth under `standards/.context/*` is
internally consistent but no longer represents the intended current project
snapshot after later merged work.

This class is **not** handled by canonical sync and should not be treated as
runtime drift.

## Non-Goals

- Reintroduce runtime writes into canonical `main`
- Make status pages depend on legacy global `active_project`
- Mix per-session runtime memory back into committed project state without an
  explicit contract
- Hide stale versioned state by silently switching to unrelated runtime state

## Candidate Design Directions

## Option A: Manual Refresh Only, Better Warnings

Keep `agenticos_refresh_entry_surfaces` as the only refresh path.

Add stale-state diagnostics to `status` / `health`, but require operators to
refresh versioned entry surfaces manually when needed.

Pros:

- smallest implementation
- keeps writes explicit
- no new automation complexity

Cons:

- stale status pages remain common if humans forget
- still weak as an operational default
- does not define when refresh becomes required

## Option B: Explicit Post-Merge Refresh Contract

Keep refresh explicit, but define a required workflow:

1. merged mainline work that changes project-facing status must also refresh
   versioned entry surfaces in the issue branch before merge, or in a dedicated
   follow-up refresh issue
2. `status` and `health` must detect and surface stale versioned entry surfaces
   as a distinct condition
3. operators must not confuse stale versioned state with runtime drift

Pros:

- preserves explicit source control semantics
- keeps canonical main read-only outside normal Git flow
- gives one normative workflow instead of tribal knowledge

Cons:

- requires stronger stale-state detection heuristics / contracts
- still depends on workflow discipline

## Option C: Automatic Refresh Derived From Merge History

Introduce a helper that tries to infer the latest merged issue and rewrite
versioned entry surfaces automatically after merge.

Pros:

- reduces manual maintenance

Cons:

- highest hallucination / mis-summary risk
- unclear source of truth across multiple merged issues
- easy to produce wrong “current task” narratives
- conflicts with the existing deterministic refresh philosophy

## Initial Recommendation

Recommend **Option B**.

The intended model should be:

1. For `github_versioned` projects, versioned entry surfaces are a committed
   project-level summary surface, not a live per-session runtime ledger.
2. They must be refreshed explicitly through deterministic inputs.
3. `status` and `health` must distinguish:
   - repo clean vs dirty
   - runtime drift vs versioned-state staleness
   - missing guardrail evidence vs stale versioned guardrail summary
4. The system should fail clearer when the visible status page is stale, instead
   of confidently rendering old task/guardrail data as if it were current.

This keeps source control semantics clean and avoids heuristic auto-rewriters.

## Refined Review Conclusions

After local review of the current implementation and historical `#99` refresh
design, the following refinements look necessary:

1. The stale-state problem is not only “missing refresh.”
   It is specifically that `status` currently renders the last committed
   `current_task`, `issue_bootstrap`, and guardrail summary as if freshness were
   already proven.

2. `entry_surface_refresh.refreshed_at` by itself is not enough.
   It proves that a refresh happened at some time, but not that the committed
   snapshot still matches the intended current mainline narrative.

3. `#288` should not introduce automatic merge-history summarization.
   That would directly conflict with the original deterministic refresh contract
   from `#99`.

4. The first implementation should separate:
   - detection of stale versioned entry surfaces
   - presentation of stale status
   - operator workflow for explicit refresh

5. The first implementation does **not** need a heavy auto-refresh mechanism.
   It needs one explicit contract and one machine-checkable stale-state model.

6. There is an adjacent write-boundary risk:
   if review/bootstrap/guardrail persistence still writes execution-time evidence
   into committed project state during worktree execution, canonical `main` can
   become dirty again even when runtime drift handling is otherwise correct.
   `#288` should at minimum account for this boundary explicitly, even if some
   write-target refactoring lands in a follow-up issue.

## Proposed Semantic Contract

### Versioned Entry Surfaces

For `github_versioned` projects:

- `standards/.context/quick-start.md`
- `standards/.context/state.yaml`

are **committed summary surfaces** for project resume and orientation.

They are not guaranteed to represent the latest local session.
They are only authoritative to the extent that they were explicitly refreshed
for the intended current project snapshot.

### Runtime State

Per-session runtime evidence belongs in runtime-managed or append-only surfaces,
not in ad hoc canonical-main writes.

### Status Semantics

`agenticos_status` should not present stale versioned state as if it were known
fresh truth.

Possible status behavior:

- if versioned entry surfaces are stale, show the stale marker first
- keep showing the last committed summary, but clearly mark it as historical
- avoid “Latest guardrail: None recorded” when the deeper reality is “current
  committed snapshot freshness is not proven”
- distinguish:
  - `Latest committed snapshot`
  - `Latest committed issue bootstrap snapshot`
  - `Latest committed guardrail snapshot`
  from fresh live/runtime truth

### Health Semantics

`agenticos_health` should gain an explicit gate for versioned entry-surface
freshness relative to the intended committed project snapshot, distinct from repo
sync/runtime drift.

Recommended initial behavior:

- `repo_sync`: checkout cleanliness and canonical branch alignment
- `entry_surface_refresh`: refresh metadata exists
- `entry_surface_staleness`: whether the committed snapshot is still fresh enough
  to trust
- `guardrail_evidence`: committed guardrail snapshot visibility is present and
  not misleadingly absent

The stale-state gate should be independent from runtime drift.

## Implementation Shape To Evaluate

This review round should specifically decide whether the likely implementation
should include:

1. a new stale-state classifier for versioned entry surfaces
2. `status` wording changes to avoid false freshness
3. `health` gate changes so stale versioned state is machine-checkable
4. an explicit documented/operator workflow for post-merge entry-surface refresh
5. optionally, a report-only helper to explain why the current versioned state is
   considered stale

## Recommended V1 Scope

The first landing should likely be limited to four bounded changes:

1. Add a machine-checkable stale committed-snapshot classifier.
2. Update `agenticos_status` and switch/status summaries to mark stale committed
   state explicitly instead of rendering it as current truth.
3. Extend `agenticos_health` with a distinct stale-versioned-state gate.
4. Document the one supported post-merge refresh workflow for
   `github_versioned` projects.

This is enough to fix the misleading status semantics without jumping straight
to auto-refresh automation.

## Recommended Workflow Contract

For `github_versioned` projects, the supported workflow should be:

1. If an issue intentionally changes the project-facing current narrative, the
   issue branch should refresh committed entry surfaces before merge.
2. If multiple issues merge without a clean single-issue narrative, a dedicated
   follow-up refresh issue is allowed and should be explicit.
3. Until refresh is completed, canonical status surfaces must say the committed
   snapshot is stale rather than pretending the old snapshot is current.
4. No runtime-only command may silently rewrite canonical `main` to “fix” this.

## Hard Questions For Review

1. What is the minimum machine-checkable signal that versioned entry surfaces are
   stale without inventing heuristics from arbitrary commit history?
2. Should stale detection be based on:
   - explicit refresh metadata only
   - explicit issue linkage
   - mismatch against newer merged task/report artifacts
   - some bounded combination of the above
3. What should `Latest guardrail` mean on a canonical status page:
   - latest committed guardrail snapshot in versioned state
   - latest persisted runtime guardrail evidence
   - or “unknown / stale” when freshness is not proven
4. Should the refresh workflow be:
   - mandatory inside issue branches before merge
   - allowed as a follow-up issue
   - or both, with clear rules

## Review Goal

Before implementation, review should converge on:

- one clear semantic model
- one supported refresh workflow
- one status/health representation for stale versioned state
- one bounded implementation slice for the first landing

## Missing Acceptance Criteria To Add

- [ ] `agenticos_status` marks stale committed snapshots explicitly instead of
      presenting their `current_task` / bootstrap / guardrail summary as fresh
      truth
- [ ] `agenticos_health` distinguishes runtime drift from stale committed entry
      surfaces
- [ ] the supported post-merge refresh workflow for `github_versioned` projects
      is explicit about “refresh in branch” vs “refresh in follow-up issue”
- [ ] the first implementation does not depend on heuristic merge-history
      summarization
- [ ] review/bootstrap/guardrail persistence semantics are at least explicitly
      bounded so #288 does not accidentally reintroduce canonical-main write
      pollution while addressing stale committed snapshots
