### PR TITLE
docs: archive issue 263 migration notes

### DIFF
--- a/tasks/issue-263-operator-migration-guide.md
+++ b/tasks/issue-263-operator-migration-guide.md
@@ -1,0 +1,251 @@
+# #263 Operator Migration Guide
+
+## Purpose
+
+This guide explains how to migrate existing managed projects after `#262` and
+the `#263` audit / per-project migration work.
+
+It is written for the normalized runtime model:
+
+- `AGENTICOS_HOME` is a long-lived runtime workspace
+- managed projects live under `projects/`
+- a project may be source-managed inside its own project directory, but the
+  home itself is not the authoritative runtime current-project switch
+
+## What Changed After #262
+
+After `#262`:
+
+- runtime target resolution no longer depends on global `registry.active_project`
+- runtime resolution now prefers:
+  1. explicit target
+  2. provable `repo_path`
+  3. session-local binding
+  4. otherwise fail closed
+- `registry.active_project` remains compatibility-only schema state
+
+That means old homes and old projects may still work, but they can contain
+legacy state that is no longer the desired normalized contract.
+
+## Current Tooling Status
+
+Available now:
+
+- `agenticos_migration_audit`
+  - report-only, per-project
+- `agenticos_migrate_home --report-only`
+  - report-only, registry-backed home inventory
+- `agenticos_migrate_project mode=plan`
+  - deterministic per-project migration plan
+- `agenticos_migrate_project mode=apply`
+  - guarded apply for the currently supported deterministic actions
+
+Still intentionally out of scope:
+
+- home-wide apply
+- orphan discovery under `AGENTICOS_HOME/projects`
+- topology / identity guessing for ambiguous projects
+- rewriting historical guardrail / bootstrap / RCA evidence
+
+## Migration Strategy
+
+Use the hybrid strategy below.
+
+Do:
+
+1. audit first
+2. migrate only the projects you actually need
+3. apply per-project with reviewed `plan_hash`
+4. leave dormant or ambiguous projects alone until they need explicit handling
+
+Do not:
+
+- run a one-shot global mutation across the entire home
+- treat `registry.active_project` as current truth
+- rely on `switch` to silently perform structural migration
+
+## Which Projects Need Immediate Attention
+
+Prioritize these first:
+
+- active projects you are about to work on
+- projects with `explicit_migration_required` findings that block intended work
+- projects whose registry identity/path metadata is obviously stale
+
+Defer these when safe:
+
+- archived/reference projects
+- dormant projects not currently being used
+- projects with compatibility-only historical evidence but no execution impact
+
+## Standard Workflow
+
+### 1. Inventory The Home
+
+Run:
+
+- `agenticos_migrate_home --report-only`
+
+Use this to answer:
+
+- which registered projects are `PASS`
+- which are `WARN`
+- which are `BLOCK`
+- which projects are safe to defer
+
+### 2. Audit One Target Project
+
+Run:
+
+- `agenticos_migration_audit`
+  - with explicit `project` or `project_path`
+
+Use this when:
+
+- a specific project is about to be worked on
+- the home inventory showed a `WARN` or `BLOCK`
+- you want the exact finding-level detail before planning migration
+
+### 3. Build A Deterministic Plan
+
+Run:
+
+- `agenticos_migrate_project mode=plan`
+
+Required operator checks:
+
+- target identity is the intended project
+- `manual_blocks` is empty
+- planned actions are narrow and expected
+- `plan_hash` is present
+
+If `manual_blocks` is non-empty:
+
+- stop
+- do not try to force apply
+- fix the ambiguous or damaged state explicitly first
+
+### 4. Apply The Reviewed Plan
+
+Run:
+
+- `agenticos_migrate_project mode=apply expected_plan_hash=...`
+
+Apply is allowed only when:
+
+- the target is explicit
+- the reviewed `plan_hash` still matches
+- the project is not in a manual-blocked state
+
+Apply currently performs only deterministic per-project actions such as:
+
+- clearing compatibility-only `registry.active_project`
+- normalizing registry path storage
+- backfilling lightweight metadata such as `last_accessed`
+- rebuilding a missing state surface when the target contract is already proven
+- writing additive migration evidence
+
+### 5. Review Post-Apply Evidence
+
+After apply, inspect:
+
+- post-apply audit status
+- migration report under `artifacts/migrations/`
+- latest migration summary in state
+
+The migration should leave:
+
+- a narrower or empty set of actionable findings
+- no hidden mutation outside the selected project and supported registry fields
+
+## Per-Project Checklist
+
+Before apply:
+
+- [ ] I selected the project explicitly with `project` or `project_path`
+- [ ] I ran `agenticos_migration_audit`
+- [ ] I ran `agenticos_migrate_project mode=plan`
+- [ ] I reviewed the `plan_hash`
+- [ ] `manual_blocks` is empty
+- [ ] The planned actions are only the deterministic actions I intend to run
+
+After apply:
+
+- [ ] `mode=apply` succeeded without a hash mismatch
+- [ ] post-apply audit no longer shows the repaired findings
+- [ ] a migration report was written under `artifacts/migrations/`
+- [ ] state contains the latest migration summary pointer
+- [ ] no unrelated project was mutated
+
+## Mixed-State Rollout Guidance
+
+During rollout, it is normal for one home to contain a mix of:
+
+- fully normalized projects
+- compatible-but-not-yet-normalized projects
+- blocked projects requiring explicit operator repair
+
+That mixed state is acceptable.
+
+The important rule is:
+
+- compatibility-on-read is allowed
+- mutation is per-project and explicit
+
+This is why the recommended migration order is:
+
+1. projects you are actively using now
+2. projects you will use soon
+3. everything else later, only if needed
+
+## FAQ
+
+### Should I migrate every project immediately?
+
+No.
+
+Only migrate projects that need near-term work or have blocking findings you
+must clear.
+
+### Should migration happen automatically during `agenticos_switch`?
+
+Only in the narrow metadata-repair sense, and only for registry-local cleanup.
+
+Structural migration must remain explicit.
+
+### Does `agenticos_migrate_home --report-only` find every directory under `projects/`?
+
+No.
+
+Current home inventory is registry-backed. Unregistered directories are not yet
+discovered automatically.
+
+### Can `mode=apply` fix ambiguous identity or missing topology automatically?
+
+No.
+
+If the tool cannot prove the intended meaning safely, it must keep blocking.
+
+### Should historical evidence be rewritten to remove old `active_project` traces?
+
+Not by default.
+
+Historical evidence stays historical. New migration evidence is written
+additively instead.
+
+## Recommended Order For Existing Installations
+
+For an existing machine with historical drift:
+
+1. run `agenticos_migrate_home --report-only`
+2. choose one active project
+3. run `agenticos_migration_audit`
+4. run `agenticos_migrate_project mode=plan`
+5. run `agenticos_migrate_project mode=apply`
+6. repeat only for the next project that actually matters
+
+This gives the intended effect:
+
+- once-only coherent correction where needed
+- no unnecessary mutation of dormant projects
+- no regression to a global runtime current-project model

