### PR TITLE
docs: archive issue 244 and 245 design notes

### DIFF
--- a/tasks/issue-244-private-continuity-technical-design.md
+++ b/tasks/issue-244-private-continuity-technical-design.md
@@ -1,0 +1,505 @@
+# Issue #244 Technical Design: Private Continuity Surface Persistence
+
+## Purpose
+
+Define the implementation plan for making `agenticos_save` persist the full
+tracked continuity surface for `github_versioned + private_continuity`
+managed projects.
+
+This issue is not another runtime-home redesign. `#262` already fixed the
+runtime project-resolution model. The gap here is narrower and policy-specific:
+
+- private GitHub-managed projects still do not get full cross-machine
+  continuity from `agenticos_save`
+
+## Problem Restatement
+
+Current `agenticos_save` stages only the narrow runtime review surface plus the
+`CLAUDE.md` state mirror.
+
+Current implementation path:
+
+- `mcp-server/src/tools/save.ts`
+- `mcp-server/src/utils/runtime-review-surface.ts`
+
+That surface is intentionally thin:
+
+- `state.yaml`
+- `.last_record`
+- configured conversations dir
+- optional `CLAUDE.md`
+
+This is not sufficient for `private_continuity`, because the declared policy
+means the repository itself is allowed to carry the full tracked continuity
+surface needed for a fresh clone to resume naturally.
+
+So today the product has a contract mismatch:
+
+- publication policy says full tracked continuity may remain in repo
+- save behavior still persists only a thin runtime subset
+
+## Goal
+
+For `source_control.context_publication_policy = private_continuity`,
+`agenticos_save` should persist the tracked continuity surface that allows:
+
+- fresh clone
+- latest pushed state
+- no manual backup reconstruction
+
+to restore usable project continuity.
+
+## Non-Goals
+
+Do not solve these in `#244`:
+
+- raw conversation isolation for `public_distilled` projects
+  - that belongs to `#245`
+- schema redesign of project context paths
+- runtime-home or session-local project resolution changes
+  - already handled by `#262`
+- archive import policy changes
+- automatic migration of historical project content
+
+## Design Principles
+
+### 1. Policy-Driven, Not Heuristic-Driven
+
+The continuity surface must be determined from the explicit managed-project
+contract:
+
+- topology
+- context publication policy
+- configured agent context paths
+
+Do not infer save behavior from ad hoc path naming.
+
+### 2. One Shared Policy / Path Authority
+
+`#244` and `#245` must not introduce separate drifting path planners.
+
+Introduce one shared policy/path resolver layer first, then build issue-specific
+planning on top of it. That shared layer is responsible for:
+
+- resolving publication policy
+- resolving configured context paths
+- determining the raw conversation write path
+- determining the tracked continuity inclusion set
+- determining sidecar-only exclusions
+- enforcing repo-boundary rules fail-closed
+
+`#244` should then add a continuity-surface planner that consumes this shared
+authority instead of re-deriving policy/path rules in `save.ts`.
+
+### 3. Separate “Continuity Surface” From “Runtime Review Surface”
+
+The existing runtime review surface should not be stretched to mean backup or
+continuity policy.
+
+Reason:
+
+- runtime review exclusion is a narrow operational concept
+- continuity persistence is a higher-level product contract
+- `#245` needs a different answer for public projects than `#244`
+
+So `#244` should introduce a new continuity planner instead of overloading
+`runtime-review-surface.ts`.
+
+### 4. Fail Closed On Unsupported Policy Shapes
+
+If a project does not declare a valid publication policy, or declares a policy
+class whose continuity behavior is not implemented in the current command,
+surface that explicitly instead of silently staging the wrong paths.
+
+### 5. Full Continuity Does Not Mean “Everything In The Repo”
+
+`private_continuity` means the repo carries the canonical tracked continuity
+surface. It does not mean `git add .`.
+
+The continuity planner must still exclude:
+
+- machine-local caches
+- `node_modules/`
+- coverage/build junk
+- `.context/.last_record`
+- sidecar transcript areas
+- archive blobs unless separately allowed
+- transient runtime scratch files
+
+## Operator Contract
+
+`#244` should make the operator-facing recovery contract explicit.
+
+| Policy | Raw conversation write path | Tracked continuity in repo | `agenticos_save` contract | Recovery guarantee |
+| --- | --- | --- | --- | --- |
+| `local_private` | local configured path | local only | keep current narrow runtime behavior | Git is not the recovery mechanism |
+| `private_continuity` | configured conversations path | full tracked continuity surface | stage full tracked continuity set | fresh private clone + latest pushed state restores usable continuity |
+| `public_distilled` | sidecar path from policy resolver | distilled tracked continuity only | not widened in this issue | raw history requires private sidecar and belongs to `#245` |
+
+For `#244`, the required operator truth is:
+
+- `private_continuity` means full tracked continuity is recoverable from Git
+- it does not imply every repo file is continuity-critical
+- it does not imply sidecar/private runtime surfaces become tracked
+
+## Current-State Analysis
+
+### Current Save Behavior
+
+`save.ts` currently:
+
+1. updates `state.yaml`
+2. syncs `CLAUDE.md`
+3. finds git root
+4. stages only `resolveRuntimeReviewSurfacePaths(...).tracked_review_excluded_paths`
+
+That is structurally too narrow for `private_continuity`.
+
+### Current Context Inputs Already Exist
+
+The system already has enough source inputs to build the continuity planner:
+
+- `projectYaml.source_control.context_publication_policy`
+- `resolveManagedProjectContextPaths()`
+- `resolveManagedProjectContextDisplayPaths()`
+
+So `#244` does not require a schema invention first.
+
+### Current Drift Risks
+
+Today policy/path logic is already spread across:
+
+- `agent-context-paths.ts`
+- `save.ts`
+- `record.ts`
+- `init.ts`
+- templates
+- generated adapter guidance
+
+If `#244` adds private continuity staging without shared authority, `#245` will
+recreate drift immediately.
+
+## Proposed Solution
+
+## A. Introduce A Shared Policy / Path Resolver First
+
+Add one shared utility family that becomes the authoritative source for managed
+project continuity behavior.
+
+Suggested new utility:
+
+- `mcp-server/src/utils/context-policy-plan.ts`
+
+Suggested output shape:
+
+```ts
+interface ContextPolicyPlan {
+  policy: 'local_private' | 'private_continuity' | 'public_distilled';
+  project_root: string;
+  repo_root: string | null;
+  tracked_context_paths: {
+    project_file: string;
+    quick_start: string;
+    state: string;
+    conversations: string;
+    knowledge: string;
+    tasks: string;
+    last_record: string;
+  };
+  raw_conversations_dir: string;
+  tracked_conversations_dir: string | null;
+  sidecar_only_paths: string[];
+  repo_boundary_violations: string[];
+}
+```
+
+This shared layer answers:
+
+- what policy is active
+- what configured paths exist
+- which path is the raw conversation destination
+- which tracked paths are continuity-relevant
+- which paths are sidecar-only
+- whether any configured path escapes the authoritative repo root
+
+Issue-specific planners then consume this:
+
+- `#244`: continuity-surface planner for `save`
+- `#245`: conversation-routing planner for `record`
+
+## B. Add A Continuity Surface Planner For `save`
+
+Add:
+
+- `mcp-server/src/utils/continuity-surface.ts`
+
+Suggested output shape:
+
+```ts
+interface ContinuitySurfacePlan {
+  policy: 'local_private' | 'private_continuity' | 'public_distilled';
+  tracked_continuity_paths: string[];
+  excluded_paths: string[];
+  required_guidance_paths: string[];
+  optional_guidance_paths: string[];
+  unsupported_reasons: string[];
+}
+```
+
+This planner should be built from `ContextPolicyPlan`, not from raw path
+guessing inside `save.ts`.
+
+## C. Define The `private_continuity` Inclusion Contract
+
+Minimum tracked continuity set for `private_continuity`:
+
+- `.project.yaml`
+- configured quick-start path
+- configured current state path
+- configured conversations directory
+- configured knowledge directory
+- configured tasks directory
+
+Required tracked continuity does not include optional mirrored guidance by
+default. Guidance surfaces are classified separately:
+
+- required tracked continuity:
+  - the minimum set above
+- optional tracked guidance surfaces:
+  - `CLAUDE.md` when present and project-local
+  - `AGENTS.md` when present and project-local
+
+Operator contract:
+
+- continuity correctness must not depend on `CLAUDE.md` / `AGENTS.md`
+- if they exist as project-local canonical guidance, `save` should stage them
+- if they are absent, continuity is still valid
+
+Notes:
+
+- use configured agent context paths, not hard-coded defaults
+- only include paths inside the authoritative repo root
+- do not assume repo root equals project root
+
+## D. Define The Exclusion Contract
+
+Explicit exclusions:
+
+- configured last-record marker path
+- `node_modules/`
+- coverage outputs
+- transient build outputs unless they are canonical checked-in source
+- `.private/conversations/`
+- `.meta/transcripts/`
+- archive/reference dump areas
+- any configured path outside the authoritative repo root
+
+## E. Repo-Boundary Rules Must Be Fail-Closed
+
+`#244` needs a deterministic rule when project root and git root differ.
+
+Authoritative staging root:
+
+- the git repo root returned for the managed project target
+
+Rules:
+
+1. build the shared `ContextPolicyPlan`
+2. resolve the authoritative repo root
+3. for every candidate tracked continuity path:
+   - if inside repo root, it is eligible
+   - if outside repo root, record a boundary violation
+4. if any required tracked continuity path escapes repo root:
+   - block `agenticos_save`
+   - return an explicit unsupported / boundary error
+5. if an optional guidance path escapes repo root:
+   - exclude it
+   - report that exclusion clearly
+
+Do not silently downgrade the required continuity contract.
+
+## F. Save Command Contract
+
+`agenticos_save` should:
+
+1. resolve the managed project target
+2. build `ContextPolicyPlan`
+3. validate publication policy and repo-boundary conditions
+4. build `ContinuitySurfacePlan`
+5. decide whether the command is allowed to proceed before mutating tracked
+   state files
+6. only after the plan is supported:
+   - update `state.yaml`
+   - sync `CLAUDE.md` / guidance mirrors if applicable
+   - stage `tracked_continuity_paths`
+7. continue to commit/push as today
+8. report the actual operator-facing contract in the result text
+
+Degraded / fail-closed rule:
+
+- unsupported policy
+- required repo-boundary violation
+- invalid continuity plan
+
+must be detected before tracked state mutation.
+
+Recommended contract:
+
+- do not update `state.yaml`
+- do not rewrite `CLAUDE.md`
+- do not stage partial continuity state
+- return a structured failure explaining why continuity persistence was blocked
+
+Do not allow a partially updated local continuity state that then fails before
+the tracked contract can be satisfied.
+
+Required result truth for `private_continuity`:
+
+- actual tracked continuity paths staged
+- optional guidance paths staged or skipped
+- whether the saved state is fully recoverable from Git alone
+
+If the policy is:
+
+- `private_continuity`
+  - fully supported in this issue
+- `local_private`
+  - keep the current narrow runtime behavior
+- `public_distilled`
+  - do not expand to full continuity here
+  - leave public raw-history isolation to `#245`
+
+## G. Documentation And Generated Guidance Contract
+
+Completion of `#244` is not just code in `save.ts`.
+
+The following operator-facing surfaces must stop teaching a universal or
+policy-agnostic continuity model:
+
+- `mcp-server/README.md`
+- product-level `README.md` where recovery semantics are described
+- `.meta/templates/.project.yaml` comments if they imply one universal meaning
+- `.meta/templates/quick-start.md` when it teaches universal conversations-path
+  semantics
+- `mcp-server/src/utils/distill.ts`
+- generated `CLAUDE.md` / `AGENTS.md` guidance if they present conversations as
+  a universal tracked startup surface
+- conformance checks that validate template/runtime truth
+
+At minimum, the docs must state:
+
+- `private_continuity` persists full tracked continuity
+- `public_distilled` is different and not covered by `#244`
+- `CLAUDE.md` / `AGENTS.md` are optional mirrored guidance surfaces, not the
+  required continuity core
+
+## File-Level Change Plan
+
+### New
+
+- `mcp-server/src/utils/context-policy-plan.ts`
+- `mcp-server/src/utils/continuity-surface.ts`
+- `mcp-server/src/utils/__tests__/context-policy-plan.test.ts`
+- `mcp-server/src/utils/__tests__/continuity-surface.test.ts`
+
+### Update
+
+- `mcp-server/src/tools/save.ts`
+- `mcp-server/src/tools/__tests__/save.test.ts`
+- `mcp-server/src/utils/distill.ts`
+- `mcp-server/README.md`
+- product `README.md` if recovery semantics are exposed there
+- `.meta/templates/.project.yaml`
+- `.meta/templates/quick-start.md`
+- conformance / standard-kit checks that encode continuity truth
+
+## Test Plan
+
+### Shared Policy / Path Resolver
+
+Cover at minimum:
+
+1. resolves policy and configured paths correctly
+2. resolves repo root vs project root correctly
+3. flags required tracked paths outside repo root
+4. classifies `.private/conversations/` as sidecar-only
+5. keeps `public_distilled` distinct from `private_continuity`
+
+### Continuity Planner
+
+Cover at minimum:
+
+1. `private_continuity` returns the full required tracked set
+2. custom configured paths are respected
+3. required vs optional guidance surfaces are classified correctly
+4. exclusions omit marker/junk paths
+5. `public_distilled` does not accidentally resolve to full continuity
+
+### Save Command
+
+Cover at minimum:
+
+1. `agenticos_save` stages:
+   - `.project.yaml`
+   - quick-start
+   - state
+   - conversations
+   - knowledge
+   - tasks
+2. `CLAUDE.md` and `AGENTS.md` are staged only when present and repo-local
+3. marker path is not staged
+4. repo-boundary violations block the command clearly
+5. result text explains Git-only recoverability truthfully
+6. `public_distilled` still does not stage raw sidecar-only content in this
+   issue
+7. no-policy or invalid-policy projects fail clearly
+8. unsupported plans fail before tracked state mutation
+
+## Rollout Plan
+
+### Tranche 1
+
+- add shared `context-policy-plan` utility
+- add shared planner tests
+
+### Tranche 2
+
+- add continuity-surface planner
+- wire `save.ts` for `private_continuity`
+- extend `save.test.ts`
+
+### Tranche 3
+
+- update docs/templates/generated guidance/conformance
+- confirm release notes if behavior ships
+
+## Open Questions
+
+These should be answered during implementation, but none block the design:
+
+1. Should `artifacts/` ever be included by default for `private_continuity`?
+   - current recommendation: no, unless later subdirectories are explicitly
+     classified as continuity-critical
+2. Should `AGENTS.md` always be staged whenever present?
+   - current recommendation: yes, if it is project-local canonical guidance
+3. Should `local_private` remain on the current narrow runtime surface?
+   - current recommendation: yes, do not widen it in `#244`
+
+## Final Recommendation
+
+Implement `#244` as:
+
+1. one shared policy/path authority layer
+2. one `private_continuity` continuity planner built on that authority
+3. one `save` surface upgrade with explicit repo-boundary and operator recovery
+   guarantees
+
+Do not try to solve `public_distilled` transcript isolation inside the same
+issue.
+
+That keeps the sequencing clean:
+
+1. `#244` makes private GitHub-managed projects recoverable from normal saved
+   state
+2. `#245` then adds the public-project sidecar isolation mode without
+   contaminating the private continuity contract