--- a/tasks/issue-263-phase2-design-review.md
+++ b/tasks/issue-263-phase2-design-review.md
@@ -1,0 +1,46 @@
+# #263 Phase 2 Design Review
+
+This file is the lightweight index for the phase-2 review.
+
+The consolidated technical proposal now lives in:
+
+- `tasks/issue-263-phase2-technical-design-review.md`
+
+Reviewed by three parallel Sub-agents plus local synthesis:
+
+- runtime semantics / command contract
+- migration action model / evidence strategy
+- concurrency safety / failure recovery
+
+## Scope
+
+The reviewed tranche is the next implementation step after the report-only audit
+slice:
+
+- explicit per-project migration
+- narrow safe lazy repair boundary
+- concurrency-safe apply semantics
+- failure recovery and migration evidence
+
+## Status
+
+Review synthesis completed.
+
+Current decision:
+
+- proceed with a per-project `dry_run` / explicit `apply` design
+- require explicit target selection for apply
+- keep registry writes patch-based
+- add a per-project migration lock and plan fingerprint precondition
+- keep historical evidence additive by default rather than rewriting it
+- defer home-wide apply, schema rename, and orphan discovery
+
+Current implementation status:
+
+- deterministic `plan` is implemented
+- guarded per-project `apply` is implemented for the current deterministic
+  actions
+- broader structural apply and home-wide mutation are still deferred
+
+For the full rationale, command contract, concurrency model, and rollout
+recommendation, use the technical review document above as the canonical source.

--- a/tasks/issue-263-phase2-technical-design-review.md
+++ b/tasks/issue-263-phase2-technical-design-review.md
@@ -1,0 +1,393 @@
+# #263 Phase 2 Technical Design Review
+
+## Purpose
+
+This document reviews the next implementation tranche for `#263` after the
+report-only audit slice landed.
+
+The goal is to define a migration design that remains consistent with `#262`
+while making legacy managed projects repairable without reintroducing
+home-global runtime coupling.
+
+## Review Basis
+
+Current contract already established by `#262` and the first `#263` slice:
+
+- `AGENTICOS_HOME` is a long-term runtime workspace, not an authoritative
+  single-project source checkout
+- `projects/` contains many managed projects that may be active in parallel
+- runtime target resolution must remain:
+  - explicit target
+  - then provable `repo_path` where applicable
+  - then session-local binding
+  - otherwise fail closed
+- `registry.active_project` is compatibility-only schema state, not runtime
+  truth
+- `#263` slice 1 already provides report-only detection through
+  `agenticos_migration_audit` and `agenticos_migrate_home`
+
+Review lenses used for this design:
+
+1. runtime semantics and command contract
+2. migration action model and idempotency
+3. concurrency safety and failure recovery
+4. operator rollout and upgrade path
+
+## Current Gap
+
+The current implementation can detect legacy state, but it cannot yet:
+
+- execute a reviewed per-project migration plan
+- apply safe metadata repair deterministically
+- persist migration evidence for later audit
+- recover cleanly from an interrupted apply
+- define a trustworthy switch-time lazy-repair boundary
+
+That phase-2 gap has now been partially closed:
+
+- deterministic planning is implemented
+- deterministic per-project apply is implemented
+- migration evidence is written additively
+
+What still remains open is broader structural apply beyond the currently
+implemented deterministic action set.
+
+## Critical Findings
+
+### 1. Apply mode must be explicit-target only
+
+`report-only` audit can safely fall back to the session-bound project.
+
+`apply` must not do that.
+
+Reason:
+
+- session-local selection is runtime convenience, not a strong enough mutation
+  intent boundary
+- migration changes durable project or registry state
+- the operator must prove which project is being mutated
+
+Design consequence:
+
+- `agenticos_migrate_project --apply` must require explicit `project` or
+  explicit `project_path`
+- session fallback may remain allowed for dry-run only, but should be avoided if
+  we want one mutation contract instead of two
+
+Recommended choice:
+
+- require explicit `project` or `project_path` for both `dry_run=false` and
+  `dry_run=true`
+- keep session fallback only on `agenticos_migration_audit`
+
+### 2. Dry-run and apply must share one planner
+
+If dry-run builds one result and apply reinterprets findings ad hoc, the design
+will drift and operators will stop trusting the tool.
+
+Design consequence:
+
+- introduce one internal planner that converts current project state into a
+  deterministic migration plan
+- `agenticos_migration_audit` remains a pure classifier
+- `agenticos_migrate_project --dry_run` returns the planned action list
+- `agenticos_migrate_project --apply` recomputes that same plan and refuses to
+  continue if it no longer matches the reviewed dry-run
+
+### 3. Registry writes must stay patch-based
+
+`#262` already established that business-path registry writes must use lock +
+reload + field patch + atomic rename.
+
+That rule must remain non-negotiable for migration apply.
+
+Must use patch-based registry APIs for:
+
+- clearing or downgrading legacy `active_project`
+- normalizing a project's stored path
+- backfilling `last_accessed`
+- updating any future migration metadata recorded in the registry
+
+Must not do:
+
+- load registry once, mutate in memory, and later write a full stale snapshot
+- combine unrelated project updates into one broad rewrite
+
+### 4. Project-file mutation needs its own lock boundary
+
+`registry.lock` protects only the home registry.
+
+It does not protect `.project.yaml`, `state.yaml`, or any migration report file
+inside a project.
+
+Design consequence:
+
+- add a per-project migration lock, e.g. under the resolved project context root
+- allow only one `agenticos_migrate_project --apply` per project at a time
+- keep registry mutation inside existing patch-based APIs when registry changes
+  are required during that same apply
+
+### 5. Structural migration must not guess topology when identity is ambiguous
+
+Some legacy projects can be normalized deterministically.
+
+Some cannot.
+
+Examples that should still block:
+
+- missing `.project.yaml` and registry identity cannot be proven
+- missing topology where runtime evidence cannot distinguish
+  `local_directory_only` from `github_versioned`
+- conflicting registry / `.project.yaml` identity
+- public/private continuity policy cannot be derived safely
+
+Design consequence:
+
+- `agenticos_migrate_project` should repair only deterministic cases
+- ambiguous cases must remain `BLOCK` with an explicit operator action
+- this issue should not smuggle in an unsafe topology inference engine
+
+### 6. Migration evidence should be additive, not historical rewrite by default
+
+Legacy compatibility evidence such as old `active_project` fields inside
+historical guardrail records is not current truth, but it is still historical
+evidence.
+
+Design consequence:
+
+- default migration should add a new migration report and state summary
+- it should not rewrite old guardrail evidence blobs by default
+- any compatibility-evidence rewrite should be an opt-in later capability, not
+  part of the minimal sufficient tranche
+
+## Recommended Command Contract
+
+### `agenticos_migrate_project`
+
+Recommended inputs:
+
+- `project_path` or `project`
+- `dry_run` default `true`
+- `apply_safe_repairs_only` default `false`
+- `expected_plan_fingerprint` required when `dry_run=false`
+
+Recommended outputs:
+
+- resolved project identity
+- current migration status
+- deterministic `plan_fingerprint`
+- planned actions in stable order
+- touched files / surfaces
+- which actions are:
+  - `safe_lazy_repair`
+  - `explicit_structural_migration`
+- whether apply is blocked
+- block reasons
+- migration report path when apply succeeds
+
+Recommended rules:
+
+- if `dry_run=true`, no writes occur
+- if `dry_run=false`, explicit `project` or `project_path` is required
+- if `dry_run=false`, `expected_plan_fingerprint` is required
+- apply recomputes the plan and fails closed if the fingerprint changed
+
+## Recommended Action Model
+
+The planner should emit bounded actions, not free-form repair logic.
+
+Recommended action families:
+
+1. `registry_patch`
+   - clear compatibility-only `active_project`
+   - normalize stored project path
+   - backfill lightweight registry metadata
+
+2. `project_yaml_patch`
+   - repair deterministic identity fields
+   - normalize deterministic topology fields only when provable
+   - normalize deterministic publication-policy fields only when provable
+
+3. `state_surface_repair`
+   - create missing state surface from the current contract
+   - backfill deterministic migration summary nodes
+
+4. `evidence_write`
+   - write a machine-readable migration report
+   - write a concise latest-migration summary into state
+
+Recommended non-goal for this tranche:
+
+- rewriting arbitrary historical guardrail/state evidence blobs
+
+## Safe Lazy Repair Boundary
+
+Safe lazy repair should remain narrow.
+
+Allowed lazy repairs during explicit project entry:
+
+- clear compatibility-only `registry.active_project`
+- backfill missing `last_accessed`
+- normalize a stored path from absolute-under-home to relative form
+
+Not allowed as lazy repair during `switch`:
+
+- rewriting `.project.yaml`
+- generating or rewriting project state structures with structural meaning
+- changing topology or publication policy
+- repairing identity mismatches
+
+Reason:
+
+- `switch` is still a routine context-load command
+- silent structural mutation during `switch` would violate the design intent of
+  `#263`
+
+## Concurrency And Failure Recovery
+
+## Required Write Order
+
+Minimal sufficient apply sequence:
+
+1. resolve explicit project target and prove identity
+2. acquire a project-local migration lock
+3. build migration plan
+4. compare plan fingerprint with `expected_plan_fingerprint`
+5. write project-local files using temp file + atomic rename
+6. apply registry patches through `patchRegistry()` or
+   `patchProjectMetadata()`
+7. write additive migration evidence
+8. release lock
+
+## Recovery Contract
+
+If apply is interrupted:
+
+- rerunning dry-run must rebuild the current plan from disk
+- already-completed atomic file writes remain valid
+- partially completed steps are re-evaluated rather than assumed
+- registry writes remain safe because they are patch-based under lock
+
+This means recovery is based on idempotent recomputation, not a separate
+rollback engine.
+
+Recommended minimum safeguards:
+
+- per-project migration lock
+- temp-file atomic rename for project-local file writes
+- patch-based registry mutation
+- deterministic planner
+- plan fingerprint check before apply
+
+## Fingerprint / Preconditions
+
+The minimal sufficient design should include a plan fingerprint.
+
+Recommended contents of the fingerprint:
+
+- project id
+- project path
+- relevant audit findings
+- current raw registry entry subset affecting the target
+- current `.project.yaml` content digest
+- current `state.yaml` content digest or missing marker
+- selected apply mode
+
+Recommended semantics:
+
+- dry-run returns `plan_fingerprint`
+- apply requires `expected_plan_fingerprint`
+- if any relevant input changed, apply returns `BLOCK` and tells the operator to
+  rerun dry-run
+
+This is enough optimistic concurrency for the current scope.
+
+A heavier transactional system is not necessary yet.
+
+## Evidence Persistence
+
+Recommended outputs after successful apply:
+
+1. a machine-readable migration report under the resolved runtime context tree
+2. a concise latest-migration summary in `state.yaml`
+
+Recommended report content:
+
+- migrated project identity
+- executed plan fingerprint
+- executed actions
+- skipped actions
+- blocked findings that remained unresolved
+- timestamps
+
+Reason for runtime-context storage instead of repo-root historical docs:
+
+- it keeps operator evidence near current runtime surfaces
+- it avoids forcing publishability assumptions for every source-managed project
+- it keeps historical issue/RCA documents intact
+
+## Rollout Strategy
+
+Recommended rollout remains hybrid:
+
+1. operator runs `agenticos_migrate_home --report-only`
+2. operator picks one active project
+3. operator runs `agenticos_migrate_project --dry_run`
+4. operator reviews the plan
+5. operator runs `agenticos_migrate_project --apply`
+6. only after repeated success do we consider optional home-wide safe-repair
+
+This still satisfies the long-term home model because:
+
+- dormant projects are not mutated unnecessarily
+- active projects can be normalized deliberately
+- multiple projects remain independently migratable
+- concurrent project work is preserved
+
+## What Is Not Necessary Right Now
+
+These items are explicitly deferrable:
+
+- renaming `active_project` to `last_selected_project`
+- home-wide `--apply-safe-repairs` mutation
+- filesystem-wide orphan discovery under `AGENTICOS_HOME/projects`
+- compatibility-evidence rewrite of historical guardrail blobs
+- a general rollback subsystem
+
+Deferring them does not block the core goal if per-project dry-run/apply is
+implemented correctly.
+
+## Can This Reach The Goal?
+
+Yes, if implemented with these constraints:
+
+- explicit-target apply only
+- one deterministic planner for dry-run and apply
+- patch-based registry writes only
+- per-project migration lock
+- plan fingerprint precondition
+- additive evidence writes
+- narrow lazy-repair boundary
+- fail closed on ambiguous topology or identity
+
+No, if implementation drifts into any of these patterns:
+
+- silent structural migration during `switch`
+- home-wide mutate-first rollout
+- reintroducing runtime dependence on `registry.active_project`
+- full-object registry rewrites from stale snapshots
+- rewriting historical evidence as a default side effect
+
+## Recommended Next Implementation Tranche
+
+The next tranche should be limited to:
+
+1. planner + `agenticos_migrate_project --dry_run`
+2. plan fingerprint + explicit apply
+3. per-project migration lock
+4. patch-based registry actions
+5. project-local state / evidence writes
+6. operator docs for the dry-run/apply workflow
+
+That is the minimal sufficient path that advances `#263` without reopening the
+state-model mistakes that `#262` just removed.