--- a/tasks/issue-245-public-raw-conversation-isolation-design.md
+++ b/tasks/issue-245-public-raw-conversation-isolation-design.md
@@ -1,0 +1,655 @@
+# Issue #245 Technical Design: Public Raw Conversation Isolation
+
+## Purpose
+
+Define the implementation plan for making `github_versioned + public_distilled`
+projects keep raw session history out of the tracked public tree while
+preserving usable agent continuity.
+
+This issue is the public-policy counterpart to `#244`.
+
+- `#244` covers full tracked continuity for `private_continuity`
+- `#245` covers raw transcript isolation for `public_distilled`
+
+These two contracts must stay separate, but they must share one policy/path
+authority.
+
+## Problem Restatement
+
+The publication-policy contract already says:
+
+- `private_continuity`
+  - full tracked continuity may remain in repo
+- `public_distilled`
+  - distilled continuity may be tracked
+  - raw session history must not remain in the tracked public tree
+
+But current product behavior does not enforce that distinction.
+
+Current state:
+
+1. templates still default:
+   - `agent_context.conversations: ".context/conversations/"`
+2. `agenticos_record` always writes to the configured conversations dir
+3. `agenticos_save` has no publication-policy-aware transcript branching
+4. generated guidance, entry surfaces, standard-kit docs, and memory contract
+   wording still broadly treat `.context/conversations/` as the canonical
+   append-only session history path
+
+So `public_distilled` is currently only a declared contract, not an end-to-end
+implemented behavior.
+
+## Goal
+
+For `source_control.context_publication_policy = public_distilled`:
+
+- raw session history must be routed to a private sidecar path
+- tracked source should retain only publishable / distilled continuity surfaces
+- `record`, `save`, resume guidance, generated docs, and conformance checks
+  must all describe the same contract
+- operators must understand what is recoverable from Git alone and what still
+  requires private sidecar continuity
+
+## Non-Goals
+
+Do not solve these in `#245`:
+
+- full tracked continuity for private repos
+  - belongs to `#244`
+- general backup surface redesign
+- runtime-home / session-local project resolution
+- estate-wide automatic migration tooling across all projects
+- rewriting old transcript history automatically
+
+## Design Principles
+
+### 1. Policy-Driven Routing
+
+Transcript routing must be derived from:
+
+- topology
+- context publication policy
+- configured agent context paths
+
+Do not treat `.private/conversations/` as a hidden convention with no contract.
+
+### 2. One Shared Validated Path Contract
+
+`#244` and `#245` must consume one shared validated policy/path layer.
+
+Do not let:
+
+- `continuity-surface.ts`
+- `conversation-routing.ts`
+- `save.ts`
+- `record.ts`
+- templates
+- generated guidance
+
+all independently reconstruct policy/path behavior.
+
+The shared layer must own:
+
+- publication policy resolution
+- absolute/display/repo-relative path normalization
+- project-root and repo-root validation
+- raw conversation destination
+- tracked continuity set
+- sidecar-only exclusions
+
+Do not add a second authority that re-derives policy, repo identity, or raw
+paths independently. Any helper introduced in `#245` must be a pure derived
+view over the shared plan, not a parallel planner with its own routing logic.
+
+### 3. Separate “Tracked Continuity” From “Private Raw History”
+
+For `public_distilled`, there are two different path classes:
+
+1. tracked, publishable continuity
+2. private, append-only raw session history
+
+The product must stop pretending one path can satisfy both.
+
+### 4. Private Sidecar Must Remain Project-Scoped
+
+Raw transcript isolation should remain project-scoped and easy to reason about.
+
+Canonical sidecar path for `#245`:
+
+- `.private/conversations/`
+
+Compatibility note:
+
+- `.meta/transcripts/` may remain a legacy/future compatibility alias
+- it should not remain co-equal or operator-facing canonical truth
+
+### 5. No Silent Public Leakage
+
+Once `public_distilled` behavior is implemented:
+
+- `agenticos_record` must stop appending raw sessions to tracked
+  `.context/conversations/`
+- `agenticos_save` must not stage raw sidecar transcript paths
+- docs/templates/guidance must not keep describing `.context/conversations/`
+  as the raw canonical path for public projects
+
+This is stronger than “`agenticos_save` does not add those files”.
+Guardrails, conformance, and generated ignore guidance must all make it harder
+to accidentally publish private raw transcript paths.
+
+### 6. Keep `agent_context.conversations` Semantically Stable
+
+`agent_context.conversations` should remain the configured project-scoped
+context/display path, not become the policy-derived raw append destination for
+`public_distilled`.
+
+For `public_distilled`:
+
+- the raw append target is policy-derived
+- the tracked/display path may remain `.context/conversations/`
+- generated guidance must clearly distinguish tracked continuity from private
+  raw history
+
+Do not repoint the field to `.private/conversations/` and collapse those two
+concepts back together.
+
+## Operator Contract
+
+The product should publish one canonical operator matrix across docs and code:
+
+| Policy | Raw conversation write path | Tracked continuity in repo | `record` truth | `save` truth | Recovery guarantee |
+| --- | --- | --- | --- | --- | --- |
+| `local_private` | configured conversations path | local only | raw history written locally | narrow runtime behavior | Git is not the recovery mechanism |
+| `private_continuity` | configured conversations path | full tracked continuity | raw history stays tracked | full continuity staged | fresh private clone restores usable continuity |
+| `public_distilled` | `.private/conversations/` | distilled tracked continuity only | raw history written to sidecar | sidecar excluded from tracked save | fresh public clone restores distilled continuity only; raw history requires sidecar |
+
+For `#245`, the minimum tracked continuity contract for `public_distilled`
+must be machine-checkable and explicit.
+
+Required tracked continuity set:
+
+- `.project.yaml`
+- configured quick-start path
+- configured state path
+- configured knowledge directory
+- configured tasks directory
+- selected project-level guidance surfaces when they are intended to be tracked
+
+Not part of the tracked public contract:
+
+- raw append-only session history
+- `.private/conversations/`
+- `.meta/transcripts/` raw sidecar content
+
+Config note:
+
+- `agent_context.conversations` remains a configured tracked/display path
+- raw transcript write destination is derived from publication policy, not read
+  directly from that field for `public_distilled`
+
+## Current-State Analysis
+
+### Template Drift
+
+`.meta/templates/.project.yaml` still defaults:
+
+- `agent_context.conversations: ".context/conversations/"`
+
+That is acceptable for:
+
+- `local_private`
+- `private_continuity`
+
+But it is misleading as universal operator truth once `public_distilled`
+becomes real behavior.
+
+### Runtime / Guidance Drift
+
+Current product surfaces still teach one universal conversations path:
+
+- `record.ts`
+- `distill.ts`
+- `entry-surface-refresh.ts`
+- `.meta/templates/quick-start.md`
+- `.meta/standard-kit/README.md`
+- memory contract standards
+
+If runtime starts writing `public_distilled` transcripts to sidecar while those
+surfaces still teach `.context/conversations/`, the product will keep
+reintroducing the wrong mental model.
+
+### Legacy Public Projects
+
+Existing public projects may already contain tracked raw transcripts under
+`.context/conversations/`.
+
+If `#245` simply switches new writes to sidecar with no rollout rule, the
+system risks:
+
+- operators reading stale public raw history as if it were current
+- silent dual-write assumptions
+- unexpected staged transcript diffs
+- no clear migration guidance
+
+## Proposed Solution
+
+## A. Reuse The Shared Policy / Path Resolver
+
+`#245` must consume the same shared validated policy/path utility introduced for
+`#244`.
+
+Suggested shared utility:
+
+- `mcp-server/src/utils/context-policy-plan.ts`
+
+This shared layer should already answer:
+
+- active publication policy
+- authoritative project root and repo root
+- configured tracked context paths
+- raw conversation destination
+- tracked conversation path, if any
+- sidecar-only paths
+- repo-boundary violations
+
+`#245` should not duplicate that logic in `record.ts`.
+
+## B. Add At Most A Derived Conversation Routing Helper
+
+If a helper is added for `record` / `save` / messaging, it must be a pure
+derived view over `ContextPolicyPlan`, not a second routing authority.
+
+Allowed shape:
+
+```ts
+interface ConversationRoutingPlan {
+  policy: 'local_private' | 'private_continuity' | 'public_distilled';
+  raw_conversations_dir: string;
+  tracked_conversations_dir: string | null;
+  is_sidecar: boolean;
+  tracked_recovery_contract: 'local_only' | 'git_full' | 'git_distilled';
+  notes: string[];
+  legacy_transcript_status:
+    | 'none'
+    | 'tracked_legacy_present'
+    | 'tracked_legacy_dirty'
+    | 'misconfigured_public_raw_target';
+}
+```
+
+This helper may summarize:
+
+- the already-resolved raw append-only session history path
+- whether that path is tracked or sidecar-only
+- what tracked path, if any, remains part of the public continuity contract
+- whether legacy tracked raw transcripts are present and need operator action
+
+It must not independently re-resolve:
+
+- repo root
+- project root
+- publication policy
+- tracked continuity paths
+- raw destination paths
+
+## C. Canonical Routing Rules
+
+### `local_private`
+
+- raw conversations remain in configured conversations dir
+- current behavior may stay unchanged
+
+### `private_continuity`
+
+- raw conversations remain in configured conversations dir
+- tracked repo continuity may include them
+- this is primarily exercised by `#244`
+
+### `public_distilled`
+
+Canonical behavior:
+
+- raw conversations write to `.private/conversations/`
+- tracked `.context/conversations/` is not the raw append target
+- `.meta/transcripts/` is not co-equal canonical behavior
+
+Rationale:
+
+- `.private/` is semantically clear
+- existing code already hints at sidecar-only intent
+- it is easier to explain and enforce than a dual-use tracked path
+
+## D. Record Command Contract
+
+`agenticos_record` should stop using the configured tracked conversations path
+as the raw destination directly.
+
+Instead it should:
+
+1. resolve the managed project target
+2. build `ContextPolicyPlan`
+3. validate repo-boundary conditions
+4. derive any routing/status helper strictly from `ContextPolicyPlan`
+5. if legacy public tracked raw transcripts require operator action, follow the
+   explicit rollout rule
+6. append session history to `raw_conversations_dir`
+7. report the actual written path and recoverability truth in the tool result
+
+For `public_distilled`, tool output must stop hard-coding:
+
+- `Conversation: .context/conversations/...`
+
+It should instead report:
+
+- actual raw sidecar file written
+- whether that path is tracked or sidecar-only
+- whether Git alone restores only distilled continuity
+
+## E. Save Contract For Public Projects
+
+`agenticos_save` should align with the shared policy/path contract so that:
+
+- `record` writes raw history into sidecar
+- `save` excludes raw sidecar transcripts
+- tracked source retains only publishable continuity surfaces
+- result text explains that raw history is not part of Git recovery
+
+`#245` must also harden the tracked save model for `public_distilled`.
+It is not enough to route `record` correctly if `save` still stages only the
+old runtime surface.
+
+Required save behavior for `public_distilled`:
+
+- consume the same policy-derived tracked continuity contract used by docs and
+  conformance
+- keep the minimum tracked continuity set machine-checkable:
+  - `.project.yaml`
+  - quick-start
+  - state
+  - knowledge
+  - tasks
+  - selected tracked guidance surfaces
+- update `runtime-review-surface.ts` so tracked vs sidecar paths reflect policy
+- ensure raw sidecar paths are excluded from normal tracked save
+- explain in result text that Git recovery is distilled-only
+
+Leakage barrier requirements:
+
+- legacy committed tracked transcripts may remain as historical evidence
+- new raw writes must not continue there
+- if a `public_distilled` project has staged or unstaged raw-transcript changes
+  under tracked paths, `save` must fail closed instead of silently publishing
+  them
+- if sidecar raw transcript paths appear in tracked diff / review scope,
+  guardrails or conformance must flag or fail them
+
+`#245` should also define how `save` behaves when legacy public tracked raw
+transcripts still exist:
+
+- historical tracked transcripts remain readable as historical evidence
+- new raw writes do not continue there
+- sidecar raw history remains excluded from tracked save
+- operator receives an explicit note or warning
+
+## F. Template / Init / Entry-Surface Contract
+
+`#245` cannot stop at routing code. Completion must include operator-surface
+truthfulness.
+
+Required scope:
+
+- `init.ts`
+- `.meta/templates/.project.yaml`
+- `.meta/templates/quick-start.md`
+- `distill.ts`
+- `entry-surface-refresh.ts`
+- standard-kit generated guidance / README wording
+- memory contract / publication-policy docs where they still present
+  `.context/conversations/` as universal canonical raw history
+
+Recommended rule:
+
+- keep schema stable
+- make runtime routing policy-aware
+- update comments/docs/generated guidance so `public_distilled` truth is explicit
+- make session-start guidance policy-aware so public projects do not treat raw
+  sidecar history as required Git-backed startup context
+
+`init` / `normalize_existing` requirements:
+
+- do not rewrite `agent_context.conversations` to `.private/conversations/`
+- do not treat that field as the live raw append target for `public_distilled`
+- comments and generated files must explicitly say raw conversation routing is
+  policy-derived and may differ from the tracked/display path
+- directory creation for `public_distilled` must be intentional:
+  - create the sidecar raw path when needed
+  - do not imply that tracked `.context/conversations/` is the active raw sink
+
+## G. Legacy Rollout And Migration Contract
+
+`#245` needs an explicit compatibility rule for existing public projects with
+tracked raw transcripts already under `.context/conversations/`.
+
+Recommended rollout behavior:
+
+1. classify legacy state explicitly:
+   - `tracked_legacy_present`
+   - `tracked_legacy_dirty`
+   - `misconfigured_public_raw_target`
+2. legacy committed tracked transcripts remain historical evidence and remain
+   readable
+3. new raw writes switch to `.private/conversations/`
+4. `agenticos_save` does not continue publishing new raw transcripts
+5. no silent dual-write mode
+6. no automatic destructive relocation in this issue
+7. migration guidance must point to an explicit migration workflow aligned with
+   the post-`#262` hybrid migration model rather than a vague future cleanup
+
+Warn / block contract:
+
+- `tracked_legacy_present`
+  - allow `record`
+  - allow `save` if no new tracked raw transcript changes are present
+  - warn persistently in operator-facing surfaces until migration/cleanup is
+    complete
+- `tracked_legacy_dirty`
+  - block `save`
+  - explain that tracked raw transcript changes would leak new private history
+- `misconfigured_public_raw_target`
+  - block `record`
+  - block `init normalize_existing`
+  - fail closed until raw destination is sidecar-only and inside the project
+
+Visibility requirements:
+
+- surface this status in `record`
+- surface it in `save`
+- surface it in switch/status operator output
+- surface it in conformance / audit results
+
+This keeps behavior safe while avoiding automatic history rewriting.
+
+## H. Docs / Conformance Are Part Of Completion
+
+`#245` should not be considered complete if only runtime routing changes land.
+
+Completion criteria must include:
+
+- README truthfulness
+- template truthfulness
+- generated guidance truthfulness
+- standard-kit truthfulness
+- conformance checks that detect contradictory public-project semantics
+- standard-kit manifest behaviors that actually encode the public-project truth
+- guardrail / review-surface checks that reject private raw transcript leakage
+
+Otherwise the product will keep regenerating the old contract.
+
+## File-Level Change Plan
+
+### New
+
+- `mcp-server/src/utils/conversation-routing.ts`
+  - only if implemented as a pure derived view over `ContextPolicyPlan`
+- `mcp-server/src/utils/__tests__/conversation-routing.test.ts`
+
+### Update
+
+- `mcp-server/src/tools/record.ts`
+- `mcp-server/src/tools/__tests__/record.test.ts`
+- `mcp-server/src/tools/save.ts`
+  - align exclusion, blocking, and operator reporting behavior
+- `mcp-server/src/tools/init.ts`
+- `mcp-server/src/tools/project.ts`
+  - switch/status-facing legacy public transcript notices
+- `mcp-server/src/tools/pr-scope-check.ts`
+  - flag private raw transcript paths in tracked review scope for public
+    projects
+- `mcp-server/src/utils/distill.ts`
+- `mcp-server/src/utils/entry-surface-refresh.ts`
+- `mcp-server/src/utils/runtime-review-surface.ts`
+- `mcp-server/src/utils/standard-kit.ts`
+- `mcp-server/src/utils/__tests__/distill.test.ts`
+- `mcp-server/src/utils/__tests__/entry-surface-refresh.test.ts`
+- `mcp-server/src/utils/__tests__/runtime-review-surface.test.ts`
+- `.meta/templates/.project.yaml`
+- `.meta/templates/quick-start.md`
+- `.meta/standard-kit/README.md`
+- `.meta/standard-kit/inheritance-rules.md`
+- `.meta/standard-kit/manifest.yaml`
+- `mcp-server/README.md`
+- product `README.md` where policy/recovery semantics are described
+- publication-policy and memory-layer standards that still encode universal raw
+  conversation semantics
+- conformance / standard-kit checks that validate public-project truth
+
+## Test Plan
+
+### Shared Policy / Path Contract
+
+Cover at minimum:
+
+1. policy resolution for `local_private`, `private_continuity`,
+   `public_distilled`
+2. default, custom, and invalid escape-path configurations
+3. repo-root and project-root boundary validation
+
+### Conversation Routing Utility / Derived View
+
+Cover at minimum:
+
+1. `public_distilled` routes raw history to `.private/conversations/`
+2. `private_continuity` keeps raw history in tracked conversations path
+3. `local_private` remains unchanged
+4. custom configured paths are normalized correctly when policy allows
+5. project-root escape attempts fail closed
+6. legacy tracked transcript detection is surfaced
+7. no second independent routing resolution is introduced
+
+### Record Command
+
+Cover at minimum:
+
+1. `agenticos_record` writes to sidecar path for `public_distilled`
+2. result message shows the actual file path written
+3. result message explains whether Git recovery is full or distilled-only
+4. `private_continuity` behavior remains tracked-path based
+5. no-policy / invalid-policy projects fail clearly
+6. legacy public tracked transcripts trigger the designed warning / note path
+7. `misconfigured_public_raw_target` fails closed
+
+### Save Alignment
+
+Cover at minimum:
+
+1. sidecar raw transcripts are not staged for `public_distilled`
+2. existing tracked distilled surfaces are not regressed
+3. save output does not claim raw sidecar history is Git-recoverable
+4. tracked raw transcript diffs block `save` for `public_distilled`
+5. tracked continuity set matches the published distilled recovery contract
+
+### Guidance / Template / Conformance
+
+Cover at minimum:
+
+1. generated guidance no longer treats conversations as a universal tracked
+   startup surface
+2. entry surfaces reflect policy-derived truth
+3. templates/comments do not misdescribe public raw transcript routing
+4. conformance checks catch contradictory semantics
+5. guardrail/review scope flags sidecar raw transcript leakage for
+   `public_distilled`
+
+### Test Matrix Dimensions
+
+At minimum cover:
+
+1. policy:
+   - `local_private`
+   - `private_continuity`
+   - `public_distilled`
+2. path shape:
+   - default
+   - custom valid override
+   - invalid escape path
+3. history state:
+   - empty project
+   - legacy tracked conversations present
+   - legacy tracked conversations dirty
+   - sidecar conversations already present
+
+## Rollout Plan
+
+### Tranche 1
+
+- consume shared `context-policy-plan` utility
+- add derived routing / legacy-status helper if needed
+- lock `agent_context.conversations` semantics
+- add planner tests
+
+### Tranche 2
+
+- wire `record.ts`
+- update record messaging
+- add legacy transcript classifier / warning behavior
+- update record tests
+
+### Tranche 3
+
+- align `save.ts` tracked continuity, exclusion, and blocking behavior
+- update `runtime-review-surface.ts`, switch/status, and guardrail scope checks
+- update docs/templates/generated guidance/standard-kit wording
+- update conformance checks and related tests
+
+## Open Questions
+
+These are implementation-time questions, not design blockers:
+
+1. Should the derived helper live in a new file or be folded into the shared
+   planner / continuity utility?
+   - requirement: no second routing authority either way
+2. Should legacy public transcript notices be elevated to conformance failure,
+   WARN, or both when historical committed leakage exists but no new diff is
+   present?
+   - requirement: tracked raw transcript diffs still block `save`
+3. Should a future issue add sanitized tracked transcript summaries?
+   - current recommendation: not in `#245`
+
+## Final Recommendation
+
+Implement `#245` as:
+
+1. policy-aware raw transcript routing for `public_distilled`
+2. a policy-aware distilled save contract, not just record-path branching
+3. legacy-compatible but non-dual-write public rollout with explicit
+   warn/block states
+4. a full operator-surface correction across docs, templates, generated
+   guidance, standard-kit, guardrails, and conformance
+
+Keep the sequencing clean:
+
+1. `#244` gives private repos full tracked continuity
+2. `#245` gives public repos private raw transcript isolation
+
+Do not merge them into one implementation issue, but do require both to build
+on the same shared validated policy/path contract.


### PR DESCRIPTION
## Summary
- archive the closed issue #244 private continuity technical design into main tasks/
- archive the closed issue #245 public raw conversation isolation design into main tasks/
- prepare the old standalone design worktrees/branches for cleanup without losing the design record

## Validation
- docs-only change
- verified diff adds only the two task design documents