--- a/tasks/issue-263-remaining-items-review.md
+++ b/tasks/issue-263-remaining-items-review.md
@@ -1,0 +1,244 @@
+# #263 Remaining Items Review
+
+## Purpose
+
+This document re-evaluates the remaining tail items after the current `#263`
+delivery state:
+
+- report-only audit is implemented
+- per-project deterministic planning is implemented
+- guarded deterministic per-project apply is implemented
+- operator migration guide and checklist are published
+
+The question is no longer “what else could be built”.
+
+The question is:
+
+- what is still necessary to satisfy the actual target model
+- what can be explicitly deferred
+- what should be closed instead of expanded
+
+## Decision Standard
+
+An item should remain in active scope only if it materially improves one of
+these goals:
+
+1. preserve the runtime-home model
+2. preserve safe multi-project parallel work
+3. make existing installations operable without forcing global mutation
+4. improve operator correctness in realistic migration workflows
+
+If an item mainly expands surface area without materially improving those
+outcomes, it should be deferred or closed.
+
+## Current Delivery Baseline
+
+Already delivered inside `#263`:
+
+- `agenticos_migration_audit`
+- `agenticos_migrate_home --report-only`
+- `agenticos_migrate_project mode=plan`
+- `agenticos_migrate_project mode=apply` for the currently supported
+  deterministic actions
+- phase-2 technical review
+- operator migration guide
+
+That means the core migration contract is now present:
+
+- audit
+- plan
+- guarded apply
+- evidence
+- operator documentation
+
+## Remaining Items
+
+### A. Home-Wide `apply-safe-repairs`
+
+#### Assessment
+
+Not necessary for the core target model.
+
+Reason:
+
+- the runtime-home model does not require estate-wide mutation
+- per-project migration already satisfies the active-project workflow
+- home-wide apply increases blast radius immediately
+- the operator guide already gives a safe incremental path
+
+#### Decision
+
+Defer.
+
+#### Reopen Only If
+
+- repeated real-world use shows that per-project apply creates unacceptable
+  operational overhead
+- a large estate has many low-risk registry-only repairs where bulk apply would
+  materially reduce toil
+
+#### Current Status
+
+- not required to close `#263`
+- should not be implemented now
+
+### B. Filesystem Orphan Discovery Under `AGENTICOS_HOME/projects`
+
+#### Assessment
+
+Useful, but not necessary for the current migration contract.
+
+Reason:
+
+- current inventory is registry-backed by design
+- the runtime model already works when project targeting is explicit
+- orphan discovery is an estate hygiene capability, not a prerequisite for safe
+  per-project migration
+- adding it now would broaden `#263` from migration correctness into discovery
+  policy
+
+#### Decision
+
+Defer, likely as a follow-up issue rather than extending `#263`.
+
+#### Reopen Only If
+
+- operators repeatedly encounter materially important unregistered project
+  directories
+- a future home-integrity or estate-audit feature needs filesystem discovery as
+  a first-class capability
+
+### C. Broader Structural Apply Beyond The Current Deterministic Actions
+
+#### Assessment
+
+Partially necessary, but not all at once.
+
+Reason:
+
+- current apply only covers the deterministic safe subset
+- some blocked findings may remain too manual for comfortable operator use
+- however, broadening structural apply too fast risks reintroducing guessing and
+  silent scope creep
+
+#### Decision
+
+Keep open, but narrow the remaining active scope.
+
+#### What Stays In Scope
+
+- only additional deterministic, provable, per-project structural repairs
+- only when the planner can describe them precisely and fail closed on
+  ambiguity
+
+#### What Leaves Scope
+
+- topology guessing
+- identity conflict auto-repair
+- damage recovery for unreadable YAML without trustworthy source inputs
+
+#### Working Rule
+
+Every new apply action must pass this test:
+
+- can the tool prove the intended target meaning without inference?
+
+If not, it should remain `manual_block`.
+
+### D. Historical Evidence Rewrite
+
+#### Assessment
+
+Not necessary, and harmful as a default.
+
+Reason:
+
+- historical evidence should remain historical evidence
+- additive migration reports already solve the operator/auditability need
+- rewriting history would blur provenance and expand risk without improving the
+  runtime model
+
+#### Decision
+
+Close for `#263`.
+
+Do not continue this direction in the current issue.
+
+### E. Schema Rename `active_project -> last_selected_project`
+
+#### Assessment
+
+Not necessary.
+
+Reason:
+
+- `#262` already removed runtime dependence on `active_project`
+- the remaining field is compatibility-only schema baggage, not runtime truth
+- renaming it now adds migration surface but does not materially improve
+  operator outcomes
+
+#### Decision
+
+Close for `#263`.
+
+If ever revisited, it should be justified as a separate schema cleanup issue,
+not bundled into migration correctness work.
+
+### F. General Rollback Subsystem
+
+#### Assessment
+
+Not necessary right now.
+
+Reason:
+
+- the current apply path is already constrained to deterministic actions
+- writes are patch-based or atomic
+- rerun + post-audit is the current recovery model
+- a general rollback framework would add much more machinery than the current
+  scope justifies
+
+#### Decision
+
+Defer.
+
+Only reopen if actual field usage shows repeated partial-apply recovery pain.
+
+## Recommended Closure State For #263
+
+### Keep Active
+
+- narrowly expand deterministic per-project structural apply only if real
+  operator cases justify it
+
+### Defer
+
+- home-wide `apply-safe-repairs`
+- filesystem orphan discovery
+- general rollback subsystem
+
+### Close
+
+- historical evidence rewrite as a default migration behavior
+- schema rename of `active_project`
+
+## Final Judgment
+
+`#263` has already reached the core target.
+
+It now provides:
+
+- audit
+- deterministic plan
+- guarded per-project apply
+- additive evidence
+- operator migration guidance
+
+That is sufficient to support the long-term runtime-home / multi-project model
+without reintroducing global current-project semantics.
+
+So the correct posture from here is:
+
+- stop expanding by default
+- only reopen narrowly justified deterministic apply actions
+- move estate-hygiene extras into follow-up issues if they become necessary

--- a/tasks/issue-263-submission-evidence.md
+++ b/tasks/issue-263-submission-evidence.md
@@ -1,0 +1,56 @@
+# Submission Evidence
+
+## Scope
+- Issue: `#263` design: legacy managed-project migration plan after `#262`
+- Task type: report-only migration audit surface, operator contract clarification, first-slice documentation
+- Branch: `redesign/263-legacy-project-migration-audit`
+- Worktree: `/Users/jeking/dev/AgenticOS/worktrees/agenticos-263-legacy-project-migration-audit`
+
+## Preflight
+- Preflight passed: not applicable for this product-repo audit/design tooling tranche
+- Blocking exceptions: none during local implementation verification
+
+## Design Loop
+- Design pass count: 1 persisted migration plan, then 1 implementation refinement pass after code/test/doc review
+- Critique completed: yes; code semantics, test coverage, and operator-facing contract were re-audited before submission
+- Acceptance defined before edit: yes; persisted in [tasks/issue-263-legacy-project-migration-plan.md](/Users/jeking/dev/AgenticOS/worktrees/agenticos-263-legacy-project-migration-audit/tasks/issue-263-legacy-project-migration-plan.md)
+
+## Sub-Agent Verification
+- Sub-agents used: 3 parallel audits
+- Inheritance packet defined: yes; each audit received the `#262` concurrent-runtime background plus `#263` first-slice goal
+- Sub-agent understanding verified before work: yes; scopes were separated into runtime semantics, test coverage, and operator UX/docs
+- Parent agent distilled important results back into canonical files: yes; findings were reflected into runtime code, tests, and persisted task docs
+
+## Verification
+- Deliverable type: MCP report-only migration audit tooling plus supporting docs
+- Commands run:
+  - `npm test -- src/tools/__tests__/migration-audit.test.ts`
+  - `npm test`
+  - `npm run lint`
+- Coverage result:
+  - `33` test files passed
+  - `266` tests passed
+  - lint passed
+- Rubric evaluation result: not applicable
+- Evidence files:
+  - [tasks/issue-263-legacy-project-migration-plan.md](/Users/jeking/dev/AgenticOS/worktrees/agenticos-263-legacy-project-migration-audit/tasks/issue-263-legacy-project-migration-plan.md)
+  - [tasks/issue-263-pr-draft.md](/Users/jeking/dev/AgenticOS/worktrees/agenticos-263-legacy-project-migration-audit/tasks/issue-263-pr-draft.md)
+  - [mcp-server/src/utils/migration-audit.ts](/Users/jeking/dev/AgenticOS/worktrees/agenticos-263-legacy-project-migration-audit/mcp-server/src/utils/migration-audit.ts)
+  - [mcp-server/src/tools/migration-audit.ts](/Users/jeking/dev/AgenticOS/worktrees/agenticos-263-legacy-project-migration-audit/mcp-server/src/tools/migration-audit.ts)
+  - [mcp-server/src/tools/__tests__/migration-audit.test.ts](/Users/jeking/dev/AgenticOS/worktrees/agenticos-263-legacy-project-migration-audit/mcp-server/src/tools/__tests__/migration-audit.test.ts)
+  - [mcp-server/src/index.ts](/Users/jeking/dev/AgenticOS/worktrees/agenticos-263-legacy-project-migration-audit/mcp-server/src/index.ts)
+  - [mcp-server/README.md](/Users/jeking/dev/AgenticOS/worktrees/agenticos-263-legacy-project-migration-audit/mcp-server/README.md)
+
+## Residual Risk
+- Remaining limitations:
+  - apply-mode migration is intentionally not implemented in this slice
+  - `agenticos_migrate_home` inventories registry-backed managed projects only
+  - orphan directories under `AGENTICOS_HOME/projects` still require future discovery logic if that becomes part of the migration contract
+- Explicit exceptions:
+  - did not implement mutate-first migration
+  - did not add home-wide apply-safe-repair behavior
+  - did not broaden the first slice into generic historical guardrail archaeology
+
+## Ready To Submit
+- Yes/No: yes, for commit/PR preparation
+- If no, what is blocked:


### PR DESCRIPTION
## Summary
- archive the surviving design and operator documents from the closed issue #263 branch into main tasks/
- preserve migration design history without reviving the old implementation branch
- prepare the stale #263 worktree/branch for cleanup after merge

## Validation
- docs-only change
- verified diff adds only issue #263 migration documents