### PR TITLE
fix: harden runtime guardrail persistence for #294

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ mcp-server/build/
 
 # Runtime-only state
 .runtime/
+.agent-workspace/
 .claude/worktrees/
 .private/
 .meta/transcripts/

--- a/mcp-server/src/tools/__tests__/edit-guard.test.ts
+++ b/mcp-server/src/tools/__tests__/edit-guard.test.ts
@@ -1,10 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const execAsyncMock = vi.hoisted(() => vi.fn());
-const yamlMock = vi.hoisted(() => ({
-  parse: vi.fn(),
-}));
 const resolveGuardrailProjectTargetMock = vi.hoisted(() => vi.fn());
+const loadLatestGuardrailStateMock = vi.hoisted(() => vi.fn());
 
 vi.mock('child_process', () => ({
   exec: vi.fn(),
@@ -14,16 +12,13 @@ vi.mock('util', () => ({
   promisify: vi.fn(() => execAsyncMock),
 }));
 
-vi.mock('fs/promises', () => ({
-  readFile: vi.fn(),
-}));
-
-vi.mock('yaml', () => ({
-  default: yamlMock,
-}));
-
 vi.mock('../../utils/registry.js', () => ({
   loadRegistry: vi.fn(),
+}));
+
+vi.mock('../../utils/guardrail-evidence.js', () => ({
+  extractLatestIssueBootstrap: (state: any) => state?.issue_bootstrap?.latest || null,
+  loadLatestGuardrailState: loadLatestGuardrailStateMock,
 }));
 
 vi.mock('../../utils/repo-boundary.js', () => ({
@@ -31,11 +26,9 @@ vi.mock('../../utils/repo-boundary.js', () => ({
   resolveGuardrailProjectTarget: resolveGuardrailProjectTargetMock,
 }));
 
-import { readFile } from 'fs/promises';
 import { loadRegistry } from '../../utils/registry.js';
 import { runEditGuard } from '../edit-guard.js';
 
-const readFileMock = readFile as unknown as ReturnType<typeof vi.fn>;
 const loadRegistryMock = loadRegistry as unknown as ReturnType<typeof vi.fn>;
 
 describe('runEditGuard', () => {
@@ -71,9 +64,10 @@ describe('runEditGuard', () => {
       }
       throw new Error(`Unexpected command: ${cmd}`);
     });
-    readFileMock.mockImplementation(async (path: string) => {
-      if (path.endsWith('/.context/state.yaml')) {
-        return JSON.stringify({
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/runtime/.agent-workspace/projects/agenticos-standards/guardrail-state.yaml',
+      state: {
           issue_bootstrap: {
             latest: {
               issue_id: '113',
@@ -94,12 +88,8 @@ describe('runEditGuard', () => {
               },
             },
           },
-        });
-      }
-
-      throw new Error(`Unexpected path: ${path}`);
+      },
     });
-    yamlMock.parse.mockImplementation((content: string) => JSON.parse(content));
   });
 
   it('passes when active project and latest preflight both match the intended edit', async () => {
@@ -116,6 +106,13 @@ describe('runEditGuard', () => {
     expect(result.status).toBe('PASS');
     expect(result.preflight_ok).toBe(true);
     expect(result.scope_ok).toBe(true);
+  });
+
+  it('handles undefined args via default destructuring', async () => {
+    const result = JSON.parse(await runEditGuard(undefined as any)) as { status: string; summary: string };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.summary).toContain('repo_path is required');
   });
 
   it('blocks when the target project cannot be resolved and asks for an explicit managed project path', async () => {
@@ -140,10 +137,30 @@ describe('runEditGuard', () => {
     expect(result.recovery_actions.join(' ')).toContain('pass project_path');
   });
 
+  it('asks for switch when no active project is available and target resolution fails', async () => {
+    resolveGuardrailProjectTargetMock.mockResolvedValue({
+      activeProjectId: null,
+      resolutionSource: null,
+      resolutionErrors: ['target project could not be resolved'],
+      targetProject: null,
+    });
+
+    const result = JSON.parse(await runEditGuard({
+      issue_id: '113',
+      task_type: 'implementation',
+      repo_path: '/workspace/source',
+      declared_target_files: ['projects/agenticos/mcp-server/src/index.ts'],
+    })) as { status: string; recovery_actions: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.recovery_actions.join(' ')).toContain('agenticos_switch');
+  });
+
   it('blocks when no preflight evidence is recorded', async () => {
-    readFileMock.mockImplementation(async (path: string) => {
-      if (path.endsWith('/.context/state.yaml')) {
-        return JSON.stringify({
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/runtime/.agent-workspace/projects/agenticos-standards/guardrail-state.yaml',
+      state: {
           issue_bootstrap: {
             latest: {
               issue_id: '113',
@@ -151,10 +168,7 @@ describe('runEditGuard', () => {
               current_branch: 'feat/113-fail-closed-edit-boundaries',
             },
           },
-        });
-      }
-
-      throw new Error(`Unexpected path: ${path}`);
+      },
     });
 
     const result = JSON.parse(await runEditGuard({
@@ -172,9 +186,10 @@ describe('runEditGuard', () => {
   });
 
   it('blocks when no issue bootstrap evidence is recorded', async () => {
-    readFileMock.mockImplementation(async (path: string) => {
-      if (path.endsWith('/.context/state.yaml')) {
-        return JSON.stringify({
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/runtime/.agent-workspace/projects/agenticos-standards/guardrail-state.yaml',
+      state: {
           guardrail_evidence: {
             preflight: {
               issue_id: '113',
@@ -187,10 +202,7 @@ describe('runEditGuard', () => {
               },
             },
           },
-        });
-      }
-
-      throw new Error(`Unexpected path: ${path}`);
+      },
     });
 
     const result = JSON.parse(await runEditGuard({
@@ -208,9 +220,10 @@ describe('runEditGuard', () => {
   });
 
   it('blocks when the latest issue bootstrap does not match the requested issue', async () => {
-    readFileMock.mockImplementation(async (path: string) => {
-      if (path.endsWith('/.context/state.yaml')) {
-        return JSON.stringify({
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/runtime/.agent-workspace/projects/agenticos-standards/guardrail-state.yaml',
+      state: {
           issue_bootstrap: {
             latest: {
               issue_id: '179',
@@ -230,10 +243,7 @@ describe('runEditGuard', () => {
               },
             },
           },
-        });
-      }
-
-      throw new Error(`Unexpected path: ${path}`);
+      },
     });
 
     const result = JSON.parse(await runEditGuard({
@@ -266,6 +276,512 @@ describe('runEditGuard', () => {
     expect(result.block_reasons.join(' ')).toContain('exceed the latest preflight scope');
   });
 
+  it('passes through for non implementation-affecting task types', async () => {
+    const result = JSON.parse(await runEditGuard({
+      task_type: 'discussion_only',
+    })) as { status: string; summary: string };
+
+    expect(result.status).toBe('PASS');
+    expect(result.summary).toContain('not required');
+  });
+
+  it('blocks when required arguments are missing', async () => {
+    const result = JSON.parse(await runEditGuard({
+      task_type: 'implementation',
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons).toContain('repo_path is required');
+    expect(result.block_reasons).toContain('issue_id is required for implementation edits');
+    expect(result.block_reasons).toContain('declared_target_files is required for implementation edits');
+  });
+
+  it('blocks when git repository identity cannot be resolved', async () => {
+    execAsyncMock.mockRejectedValue(new Error('git failed'));
+
+    const result = JSON.parse(await runEditGuard({
+      issue_id: '113',
+      task_type: 'implementation',
+      repo_path: '/workspace/source',
+      project_path: '/workspace/projects/agenticos/standards',
+      declared_target_files: ['projects/agenticos/mcp-server/src/index.ts'],
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons.join(' ')).toContain('failed to resolve git repository identity');
+  });
+
+  it('blocks when runtime guardrail state cannot be loaded', async () => {
+    loadLatestGuardrailStateMock.mockRejectedValue(new Error('boom'));
+
+    const result = JSON.parse(await runEditGuard({
+      issue_id: '113',
+      task_type: 'implementation',
+      repo_path: '/workspace/source',
+      project_path: '/workspace/projects/agenticos/standards',
+      declared_target_files: ['projects/agenticos/mcp-server/src/index.ts'],
+    })) as { status: string; block_reasons: string[]; recovery_actions: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons.join(' ')).toContain('managed project guardrail state is missing or unreadable');
+    expect(result.recovery_actions.join(' ')).toContain('guardrail state');
+  });
+
+  it('blocks when the latest issue bootstrap repo_path differs from the current repo', async () => {
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/runtime/.agent-workspace/projects/agenticos-standards/guardrail-state.yaml',
+      state: {
+        issue_bootstrap: {
+          latest: {
+            issue_id: '113',
+            repo_path: '/workspace/other',
+            current_branch: 'feat/113-fail-closed-edit-boundaries',
+          },
+        },
+        guardrail_evidence: {
+          preflight: {
+            issue_id: '113',
+            repo_path: '/workspace/source',
+            declared_target_files: ['projects/agenticos/mcp-server/src/index.ts'],
+            result: { status: 'PASS' },
+          },
+        },
+      },
+    });
+
+    const result = JSON.parse(await runEditGuard({
+      issue_id: '113',
+      task_type: 'implementation',
+      repo_path: '/workspace/source',
+      project_path: '/workspace/projects/agenticos/standards',
+      declared_target_files: ['projects/agenticos/mcp-server/src/index.ts'],
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons.join(' ')).toContain('different repo_path');
+  });
+
+  it('blocks when the latest issue bootstrap branch differs from the current branch', async () => {
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/runtime/.agent-workspace/projects/agenticos-standards/guardrail-state.yaml',
+      state: {
+        issue_bootstrap: {
+          latest: {
+            issue_id: '113',
+            repo_path: '/workspace/source',
+            current_branch: 'other-branch',
+          },
+        },
+        guardrail_evidence: {
+          preflight: {
+            issue_id: '113',
+            repo_path: '/workspace/source',
+            declared_target_files: ['projects/agenticos/mcp-server/src/index.ts'],
+            result: { status: 'PASS' },
+          },
+        },
+      },
+    });
+
+    const result = JSON.parse(await runEditGuard({
+      issue_id: '113',
+      task_type: 'implementation',
+      repo_path: '/workspace/source',
+      project_path: '/workspace/projects/agenticos/standards',
+      declared_target_files: ['projects/agenticos/mcp-server/src/index.ts'],
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons.join(' ')).toContain('does not match current branch');
+  });
+
+  it('blocks when the latest preflight belongs to a different issue', async () => {
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/runtime/.agent-workspace/projects/agenticos-standards/guardrail-state.yaml',
+      state: {
+        issue_bootstrap: {
+          latest: {
+            issue_id: '113',
+            repo_path: '/workspace/source',
+            current_branch: 'feat/113-fail-closed-edit-boundaries',
+          },
+        },
+        guardrail_evidence: {
+          preflight: {
+            issue_id: '999',
+            repo_path: '/workspace/source',
+            declared_target_files: ['projects/agenticos/mcp-server/src/index.ts'],
+            result: { status: 'PASS' },
+          },
+        },
+      },
+    });
+
+    const result = JSON.parse(await runEditGuard({
+      issue_id: '113',
+      task_type: 'implementation',
+      repo_path: '/workspace/source',
+      project_path: '/workspace/projects/agenticos/standards',
+      declared_target_files: ['projects/agenticos/mcp-server/src/index.ts'],
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons.join(' ')).toContain('latest preflight issue');
+  });
+
+  it('blocks when the latest preflight repo_path differs from the current repo', async () => {
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/runtime/.agent-workspace/projects/agenticos-standards/guardrail-state.yaml',
+      state: {
+        issue_bootstrap: {
+          latest: {
+            issue_id: '113',
+            repo_path: '/workspace/source',
+            current_branch: 'feat/113-fail-closed-edit-boundaries',
+          },
+        },
+        guardrail_evidence: {
+          preflight: {
+            issue_id: '113',
+            repo_path: '/workspace/other',
+            declared_target_files: ['projects/agenticos/mcp-server/src/index.ts'],
+            result: { status: 'PASS' },
+          },
+        },
+      },
+    });
+
+    const result = JSON.parse(await runEditGuard({
+      issue_id: '113',
+      task_type: 'implementation',
+      repo_path: '/workspace/source',
+      project_path: '/workspace/projects/agenticos/standards',
+      declared_target_files: ['projects/agenticos/mcp-server/src/index.ts'],
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons.join(' ')).toContain('latest preflight was recorded for a different repo_path');
+  });
+
+  it('blocks when the latest preflight status is not PASS', async () => {
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/runtime/.agent-workspace/projects/agenticos-standards/guardrail-state.yaml',
+      state: {
+        issue_bootstrap: {
+          latest: {
+            issue_id: '113',
+            repo_path: '/workspace/source',
+            current_branch: 'feat/113-fail-closed-edit-boundaries',
+          },
+        },
+        guardrail_evidence: {
+          preflight: {
+            issue_id: '113',
+            repo_path: '/workspace/source',
+            declared_target_files: ['projects/agenticos/mcp-server/src/index.ts'],
+            result: { status: 'BLOCK' },
+          },
+        },
+      },
+    });
+
+    const result = JSON.parse(await runEditGuard({
+      issue_id: '113',
+      task_type: 'implementation',
+      repo_path: '/workspace/source',
+      project_path: '/workspace/projects/agenticos/standards',
+      declared_target_files: ['projects/agenticos/mcp-server/src/index.ts'],
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons.join(' ')).toContain('instead of PASS');
+  });
+
+  it('normalizes missing preflight declared_target_files to an empty list', async () => {
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/runtime/.agent-workspace/projects/agenticos-standards/guardrail-state.yaml',
+      state: {
+        issue_bootstrap: {
+          latest: {
+            issue_id: '113',
+            repo_path: '/workspace/source',
+            current_branch: 'feat/113-fail-closed-edit-boundaries',
+          },
+        },
+        guardrail_evidence: {
+          preflight: {
+            issue_id: '113',
+            repo_path: '/workspace/source',
+            declared_target_files: null,
+            result: { status: 'PASS' },
+          },
+        },
+      },
+    });
+
+    const result = JSON.parse(await runEditGuard({
+      issue_id: '113',
+      task_type: 'implementation',
+      repo_path: '/workspace/source',
+      project_path: '/workspace/projects/agenticos/standards',
+      declared_target_files: ['projects/agenticos/mcp-server/src/index.ts'],
+    })) as { status: string; evidence: { preflight_declared_target_files: string[] } };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.evidence.preflight_declared_target_files).toEqual([]);
+  });
+
+  it('normalizes falsey attempted target entries before scope comparison', async () => {
+    const result = JSON.parse(await runEditGuard({
+      issue_id: '113',
+      task_type: 'implementation',
+      repo_path: '/workspace/source',
+      project_path: '/workspace/projects/agenticos/standards',
+      declared_target_files: ['projects/agenticos/mcp-server/src/index.ts', '' as any, undefined as any],
+    })) as { status: string; scope_ok: boolean };
+
+    expect(result.status).toBe('PASS');
+    expect(result.scope_ok).toBe(true);
+  });
+
+  it('falls back evidence fields to null when bootstrap metadata is not string typed', async () => {
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/runtime/.agent-workspace/projects/agenticos-standards/guardrail-state.yaml',
+      state: {
+        issue_bootstrap: {
+          latest: {
+            issue_id: 113,
+            repo_path: null,
+            current_branch: null,
+          },
+        },
+      },
+    });
+
+    const result = JSON.parse(await runEditGuard({
+      issue_id: '113',
+      task_type: 'implementation',
+      repo_path: '/workspace/source',
+      project_path: '/workspace/projects/agenticos/standards',
+      declared_target_files: ['projects/agenticos/mcp-server/src/index.ts'],
+    })) as { evidence: { issue_bootstrap_issue_id: null; issue_bootstrap_repo_path: null; issue_bootstrap_branch: null } };
+
+    expect(result.evidence.issue_bootstrap_issue_id).toBeNull();
+    expect(result.evidence.issue_bootstrap_repo_path).toBeNull();
+    expect(result.evidence.issue_bootstrap_branch).toBeNull();
+  });
+
+  it('renders unknown issue id when bootstrap mismatch has no stored issue id', async () => {
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/runtime/.agent-workspace/projects/agenticos-standards/guardrail-state.yaml',
+      state: {
+        issue_bootstrap: {
+          latest: {
+            issue_id: '',
+            repo_path: '/workspace/source',
+            current_branch: 'feat/113-fail-closed-edit-boundaries',
+          },
+        },
+        guardrail_evidence: {
+          preflight: {
+            issue_id: '113',
+            repo_path: '/workspace/source',
+            declared_target_files: ['projects/agenticos/mcp-server/src/index.ts'],
+            result: { status: 'PASS' },
+          },
+        },
+      },
+    });
+
+    const result = JSON.parse(await runEditGuard({
+      issue_id: '113',
+      task_type: 'implementation',
+      repo_path: '/workspace/source',
+      project_path: '/workspace/projects/agenticos/standards',
+      declared_target_files: ['projects/agenticos/mcp-server/src/index.ts'],
+    })) as { block_reasons: string[] };
+
+    expect(result.block_reasons.join(' ')).toContain('unknown');
+  });
+
+  it('treats missing bootstrap repo_path as a repo mismatch for fail-closed safety', async () => {
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/runtime/.agent-workspace/projects/agenticos-standards/guardrail-state.yaml',
+      state: {
+        issue_bootstrap: {
+          latest: {
+            issue_id: '113',
+            current_branch: 'feat/113-fail-closed-edit-boundaries',
+          },
+        },
+        guardrail_evidence: {
+          preflight: {
+            issue_id: '113',
+            repo_path: '/workspace/source',
+            declared_target_files: ['projects/agenticos/mcp-server/src/index.ts'],
+            result: { status: 'PASS' },
+          },
+        },
+      },
+    });
+
+    const result = JSON.parse(await runEditGuard({
+      issue_id: '113',
+      task_type: 'implementation',
+      repo_path: '/workspace/source',
+      project_path: '/workspace/projects/agenticos/standards',
+      declared_target_files: ['projects/agenticos/mcp-server/src/index.ts'],
+    })) as { block_reasons: string[] };
+
+    expect(result.block_reasons.join(' ')).toContain('different repo_path');
+  });
+
+  it('falls back preflight evidence fields to null when metadata is not string typed', async () => {
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/runtime/.agent-workspace/projects/agenticos-standards/guardrail-state.yaml',
+      state: {
+        issue_bootstrap: {
+          latest: {
+            issue_id: '113',
+            repo_path: '/workspace/source',
+            current_branch: 'feat/113-fail-closed-edit-boundaries',
+          },
+        },
+        guardrail_evidence: {
+          preflight: {
+            issue_id: 113,
+            repo_path: null,
+            declared_target_files: ['projects/agenticos/mcp-server/src/index.ts'],
+            result: { status: null },
+          },
+        },
+      },
+    });
+
+    const result = JSON.parse(await runEditGuard({
+      issue_id: '113',
+      task_type: 'implementation',
+      repo_path: '/workspace/source',
+      project_path: '/workspace/projects/agenticos/standards',
+      declared_target_files: ['projects/agenticos/mcp-server/src/index.ts'],
+    })) as { evidence: { preflight_issue_id: null; preflight_repo_path: null; preflight_status: null } };
+
+    expect(result.evidence.preflight_issue_id).toBeNull();
+    expect(result.evidence.preflight_repo_path).toBeNull();
+    expect(result.evidence.preflight_status).toBeNull();
+  });
+
+  it('renders unknown issue id when preflight mismatch has no stored issue id', async () => {
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/runtime/.agent-workspace/projects/agenticos-standards/guardrail-state.yaml',
+      state: {
+        issue_bootstrap: {
+          latest: {
+            issue_id: '113',
+            repo_path: '/workspace/source',
+            current_branch: 'feat/113-fail-closed-edit-boundaries',
+          },
+        },
+        guardrail_evidence: {
+          preflight: {
+            issue_id: '',
+            repo_path: '/workspace/source',
+            declared_target_files: ['projects/agenticos/mcp-server/src/index.ts'],
+            result: { status: 'PASS' },
+          },
+        },
+      },
+    });
+
+    const result = JSON.parse(await runEditGuard({
+      issue_id: '113',
+      task_type: 'implementation',
+      repo_path: '/workspace/source',
+      project_path: '/workspace/projects/agenticos/standards',
+      declared_target_files: ['projects/agenticos/mcp-server/src/index.ts'],
+    })) as { block_reasons: string[] };
+
+    expect(result.block_reasons.join(' ')).toContain('unknown');
+  });
+
+  it('treats missing preflight repo_path as a repo mismatch for fail-closed safety', async () => {
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/runtime/.agent-workspace/projects/agenticos-standards/guardrail-state.yaml',
+      state: {
+        issue_bootstrap: {
+          latest: {
+            issue_id: '113',
+            repo_path: '/workspace/source',
+            current_branch: 'feat/113-fail-closed-edit-boundaries',
+          },
+        },
+        guardrail_evidence: {
+          preflight: {
+            issue_id: '113',
+            declared_target_files: ['projects/agenticos/mcp-server/src/index.ts'],
+            result: { status: 'PASS' },
+          },
+        },
+      },
+    });
+
+    const result = JSON.parse(await runEditGuard({
+      issue_id: '113',
+      task_type: 'implementation',
+      repo_path: '/workspace/source',
+      project_path: '/workspace/projects/agenticos/standards',
+      declared_target_files: ['projects/agenticos/mcp-server/src/index.ts'],
+    })) as { block_reasons: string[] };
+
+    expect(result.block_reasons.join(' ')).toContain('latest preflight was recorded for a different repo_path');
+  });
+
+  it('renders unknown preflight status when the stored status is missing', async () => {
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/runtime/.agent-workspace/projects/agenticos-standards/guardrail-state.yaml',
+      state: {
+        issue_bootstrap: {
+          latest: {
+            issue_id: '113',
+            repo_path: '/workspace/source',
+            current_branch: 'feat/113-fail-closed-edit-boundaries',
+          },
+        },
+        guardrail_evidence: {
+          preflight: {
+            issue_id: '113',
+            repo_path: '/workspace/source',
+            declared_target_files: ['projects/agenticos/mcp-server/src/index.ts'],
+            result: {},
+          },
+        },
+      },
+    });
+
+    const result = JSON.parse(await runEditGuard({
+      issue_id: '113',
+      task_type: 'implementation',
+      repo_path: '/workspace/source',
+      project_path: '/workspace/projects/agenticos/standards',
+      declared_target_files: ['projects/agenticos/mcp-server/src/index.ts'],
+    })) as { block_reasons: string[] };
+
+    expect(result.block_reasons.join(' ')).toContain('unknown instead of PASS');
+  });
+
   it('passes bugfix edits when the worktree root is declared even if the common repo root differs', async () => {
     resolveGuardrailProjectTargetMock.mockResolvedValue({
       activeProjectId: 'agenticos-standards',
@@ -293,9 +809,10 @@ describe('runEditGuard', () => {
       }
       throw new Error(`Unexpected command: ${cmd}`);
     });
-    readFileMock.mockImplementation(async (path: string) => {
-      if (path.endsWith('/.context/state.yaml')) {
-        return JSON.stringify({
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/runtime/.agent-workspace/projects/agenticos-standards/guardrail-state.yaml',
+      state: {
           issue_bootstrap: {
             latest: {
               issue_id: '268',
@@ -315,9 +832,7 @@ describe('runEditGuard', () => {
               },
             },
           },
-        });
-      }
-      throw new Error(`Unexpected path: ${path}`);
+      },
     });
 
     const result = JSON.parse(await runEditGuard({

--- a/mcp-server/src/tools/__tests__/init.test.ts
+++ b/mcp-server/src/tools/__tests__/init.test.ts
@@ -30,6 +30,10 @@ vi.mock('yaml', () => ({
   default: yamlMock,
 }));
 
+vi.mock('../../utils/canonical-main-guard.js', () => ({
+  detectCanonicalMainWriteProtection: vi.fn(async () => ({ blocked: false })),
+}));
+
 // Mock the distill utils module
 vi.mock('../utils/distill.js', () => ({
   generateClaudeMd: vi.fn(() => '# CLAUDE.md\n\nMocked CLAUDE.md content'),

--- a/mcp-server/src/tools/__tests__/preflight.test.ts
+++ b/mcp-server/src/tools/__tests__/preflight.test.ts
@@ -1,10 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const execAsyncMock = vi.hoisted(() => vi.fn());
-const readFileMock = vi.hoisted(() => vi.fn());
-const yamlMock = vi.hoisted(() => ({
-  parse: vi.fn(),
-}));
+const loadLatestGuardrailStateMock = vi.hoisted(() => vi.fn());
 
 vi.mock('child_process', () => ({
   exec: vi.fn(),
@@ -12,14 +9,6 @@ vi.mock('child_process', () => ({
 
 vi.mock('util', () => ({
   promisify: vi.fn(() => execAsyncMock),
-}));
-
-vi.mock('fs/promises', () => ({
-  readFile: readFileMock,
-}));
-
-vi.mock('yaml', () => ({
-  default: yamlMock,
 }));
 
 const persistGuardrailEvidenceMock = vi.hoisted(() => vi.fn().mockResolvedValue({
@@ -34,6 +23,7 @@ const resolveGuardrailProjectTargetMock = vi.hoisted(() => vi.fn());
 vi.mock('../../utils/guardrail-evidence.js', () => ({
   persistGuardrailEvidence: persistGuardrailEvidenceMock,
   extractLatestIssueBootstrap: (state: any) => state?.issue_bootstrap?.latest || null,
+  loadLatestGuardrailState: loadLatestGuardrailStateMock,
 }));
 
 vi.mock('../../utils/repo-boundary.js', () => ({
@@ -77,27 +67,30 @@ describe('runPreflight', () => {
         sourceRepoRootsDeclared: true,
       },
     });
-    readFileMock.mockResolvedValue(JSON.stringify({
-      issue_bootstrap: {
-        updated_at: '2026-04-06T00:00:00.000Z',
-        latest: {
-          recorded_at: '2026-04-06T00:00:00.000Z',
-          issue_id: '36',
-          repo_path: '/repo',
-          current_branch: 'feat/36-guardrail-preflight',
-          startup_context_paths: [
-            '/workspace/projects/agenticos/standards/.project.yaml',
-            '/workspace/projects/agenticos/standards/.context/quick-start.md',
-          ],
-          stages: {
-            context_reset_performed: true,
-            project_hot_load_performed: true,
-            issue_payload_attached: true,
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/runtime/.agent-workspace/projects/agenticos/guardrail-state.yaml',
+      state: {
+        issue_bootstrap: {
+          updated_at: '2026-04-06T00:00:00.000Z',
+          latest: {
+            recorded_at: '2026-04-06T00:00:00.000Z',
+            issue_id: '36',
+            repo_path: '/repo',
+            current_branch: 'feat/36-guardrail-preflight',
+            startup_context_paths: [
+              '/workspace/projects/agenticos/standards/.project.yaml',
+              '/workspace/projects/agenticos/standards/.context/quick-start.md',
+            ],
+            stages: {
+              context_reset_performed: true,
+              project_hot_load_performed: true,
+              issue_payload_attached: true,
+            },
           },
         },
       },
-    }));
-    yamlMock.parse.mockImplementation((content: string) => JSON.parse(content));
+    });
   });
 
   it('returns PASS for a correctly isolated implementation branch', async () => {
@@ -153,6 +146,133 @@ describe('runPreflight', () => {
     expect(result.redirect_actions[0]).toContain('isolated issue branch/worktree');
   });
 
+  it('returns BLOCK immediately when repo_path is missing', async () => {
+    const result = JSON.parse(await runPreflight({
+      task_type: 'implementation',
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons).toContain('repo_path is required');
+  });
+
+  it('treats workspace detection failures as canonical main for safety', async () => {
+    execAsyncMock.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('rev-parse --show-toplevel')) {
+        return { stdout: '/repo\n', stderr: '' };
+      }
+      if (cmd.includes('rev-parse --git-common-dir')) {
+        return { stdout: '.git\n', stderr: '' };
+      }
+      if (cmd.includes('config --get remote.origin.url')) {
+        return { stdout: 'git@github.com:madlouse/AgenticOS.git\n', stderr: '' };
+      }
+      if (cmd.includes('rev-parse --abbrev-ref HEAD')) {
+        return { stdout: 'feat/36-guardrail-preflight\n', stderr: '' };
+      }
+      if (cmd.includes('rev-parse HEAD')) {
+        return { stdout: 'abc123\n', stderr: '' };
+      }
+      if (cmd.includes('rev-parse origin/main')) {
+        return { stdout: 'base999\n', stderr: '' };
+      }
+      if (cmd.includes('merge-base HEAD origin/main')) {
+        return { stdout: 'base999\n', stderr: '' };
+      }
+      if (cmd.includes('worktree list --porcelain')) {
+        throw new Error('git worktree failed');
+      }
+      if (cmd.includes('log --format=%s origin/main..HEAD')) {
+        return { stdout: '', stderr: '' };
+      }
+      throw new Error(`Unexpected command: ${cmd}`);
+    });
+
+    const result = JSON.parse(await runPreflight({
+      issue_id: '36',
+      task_type: 'implementation',
+      repo_path: '/repo',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/preflight.ts'],
+      worktree_required: true,
+    })) as { status: string; redirect_actions: string[] };
+
+    expect(result.status).toBe('REDIRECT');
+    expect(result.redirect_actions.join(' ')).toContain('isolated issue branch/worktree');
+  });
+
+  it('returns BLOCK when implementation-affecting arguments are missing', async () => {
+    const result = JSON.parse(await runPreflight({
+      task_type: 'implementation',
+      repo_path: '/repo',
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons).toContain('issue_id is required for implementation work');
+    expect(result.block_reasons).toContain('declared_target_files is required for implementation work');
+  });
+
+  it('adds explicit redirect guidance when project_path is invalid', async () => {
+    resolveGuardrailProjectTargetMock.mockResolvedValue({
+      activeProjectId: 'agenticos',
+      resolutionSource: null,
+      resolutionErrors: ['project_path is not a resolvable managed project: /bad/project'],
+      targetProject: null,
+    });
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --git-common-dir': '.git\n',
+      'config --get remote.origin.url': 'git@github.com:madlouse/AgenticOS.git\n',
+      'rev-parse --abbrev-ref HEAD': 'feat/36-guardrail-preflight\n',
+      'rev-parse HEAD': 'abc123\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo\nHEAD abc123\nbranch refs/heads/feat/36-guardrail-preflight\n',
+      'log --format=%s origin/main..HEAD': '',
+    });
+
+    const result = JSON.parse(await runPreflight({
+      issue_id: '36',
+      task_type: 'implementation',
+      repo_path: '/repo',
+      project_path: '/bad/project',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/preflight.ts'],
+      worktree_required: true,
+    })) as { status: string; redirect_actions: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.redirect_actions.join(' ')).toContain('valid project_path');
+  });
+
+  it('adds switch guidance when no explicit project identity is available', async () => {
+    resolveGuardrailProjectTargetMock.mockResolvedValue({
+      activeProjectId: null,
+      resolutionSource: null,
+      resolutionErrors: ['target project could not be resolved'],
+      targetProject: null,
+    });
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --git-common-dir': '.git\n',
+      'config --get remote.origin.url': 'git@github.com:madlouse/AgenticOS.git\n',
+      'rev-parse --abbrev-ref HEAD': 'feat/36-guardrail-preflight\n',
+      'rev-parse HEAD': 'abc123\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo\nHEAD abc123\nbranch refs/heads/feat/36-guardrail-preflight\n',
+      'log --format=%s origin/main..HEAD': '',
+    });
+
+    const result = JSON.parse(await runPreflight({
+      issue_id: '36',
+      task_type: 'implementation',
+      repo_path: '/repo',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/preflight.ts'],
+      worktree_required: true,
+    })) as { status: string; redirect_actions: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.redirect_actions.join(' ')).toContain('agenticos_switch');
+  });
+
   it('passes project_path through to guardrail evidence persistence when provided', async () => {
     mockGitResponses({
       'rev-parse --show-toplevel': '/repo\n',
@@ -165,21 +285,25 @@ describe('runPreflight', () => {
       'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo\nHEAD abc123\nbranch refs/heads/feat/113-fail-closed-edit-boundaries\n',
       'log --format=%s origin/main..HEAD': '',
     });
-    readFileMock.mockResolvedValue(JSON.stringify({
-      issue_bootstrap: {
-        latest: {
-          issue_id: '113',
-          repo_path: '/repo',
-          current_branch: 'feat/113-fail-closed-edit-boundaries',
-          startup_context_paths: ['/repo/projects/agenticos/standards/.project.yaml'],
-          stages: {
-            context_reset_performed: true,
-            project_hot_load_performed: true,
-            issue_payload_attached: true,
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/runtime/.agent-workspace/projects/agenticos/guardrail-state.yaml',
+      state: {
+        issue_bootstrap: {
+          latest: {
+            issue_id: '113',
+            repo_path: '/repo',
+            current_branch: 'feat/113-fail-closed-edit-boundaries',
+            startup_context_paths: ['/repo/projects/agenticos/standards/.project.yaml'],
+            stages: {
+              context_reset_performed: true,
+              project_hot_load_performed: true,
+              issue_payload_attached: true,
+            },
           },
         },
       },
-    }));
+    });
 
     await runPreflight({
       issue_id: '113',
@@ -221,21 +345,25 @@ describe('runPreflight', () => {
         sourceRepoRootsDeclared: true,
       },
     });
-    readFileMock.mockResolvedValue(JSON.stringify({
-      issue_bootstrap: {
-        latest: {
-          issue_id: '160',
-          repo_path: '/repo',
-          current_branch: 'feat/160-source-repo-boundary-enforcement',
-          startup_context_paths: ['/repo/projects/agenticos/standards/.project.yaml'],
-          stages: {
-            context_reset_performed: true,
-            project_hot_load_performed: true,
-            issue_payload_attached: true,
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/runtime/.agent-workspace/projects/agenticos-standards/guardrail-state.yaml',
+      state: {
+        issue_bootstrap: {
+          latest: {
+            issue_id: '160',
+            repo_path: '/repo',
+            current_branch: 'feat/160-source-repo-boundary-enforcement',
+            startup_context_paths: ['/repo/projects/agenticos/standards/.project.yaml'],
+            stages: {
+              context_reset_performed: true,
+              project_hot_load_performed: true,
+              issue_payload_attached: true,
+            },
           },
         },
       },
-    }));
+    });
 
     await runPreflight({
       issue_id: '160',
@@ -275,6 +403,141 @@ describe('runPreflight', () => {
     expect(result.block_reasons[0]).toContain('unrelated commits');
   });
 
+  it('accepts branch commits when they all include the requested issue marker', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --git-common-dir': '.git\n',
+      'config --get remote.origin.url': 'git@github.com:madlouse/AgenticOS.git\n',
+      'rev-parse --abbrev-ref HEAD': 'feat/36-guardrail-preflight\n',
+      'rev-parse HEAD': 'abc123\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo\nHEAD abc123\nbranch refs/heads/feat/36-guardrail-preflight\n',
+      'log --format=%s origin/main..HEAD': 'feat: tighten guardrail flow (#36)\nfix: preserve branch evidence (#36)\n',
+    });
+
+    const result = JSON.parse(await runPreflight({
+      issue_id: '36',
+      task_type: 'implementation',
+      repo_path: '/repo',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/preflight.ts'],
+      worktree_required: true,
+    })) as { status: string; branch_based_on_intended_remote: boolean };
+
+    expect(result.status).toBe('PASS');
+    expect(result.branch_based_on_intended_remote).toBe(true);
+  });
+
+  it('treats missing issue id as an empty issue marker when scanning commit subjects', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --git-common-dir': '.git\n',
+      'config --get remote.origin.url': 'git@github.com:madlouse/AgenticOS.git\n',
+      'rev-parse --abbrev-ref HEAD': 'feat/guardrail-preflight\n',
+      'rev-parse HEAD': 'abc123\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo\nHEAD abc123\nbranch refs/heads/feat/guardrail-preflight\n',
+      'log --format=%s origin/main..HEAD': 'feat: change with no issue marker\n',
+    });
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/runtime/.agent-workspace/projects/agenticos/guardrail-state.yaml',
+      state: {
+        issue_bootstrap: {
+          latest: {
+            repo_path: '/repo',
+            current_branch: 'feat/guardrail-preflight',
+            startup_context_paths: ['/workspace/projects/agenticos/standards/.project.yaml'],
+            stages: {
+              context_reset_performed: true,
+              project_hot_load_performed: true,
+              issue_payload_attached: true,
+            },
+          },
+        },
+      },
+    });
+
+    const result = JSON.parse(await runPreflight({
+      task_type: 'implementation',
+      repo_path: '/repo',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/preflight.ts'],
+      worktree_required: true,
+    })) as { block_reasons: string[]; branch_based_on_intended_remote: boolean };
+
+    expect(result.block_reasons).toContain('issue_id is required for implementation work');
+    expect(result.block_reasons.join(' ')).toContain('unrelated commits');
+    expect(result.branch_based_on_intended_remote).toBe(false);
+  });
+
+  it('returns BLOCK and persists evidence when git repository resolution fails', async () => {
+    execAsyncMock.mockRejectedValue(new Error('git failed'));
+
+    const result = JSON.parse(await runPreflight({
+      issue_id: '36',
+      task_type: 'implementation',
+      repo_path: '/repo',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/preflight.ts'],
+      worktree_required: true,
+    })) as { status: string; block_reasons: string[]; persistence?: { persisted: boolean } };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons.join(' ')).toContain('failed to resolve git repository identity or remote base');
+    expect(result.persistence?.persisted).toBe(true);
+  });
+
+  it('uses explicit project_path fallbacks in persisted evidence when git resolution fails before target proof exists', async () => {
+    resolveGuardrailProjectTargetMock.mockResolvedValue({
+      activeProjectId: 'agenticos',
+      resolutionSource: null,
+      resolutionErrors: ['project_path is not a resolvable managed project: /bad/project'],
+      targetProject: null,
+    });
+    execAsyncMock.mockRejectedValue(new Error('git failed'));
+
+    await runPreflight({
+      task_type: 'implementation',
+      repo_path: '/repo',
+      project_path: '/bad/project',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/preflight.ts'],
+      worktree_required: true,
+    });
+
+    expect(persistGuardrailEvidenceMock).toHaveBeenCalledWith(expect.objectContaining({
+      project_path: '/bad/project',
+      payload: expect.objectContaining({
+        issue_id: null,
+        project_path: '/bad/project',
+      }),
+    }));
+  });
+
+  it('falls back to null project identity in persisted evidence when git resolution fails without any resolved project', async () => {
+    resolveGuardrailProjectTargetMock.mockResolvedValue({
+      activeProjectId: null,
+      resolutionSource: null,
+      resolutionErrors: ['target project could not be resolved'],
+      targetProject: null,
+    });
+    execAsyncMock.mockRejectedValue(new Error('git failed'));
+
+    await runPreflight({
+      task_type: 'implementation',
+      repo_path: '/repo',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/preflight.ts'],
+      worktree_required: true,
+    });
+
+    expect(persistGuardrailEvidenceMock).toHaveBeenCalledWith(expect.objectContaining({
+      project_path: undefined,
+      payload: expect.objectContaining({
+        issue_id: null,
+        project_path: null,
+      }),
+    }));
+  });
+
   it('returns BLOCK when no matching issue bootstrap evidence is recorded', async () => {
     mockGitResponses({
       'rev-parse --show-toplevel': '/repo\n',
@@ -287,7 +550,11 @@ describe('runPreflight', () => {
       'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo\nHEAD abc123\nbranch refs/heads/feat/36-guardrail-preflight\n',
       'log --format=%s origin/main..HEAD': '',
     });
-    readFileMock.mockResolvedValue(JSON.stringify({}));
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: null,
+      state_path: '/runtime/.agent-workspace/projects/agenticos/guardrail-state.yaml',
+      state: {},
+    });
 
     const result = JSON.parse(await runPreflight({
       issue_id: '36',
@@ -313,21 +580,25 @@ describe('runPreflight', () => {
       'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo\nHEAD abc123\nbranch refs/heads/feat/36-guardrail-preflight\n',
       'log --format=%s origin/main..HEAD': '',
     });
-    readFileMock.mockResolvedValue(JSON.stringify({
-      issue_bootstrap: {
-        latest: {
-          issue_id: '999',
-          repo_path: '/repo',
-          current_branch: 'feat/36-guardrail-preflight',
-          startup_context_paths: ['/workspace/projects/agenticos/standards/.project.yaml'],
-          stages: {
-            context_reset_performed: true,
-            project_hot_load_performed: true,
-            issue_payload_attached: true,
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/runtime/.agent-workspace/projects/agenticos/guardrail-state.yaml',
+      state: {
+        issue_bootstrap: {
+          latest: {
+            issue_id: '999',
+            repo_path: '/repo',
+            current_branch: 'feat/36-guardrail-preflight',
+            startup_context_paths: ['/workspace/projects/agenticos/standards/.project.yaml'],
+            stages: {
+              context_reset_performed: true,
+              project_hot_load_performed: true,
+              issue_payload_attached: true,
+            },
           },
         },
       },
-    }));
+    });
 
     const result = JSON.parse(await runPreflight({
       issue_id: '36',
@@ -339,6 +610,301 @@ describe('runPreflight', () => {
 
     expect(result.status).toBe('BLOCK');
     expect(result.block_reasons.join(' ')).toContain('does not match requested issue');
+  });
+
+  it('returns BLOCK when the latest issue bootstrap repo_path differs from the current repo', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --git-common-dir': '.git\n',
+      'config --get remote.origin.url': 'git@github.com:madlouse/AgenticOS.git\n',
+      'rev-parse --abbrev-ref HEAD': 'feat/36-guardrail-preflight\n',
+      'rev-parse HEAD': 'abc123\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo\nHEAD abc123\nbranch refs/heads/feat/36-guardrail-preflight\n',
+      'log --format=%s origin/main..HEAD': '',
+    });
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/runtime/.agent-workspace/projects/agenticos/guardrail-state.yaml',
+      state: {
+        issue_bootstrap: {
+          latest: {
+            issue_id: '36',
+            repo_path: '/other',
+            current_branch: 'feat/36-guardrail-preflight',
+            startup_context_paths: ['/workspace/projects/agenticos/standards/.project.yaml'],
+            stages: {
+              context_reset_performed: true,
+              project_hot_load_performed: true,
+              issue_payload_attached: true,
+            },
+          },
+        },
+      },
+    });
+
+    const result = JSON.parse(await runPreflight({
+      issue_id: '36',
+      task_type: 'implementation',
+      repo_path: '/repo',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/preflight.ts'],
+      worktree_required: true,
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons.join(' ')).toContain('different repo_path');
+  });
+
+  it('returns BLOCK when the latest issue bootstrap branch differs from the current branch', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --git-common-dir': '.git\n',
+      'config --get remote.origin.url': 'git@github.com:madlouse/AgenticOS.git\n',
+      'rev-parse --abbrev-ref HEAD': 'feat/36-guardrail-preflight\n',
+      'rev-parse HEAD': 'abc123\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo\nHEAD abc123\nbranch refs/heads/feat/36-guardrail-preflight\n',
+      'log --format=%s origin/main..HEAD': '',
+    });
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/runtime/.agent-workspace/projects/agenticos/guardrail-state.yaml',
+      state: {
+        issue_bootstrap: {
+          latest: {
+            issue_id: '36',
+            repo_path: '/repo',
+            current_branch: 'other-branch',
+            startup_context_paths: ['/workspace/projects/agenticos/standards/.project.yaml'],
+            stages: {
+              context_reset_performed: true,
+              project_hot_load_performed: true,
+              issue_payload_attached: true,
+            },
+          },
+        },
+      },
+    });
+
+    const result = JSON.parse(await runPreflight({
+      issue_id: '36',
+      task_type: 'implementation',
+      repo_path: '/repo',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/preflight.ts'],
+      worktree_required: true,
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons.join(' ')).toContain('does not match current branch');
+  });
+
+  it('returns BLOCK when bootstrap stage evidence is incomplete', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --git-common-dir': '.git\n',
+      'config --get remote.origin.url': 'git@github.com:madlouse/AgenticOS.git\n',
+      'rev-parse --abbrev-ref HEAD': 'feat/36-guardrail-preflight\n',
+      'rev-parse HEAD': 'abc123\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo\nHEAD abc123\nbranch refs/heads/feat/36-guardrail-preflight\n',
+      'log --format=%s origin/main..HEAD': '',
+    });
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/runtime/.agent-workspace/projects/agenticos/guardrail-state.yaml',
+      state: {
+        issue_bootstrap: {
+          latest: {
+            issue_id: '36',
+            repo_path: '/repo',
+            current_branch: 'feat/36-guardrail-preflight',
+            startup_context_paths: [],
+            stages: {
+              context_reset_performed: false,
+              project_hot_load_performed: false,
+              issue_payload_attached: false,
+            },
+          },
+        },
+      },
+    });
+
+    const result = JSON.parse(await runPreflight({
+      issue_id: '36',
+      task_type: 'implementation',
+      repo_path: '/repo',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/preflight.ts'],
+      worktree_required: true,
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons.join(' ')).toContain('clear-equivalent context reset');
+    expect(result.block_reasons.join(' ')).toContain('project hot-load occurred');
+    expect(result.block_reasons.join(' ')).toContain('issue payload attachment');
+    expect(result.block_reasons.join(' ')).toContain('startup context evidence');
+  });
+
+  it('returns BLOCK when runtime guardrail state cannot be loaded', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --git-common-dir': '.git\n',
+      'config --get remote.origin.url': 'git@github.com:madlouse/AgenticOS.git\n',
+      'rev-parse --abbrev-ref HEAD': 'feat/36-guardrail-preflight\n',
+      'rev-parse HEAD': 'abc123\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo\nHEAD abc123\nbranch refs/heads/feat/36-guardrail-preflight\n',
+      'log --format=%s origin/main..HEAD': '',
+    });
+    loadLatestGuardrailStateMock.mockRejectedValue(new Error('boom'));
+
+    const result = JSON.parse(await runPreflight({
+      issue_id: '36',
+      task_type: 'implementation',
+      repo_path: '/repo',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/preflight.ts'],
+      worktree_required: true,
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons.join(' ')).toContain('guardrail state is missing or unreadable');
+  });
+
+  it('falls back bootstrap evidence fields to null when runtime bootstrap metadata is not string typed', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --git-common-dir': '.git\n',
+      'config --get remote.origin.url': 'git@github.com:madlouse/AgenticOS.git\n',
+      'rev-parse --abbrev-ref HEAD': 'feat/36-guardrail-preflight\n',
+      'rev-parse HEAD': 'abc123\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo\nHEAD abc123\nbranch refs/heads/feat/36-guardrail-preflight\n',
+      'log --format=%s origin/main..HEAD': '',
+    });
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/runtime/.agent-workspace/projects/agenticos/guardrail-state.yaml',
+      state: {
+        issue_bootstrap: {
+          latest: {
+            recorded_at: '',
+            issue_id: '',
+            repo_path: '',
+            current_branch: '',
+            startup_context_paths: ['/workspace/projects/agenticos/standards/.project.yaml'],
+            stages: {
+              context_reset_performed: true,
+              project_hot_load_performed: true,
+              issue_payload_attached: true,
+            },
+          },
+        },
+      },
+    });
+
+    const result = JSON.parse(await runPreflight({
+      issue_id: '36',
+      task_type: 'implementation',
+      repo_path: '/repo',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/preflight.ts'],
+      worktree_required: true,
+    })) as { evidence: { issue_bootstrap: { recorded_at: null; issue_id: null; repo_path: null; current_branch: null } | null } };
+
+    expect(result.evidence.issue_bootstrap).toEqual({
+      recorded_at: null,
+      issue_id: null,
+      repo_path: null,
+      current_branch: null,
+    });
+  });
+
+  it('renders unknown bootstrap issue id when mismatch evidence has no stored id', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --git-common-dir': '.git\n',
+      'config --get remote.origin.url': 'git@github.com:madlouse/AgenticOS.git\n',
+      'rev-parse --abbrev-ref HEAD': 'feat/36-guardrail-preflight\n',
+      'rev-parse HEAD': 'abc123\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo\nHEAD abc123\nbranch refs/heads/feat/36-guardrail-preflight\n',
+      'log --format=%s origin/main..HEAD': '',
+    });
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/runtime/.agent-workspace/projects/agenticos/guardrail-state.yaml',
+      state: {
+        issue_bootstrap: {
+          latest: {
+            issue_id: '',
+            repo_path: '/repo',
+            current_branch: 'feat/36-guardrail-preflight',
+            startup_context_paths: ['/workspace/projects/agenticos/standards/.project.yaml'],
+            stages: {
+              context_reset_performed: true,
+              project_hot_load_performed: true,
+              issue_payload_attached: true,
+            },
+          },
+        },
+      },
+    });
+
+    const result = JSON.parse(await runPreflight({
+      issue_id: '36',
+      task_type: 'implementation',
+      repo_path: '/repo',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/preflight.ts'],
+      worktree_required: true,
+    })) as { block_reasons: string[] };
+
+    expect(result.block_reasons.join(' ')).toContain('unknown');
+  });
+
+  it('treats missing bootstrap repo_path as a repo mismatch for fail-closed safety', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --git-common-dir': '.git\n',
+      'config --get remote.origin.url': 'git@github.com:madlouse/AgenticOS.git\n',
+      'rev-parse --abbrev-ref HEAD': 'feat/36-guardrail-preflight\n',
+      'rev-parse HEAD': 'abc123\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo\nHEAD abc123\nbranch refs/heads/feat/36-guardrail-preflight\n',
+      'log --format=%s origin/main..HEAD': '',
+    });
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/runtime/.agent-workspace/projects/agenticos/guardrail-state.yaml',
+      state: {
+        issue_bootstrap: {
+          latest: {
+            issue_id: '36',
+            current_branch: 'feat/36-guardrail-preflight',
+            startup_context_paths: ['/workspace/projects/agenticos/standards/.project.yaml'],
+            stages: {
+              context_reset_performed: true,
+              project_hot_load_performed: true,
+              issue_payload_attached: true,
+            },
+          },
+        },
+      },
+    });
+
+    const result = JSON.parse(await runPreflight({
+      issue_id: '36',
+      task_type: 'implementation',
+      repo_path: '/repo',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/preflight.ts'],
+      worktree_required: true,
+    })) as { block_reasons: string[] };
+
+    expect(result.block_reasons.join(' ')).toContain('different repo_path');
   });
 
   it('returns BLOCK for structural move without root exception or reproducibility gate', async () => {
@@ -370,6 +936,77 @@ describe('runPreflight', () => {
     expect(result.block_reasons.join(' ')).toContain('clean_reproducibility_gate');
   });
 
+  it('accepts structural move when root exception and reproducibility gate are both defined', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --git-common-dir': '.git\n',
+      'config --get remote.origin.url': 'git@github.com:madlouse/AgenticOS.git\n',
+      'rev-parse --abbrev-ref HEAD': 'feat/40-self-hosting\n',
+      'rev-parse HEAD': 'abc123\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo\nHEAD abc123\nbranch refs/heads/feat/40-self-hosting\n',
+      'log --format=%s origin/main..HEAD': '',
+    });
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/runtime/.agent-workspace/projects/agenticos/guardrail-state.yaml',
+      state: {
+        issue_bootstrap: {
+          latest: {
+            issue_id: '40',
+            repo_path: '/repo',
+            current_branch: 'feat/40-self-hosting',
+            startup_context_paths: ['/workspace/projects/agenticos/standards/.project.yaml'],
+            stages: {
+              context_reset_performed: true,
+              project_hot_load_performed: true,
+              issue_payload_attached: true,
+            },
+          },
+        },
+      },
+    });
+
+    const result = JSON.parse(await runPreflight({
+      issue_id: '40',
+      task_type: 'implementation',
+      repo_path: '/repo',
+      declared_target_files: ['projects/agenticos/**'],
+      worktree_required: true,
+      structural_move: true,
+      root_scoped_exceptions: ['.github/'],
+      clean_reproducibility_gate: ['npm run build'],
+    })) as { status: string; reproducibility_gate_defined: boolean };
+
+    expect(result.status).toBe('PASS');
+    expect(result.reproducibility_gate_defined).toBe(true);
+  });
+
+  it('returns PASS for non implementation-affecting task types without bootstrap enforcement', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --git-common-dir': '.git\n',
+      'config --get remote.origin.url': 'git@github.com:madlouse/AgenticOS.git\n',
+      'rev-parse --abbrev-ref HEAD': 'docs/notes\n',
+      'rev-parse HEAD': 'abc123\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo\nHEAD abc123\nbranch refs/heads/docs/notes\n',
+    });
+
+    const result = JSON.parse(await runPreflight({
+      task_type: 'analysis_or_doc',
+      repo_path: '/repo',
+      declared_target_files: [],
+      worktree_required: false,
+    })) as { status: string; scope_ok: boolean; reproducibility_gate_defined: boolean };
+
+    expect(result.status).toBe('PASS');
+    expect(result.scope_ok).toBe(true);
+    expect(result.reproducibility_gate_defined).toBe(true);
+  });
+
   it('returns PASS when the worktree root is declared and the remote matches the declared github repo', async () => {
     resolveGuardrailProjectTargetMock.mockResolvedValue({
       activeProjectId: 'agenticos',
@@ -386,21 +1023,25 @@ describe('runPreflight', () => {
         sourceRepoRootsDeclared: true,
       },
     });
-    readFileMock.mockResolvedValue(JSON.stringify({
-      issue_bootstrap: {
-        latest: {
-          issue_id: '160',
-          repo_path: '/repo/worktrees/issue-160',
-          current_branch: 'fix/160-source-repo-boundary-enforcement',
-          startup_context_paths: ['/repo/worktrees/issue-160/.project.yaml'],
-          stages: {
-            context_reset_performed: true,
-            project_hot_load_performed: true,
-            issue_payload_attached: true,
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/runtime/.agent-workspace/projects/agenticos/guardrail-state.yaml',
+      state: {
+        issue_bootstrap: {
+          latest: {
+            issue_id: '160',
+            repo_path: '/repo/worktrees/issue-160',
+            current_branch: 'fix/160-source-repo-boundary-enforcement',
+            startup_context_paths: ['/repo/worktrees/issue-160/.project.yaml'],
+            stages: {
+              context_reset_performed: true,
+              project_hot_load_performed: true,
+              issue_payload_attached: true,
+            },
           },
         },
       },
-    }));
+    });
     mockGitResponses({
       'rev-parse --show-toplevel': '/repo/worktrees/issue-160\n',
       'rev-parse --git-common-dir': '/external/.git\n',
@@ -442,21 +1083,25 @@ describe('runPreflight', () => {
         sourceRepoRootsDeclared: true,
       },
     });
-    readFileMock.mockResolvedValue(JSON.stringify({
-      issue_bootstrap: {
-        latest: {
-          issue_id: '160',
-          repo_path: '/repo/worktrees/issue-160',
-          current_branch: 'fix/160-source-repo-boundary-enforcement',
-          startup_context_paths: ['/repo/worktrees/issue-160/.project.yaml'],
-          stages: {
-            context_reset_performed: true,
-            project_hot_load_performed: true,
-            issue_payload_attached: true,
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/runtime/.agent-workspace/projects/agenticos/guardrail-state.yaml',
+      state: {
+        issue_bootstrap: {
+          latest: {
+            issue_id: '160',
+            repo_path: '/repo/worktrees/issue-160',
+            current_branch: 'fix/160-source-repo-boundary-enforcement',
+            startup_context_paths: ['/repo/worktrees/issue-160/.project.yaml'],
+            stages: {
+              context_reset_performed: true,
+              project_hot_load_performed: true,
+              issue_payload_attached: true,
+            },
           },
         },
       },
-    }));
+    });
     mockGitResponses({
       'rev-parse --show-toplevel': '/repo/worktrees/issue-160\n',
       'rev-parse --git-common-dir': '/external/.git\n',

--- a/mcp-server/src/tools/__tests__/project.test.ts
+++ b/mcp-server/src/tools/__tests__/project.test.ts
@@ -5,6 +5,7 @@ const yamlMock = vi.hoisted(() => ({
   parse: vi.fn(),
   stringify: vi.fn((obj: unknown) => JSON.stringify(obj)),
 }));
+const loadLatestGuardrailStateMock = vi.hoisted(() => vi.fn());
 
 // Mock modules
 vi.mock('fs/promises', () => ({
@@ -12,6 +13,9 @@ vi.mock('fs/promises', () => ({
   writeFile: vi.fn(),
   mkdir: vi.fn(),
   access: vi.fn(),
+  rename: vi.fn(),
+  rm: vi.fn(),
+  stat: vi.fn(),
 }));
 
 vi.mock('fs', () => ({
@@ -44,6 +48,10 @@ vi.mock('../../utils/distill.js', () => ({
   extractTemplateVersion: vi.fn(() => 2),
 }));
 
+vi.mock('../../utils/guardrail-evidence.js', () => ({
+  loadLatestGuardrailState: loadLatestGuardrailStateMock,
+}));
+
 import { switchProject, listProjects, getStatus } from '../project.js';
 import * as fsPromises from 'fs/promises';
 import * as registry from '../../utils/registry.js';
@@ -74,6 +82,19 @@ function mockStatusReads(projectYaml: unknown, state: unknown | Error = {}): voi
     }
     return JSON.stringify(state);
   });
+  if (state instanceof Error) {
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: null,
+      state: {},
+      state_path: null,
+    });
+    return;
+  }
+  loadLatestGuardrailStateMock.mockResolvedValue({
+    source: 'committed',
+    state,
+    state_path: '/mock/state.yaml',
+  });
 }
 
 describe('switchProject', () => {
@@ -84,6 +105,11 @@ describe('switchProject', () => {
     fsMock.existsSync.mockReturnValue(false);
     yamlMock.parse.mockImplementation((content: string) => {
       try { return JSON.parse(content); } catch { return undefined; }
+    });
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: null,
+      state: {},
+      state_path: null,
     });
     fsPromisesMock.readFile.mockResolvedValue(JSON.stringify({
       meta: { description: '' },
@@ -187,6 +213,52 @@ describe('switchProject', () => {
     expect(result).toContain('Project B');
     expect(result).toContain('project-a');
     expect(result).toContain('project-b');
+  });
+
+  it('returns a topology initialization error when project metadata cannot be read', async () => {
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: null,
+      projects: [
+        {
+          id: 'my-project',
+          name: 'My Project',
+          path: '/test/path',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+    fsPromisesMock.readFile.mockRejectedValue(new Error('missing project yaml'));
+
+    const result = await switchProject({ project: 'my-project' });
+
+    expect(result).toContain('has not completed source-control topology initialization');
+  });
+
+  it('returns a topology initialization error when project metadata parses to null', async () => {
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: null,
+      projects: [
+        {
+          id: 'my-project',
+          name: 'My Project',
+          path: '/test/path',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+    fsPromisesMock.readFile.mockResolvedValue('null');
+
+    const result = await switchProject({ project: 'my-project' });
+
+    expect(result).toContain('has not completed source-control topology initialization');
   });
 
   it('updates last_accessed timestamp on switch', async () => {
@@ -341,6 +413,126 @@ describe('switchProject', () => {
     expect(result).toContain('🛡️ Latest guardrail: None recorded');
   });
 
+  it('shows no guardrail when last command is preflight but the runtime slot is missing', async () => {
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: null,
+      projects: [
+        {
+          id: 'my-project',
+          name: 'My Project',
+          path: '/test/path',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+    fsPromisesMock.readFile
+      .mockResolvedValueOnce(JSON.stringify({
+        meta: { description: '' },
+        source_control: { topology: 'local_directory_only' },
+      }))
+      .mockResolvedValueOnce(JSON.stringify({
+        working_memory: { pending: [], decisions: [] },
+      }))
+      .mockResolvedValueOnce('# Quick Start\n\nProject summary');
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/home/testuser/AgenticOS/.agent-workspace/projects/my-project/guardrail-state.yaml',
+      state: {
+        guardrail_evidence: {
+          last_command: 'agenticos_preflight',
+        },
+      },
+    });
+
+    const result = await switchProject({ project: 'my-project' });
+
+    expect(result).toContain('🛡️ Latest guardrail: None recorded');
+  });
+
+  it('shows no guardrail when last command is branch bootstrap but the runtime slot is missing', async () => {
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: null,
+      projects: [
+        {
+          id: 'my-project',
+          name: 'My Project',
+          path: '/test/path',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+    fsPromisesMock.readFile
+      .mockResolvedValueOnce(JSON.stringify({
+        meta: { description: '' },
+        source_control: { topology: 'local_directory_only' },
+      }))
+      .mockResolvedValueOnce(JSON.stringify({
+        working_memory: { pending: [], decisions: [] },
+      }))
+      .mockResolvedValueOnce('# Quick Start\n\nProject summary');
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/home/testuser/AgenticOS/.agent-workspace/projects/my-project/guardrail-state.yaml',
+      state: {
+        guardrail_evidence: {
+          last_command: 'agenticos_branch_bootstrap',
+        },
+      },
+    });
+
+    const result = await switchProject({ project: 'my-project' });
+
+    expect(result).toContain('🛡️ Latest guardrail: None recorded');
+  });
+
+  it('shows no guardrail when last command is pr-scope-check but the runtime slot is missing', async () => {
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: null,
+      projects: [
+        {
+          id: 'my-project',
+          name: 'My Project',
+          path: '/test/path',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+    fsPromisesMock.readFile
+      .mockResolvedValueOnce(JSON.stringify({
+        meta: { description: '' },
+        source_control: { topology: 'local_directory_only' },
+      }))
+      .mockResolvedValueOnce(JSON.stringify({
+        working_memory: { pending: [], decisions: [] },
+      }))
+      .mockResolvedValueOnce('# Quick Start\n\nProject summary');
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/home/testuser/AgenticOS/.agent-workspace/projects/my-project/guardrail-state.yaml',
+      state: {
+        guardrail_evidence: {
+          last_command: 'agenticos_pr_scope_check',
+        },
+      },
+    });
+
+    const result = await switchProject({ project: 'my-project' });
+
+    expect(result).toContain('🛡️ Latest guardrail: None recorded');
+  });
+
   it('shows the latest guardrail summary in switch output when evidence exists', async () => {
     registryMock.loadRegistry.mockResolvedValue({
       version: '1.0.0',
@@ -358,25 +550,33 @@ describe('switchProject', () => {
       ],
     });
 
+    const guardrailState = {
+      guardrail_evidence: {
+        updated_at: '2025-01-02T14:00:00.000Z',
+        last_command: 'agenticos_preflight',
+        preflight: {
+          command: 'agenticos_preflight',
+          recorded_at: '2025-01-02T14:00:00.000Z',
+          issue_id: '76',
+          result: {
+            status: 'REDIRECT',
+            redirect_actions: ['create an isolated issue branch/worktree before implementation'],
+          },
+        },
+      },
+    };
     fsPromisesMock.readFile.mockResolvedValue(
       JSON.stringify({
         meta: { description: '' },
         source_control: { topology: 'local_directory_only' },
-        guardrail_evidence: {
-          updated_at: '2025-01-02T14:00:00.000Z',
-          last_command: 'agenticos_preflight',
-          preflight: {
-            command: 'agenticos_preflight',
-            recorded_at: '2025-01-02T14:00:00.000Z',
-            issue_id: '76',
-            result: {
-              status: 'REDIRECT',
-              redirect_actions: ['create an isolated issue branch/worktree before implementation'],
-            },
-          },
-        },
+        ...guardrailState,
       })
     );
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state: guardrailState,
+      state_path: '/home/testuser/AgenticOS/.agent-workspace/projects/my-project/guardrail-state.yaml',
+    });
 
     const result = await switchProject({ project: 'my-project' });
 
@@ -422,6 +622,23 @@ describe('switchProject', () => {
         },
       }))
       .mockResolvedValueOnce('# Quick Start\n\nProject summary');
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state: {
+        issue_bootstrap: {
+          updated_at: '2025-01-02T15:00:00.000Z',
+          latest: {
+            issue_id: '179',
+            issue_title: 'Implement bootstrap evidence',
+            recorded_at: '2025-01-02T15:00:00.000Z',
+            current_branch: 'feat/179-issue-start-bootstrap-evidence',
+            startup_context_paths: ['.project.yaml', '.context/quick-start.md'],
+            additional_context: [{ path: 'knowledge/issue-158.md', reason: 'design reference' }],
+          },
+        },
+      },
+      state_path: '/home/testuser/AgenticOS/.agent-workspace/projects/my-project/guardrail-state.yaml',
+    });
 
     const result = await switchProject({ project: 'my-project' });
 
@@ -566,6 +783,20 @@ describe('switchProject', () => {
         },
       }))
       .mockResolvedValueOnce('# Quick Start\n\nCanonical quick start');
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/home/testuser/AgenticOS/.agent-workspace/projects/agenticos/guardrail-state.yaml',
+      state: {
+        issue_bootstrap: {
+          latest: {
+            issue_id: '260',
+            current_branch: 'fix/260-stop-active-project-drift-and-main-state-pollution',
+            workspace_type: 'isolated_worktree',
+            repo_path: '/tmp/worktrees/issue-260',
+          },
+        },
+      },
+    });
 
     const result = await switchProject({ project: 'agenticos' });
 
@@ -573,6 +804,434 @@ describe('switchProject', () => {
     expect(result).toContain('🛡️ Latest committed guardrail snapshot: freshness not proven');
     expect(result).toContain('🧭 Latest committed issue bootstrap snapshot: #260 on fix/260-stop-active-project-drift-and-main-state-pollution');
     expect(result).toContain('🎯 Current committed task snapshot: Implement #262 concurrent runtime project resolution (in_progress)');
+  });
+
+  it('prefers runtime guardrail and bootstrap summaries in switch output', async () => {
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: null,
+      projects: [
+        {
+          id: 'agenticos',
+          name: 'AgenticOS',
+          path: '/workspace/projects/agenticos',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    fsPromisesMock.readFile
+      .mockResolvedValueOnce(JSON.stringify({
+        meta: { description: 'Self-hosting product' },
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'public_distilled',
+          github_repo: 'madlouse/AgenticOS',
+          branch_strategy: 'github_flow',
+        },
+        execution: {
+          source_repo_roots: ['.'],
+        },
+        agent_context: {
+          quick_start: 'standards/.context/quick-start.md',
+          current_state: 'standards/.context/state.yaml',
+        },
+      }))
+      .mockResolvedValueOnce(JSON.stringify({
+        current_task: { title: 'Canonical state', status: 'active' },
+        working_memory: { pending: [], decisions: [] },
+        issue_bootstrap: {
+          latest: {
+            issue_id: '236',
+            current_branch: 'chore/236-old-bootstrap',
+          },
+        },
+      }))
+      .mockResolvedValueOnce('# Quick Start\n\nCanonical quick start');
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/home/testuser/AgenticOS/.agent-workspace/projects/agenticos/guardrail-state.yaml',
+      state: {
+        guardrail_evidence: {
+          last_command: 'agenticos_preflight',
+          updated_at: '2025-01-03T15:00:00.000Z',
+          preflight: {
+            command: 'agenticos_preflight',
+            recorded_at: '2025-01-03T15:00:00.000Z',
+            issue_id: '294',
+            result: { status: 'PASS', summary: 'runtime preflight passed' },
+          },
+        },
+        issue_bootstrap: {
+          latest: {
+            issue_id: '294',
+            current_branch: 'chore/294-eliminate-canonical-main-runtime-write-paths',
+          },
+        },
+      },
+    });
+
+    const result = await switchProject({ project: 'agenticos' });
+
+    expect(result).toContain('Issue: #294');
+    expect(result).toContain('#294 on chore/294-eliminate-canonical-main-runtime-write-paths');
+    expect(result).not.toContain('#236 on chore/236-old-bootstrap');
+  });
+
+  it('shows branch bootstrap guardrail summaries with fallback timestamp text', async () => {
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: null,
+      projects: [
+        {
+          id: 'my-project',
+          name: 'My Project',
+          path: '/test/path',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+    fsPromisesMock.readFile
+      .mockResolvedValueOnce(JSON.stringify({
+        meta: { description: '' },
+        source_control: { topology: 'local_directory_only' },
+      }))
+      .mockResolvedValueOnce(JSON.stringify({
+        working_memory: { pending: [], decisions: [] },
+      }))
+      .mockResolvedValueOnce('# Quick Start\n\nProject summary');
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/home/testuser/AgenticOS/.agent-workspace/projects/my-project/guardrail-state.yaml',
+      state: {
+        guardrail_evidence: {
+          last_command: 'agenticos_branch_bootstrap',
+          updated_at: 'not-a-date',
+          branch_bootstrap: {
+            command: 'agenticos_branch_bootstrap',
+            result: {
+              status: 'CREATED',
+              branch_name: 'feat/71-runtime-guardrails',
+            },
+          },
+        },
+      },
+    });
+
+    const result = await switchProject({ project: 'my-project' });
+
+    expect(result).toContain('agenticos_branch_bootstrap -> CREATED (Unknown time)');
+    expect(result).toContain('Detail: created feat/71-runtime-guardrails');
+  });
+
+  it('shows pr-scope guardrail summaries and preserves summary text', async () => {
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: null,
+      projects: [
+        {
+          id: 'my-project',
+          name: 'My Project',
+          path: '/test/path',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+    fsPromisesMock.readFile
+      .mockResolvedValueOnce(JSON.stringify({
+        meta: { description: '' },
+        source_control: { topology: 'local_directory_only' },
+      }))
+      .mockResolvedValueOnce(JSON.stringify({
+        working_memory: { pending: [], decisions: [] },
+      }))
+      .mockResolvedValueOnce('# Quick Start\n\nProject summary');
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/home/testuser/AgenticOS/.agent-workspace/projects/my-project/guardrail-state.yaml',
+      state: {
+        guardrail_evidence: {
+          last_command: 'agenticos_pr_scope_check',
+          pr_scope_check: {
+            command: 'agenticos_pr_scope_check',
+            recorded_at: '2025-01-03T10:00:00.000Z',
+            issue_id: '88',
+            result: {
+              status: 'PASS',
+              summary: 'diff scope matches declared issue boundary',
+            },
+          },
+        },
+      },
+    });
+
+    const result = await switchProject({ project: 'my-project' });
+
+    expect(result).toContain('agenticos_pr_scope_check -> PASS');
+    expect(result).toContain('Issue: #88');
+    expect(result).toContain('diff scope matches declared issue boundary');
+  });
+
+  it('shows unknown guardrail status when the latest entry has no result payload', async () => {
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: null,
+      projects: [
+        {
+          id: 'my-project',
+          name: 'My Project',
+          path: '/test/path',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+    fsPromisesMock.readFile
+      .mockResolvedValueOnce(JSON.stringify({
+        meta: { description: '' },
+        source_control: { topology: 'local_directory_only' },
+      }))
+      .mockResolvedValueOnce(JSON.stringify({
+        working_memory: { pending: [], decisions: [] },
+      }))
+      .mockResolvedValueOnce('# Quick Start\n\nProject summary');
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/home/testuser/AgenticOS/.agent-workspace/projects/my-project/guardrail-state.yaml',
+      state: {
+        guardrail_evidence: {
+          last_command: 'agenticos_preflight',
+          preflight: {
+            command: 'agenticos_preflight',
+          },
+        },
+      },
+    });
+
+    const result = await switchProject({ project: 'my-project' });
+
+    expect(result).toContain('agenticos_preflight -> UNKNOWN (Unknown time)');
+  });
+
+  it('uses branch bootstrap notes when no branch name is recorded', async () => {
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: null,
+      projects: [
+        {
+          id: 'my-project',
+          name: 'My Project',
+          path: '/test/path',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+    fsPromisesMock.readFile
+      .mockResolvedValueOnce(JSON.stringify({
+        meta: { description: '' },
+        source_control: { topology: 'local_directory_only' },
+      }))
+      .mockResolvedValueOnce(JSON.stringify({
+        working_memory: { pending: [], decisions: [] },
+      }))
+      .mockResolvedValueOnce('# Quick Start\n\nProject summary');
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/home/testuser/AgenticOS/.agent-workspace/projects/my-project/guardrail-state.yaml',
+      state: {
+        guardrail_evidence: {
+          last_command: 'agenticos_branch_bootstrap',
+          branch_bootstrap: {
+            command: 'agenticos_branch_bootstrap',
+            result: {
+              status: 'CREATED',
+              notes: ['created worktree without explicit branch label'],
+            },
+          },
+        },
+      },
+    });
+
+    const result = await switchProject({ project: 'my-project' });
+
+    expect(result).toContain('created worktree without explicit branch label');
+  });
+
+  it('omits guardrail detail when the latest entry has no detail-bearing fields', async () => {
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: null,
+      projects: [
+        {
+          id: 'my-project',
+          name: 'My Project',
+          path: '/test/path',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+    fsPromisesMock.readFile
+      .mockResolvedValueOnce(JSON.stringify({
+        meta: { description: '' },
+        source_control: { topology: 'local_directory_only' },
+      }))
+      .mockResolvedValueOnce(JSON.stringify({
+        working_memory: { pending: [], decisions: [] },
+      }))
+      .mockResolvedValueOnce('# Quick Start\n\nProject summary');
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/home/testuser/AgenticOS/.agent-workspace/projects/my-project/guardrail-state.yaml',
+      state: {
+        guardrail_evidence: {
+          last_command: 'agenticos_preflight',
+          preflight: {
+            command: 'agenticos_preflight',
+            recorded_at: '2025-01-03T10:00:00.000Z',
+            result: {
+              status: 'PASS',
+            },
+          },
+        },
+      },
+    });
+
+    const result = await switchProject({ project: 'my-project' });
+
+    expect(result).toContain('agenticos_preflight -> PASS');
+    expect(result).not.toContain('Detail:');
+  });
+
+  it('shows unknown issue bootstrap labels when issue metadata is missing', async () => {
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: null,
+      projects: [
+        {
+          id: 'my-project',
+          name: 'My Project',
+          path: '/test/path',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+    fsPromisesMock.readFile
+      .mockResolvedValueOnce(JSON.stringify({
+        meta: { description: '' },
+        source_control: { topology: 'local_directory_only' },
+      }))
+      .mockResolvedValueOnce(JSON.stringify({
+        working_memory: { pending: [], decisions: [] },
+      }))
+      .mockResolvedValueOnce('# Quick Start\n\nProject summary');
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/home/testuser/AgenticOS/.agent-workspace/projects/my-project/guardrail-state.yaml',
+      state: {
+        issue_bootstrap: {
+          updated_at: 'bad-date',
+          latest: {},
+        },
+      },
+    });
+
+    const result = await switchProject({ project: 'my-project' });
+
+    expect(result).toContain('🧭 Latest issue bootstrap: unknown issue (Unknown time)');
+  });
+
+  it('surfaces a registry metadata patch warning during switch bootstrap', async () => {
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: null,
+      projects: [
+        {
+          id: 'my-project',
+          name: 'My Project',
+          path: '/test/path',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+    registryMock.patchProjectMetadata.mockRejectedValue(new Error('registry busy'));
+    fsPromisesMock.readFile.mockImplementation(async (path: string) => {
+      if (path.endsWith('/.project.yaml')) {
+        return JSON.stringify({
+          meta: { description: '' },
+          source_control: { topology: 'local_directory_only' },
+        });
+      }
+      if (path.endsWith('/.context/quick-start.md')) {
+        return '# Only headings\n- ignored';
+      }
+      return JSON.stringify({});
+    });
+
+    const result = await switchProject({ project: 'my-project' });
+
+    expect(result).toContain('⚠️ Session bound, but registry metadata was not updated: registry busy');
+  });
+
+  it('falls back to committed switch state when runtime guardrail loading fails', async () => {
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: null,
+      projects: [
+        {
+          id: 'my-project',
+          name: 'My Project',
+          path: '/test/path',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    fsPromisesMock.readFile
+      .mockResolvedValueOnce(JSON.stringify({
+        meta: { description: '' },
+        source_control: { topology: 'local_directory_only' },
+      }))
+      .mockResolvedValueOnce(JSON.stringify({
+        working_memory: { pending: [], decisions: [] },
+        issue_bootstrap: {
+          latest: {
+            issue_id: '179',
+            current_branch: 'feat/179-issue-start-bootstrap-evidence',
+          },
+        },
+      }))
+      .mockResolvedValueOnce('# Quick Start\n\nProject summary');
+    loadLatestGuardrailStateMock.mockRejectedValue(new Error('runtime unavailable'));
+
+    const result = await switchProject({ project: 'my-project' });
+
+    expect(result).toContain('#179 on feat/179-issue-start-bootstrap-evidence');
   });
 
   it('falls back to quick-start summary when project description is missing', async () => {
@@ -610,6 +1269,84 @@ describe('switchProject', () => {
     const result = await switchProject({ project: 'my-project' });
 
     expect(result).toContain('📖 Project summary: Fallback project summary from quick-start.');
+  });
+
+  it('does not infer a project summary from heading-only quick-start content and falls back task status to unknown', async () => {
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: null,
+      projects: [
+        {
+          id: 'my-project',
+          name: 'My Project',
+          path: '/test/path',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    fsPromisesMock.readFile
+      .mockResolvedValueOnce(JSON.stringify({
+        meta: { description: '' },
+        source_control: { topology: 'local_directory_only' },
+      }))
+      .mockResolvedValueOnce(JSON.stringify({
+        current_task: {
+          title: 'Runtime-only summary',
+        },
+        working_memory: {
+          pending: [],
+          decisions: [],
+        },
+      }))
+      .mockResolvedValueOnce('# Quick Start\n\n# Heading Only\n- ignored bullet');
+
+    const result = await switchProject({ project: 'my-project' });
+
+    expect(result).toContain('🎯 Current task: Runtime-only summary (unknown)');
+    expect(result).not.toContain('📖 Project summary:');
+  });
+
+  it('switches successfully when committed state and quick-start files are missing', async () => {
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: null,
+      projects: [
+        {
+          id: 'my-project',
+          name: 'My Project',
+          path: '/test/path',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+    fsMock.existsSync.mockReturnValue(true);
+    fsPromisesMock.readFile.mockImplementation(async (path: string) => {
+      if (path.endsWith('/.project.yaml')) {
+        return JSON.stringify({
+          meta: { description: '' },
+          source_control: { topology: 'local_directory_only' },
+        });
+      }
+      if (path.endsWith('/CLAUDE.md')) {
+        return '# CLAUDE.md\n\nCurrent';
+      }
+      if (path.endsWith('/AGENTS.md')) {
+        return '# AGENTS.md\n\nCurrent';
+      }
+      throw new Error(`missing: ${path}`);
+    });
+
+    const result = await switchProject({ project: 'my-project' });
+
+    expect(result).toContain('✅ Switched to project "My Project"');
+    expect(result).not.toContain('📝');
   });
 
   it('surfaces the public_distilled transcript contract in switch output', async () => {
@@ -1152,6 +1889,211 @@ describe('getStatus', () => {
 
     expect(result).toContain('🧭 Latest issue bootstrap: #179 on feat/179-issue-start-bootstrap-evidence');
     expect(result).toContain('Title: Implement bootstrap evidence');
+  });
+
+  it('prefers runtime guardrail and bootstrap summaries in status output', async () => {
+    bindSessionProject({
+      projectId: 'agenticos',
+      projectName: 'AgenticOS',
+      projectPath: '/workspace/projects/agenticos',
+    });
+
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: 'agenticos',
+      projects: [
+        {
+          id: 'agenticos',
+          name: 'AgenticOS',
+          path: '/workspace/projects/agenticos',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    mockStatusReads(
+      {
+        meta: { id: 'agenticos', name: 'AgenticOS' },
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'public_distilled',
+          github_repo: 'madlouse/AgenticOS',
+          branch_strategy: 'github_flow',
+        },
+        execution: {
+          source_repo_roots: ['.'],
+        },
+      },
+      {
+        current_task: { title: 'Canonical status', status: 'active' },
+        working_memory: { pending: [], decisions: [] },
+        issue_bootstrap: {
+          latest: {
+            issue_id: '236',
+            current_branch: 'chore/236-old-bootstrap',
+          },
+        },
+      }
+    );
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/home/testuser/AgenticOS/.agent-workspace/projects/agenticos/guardrail-state.yaml',
+      state: {
+        guardrail_evidence: {
+          last_command: 'agenticos_preflight',
+          updated_at: '2025-01-03T15:00:00.000Z',
+          preflight: {
+            command: 'agenticos_preflight',
+            recorded_at: '2025-01-03T15:00:00.000Z',
+            issue_id: '294',
+            result: { status: 'PASS', summary: 'runtime preflight passed' },
+          },
+        },
+        issue_bootstrap: {
+          latest: {
+            issue_id: '294',
+            current_branch: 'chore/294-eliminate-canonical-main-runtime-write-paths',
+          },
+        },
+      },
+    });
+
+    const result = await getStatus();
+
+    expect(result).toContain('Issue: #294');
+    expect(result).toContain('#294 on chore/294-eliminate-canonical-main-runtime-write-paths');
+    expect(result).not.toContain('#236 on chore/236-old-bootstrap');
+  });
+
+  it('falls back to committed status state when runtime guardrail loading fails', async () => {
+    bindSessionProject({
+      projectId: 'my-project',
+      projectName: 'My Project',
+      projectPath: '/test/path',
+    });
+
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: 'my-project',
+      projects: [
+        {
+          id: 'my-project',
+          name: 'My Project',
+          path: '/test/path',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    mockStatusReads(
+      {
+        meta: { id: 'my-project', name: 'My Project' },
+        source_control: { topology: 'local_directory_only' },
+      },
+      {
+        working_memory: { pending: [], decisions: [] },
+        issue_bootstrap: {
+          latest: {
+            issue_id: '179',
+            current_branch: 'feat/179-issue-start-bootstrap-evidence',
+          },
+        },
+      }
+    );
+    loadLatestGuardrailStateMock.mockRejectedValue(new Error('runtime unavailable'));
+
+    const result = await getStatus();
+
+    expect(result).toContain('#179 on feat/179-issue-start-bootstrap-evidence');
+  });
+
+  it('treats a null parsed status state as an empty state object', async () => {
+    bindSessionProject({
+      projectId: 'my-project',
+      projectName: 'My Project',
+      projectPath: '/test/path',
+    });
+
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: 'my-project',
+      projects: [
+        {
+          id: 'my-project',
+          name: 'My Project',
+          path: '/test/path',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    fsPromisesMock.readFile.mockImplementation(async (path: string) => {
+      if (path.endsWith('/.project.yaml')) {
+        return JSON.stringify({
+          meta: { id: 'my-project', name: 'My Project' },
+          source_control: { topology: 'local_directory_only' },
+        });
+      }
+      return 'null';
+    });
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'committed',
+      state: {},
+      state_path: '/mock/state.yaml',
+    });
+
+    const result = await getStatus();
+
+    expect(result).toContain('🎯 Current task: None');
+  });
+
+  it('uses task fallback labels when status task metadata is incomplete', async () => {
+    bindSessionProject({
+      projectId: 'my-project',
+      projectName: 'My Project',
+      projectPath: '/test/path',
+    });
+
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: 'my-project',
+      projects: [
+        {
+          id: 'my-project',
+          name: 'My Project',
+          path: '/test/path',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    mockStatusReads(
+      {
+        meta: { id: 'my-project', name: 'My Project' },
+        source_control: { topology: 'local_directory_only' },
+      },
+      {
+        current_task: {},
+        working_memory: { pending: [], decisions: [] },
+      }
+    );
+
+    const result = await getStatus();
+
+    expect(result).toContain('🎯 Current task: Untitled (unknown)');
+    expect(result).toContain('📋 Pending: None');
   });
 
   it('marks stale committed github-versioned status explicitly', async () => {

--- a/mcp-server/src/tools/edit-guard.ts
+++ b/mcp-server/src/tools/edit-guard.ts
@@ -1,9 +1,7 @@
-import { readFile } from 'fs/promises';
 import { exec } from 'child_process';
 import { dirname, resolve } from 'path';
 import { promisify } from 'util';
-import yaml from 'yaml';
-import { extractLatestIssueBootstrap } from '../utils/guardrail-evidence.js';
+import { extractLatestIssueBootstrap, loadLatestGuardrailState } from '../utils/guardrail-evidence.js';
 import {
   isImplementationAffectingTask,
   resolveGuardrailProjectTarget,
@@ -183,10 +181,14 @@ export async function runEditGuard(args: EditGuardArgs): Promise<string> {
   let state: any = {};
   if (result.target_project) {
     try {
-      state = yaml.parse(await readFile(result.target_project.state_path, 'utf-8')) || {};
+      const loadedGuardrailState = await loadLatestGuardrailState({
+        project_id: result.target_project.id,
+        committed_state_path: result.target_project.state_path,
+      });
+      state = loadedGuardrailState.state;
     } catch {
-      result.block_reasons.push(`managed project state is missing or unreadable: ${result.target_project.state_path}`);
-      result.recovery_actions.push('ensure the managed project state exists before using the edit guard');
+      result.block_reasons.push(`managed project guardrail state is missing or unreadable: ${result.target_project.state_path}`);
+      result.recovery_actions.push('ensure the managed project guardrail state exists before using the edit guard');
     }
   }
 

--- a/mcp-server/src/tools/preflight.ts
+++ b/mcp-server/src/tools/preflight.ts
@@ -1,9 +1,12 @@
 import { exec } from 'child_process';
 import { dirname, resolve } from 'path';
 import { promisify } from 'util';
-import { readFile } from 'fs/promises';
-import yaml from 'yaml';
-import { extractLatestIssueBootstrap, persistGuardrailEvidence, type GuardrailPersistenceResult } from '../utils/guardrail-evidence.js';
+import {
+  extractLatestIssueBootstrap,
+  loadLatestGuardrailState,
+  persistGuardrailEvidence,
+  type GuardrailPersistenceResult,
+} from '../utils/guardrail-evidence.js';
 import {
   isImplementationAffectingTask,
   resolveGuardrailProjectTarget,
@@ -309,8 +312,11 @@ export async function runPreflight(args: PreflightArgs): Promise<string> {
 
     if (projectResolution.targetProject && result.worktree_ok) {
       try {
-        const state = yaml.parse(await readFile(projectResolution.targetProject.statePath, 'utf-8')) || {};
-        const latestBootstrap = extractLatestIssueBootstrap(state);
+        const guardrailState = await loadLatestGuardrailState({
+          project_id: projectResolution.targetProject.id,
+          committed_state_path: projectResolution.targetProject.statePath,
+        });
+        const latestBootstrap = extractLatestIssueBootstrap(guardrailState.state);
         result.evidence.issue_bootstrap = latestBootstrap
           ? {
               recorded_at: latestBootstrap.recorded_at || null,
@@ -353,7 +359,7 @@ export async function runPreflight(args: PreflightArgs): Promise<string> {
           }
         }
       } catch {
-        result.block_reasons.push(`managed project state is missing or unreadable: ${projectResolution.targetProject.statePath}`);
+        result.block_reasons.push(`managed project guardrail state is missing or unreadable: ${projectResolution.targetProject.statePath}`);
       }
     }
   } else {

--- a/mcp-server/src/tools/project.ts
+++ b/mcp-server/src/tools/project.ts
@@ -7,7 +7,7 @@ import { generateClaudeMd, generateAgentsMd, updateClaudeMdState, upgradeClaudeM
 import { writeFile } from 'fs/promises';
 import { buildArchivedReferenceMessage, isArchivedReferenceProject, validateManagedProjectTopology } from '../utils/project-contract.js';
 import { resolveManagedProjectContextPaths, resolveManagedProjectTarget } from '../utils/project-target.js';
-import { type IssueBootstrapRecord, type IssueBootstrapState } from '../utils/guardrail-evidence.js';
+import { loadLatestGuardrailState, type IssueBootstrapRecord, type IssueBootstrapState } from '../utils/guardrail-evidence.js';
 import { resolveManagedProjectContextDisplayPaths } from '../utils/agent-context-paths.js';
 import { resolveContextPolicyPlan } from '../utils/context-policy-plan.js';
 import {
@@ -308,6 +308,7 @@ export async function switchProject(args: any): Promise<string> {
 
   let description = '';
   let state: any = undefined;
+  let displayState: any = undefined;
   let quickStart = '';
   description = projectYaml?.meta?.description || '';
   const contextPaths = resolveManagedProjectContextPaths(found.path, projectYaml);
@@ -315,6 +316,15 @@ export async function switchProject(args: any): Promise<string> {
   try {
     state = yaml.parse(await readFile(contextPaths.statePath, 'utf-8'));
   } catch {}
+  try {
+    const loadedGuardrailState = await loadLatestGuardrailState({
+      project_id: found.id,
+      committed_state_path: contextPaths.statePath,
+    });
+    displayState = loadedGuardrailState.state;
+  } catch {
+    displayState = state;
+  }
   try {
     quickStart = await readFile(contextPaths.quickStartPath, 'utf-8');
   } catch {}
@@ -365,11 +375,11 @@ export async function switchProject(args: any): Promise<string> {
   });
   const committedSnapshotSummary = buildCommittedSnapshotSummaryLines(committedSnapshotAssessment);
   const guardrailSummary = buildGuardrailSummaryLines(
-    state?.guardrail_evidence as GuardrailEvidenceState | undefined,
+    displayState?.guardrail_evidence as GuardrailEvidenceState | undefined,
     committedSnapshotAssessment,
   );
   const issueBootstrapSummary = buildIssueBootstrapSummaryLines({
-    issueBootstrap: state?.issue_bootstrap as IssueBootstrapState | undefined,
+    issueBootstrap: displayState?.issue_bootstrap as IssueBootstrapState | undefined,
     committedSnapshotAssessment,
   });
   const contextSummary = buildSwitchContextSummaryLines({
@@ -423,11 +433,21 @@ export async function getStatus(args: any = {}): Promise<string> {
 
   const { project, statePath } = resolved;
   let state: any = {};
+  let displayState: any = {};
   try {
     const content = await readFile(statePath, 'utf-8');
     state = yaml.parse(content) || {};
   } catch {
     return `❌ Failed to read state.yaml for project "${project.name}"`;
+  }
+  try {
+    const loadedGuardrailState = await loadLatestGuardrailState({
+      project_id: project.id,
+      committed_state_path: statePath,
+    });
+    displayState = loadedGuardrailState.state;
+  } catch {
+    displayState = state;
   }
 
   const lines: string[] = [];
@@ -465,11 +485,11 @@ export async function getStatus(args: any = {}): Promise<string> {
 
   lines.push(...buildCommittedSnapshotSummaryLines(committedSnapshotAssessment));
   lines.push(...buildGuardrailSummaryLines(
-    state.guardrail_evidence as GuardrailEvidenceState | undefined,
+    displayState.guardrail_evidence as GuardrailEvidenceState | undefined,
     committedSnapshotAssessment,
   ));
   lines.push(...buildIssueBootstrapSummaryLines({
-    issueBootstrap: state.issue_bootstrap as IssueBootstrapState | undefined,
+    issueBootstrap: displayState.issue_bootstrap as IssueBootstrapState | undefined,
     committedSnapshotAssessment,
   }));
 

--- a/mcp-server/src/utils/__tests__/canonical-main-guard.test.ts
+++ b/mcp-server/src/utils/__tests__/canonical-main-guard.test.ts
@@ -47,4 +47,30 @@ describe('detectCanonicalMainWriteProtection', () => {
     expect(result.blocked).toBe(false);
     expect(result.workspace_type).toBe('isolated_worktree');
   });
+
+  it('fails closed when git inspection cannot determine workspace safety', async () => {
+    execAsyncMock.mockRejectedValue(new Error('git unavailable'));
+
+    const result = await detectCanonicalMainWriteProtection('/workspace/root');
+
+    expect(result.blocked).toBe(true);
+    expect(result.reason).toContain('failed to verify canonical main write protection');
+  });
+
+  it('allows non-git runtime directories', async () => {
+    execAsyncMock.mockRejectedValue(new Error('fatal: not a git repository'));
+
+    const result = await detectCanonicalMainWriteProtection('/runtime/home');
+
+    expect(result.blocked).toBe(false);
+  });
+
+  it('returns the generic failure reason when git inspection throws a non-Error value', async () => {
+    execAsyncMock.mockRejectedValue('boom');
+
+    const result = await detectCanonicalMainWriteProtection('/workspace/root');
+
+    expect(result.blocked).toBe(true);
+    expect(result.reason).toBe('failed to verify canonical main write protection');
+  });
 });

--- a/mcp-server/src/utils/__tests__/guardrail-evidence.test.ts
+++ b/mcp-server/src/utils/__tests__/guardrail-evidence.test.ts
@@ -7,7 +7,11 @@ const yamlMock = vi.hoisted(() => ({
 
 vi.mock('fs/promises', () => ({
   access: vi.fn(),
+  mkdir: vi.fn(),
   readFile: vi.fn(),
+  rename: vi.fn(),
+  rm: vi.fn(),
+  stat: vi.fn(),
   writeFile: vi.fn(),
 }));
 
@@ -16,6 +20,7 @@ vi.mock('yaml', () => ({
 }));
 
 vi.mock('../registry.js', () => ({
+  getAgenticOSHome: vi.fn(() => '/runtime'),
   loadRegistry: vi.fn(),
 }));
 
@@ -23,18 +28,34 @@ vi.mock('../canonical-main-guard.js', () => ({
   detectCanonicalMainWriteProtection: vi.fn(async () => ({ blocked: false })),
 }));
 
-import { access, readFile, writeFile } from 'fs/promises';
+import { access, mkdir, readFile, rename, rm, stat, writeFile } from 'fs/promises';
 import { detectCanonicalMainWriteProtection } from '../canonical-main-guard.js';
 import { loadRegistry } from '../registry.js';
-import { persistGuardrailEvidence, persistIssueBootstrapEvidence } from '../guardrail-evidence.js';
+import {
+  extractLatestIssueBootstrap,
+  loadLatestGuardrailState,
+  persistGuardrailEvidence,
+  persistIssueBootstrapEvidence,
+} from '../guardrail-evidence.js';
 
 const accessMock = access as unknown as ReturnType<typeof vi.fn>;
+const mkdirMock = mkdir as unknown as ReturnType<typeof vi.fn>;
 const readFileMock = readFile as unknown as ReturnType<typeof vi.fn>;
+const renameMock = rename as unknown as ReturnType<typeof vi.fn>;
+const rmMock = rm as unknown as ReturnType<typeof vi.fn>;
+const statMock = stat as unknown as ReturnType<typeof vi.fn>;
 const writeFileMock = writeFile as unknown as ReturnType<typeof vi.fn>;
 const loadRegistryMock = loadRegistry as unknown as ReturnType<typeof vi.fn>;
 const detectCanonicalMainWriteProtectionMock = detectCanonicalMainWriteProtection as unknown as ReturnType<typeof vi.fn>;
 
-describe('persistGuardrailEvidence', () => {
+function defaultProjectYaml(id = 'agenticos', name = 'AgenticOS'): string {
+  return JSON.stringify({
+    meta: { id, name },
+    agent_context: { current_state: 'standards/.context/state.yaml' },
+  });
+}
+
+describe('guardrail runtime persistence', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     yamlMock.parse.mockImplementation((content: string) => {
@@ -59,22 +80,21 @@ describe('persistGuardrailEvidence', () => {
       ],
     });
     accessMock.mockResolvedValue(undefined);
-    readFileMock.mockResolvedValue(JSON.stringify({ session: {}, working_memory: { facts: [], decisions: [], pending: [] } }));
+    mkdirMock.mockResolvedValue(undefined);
+    renameMock.mockResolvedValue(undefined);
+    rmMock.mockResolvedValue(undefined);
+    statMock.mockResolvedValue({ mtimeMs: Date.now() });
     writeFileMock.mockResolvedValue(undefined);
     detectCanonicalMainWriteProtectionMock.mockResolvedValue({ blocked: false });
-  });
-
-  it('persists latest preflight evidence into the matching managed project state', async () => {
     readFileMock.mockImplementation(async (path: string) => {
       if (path.endsWith('/.project.yaml')) {
-        return JSON.stringify({
-          meta: { id: 'agenticos', name: 'AgenticOS' },
-          agent_context: { current_state: 'standards/.context/state.yaml' },
-        });
+        return defaultProjectYaml();
       }
-      return JSON.stringify({ session: {}, working_memory: { facts: [], decisions: [], pending: [] } });
+      throw new Error(`missing: ${path}`);
     });
+  });
 
+  it('persists latest preflight evidence into the runtime guardrail state file', async () => {
     const result = await persistGuardrailEvidence({
       command: 'agenticos_preflight',
       repo_path: '/workspace/projects/agenticos/mcp-server',
@@ -86,8 +106,12 @@ describe('persistGuardrailEvidence', () => {
 
     expect(result.persisted).toBe(true);
     expect(result.project_id).toBe('agenticos');
+    expect(result.state_path).toBe('/runtime/.agent-workspace/projects/agenticos/guardrail-state.yaml');
     expect(writeFileMock).toHaveBeenCalledTimes(1);
-    expect(writeFileMock.mock.calls[0]?.[0]).toBe('/workspace/projects/agenticos/standards/.context/state.yaml');
+    expect(renameMock).toHaveBeenCalledWith(
+      expect.stringContaining('/runtime/.agent-workspace/projects/agenticos/guardrail-state.yaml.tmp-'),
+      '/runtime/.agent-workspace/projects/agenticos/guardrail-state.yaml',
+    );
 
     const [, content] = writeFileMock.mock.calls[0];
     const writtenState = JSON.parse(content as string);
@@ -96,30 +120,80 @@ describe('persistGuardrailEvidence', () => {
     expect(writtenState.guardrail_evidence.preflight.result.status).toBe('PASS');
   });
 
-  it('overwrites the previous latest entry for the same command instead of appending', async () => {
+  it('stores runtime guardrail state under an encoded project id segment', async () => {
+    loadRegistryMock.mockResolvedValue({
+      active_project: '../escaped-project',
+      projects: [
+        {
+          id: '../escaped-project',
+          name: 'Escaped Project',
+          path: '/workspace/projects/escaped',
+          status: 'active',
+          created: '2026-03-23',
+          last_accessed: '2026-03-23T00:00:00.000Z',
+        },
+      ],
+    });
     readFileMock.mockImplementation(async (path: string) => {
       if (path.endsWith('/.project.yaml')) {
+        return defaultProjectYaml('../escaped-project', 'Escaped Project');
+      }
+      throw new Error(`missing: ${path}`);
+    });
+
+    const result = await persistGuardrailEvidence({
+      command: 'agenticos_preflight',
+      repo_path: '/workspace/projects/escaped/mcp-server',
+      payload: {
+        issue_id: '62',
+      },
+    });
+
+    expect(result.persisted).toBe(true);
+    expect(result.state_path).toBe('/runtime/.agent-workspace/projects/..%2Fescaped-project/guardrail-state.yaml');
+    expect(renameMock).toHaveBeenCalledWith(
+      expect.stringContaining('/runtime/.agent-workspace/projects/..%2Fescaped-project/guardrail-state.yaml.tmp-'),
+      '/runtime/.agent-workspace/projects/..%2Fescaped-project/guardrail-state.yaml',
+    );
+  });
+
+  it('resolves registry-backed projects when repo_path equals the project root exactly', async () => {
+    const result = await persistGuardrailEvidence({
+      command: 'agenticos_preflight',
+      repo_path: '/workspace/projects/agenticos',
+      payload: {
+        issue_id: '62',
+      },
+    });
+
+    expect(result.persisted).toBe(true);
+    expect(result.project_id).toBe('agenticos');
+  });
+
+  it('overwrites the previous latest entry for the same command in runtime state', async () => {
+    readFileMock.mockImplementation(async (path: string) => {
+      if (path.endsWith('/.project.yaml')) {
+        return defaultProjectYaml();
+      }
+      if (path.endsWith('/guardrail-state.yaml')) {
         return JSON.stringify({
-          meta: { id: 'agenticos', name: 'AgenticOS' },
-          agent_context: { current_state: 'standards/.context/state.yaml' },
+          guardrail_evidence: {
+            last_command: 'agenticos_preflight',
+            preflight: {
+              command: 'agenticos_preflight',
+              recorded_at: '2026-03-23T09:00:00.000Z',
+              issue_id: '36',
+              result: { status: 'BLOCK' },
+            },
+            pr_scope_check: {
+              command: 'agenticos_pr_scope_check',
+              issue_id: '36',
+              result: { status: 'PASS' },
+            },
+          },
         });
       }
-      return JSON.stringify({
-        guardrail_evidence: {
-          last_command: 'agenticos_preflight',
-          preflight: {
-            command: 'agenticos_preflight',
-            recorded_at: '2026-03-23T09:00:00.000Z',
-            issue_id: '36',
-            result: { status: 'BLOCK' },
-          },
-          pr_scope_check: {
-            command: 'agenticos_pr_scope_check',
-            issue_id: '36',
-            result: { status: 'PASS' },
-          },
-        },
-      });
+      throw new Error(`missing: ${path}`);
     });
 
     await persistGuardrailEvidence({
@@ -138,6 +212,23 @@ describe('persistGuardrailEvidence', () => {
     expect(writtenState.guardrail_evidence.pr_scope_check.issue_id).toBe('36');
   });
 
+  it('persists pr-scope-check evidence into the matching runtime slot', async () => {
+    const result = await persistGuardrailEvidence({
+      command: 'agenticos_pr_scope_check',
+      repo_path: '/workspace/projects/agenticos/mcp-server',
+      payload: {
+        issue_id: '71',
+        result: { status: 'PASS' },
+      },
+    });
+
+    expect(result.persisted).toBe(true);
+    const [, content] = writeFileMock.mock.calls[0];
+    const writtenState = JSON.parse(content as string);
+    expect(writtenState.guardrail_evidence.last_command).toBe('agenticos_pr_scope_check');
+    expect(writtenState.guardrail_evidence.pr_scope_check.issue_id).toBe('71');
+  });
+
   it('falls back to the nearest on-disk project root when registry does not contain the repo path', async () => {
     loadRegistryMock.mockResolvedValue({
       active_project: null,
@@ -147,9 +238,7 @@ describe('persistGuardrailEvidence', () => {
       .mockRejectedValueOnce(new Error('missing repo-level .project.yaml'))
       .mockResolvedValueOnce(undefined)
       .mockResolvedValueOnce(undefined);
-    readFileMock
-      .mockResolvedValueOnce(JSON.stringify({ meta: { id: 'local-agenticos' } }))
-      .mockResolvedValueOnce(JSON.stringify({ session: {}, working_memory: { facts: [], decisions: [], pending: [] } }));
+    readFileMock.mockResolvedValueOnce(JSON.stringify({ meta: { id: 'local-agenticos' } }));
 
     const result = await persistGuardrailEvidence({
       command: 'agenticos_branch_bootstrap',
@@ -162,11 +251,104 @@ describe('persistGuardrailEvidence', () => {
 
     expect(result.persisted).toBe(true);
     expect(result.project_id).toBe('local-agenticos');
+    expect(result.state_path).toBe('/runtime/.agent-workspace/projects/local-agenticos/guardrail-state.yaml');
+  });
 
-    const [statePath, content] = writeFileMock.mock.calls[0];
-    expect(statePath).toBe('/workspace/source/projects/agenticos/.context/state.yaml');
-    const writtenState = JSON.parse(content as string);
-    expect(writtenState.guardrail_evidence.branch_bootstrap.issue_id).toBe('62');
+  it('walks up from unreadable nested project metadata until it finds a usable parent project root', async () => {
+    loadRegistryMock.mockResolvedValue({
+      active_project: null,
+      projects: [],
+    });
+    accessMock.mockImplementation(async (path: string) => {
+      const text = String(path);
+      if (text.endsWith('/nested/.project.yaml')) return undefined;
+      if (text.endsWith('/nested/.context/state.yaml')) throw new Error('missing');
+      if (text.endsWith('/parent/.project.yaml')) return undefined;
+      if (text.endsWith('/parent/.context/state.yaml')) return undefined;
+      throw new Error('missing');
+    });
+    readFileMock.mockImplementation(async (path: string) => {
+      const text = String(path);
+      if (text.endsWith('/nested/.project.yaml')) {
+        throw new Error('bad yaml');
+      }
+      if (text.endsWith('/parent/.project.yaml')) {
+        return JSON.stringify({ meta: { id: 'parent-project' } });
+      }
+      throw new Error(`missing: ${path}`);
+    });
+
+    const result = await persistGuardrailEvidence({
+      command: 'agenticos_branch_bootstrap',
+      repo_path: '/workspace/source/parent/nested/mcp-server',
+      payload: {
+        issue_id: '62',
+        result: { status: 'CREATED', branch_name: 'feat/62-guardrail-evidence' },
+      },
+    });
+
+    expect(result.persisted).toBe(true);
+    expect(result.project_id).toBe('parent-project');
+    expect(result.state_path).toBe('/runtime/.agent-workspace/projects/parent-project/guardrail-state.yaml');
+  });
+
+  it('falls back to a directory-derived id when walked-up project metadata parses to null', async () => {
+    loadRegistryMock.mockResolvedValue({
+      active_project: null,
+      projects: [],
+    });
+    accessMock.mockImplementation(async (path: string) => {
+      const text = String(path);
+      if (text.endsWith('/nested/.project.yaml')) return undefined;
+      if (text.endsWith('/nested/.context/state.yaml')) return undefined;
+      throw new Error('missing');
+    });
+    readFileMock.mockImplementation(async (path: string) => {
+      if (String(path).endsWith('/nested/.project.yaml')) {
+        return 'null';
+      }
+      throw new Error(`missing: ${path}`);
+    });
+
+    const result = await persistGuardrailEvidence({
+      command: 'agenticos_branch_bootstrap',
+      repo_path: '/workspace/source/nested/mcp-server',
+      payload: {
+        issue_id: '62',
+      },
+    });
+
+    expect(result.persisted).toBe(true);
+    expect(result.project_id).toBe('nested');
+  });
+
+  it('returns unresolved when the filesystem root has project metadata but no readable state surface', async () => {
+    loadRegistryMock.mockResolvedValue({
+      active_project: null,
+      projects: [],
+    });
+    accessMock.mockImplementation(async (path: string) => {
+      const text = String(path);
+      if (text === '/.project.yaml') return undefined;
+      throw new Error('missing');
+    });
+    readFileMock.mockImplementation(async (path: string) => {
+      if (String(path) === '/.project.yaml') {
+        return JSON.stringify({ meta: { id: 'root-project' } });
+      }
+      throw new Error(`missing: ${path}`);
+    });
+
+    const result = await persistGuardrailEvidence({
+      command: 'agenticos_preflight',
+      repo_path: '/',
+      payload: {
+        issue_id: '62',
+      },
+    });
+
+    expect(result.persisted).toBe(false);
+    expect(result.reason).toContain('not within a resolvable AgenticOS project');
   });
 
   it('uses explicit project_path when repo_path is a larger checkout root', async () => {
@@ -174,12 +356,15 @@ describe('persistGuardrailEvidence', () => {
       active_project: null,
       projects: [],
     });
-    accessMock
-      .mockResolvedValueOnce(undefined)
-      .mockResolvedValueOnce(undefined);
-    readFileMock
-      .mockResolvedValueOnce(JSON.stringify({ meta: { id: 'agenticos-standards' }, agent_context: { current_state: '.context/state.yaml' } }))
-      .mockResolvedValueOnce(JSON.stringify({ session: {}, working_memory: { facts: [], decisions: [], pending: [] } }));
+    readFileMock.mockImplementation(async (path: string) => {
+      if (path.endsWith('/.project.yaml')) {
+        return JSON.stringify({
+          meta: { id: 'agenticos-standards' },
+          agent_context: { current_state: '.context/state.yaml' },
+        });
+      }
+      throw new Error(`missing: ${path}`);
+    });
 
     const result = await persistGuardrailEvidence({
       command: 'agenticos_preflight',
@@ -193,35 +378,194 @@ describe('persistGuardrailEvidence', () => {
 
     expect(result.persisted).toBe(true);
     expect(result.project_id).toBe('agenticos-standards');
-
-    const [statePath] = writeFileMock.mock.calls[0];
-    expect(statePath).toBe('/workspace/source/projects/agenticos/standards/.context/state.yaml');
+    expect(result.state_path).toBe('/runtime/.agent-workspace/projects/agenticos-standards/guardrail-state.yaml');
   });
 
-  it('uses registry project metadata to resolve canonical state paths for self-hosting roots', async () => {
-    readFileMock.mockImplementation(async (path: string) => {
-      if (path.endsWith('/.project.yaml')) {
-        return JSON.stringify({
-          meta: { id: 'agenticos', name: 'AgenticOS' },
-          agent_context: { current_state: 'standards/.context/state.yaml' },
-        });
-      }
-      return JSON.stringify({ session: {}, working_memory: { facts: [], decisions: [], pending: [] } });
-    });
+  it('fails closed when explicit project_path is not a resolvable AgenticOS project', async () => {
+    accessMock.mockRejectedValue(new Error('missing'));
 
-    await persistGuardrailEvidence({
-      command: 'agenticos_branch_bootstrap',
-      repo_path: '/workspace/projects/agenticos/mcp-server',
+    const result = await persistGuardrailEvidence({
+      command: 'agenticos_preflight',
+      repo_path: '/workspace/source',
+      project_path: '/workspace/source/projects/missing',
       payload: {
-        issue_id: '167',
-        result: { status: 'CREATED', branch_name: 'fix/167-self-hosting-root-project-identity-resolution' },
+        issue_id: '113',
       },
     });
 
-    expect(writeFileMock.mock.calls[0]?.[0]).toBe('/workspace/projects/agenticos/standards/.context/state.yaml');
+    expect(result.persisted).toBe(false);
+    expect(result.reason).toContain('project_path is not a resolvable AgenticOS project');
   });
 
-  it('does not write state when repo_path is outside managed projects', async () => {
+  it('fails closed when explicit project_path metadata is unreadable or missing state', async () => {
+    accessMock.mockImplementation(async (path: string) => {
+      if (String(path).endsWith('/projects/explicit/.project.yaml')) {
+        return undefined;
+      }
+      throw new Error('missing');
+    });
+    readFileMock.mockImplementation(async (path: string) => {
+      if (String(path).endsWith('/projects/explicit/.project.yaml')) {
+        throw new Error('bad yaml');
+      }
+      throw new Error(`missing: ${path}`);
+    });
+
+    const result = await persistGuardrailEvidence({
+      command: 'agenticos_preflight',
+      repo_path: '/workspace/source',
+      project_path: '/workspace/source/projects/explicit',
+      payload: {
+        issue_id: '113',
+      },
+    });
+
+    expect(result.persisted).toBe(false);
+    expect(result.reason).toContain('project_path is not a resolvable AgenticOS project');
+  });
+
+  it('falls back to basename when explicit project metadata parses to null but state exists', async () => {
+    accessMock.mockImplementation(async (path: string) => {
+      const text = String(path);
+      if (text.endsWith('/projects/explicit/.project.yaml')) return undefined;
+      if (text.endsWith('/projects/explicit/.context/state.yaml')) return undefined;
+      throw new Error('missing');
+    });
+    readFileMock.mockImplementation(async (path: string) => {
+      if (String(path).endsWith('/projects/explicit/.project.yaml')) {
+        return 'null';
+      }
+      throw new Error(`missing: ${path}`);
+    });
+
+    const result = await persistGuardrailEvidence({
+      command: 'agenticos_preflight',
+      repo_path: '/workspace/source',
+      project_path: '/workspace/source/projects/explicit',
+      payload: {
+        issue_id: '113',
+      },
+    });
+
+    expect(result.persisted).toBe(true);
+    expect(result.project_id).toBe('explicit');
+  });
+
+  it('falls back to empty project yaml metadata when registry project yaml cannot be parsed', async () => {
+    readFileMock.mockImplementation(async (path: string) => {
+      if (path.endsWith('/workspace/projects/agenticos/.project.yaml') || path.endsWith('/workspace/projects/agenticos/.project.yaml'.replace('/workspace', ''))) {
+        throw new Error('bad yaml');
+      }
+      if (path.endsWith('/guardrail-state.yaml')) {
+        throw new Error(`missing: ${path}`);
+      }
+      throw new Error(`missing: ${path}`);
+    });
+
+    const result = await persistGuardrailEvidence({
+      command: 'agenticos_preflight',
+      repo_path: '/workspace/projects/agenticos/mcp-server',
+      payload: {
+        issue_id: '62',
+      },
+    });
+
+    expect(result.persisted).toBe(true);
+    expect(result.project_id).toBe('agenticos');
+  });
+
+  it('falls back to the registry project id when registry project metadata parses to null', async () => {
+    accessMock.mockImplementation(async (path: string) => {
+      const text = String(path);
+      if (text.endsWith('/workspace/projects/agenticos/.project.yaml')) return undefined;
+      if (text.endsWith('/workspace/projects/agenticos/.context/state.yaml')) return undefined;
+      throw new Error('missing');
+    });
+    readFileMock.mockImplementation(async (path: string) => {
+      if (String(path).endsWith('/workspace/projects/agenticos/.project.yaml')) {
+        return 'null';
+      }
+      throw new Error(`missing: ${path}`);
+    });
+
+    const result = await persistGuardrailEvidence({
+      command: 'agenticos_preflight',
+      repo_path: '/workspace/projects/agenticos/mcp-server',
+      payload: {
+        issue_id: '62',
+      },
+    });
+
+    expect(result.persisted).toBe(true);
+    expect(result.project_id).toBe('agenticos');
+  });
+
+  it('falls back to basename when registry metadata has neither meta.id nor fallback id', async () => {
+    loadRegistryMock.mockResolvedValue({
+      active_project: '',
+      projects: [
+        {
+          id: '',
+          name: 'AgenticOS',
+          path: '/workspace/projects/agenticos',
+          status: 'active',
+          created: '2026-03-23',
+          last_accessed: '2026-03-23T00:00:00.000Z',
+        },
+      ],
+    });
+    accessMock.mockImplementation(async (path: string) => {
+      const text = String(path);
+      if (text.endsWith('/workspace/projects/agenticos/.project.yaml')) return undefined;
+      if (text.endsWith('/workspace/projects/agenticos/.context/state.yaml')) return undefined;
+      throw new Error('missing');
+    });
+    readFileMock.mockImplementation(async (path: string) => {
+      if (String(path).endsWith('/workspace/projects/agenticos/.project.yaml')) {
+        return 'null';
+      }
+      throw new Error(`missing: ${path}`);
+    });
+
+    const result = await persistGuardrailEvidence({
+      command: 'agenticos_preflight',
+      repo_path: '/workspace/projects/agenticos/mcp-server',
+      payload: {
+        issue_id: '62',
+      },
+    });
+
+    expect(result.persisted).toBe(true);
+    expect(result.project_id).toBe('agenticos');
+  });
+
+  it('fails when registry project metadata resolves to a state path that does not exist', async () => {
+    accessMock.mockImplementation(async (path: string) => {
+      if (String(path).endsWith('/.project.yaml')) {
+        return undefined;
+      }
+      throw new Error('missing');
+    });
+    readFileMock.mockImplementation(async (path: string) => {
+      if (path.endsWith('/.project.yaml')) {
+        return defaultProjectYaml();
+      }
+      throw new Error(`missing: ${path}`);
+    });
+
+    const result = await persistGuardrailEvidence({
+      command: 'agenticos_preflight',
+      repo_path: '/workspace/projects/agenticos/mcp-server',
+      payload: {
+        issue_id: '62',
+      },
+    });
+
+    expect(result.persisted).toBe(false);
+    expect(result.reason).toContain('not within a resolvable AgenticOS project');
+  });
+
+  it('does not write runtime state when repo_path is outside managed projects', async () => {
     loadRegistryMock.mockResolvedValue({
       active_project: null,
       projects: [],
@@ -243,19 +587,21 @@ describe('persistGuardrailEvidence', () => {
     expect(writeFileMock).not.toHaveBeenCalled();
   });
 
-  it('does not persist guardrail evidence into canonical main checkouts', async () => {
-    readFileMock.mockImplementation(async (path: string) => {
-      if (path.endsWith('/.project.yaml')) {
-        return JSON.stringify({
-          meta: { id: 'agenticos', name: 'AgenticOS' },
-          agent_context: { current_state: 'standards/.context/state.yaml' },
-        });
-      }
-      return JSON.stringify({ session: {}, working_memory: { facts: [], decisions: [], pending: [] } });
-    });
+  it('fails closed when guardrail evidence persistence is called without repo_path', async () => {
+    const result = await persistGuardrailEvidence({
+      command: 'agenticos_preflight',
+      payload: { issue_id: '62' },
+    } as any);
+
+    expect(result.persisted).toBe(false);
+    expect(result.attempted).toBe(false);
+    expect(result.reason).toContain('repo_path is required');
+  });
+
+  it('does not persist runtime guardrail evidence when AGENTICOS_HOME is canonical main', async () => {
     detectCanonicalMainWriteProtectionMock.mockResolvedValue({
       blocked: true,
-      reason: 'canonical main checkout is write-protected for runtime persistence: /workspace/root',
+      reason: 'canonical main checkout is write-protected for runtime persistence: /runtime',
     });
 
     const result = await persistGuardrailEvidence({
@@ -269,49 +615,11 @@ describe('persistGuardrailEvidence', () => {
 
     expect(result.persisted).toBe(false);
     expect(result.reason).toContain('write-protected');
+    expect(result.state_path).toBe('/runtime/.agent-workspace/projects/agenticos/guardrail-state.yaml');
     expect(writeFileMock).not.toHaveBeenCalled();
   });
-});
 
-describe('persistIssueBootstrapEvidence', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    yamlMock.parse.mockImplementation((content: string) => {
-      try {
-        return JSON.parse(content);
-      } catch {
-        return undefined;
-      }
-    });
-    yamlMock.stringify.mockImplementation((obj: unknown) => JSON.stringify(obj));
-    loadRegistryMock.mockResolvedValue({
-      active_project: 'agenticos',
-      projects: [
-        {
-          id: 'agenticos',
-          name: 'AgenticOS',
-          path: '/workspace/projects/agenticos',
-          status: 'active',
-          created: '2026-03-23',
-          last_accessed: '2026-03-23T00:00:00.000Z',
-        },
-      ],
-    });
-    accessMock.mockResolvedValue(undefined);
-    readFileMock.mockImplementation(async (path: string) => {
-      if (path.endsWith('/.project.yaml')) {
-        return JSON.stringify({
-          meta: { id: 'agenticos', name: 'AgenticOS' },
-          agent_context: { current_state: 'standards/.context/state.yaml' },
-        });
-      }
-      return JSON.stringify({ session: {}, working_memory: { facts: [], decisions: [], pending: [] } });
-    });
-    writeFileMock.mockResolvedValue(undefined);
-    detectCanonicalMainWriteProtectionMock.mockResolvedValue({ blocked: false });
-  });
-
-  it('persists the latest issue bootstrap record into the matching managed project state', async () => {
+  it('persists the latest issue bootstrap record into runtime guardrail state', async () => {
     const result = await persistIssueBootstrapEvidence({
       repo_path: '/workspace/projects/agenticos/mcp-server',
       payload: {
@@ -323,8 +631,7 @@ describe('persistIssueBootstrapEvidence', () => {
 
     expect(result.persisted).toBe(true);
     expect(result.project_id).toBe('agenticos');
-    expect(writeFileMock).toHaveBeenCalledTimes(1);
-    expect(writeFileMock.mock.calls[0]?.[0]).toBe('/workspace/projects/agenticos/standards/.context/state.yaml');
+    expect(result.state_path).toBe('/runtime/.agent-workspace/projects/agenticos/guardrail-state.yaml');
 
     const [, content] = writeFileMock.mock.calls[0];
     const writtenState = JSON.parse(content as string);
@@ -333,14 +640,63 @@ describe('persistIssueBootstrapEvidence', () => {
     expect(writtenState.issue_bootstrap.latest.repo_path).toBe('/workspace/projects/agenticos/mcp-server');
   });
 
-  it('does not persist issue bootstrap evidence into canonical main checkouts', async () => {
+  it('fails closed when issue bootstrap persistence is called without repo_path', async () => {
+    const result = await persistIssueBootstrapEvidence({
+      payload: {
+        issue_id: '260',
+        issue_title: 'Stop runtime persistence pollution',
+      },
+    } as any);
+
+    expect(result.persisted).toBe(false);
+    expect(result.attempted).toBe(false);
+    expect(result.reason).toContain('repo_path is required');
+  });
+
+  it('does not persist issue bootstrap evidence when the target project cannot be resolved', async () => {
+    loadRegistryMock.mockResolvedValue({
+      active_project: null,
+      projects: [],
+    });
+    accessMock.mockRejectedValue(new Error('missing'));
+    readFileMock.mockRejectedValue(new Error('missing'));
+
+    const result = await persistIssueBootstrapEvidence({
+      repo_path: '/external/repo',
+      payload: {
+        issue_id: '260',
+        issue_title: 'Stop runtime persistence pollution',
+      },
+    });
+
+    expect(result.persisted).toBe(false);
+    expect(result.reason).toContain('not within a resolvable AgenticOS project');
+  });
+
+  it('fails closed when explicit project_path for issue bootstrap is not resolvable', async () => {
+    accessMock.mockRejectedValue(new Error('missing'));
+
+    const result = await persistIssueBootstrapEvidence({
+      repo_path: '/workspace/source',
+      project_path: '/workspace/source/projects/missing',
+      payload: {
+        issue_id: '260',
+        issue_title: 'Stop runtime persistence pollution',
+      },
+    });
+
+    expect(result.persisted).toBe(false);
+    expect(result.reason).toContain('project_path is not a resolvable AgenticOS project');
+  });
+
+  it('does not persist issue bootstrap evidence when AGENTICOS_HOME is canonical main', async () => {
     detectCanonicalMainWriteProtectionMock.mockResolvedValue({
       blocked: true,
-      reason: 'canonical main checkout is write-protected for runtime persistence: /workspace/root',
+      reason: 'canonical main checkout is write-protected for runtime persistence: /runtime',
     });
 
     const result = await persistIssueBootstrapEvidence({
-      repo_path: '/workspace/root/projects/agenticos/mcp-server',
+      repo_path: '/workspace/projects/agenticos/mcp-server',
       payload: {
         issue_id: '260',
         issue_title: 'Stop runtime persistence pollution',
@@ -349,6 +705,338 @@ describe('persistIssueBootstrapEvidence', () => {
 
     expect(result.persisted).toBe(false);
     expect(result.reason).toContain('write-protected');
-    expect(writeFileMock).not.toHaveBeenCalled();
+    expect(result.state_path).toBe('/runtime/.agent-workspace/projects/agenticos/guardrail-state.yaml');
+  });
+
+  it('returns an error when the runtime lock cannot be acquired', async () => {
+    let mkdirCalls = 0;
+    mkdirMock.mockImplementation(async (path: string) => {
+      mkdirCalls += 1;
+      if (String(path).endsWith('/guardrail-state.lock')) {
+        throw new Error('busy');
+      }
+      return undefined;
+    });
+
+    const result = await persistGuardrailEvidence({
+      command: 'agenticos_preflight',
+      repo_path: '/workspace/projects/agenticos/mcp-server',
+      payload: {
+        issue_id: '62',
+      },
+    });
+
+    expect(result.persisted).toBe(false);
+    expect(result.reason).toContain('failed to acquire guardrail runtime lock');
+    expect(mkdirCalls).toBeGreaterThan(1);
+  });
+
+  it('fails lock acquisition when lock metadata cannot be inspected', async () => {
+    mkdirMock.mockImplementation(async (path: string) => {
+      if (String(path).endsWith('/guardrail-state.lock')) {
+        throw new Error('busy');
+      }
+      return undefined;
+    });
+    statMock.mockRejectedValue(new Error('stat failed'));
+
+    const result = await persistGuardrailEvidence({
+      command: 'agenticos_preflight',
+      repo_path: '/workspace/projects/agenticos/mcp-server',
+      payload: {
+        issue_id: '62',
+      },
+    });
+
+    expect(result.persisted).toBe(false);
+    expect(result.reason).toContain('failed to acquire guardrail runtime lock');
+  });
+
+  it('reaps a stale runtime lock before persisting new evidence', async () => {
+    let lockAttempts = 0;
+    mkdirMock.mockImplementation(async (path: string) => {
+      const text = String(path);
+      if (!text.endsWith('/guardrail-state.lock')) {
+        return undefined;
+      }
+      lockAttempts += 1;
+      if (lockAttempts === 1) {
+        throw new Error('busy');
+      }
+      return undefined;
+    });
+    statMock.mockResolvedValue({ mtimeMs: Date.now() - 60_000 });
+
+    const result = await persistGuardrailEvidence({
+      command: 'agenticos_preflight',
+      repo_path: '/workspace/projects/agenticos/mcp-server',
+      payload: {
+        issue_id: '62',
+      },
+    });
+
+    expect(result.persisted).toBe(true);
+    expect(rmMock).toHaveBeenCalledWith(
+      '/runtime/.agent-workspace/projects/agenticos/guardrail-state.lock',
+      { recursive: true, force: true },
+    );
+    expect(lockAttempts).toBe(2);
+  });
+
+  it('uses the non-Error fallback message when guardrail persistence throws a primitive', async () => {
+    writeFileMock.mockRejectedValue('primitive-failure');
+
+    const result = await persistGuardrailEvidence({
+      command: 'agenticos_preflight',
+      repo_path: '/workspace/projects/agenticos/mcp-server',
+      payload: {
+        issue_id: '62',
+      },
+    });
+
+    expect(result.persisted).toBe(false);
+    expect(result.reason).toBe('failed to persist runtime guardrail evidence');
+  });
+
+  it('uses repo_path when issue bootstrap payload omits repo_path', async () => {
+    const result = await persistIssueBootstrapEvidence({
+      repo_path: '/workspace/projects/agenticos/mcp-server',
+      payload: {
+        issue_id: '260',
+        issue_title: 'Stop runtime persistence pollution',
+      },
+    });
+
+    expect(result.persisted).toBe(true);
+    const [, content] = writeFileMock.mock.calls[0];
+    const writtenState = JSON.parse(content as string);
+    expect(writtenState.issue_bootstrap.latest.repo_path).toBe('/workspace/projects/agenticos/mcp-server');
+  });
+
+  it('uses the non-Error fallback message when issue bootstrap persistence throws a primitive', async () => {
+    writeFileMock.mockRejectedValue('primitive-failure');
+
+    const result = await persistIssueBootstrapEvidence({
+      repo_path: '/workspace/projects/agenticos/mcp-server',
+      payload: {
+        issue_id: '260',
+        issue_title: 'Stop runtime persistence pollution',
+      },
+    });
+
+    expect(result.persisted).toBe(false);
+    expect(result.reason).toBe('failed to persist runtime issue bootstrap evidence');
+  });
+});
+
+describe('loadLatestGuardrailState', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    yamlMock.parse.mockImplementation((content: string) => {
+      try {
+        return JSON.parse(content);
+      } catch {
+        return undefined;
+      }
+    });
+  });
+
+  it('prefers runtime state and merges missing fields from committed state', async () => {
+    readFileMock.mockImplementation(async (path: string) => {
+      if (path.endsWith('/guardrail-state.yaml')) {
+        return JSON.stringify({
+          guardrail_evidence: {
+            preflight: {
+              issue_id: '294',
+              result: { status: 'PASS' },
+            },
+          },
+        });
+      }
+      if (path.endsWith('/standards/.context/state.yaml')) {
+        return JSON.stringify({
+          issue_bootstrap: {
+            latest: {
+              issue_id: '294',
+              current_branch: 'chore/294-eliminate-canonical-main-runtime-write-paths',
+            },
+          },
+        });
+      }
+      throw new Error(`missing: ${path}`);
+    });
+
+    const loaded = await loadLatestGuardrailState({
+      project_id: 'agenticos',
+      committed_state_path: '/workspace/projects/agenticos/standards/.context/state.yaml',
+    });
+
+    expect(loaded.source).toBe('runtime');
+    expect(loaded.state_path).toBe('/runtime/.agent-workspace/projects/agenticos/guardrail-state.yaml');
+    expect(loaded.state.guardrail_evidence?.preflight?.issue_id).toBe('294');
+    expect(loaded.state.issue_bootstrap?.latest?.issue_id).toBe('294');
+  });
+
+  it('merges committed guardrail slots when runtime state only updates a subset of evidence', async () => {
+    readFileMock.mockImplementation(async (path: string) => {
+      if (String(path).endsWith('/guardrail-state.yaml')) {
+        return JSON.stringify({
+          guardrail_evidence: {
+            last_command: 'agenticos_branch_bootstrap',
+            branch_bootstrap: {
+              issue_id: '294',
+              result: { status: 'CREATED' },
+            },
+          },
+        });
+      }
+      if (String(path).endsWith('/standards/.context/state.yaml')) {
+        return JSON.stringify({
+          guardrail_evidence: {
+            last_command: 'agenticos_preflight',
+            preflight: {
+              issue_id: '260',
+              result: { status: 'PASS' },
+            },
+          },
+        });
+      }
+      throw new Error(`missing: ${path}`);
+    });
+
+    const loaded = await loadLatestGuardrailState({
+      project_id: 'agenticos',
+      committed_state_path: '/workspace/projects/agenticos/standards/.context/state.yaml',
+    });
+
+    expect(loaded.source).toBe('runtime');
+    expect(loaded.state.guardrail_evidence?.last_command).toBe('agenticos_branch_bootstrap');
+    expect(loaded.state.guardrail_evidence?.branch_bootstrap?.issue_id).toBe('294');
+    expect(loaded.state.guardrail_evidence?.preflight?.issue_id).toBe('260');
+  });
+
+  it('merges committed snapshots when runtime state omits guardrail and bootstrap sections', async () => {
+    readFileMock.mockImplementation(async (path: string) => {
+      if (String(path).endsWith('/guardrail-state.yaml')) {
+        return JSON.stringify({ other: true });
+      }
+      if (String(path).endsWith('/standards/.context/state.yaml')) {
+        return JSON.stringify({
+          guardrail_evidence: {
+            preflight: {
+              issue_id: '294',
+            },
+          },
+          issue_bootstrap: {
+            latest: {
+              issue_id: '294',
+            },
+          },
+        });
+      }
+      throw new Error(`missing: ${path}`);
+    });
+
+    const loaded = await loadLatestGuardrailState({
+      project_id: 'agenticos',
+      committed_state_path: '/workspace/projects/agenticos/standards/.context/state.yaml',
+    });
+
+    expect(loaded.state.guardrail_evidence?.preflight?.issue_id).toBe('294');
+    expect(loaded.state.issue_bootstrap?.latest?.issue_id).toBe('294');
+  });
+
+  it('falls back to committed state when runtime state parses to a non-object value', async () => {
+    readFileMock.mockImplementation(async (path: string) => {
+      if (String(path).endsWith('/guardrail-state.yaml')) {
+        return '"bad-state"';
+      }
+      if (String(path).endsWith('/standards/.context/state.yaml')) {
+        return JSON.stringify({
+          issue_bootstrap: {
+            latest: {
+              issue_id: '260',
+            },
+          },
+        });
+      }
+      throw new Error(`missing: ${path}`);
+    });
+
+    const loaded = await loadLatestGuardrailState({
+      project_id: 'agenticos',
+      committed_state_path: '/workspace/projects/agenticos/standards/.context/state.yaml',
+    });
+
+    expect(loaded.source).toBe('committed');
+    expect(loaded.state.issue_bootstrap?.latest?.issue_id).toBe('260');
+  });
+
+  it('falls back to committed state when runtime state is absent', async () => {
+    readFileMock.mockImplementation(async (path: string) => {
+      if (path.endsWith('/guardrail-state.yaml')) {
+        throw new Error(`missing: ${path}`);
+      }
+      if (path.endsWith('/standards/.context/state.yaml')) {
+        return JSON.stringify({
+          issue_bootstrap: {
+            latest: {
+              issue_id: '260',
+            },
+          },
+        });
+      }
+      throw new Error(`missing: ${path}`);
+    });
+
+    const loaded = await loadLatestGuardrailState({
+      project_id: 'agenticos',
+      committed_state_path: '/workspace/projects/agenticos/standards/.context/state.yaml',
+    });
+
+    expect(loaded.source).toBe('committed');
+    expect(loaded.state_path).toBe('/workspace/projects/agenticos/standards/.context/state.yaml');
+    expect(loaded.state.issue_bootstrap?.latest?.issue_id).toBe('260');
+  });
+
+  it('returns an empty runtime result when neither runtime nor committed state exists', async () => {
+    readFileMock.mockRejectedValue(new Error('missing'));
+
+    const loaded = await loadLatestGuardrailState({
+      project_id: 'agenticos',
+    });
+
+    expect(loaded.source).toBeNull();
+    expect(loaded.state_path).toBe('/runtime/.agent-workspace/projects/agenticos/guardrail-state.yaml');
+    expect(loaded.state).toEqual({});
+  });
+
+  it('keeps a runtime-only state when neither runtime nor committed guardrail sections exist', async () => {
+    readFileMock.mockImplementation(async (path: string) => {
+      if (String(path).endsWith('/guardrail-state.yaml')) {
+        return JSON.stringify({ other: true });
+      }
+      throw new Error(`missing: ${path}`);
+    });
+
+    const loaded = await loadLatestGuardrailState({
+      project_id: 'agenticos',
+    });
+
+    expect(loaded.source).toBe('runtime');
+    expect(loaded.state).toEqual({ other: true, guardrail_evidence: undefined, issue_bootstrap: undefined });
+  });
+
+  it('extracts the latest issue bootstrap only when the state shape is valid', () => {
+    expect(extractLatestIssueBootstrap(undefined)).toBeNull();
+    expect(extractLatestIssueBootstrap({ issue_bootstrap: { latest: null } } as any)).toBeNull();
+    expect(extractLatestIssueBootstrap({ issue_bootstrap: { latest: 'bad-shape' } } as any)).toBeNull();
+    expect(extractLatestIssueBootstrap({
+      issue_bootstrap: {
+        latest: {
+          issue_id: '294',
+        },
+      },
+    } as any)?.issue_id).toBe('294');
   });
 });

--- a/mcp-server/src/utils/canonical-main-guard.ts
+++ b/mcp-server/src/utils/canonical-main-guard.ts
@@ -52,7 +52,15 @@ export async function detectCanonicalMainWriteProtection(repoPath: string): Prom
       current_branch: currentBranch,
       workspace_type: workspaceType,
     };
-  } catch {
-    return { blocked: false };
+  } catch (error) {
+    if (error instanceof Error && /not a git repository/i.test(error.message)) {
+      return { blocked: false };
+    }
+    return {
+      blocked: true,
+      reason: error instanceof Error
+        ? `failed to verify canonical main write protection: ${error.message}`
+        : 'failed to verify canonical main write protection',
+    };
   }
 }

--- a/mcp-server/src/utils/guardrail-evidence.ts
+++ b/mcp-server/src/utils/guardrail-evidence.ts
@@ -1,7 +1,7 @@
-import { access, readFile, writeFile } from 'fs/promises';
+import { access, mkdir, readFile, rename, rm, stat, writeFile } from 'fs/promises';
 import { basename, dirname, join, resolve, sep } from 'path';
 import yaml from 'yaml';
-import { loadRegistry } from './registry.js';
+import { getAgenticOSHome, loadRegistry } from './registry.js';
 import { detectCanonicalMainWriteProtection } from './canonical-main-guard.js';
 
 type GuardrailCommand =
@@ -55,6 +55,12 @@ interface StateYaml {
   [key: string]: unknown;
 }
 
+export interface LoadedGuardrailState {
+  source: 'runtime' | 'committed' | null;
+  state: StateYaml;
+  state_path: string | null;
+}
+
 export interface GuardrailPersistenceResult {
   attempted: boolean;
   persisted: boolean;
@@ -80,6 +86,11 @@ interface ResolvedProjectTarget {
   id: string;
   path: string;
   statePath: string;
+}
+
+interface LoadLatestGuardrailStateArgs {
+  project_id: string;
+  committed_state_path?: string;
 }
 
 function normalizePath(path: string): string {
@@ -110,6 +121,20 @@ function getCommandSlot(command: GuardrailCommand): GuardrailEvidenceSlot {
   }
 }
 
+function getProjectGuardrailRuntimeDir(projectId: string): string {
+  return join(getAgenticOSHome(), '.agent-workspace', 'projects', encodeURIComponent(projectId));
+}
+
+function getProjectGuardrailRuntimeStatePath(projectId: string): string {
+  return join(getProjectGuardrailRuntimeDir(projectId), 'guardrail-state.yaml');
+}
+
+function getProjectGuardrailRuntimeLockPath(projectId: string): string {
+  return join(getProjectGuardrailRuntimeDir(projectId), 'guardrail-state.lock');
+}
+
+const GUARDRAIL_LOCK_STALE_MS = 30_000;
+
 async function pathExists(path: string): Promise<boolean> {
   try {
     await access(path);
@@ -117,6 +142,116 @@ async function pathExists(path: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
+}
+
+async function readStateYaml(path: string): Promise<StateYaml | null> {
+  try {
+    const content = await readFile(path, 'utf-8');
+    const parsed = yaml.parse(content);
+    return parsed && typeof parsed === 'object' ? parsed as StateYaml : null;
+  } catch {
+    return null;
+  }
+}
+
+async function ensureRuntimeWriteAllowed(): Promise<void> {
+  const writeProtection = await detectCanonicalMainWriteProtection(getAgenticOSHome());
+  if (writeProtection.blocked) {
+    throw new Error(writeProtection.reason);
+  }
+}
+
+async function reapStaleGuardrailRuntimeLock(lockPath: string): Promise<boolean> {
+  try {
+    const lockStat = await stat(lockPath);
+    if ((Date.now() - lockStat.mtimeMs) <= GUARDRAIL_LOCK_STALE_MS) {
+      return false;
+    }
+    await rm(lockPath, { recursive: true, force: true });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function withProjectGuardrailRuntimeLock<T>(
+  projectId: string,
+  callback: (runtimeStatePath: string) => Promise<T>,
+): Promise<T> {
+  await ensureRuntimeWriteAllowed();
+
+  const runtimeDir = getProjectGuardrailRuntimeDir(projectId);
+  const lockPath = getProjectGuardrailRuntimeLockPath(projectId);
+  await mkdir(runtimeDir, { recursive: true });
+
+  let locked = false;
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    try {
+      await mkdir(lockPath);
+      locked = true;
+      break;
+    } catch {
+      const reapedStaleLock = await reapStaleGuardrailRuntimeLock(lockPath);
+      if (reapedStaleLock) {
+        continue;
+      }
+      await sleep(10);
+    }
+  }
+
+  if (!locked) {
+    throw new Error(`failed to acquire guardrail runtime lock at ${lockPath}`);
+  }
+
+  try {
+    return await callback(getProjectGuardrailRuntimeStatePath(projectId));
+  } finally {
+    await rm(lockPath, { recursive: true, force: true }).catch(() => undefined);
+  }
+}
+
+async function writeRuntimeGuardrailState(
+  projectId: string,
+  mutate: (state: StateYaml, runtimeStatePath: string) => void | Promise<void>,
+): Promise<string> {
+  return await withProjectGuardrailRuntimeLock(projectId, async (runtimeStatePath) => {
+    const state = (await readStateYaml(runtimeStatePath)) || {};
+    await mutate(state, runtimeStatePath);
+    const tempPath = `${runtimeStatePath}.tmp-${process.pid}-${Date.now()}`;
+    await writeFile(tempPath, yaml.stringify(state), 'utf-8');
+    await rename(tempPath, runtimeStatePath);
+    return runtimeStatePath;
+  });
+}
+
+function mergeGuardrailEvidenceState(
+  runtimeGuardrail: GuardrailEvidenceState | undefined,
+  committedGuardrail: GuardrailEvidenceState | undefined,
+): GuardrailEvidenceState | undefined {
+  if (!runtimeGuardrail && !committedGuardrail) {
+    return undefined;
+  }
+
+  return {
+    ...(committedGuardrail || {}),
+    ...(runtimeGuardrail || {}),
+    preflight: runtimeGuardrail?.preflight ?? committedGuardrail?.preflight,
+    branch_bootstrap: runtimeGuardrail?.branch_bootstrap ?? committedGuardrail?.branch_bootstrap,
+    pr_scope_check: runtimeGuardrail?.pr_scope_check ?? committedGuardrail?.pr_scope_check,
+  };
+}
+
+function mergeGuardrailState(runtimeState: StateYaml, committedState: StateYaml | null): StateYaml {
+  return {
+    ...(committedState || {}),
+    ...runtimeState,
+    guardrail_evidence: mergeGuardrailEvidenceState(runtimeState?.guardrail_evidence, committedState?.guardrail_evidence),
+    issue_bootstrap: runtimeState?.issue_bootstrap ?? committedState?.issue_bootstrap,
+  };
 }
 
 async function findProjectRootFromRepoPath(repoPath: string): Promise<ResolvedProjectTarget | null> {
@@ -235,6 +370,41 @@ async function resolveProjectTarget(repoPath: string, projectPath?: string): Pro
   return findProjectRootFromRepoPath(normalizedRepoPath);
 }
 
+export async function loadLatestGuardrailState(
+  args: LoadLatestGuardrailStateArgs,
+): Promise<LoadedGuardrailState> {
+  const runtimeStatePath = getProjectGuardrailRuntimeStatePath(args.project_id);
+  const runtimeState = await readStateYaml(runtimeStatePath);
+  const committedStatePath = typeof args.committed_state_path === 'string' && args.committed_state_path.length > 0
+    ? args.committed_state_path
+    : null;
+  const committedState = committedStatePath
+    ? await readStateYaml(committedStatePath)
+    : null;
+
+  if (runtimeState) {
+    return {
+      source: 'runtime',
+      state: mergeGuardrailState(runtimeState, committedState),
+      state_path: runtimeStatePath,
+    };
+  }
+
+  if (committedStatePath && committedState) {
+    return {
+      source: 'committed',
+      state: committedState,
+      state_path: committedStatePath,
+    };
+  }
+
+  return {
+    source: null,
+    state: {},
+    state_path: runtimeStatePath,
+  };
+}
+
 export async function persistGuardrailEvidence(
   args: PersistGuardrailEvidenceArgs,
 ): Promise<GuardrailPersistenceResult> {
@@ -259,51 +429,40 @@ export async function persistGuardrailEvidence(
     };
   }
 
-  const writeProtection = await detectCanonicalMainWriteProtection(repo_path);
-  if (writeProtection.blocked) {
+  try {
+    const statePath = await writeRuntimeGuardrailState(project.id, async (state) => {
+      if (!state.guardrail_evidence) {
+        state.guardrail_evidence = {};
+      }
+
+      const recordedAt = new Date().toISOString();
+      const slot = getCommandSlot(command);
+
+      state.guardrail_evidence.updated_at = recordedAt;
+      state.guardrail_evidence.last_command = command;
+      state.guardrail_evidence[slot] = {
+        command,
+        recorded_at: recordedAt,
+        repo_path,
+        ...payload,
+      };
+    });
+
+    return {
+      attempted: true,
+      persisted: true,
+      project_id: project.id,
+      state_path: statePath,
+    };
+  } catch (error) {
     return {
       attempted: true,
       persisted: false,
       project_id: project.id,
-      state_path: project.statePath,
-      reason: writeProtection.reason,
+      state_path: getProjectGuardrailRuntimeStatePath(project.id),
+      reason: error instanceof Error ? error.message : 'failed to persist runtime guardrail evidence',
     };
   }
-
-  const statePath = project.statePath;
-  let state: StateYaml = {};
-
-  try {
-    const content = await readFile(statePath, 'utf-8');
-    state = (yaml.parse(content) || {}) as StateYaml;
-  } catch {
-    state = {};
-  }
-
-  if (!state.guardrail_evidence) {
-    state.guardrail_evidence = {};
-  }
-
-  const recordedAt = new Date().toISOString();
-  const slot = getCommandSlot(command);
-
-  state.guardrail_evidence.updated_at = recordedAt;
-  state.guardrail_evidence.last_command = command;
-  state.guardrail_evidence[slot] = {
-    command,
-    recorded_at: recordedAt,
-    repo_path,
-    ...payload,
-  };
-
-  await writeFile(statePath, yaml.stringify(state), 'utf-8');
-
-  return {
-    attempted: true,
-    persisted: true,
-    project_id: project.id,
-    state_path: statePath,
-  };
 }
 
 export function extractLatestIssueBootstrap(state: StateYaml | null | undefined): IssueBootstrapRecord | null {
@@ -337,44 +496,33 @@ export async function persistIssueBootstrapEvidence(
     };
   }
 
-  const writeProtection = await detectCanonicalMainWriteProtection(repo_path);
-  if (writeProtection.blocked) {
+  try {
+    const statePath = await writeRuntimeGuardrailState(project.id, async (state) => {
+      const recordedAt = payload.recorded_at || new Date().toISOString();
+      state.issue_bootstrap = {
+        updated_at: recordedAt,
+        latest: {
+          ...payload,
+          recorded_at: recordedAt,
+          project_path: payload.project_path || project.path,
+          repo_path: payload.repo_path || repo_path,
+        },
+      };
+    });
+
+    return {
+      attempted: true,
+      persisted: true,
+      project_id: project.id,
+      state_path: statePath,
+    };
+  } catch (error) {
     return {
       attempted: true,
       persisted: false,
       project_id: project.id,
-      state_path: project.statePath,
-      reason: writeProtection.reason,
+      state_path: getProjectGuardrailRuntimeStatePath(project.id),
+      reason: error instanceof Error ? error.message : 'failed to persist runtime issue bootstrap evidence',
     };
   }
-
-  const statePath = project.statePath;
-  let state: StateYaml = {};
-
-  try {
-    const content = await readFile(statePath, 'utf-8');
-    state = (yaml.parse(content) || {}) as StateYaml;
-  } catch {
-    state = {};
-  }
-
-  const recordedAt = payload.recorded_at || new Date().toISOString();
-  state.issue_bootstrap = {
-    updated_at: recordedAt,
-    latest: {
-      ...payload,
-      recorded_at: recordedAt,
-      project_path: payload.project_path || project.path,
-      repo_path: payload.repo_path || repo_path,
-    },
-  };
-
-  await writeFile(statePath, yaml.stringify(state), 'utf-8');
-
-  return {
-    attempted: true,
-    persisted: true,
-    project_id: project.id,
-    state_path: statePath,
-  };
 }

--- a/tasks/issue-294-canonical-main-write-boundary-audit.md
+++ b/tasks/issue-294-canonical-main-write-boundary-audit.md
@@ -1,0 +1,297 @@
+# Issue #294: Canonical Main Runtime Write Boundary Audit
+
+## Summary
+
+`#294` closes the remaining write-boundary gap left after `#262`, `#286`, and
+`#288`.
+
+The current system no longer relies on a home-global `active_project` for
+resolution, and canonical checkout cleanup exists, but normal guardrail commands
+still persist execution-time evidence into each project's configured
+`current_state` file.
+
+For `github_versioned` projects such as AgenticOS itself, that file is a
+versioned source path:
+
+- `standards/.context/state.yaml`
+
+So normal runtime commands like `agenticos_issue_bootstrap` and
+`agenticos_preflight` can still dirty committed project state and, on canonical
+`main`, reintroduce exactly the runtime-write pollution that prior issues were
+trying to eliminate.
+
+## Problem Statement
+
+The intended model is now clear:
+
+- `AGENTICOS_HOME` is a long-term runtime workspace
+- `projects/` contains managed projects
+- source-controlled projects may live under `projects/<id>/`
+- runtime-only evidence must not silently rewrite committed canonical state
+
+The remaining gap is that guardrail persistence still treats project
+`current_state` as the sink for live execution evidence.
+
+That violates the runtime model in two ways:
+
+1. it can dirty canonical `main`
+2. it mixes execution-time trust-chain evidence with committed status-summary
+   surfaces
+
+## Current Write Paths
+
+The concrete remaining write entrypoint is:
+
+- `mcp-server/src/utils/guardrail-evidence.ts`
+
+### `persistGuardrailEvidence(...)`
+
+Current behavior:
+
+- resolves the target managed project
+- resolves that project's configured `current_state`
+- reads the existing state YAML
+- updates `state.guardrail_evidence`
+- writes the full YAML back to `state.yaml`
+
+Current writers:
+
+- `agenticos_preflight`
+- `agenticos_branch_bootstrap`
+- `agenticos_pr_scope_check`
+
+### `persistIssueBootstrapEvidence(...)`
+
+Current behavior:
+
+- resolves the target managed project
+- resolves that project's configured `current_state`
+- reads the existing state YAML
+- updates `state.issue_bootstrap`
+- writes the full YAML back to `state.yaml`
+
+Current writer:
+
+- `agenticos_issue_bootstrap`
+
+## Current Read Dependencies
+
+The current read side is split into two semantics that should no longer share
+the same file.
+
+### Execution / Guardrail Trust Chain
+
+These commands depend on the latest issue/bootstrap evidence for live execution:
+
+- `agenticos_preflight`
+  - reads `issue_bootstrap.latest` to verify the current issue/worktree
+- `agenticos_edit_guard`
+  - reads `issue_bootstrap.latest`
+  - reads `guardrail_evidence.preflight`
+
+These are runtime execution checks, not committed project-summary reads.
+
+### Status / Historical Snapshot Reads
+
+These reads are committed-snapshot oriented:
+
+- `agenticos_status` via `mcp-server/src/tools/project.ts`
+- `agenticos_health` via `mcp-server/src/utils/health.ts`
+- `versioned-entry-surface-state`
+
+These are supposed to reason about the tracked project snapshot and stale/fresh
+semantics introduced by `#288`.
+
+That means the same `state.yaml` file is currently being used for two different
+things:
+
+1. live execution evidence
+2. committed summary snapshot
+
+That coupling is the root design error.
+
+## Why The Existing Canonical-Main Guard Is Not Enough
+
+`mcp-server/src/utils/canonical-main-guard.ts` blocks runtime persistence when
+the target repo is the canonical `main` checkout.
+
+That protection is necessary, but not sufficient.
+
+It still leaves three failures:
+
+1. isolated issue worktrees still write execution evidence into versioned
+   project state
+2. canonical status surfaces still depend on fields that were populated by
+   runtime commands rather than explicit committed refresh
+3. the design still says “latest execution evidence belongs in committed
+   project state unless we happened to be on canonical `main`”
+
+That is opposite of the intended runtime/home model.
+
+## Design Goal For `#294`
+
+Normal runtime guardrail commands must no longer write to committed project
+entry surfaces.
+
+The system should distinguish:
+
+- runtime guardrail evidence
+- committed project snapshot evidence
+
+Runtime guardrail evidence should live in a runtime-managed surface under
+`AGENTICOS_HOME`, not under tracked project context paths.
+
+## Recommended Runtime Surface
+
+Recommended V1 storage target:
+
+- `AGENTICOS_HOME/.agent-workspace/projects/<project-id>/guardrail-state.yaml`
+
+Why this location:
+
+- it is home-runtime scoped, not repo scoped
+- it remains project-specific
+- it does not depend on whether the project is source-controlled
+- it fits the established `.agent-workspace` runtime namespace
+- it keeps guardrail evidence outside tracked project files
+
+Recommended V1 shape:
+
+```yaml
+version: 1.0.0
+updated_at: <iso>
+guardrail_evidence:
+  updated_at: <iso>
+  last_command: agenticos_preflight
+  preflight: ...
+  branch_bootstrap: ...
+  pr_scope_check: ...
+issue_bootstrap:
+  updated_at: <iso>
+  latest: ...
+```
+
+This intentionally preserves the existing data model so the write-boundary
+change stays narrow.
+
+## Resolution And Read Contract
+
+### Runtime Authoritative Reads
+
+For execution-time trust chain:
+
+- `agenticos_issue_bootstrap` writes runtime guardrail state
+- `agenticos_preflight` reads runtime `issue_bootstrap.latest`
+- `agenticos_edit_guard` reads runtime `issue_bootstrap.latest` and runtime
+  `guardrail_evidence.preflight`
+
+### Compatibility Fallback
+
+During rollout, reads may fall back to project `state.yaml` only when runtime
+guardrail state is absent.
+
+This gives safe migration without requiring an immediate one-shot rewrite of all
+existing project state files.
+
+### Committed Snapshot Reads
+
+`agenticos_status`, `agenticos_health`, and stale committed-snapshot assessment
+should continue to treat project `state.yaml` as a committed snapshot surface,
+not as the live execution ledger.
+
+This means `#294` does **not** need to make status pages display live runtime
+guardrail evidence as if it were committed truth.
+
+That separation is the point.
+
+## Concurrency Notes
+
+The current latest-only model is still not ideal for many parallel issue
+worktrees within one project.
+
+However, that is a separate semantic expansion.
+
+For `#294`, the bounded goal should be:
+
+- move latest runtime evidence out of committed state
+- make runtime writes concurrency-safe
+- keep the existing latest-only semantics for now
+
+Recommended minimum write-safety for the runtime file:
+
+- per-project lock under `.agent-workspace/projects/<project-id>/`
+- reload inside the lock
+- field-level patch
+- temp file + atomic rename
+
+That matches the `#262` registry-write contract.
+
+## Options Considered
+
+### Option A: Keep Writing `state.yaml`, Just Strengthen Canonical Main Blocking
+
+Reject.
+
+This only reduces one symptom. It still treats committed state as the normal
+live execution sink.
+
+### Option B: Move Only `guardrail_evidence`, Keep `issue_bootstrap` In `state.yaml`
+
+Reject.
+
+`issue_bootstrap.latest` is part of the execution trust chain used by
+`preflight` and `edit-guard`. Leaving it in committed state preserves the same
+boundary error.
+
+### Option C: Move Both Latest Guardrail Evidence And Latest Issue Bootstrap To
+Runtime State
+
+Recommend.
+
+This is the smallest change that actually matches the runtime/home model.
+
+## Recommended V1 Implementation Slice
+
+`#294` V1 should land the following bounded changes:
+
+1. Add a runtime guardrail state resolver under `.agent-workspace/projects`.
+2. Add concurrency-safe runtime read/write helpers for:
+   - `guardrail_evidence`
+   - `issue_bootstrap`
+3. Change `persistGuardrailEvidence(...)` to write runtime state instead of
+   project `state.yaml`.
+4. Change `persistIssueBootstrapEvidence(...)` to write runtime state instead of
+   project `state.yaml`.
+5. Update `preflight` and `edit-guard` to read latest bootstrap / preflight
+   evidence from runtime state first, then fall back to committed state for
+   compatibility.
+6. Preserve project `state.yaml` reads for status/history surfaces.
+
+## Explicit Non-Goals For `#294`
+
+- do not redesign guardrail evidence into a multi-issue append-only journal
+- do not automatically refresh committed entry surfaces from runtime state
+- do not widen `#294` into `#292` or `#293`
+- do not change the committed-snapshot stale/fresh semantics from `#288`
+
+## Validation Expectations
+
+At minimum, `#294` should prove:
+
+1. `agenticos_issue_bootstrap` no longer dirties project `state.yaml`
+2. `agenticos_preflight` no longer dirties project `state.yaml`
+3. canonical `main` remains clean after normal guardrail commands
+4. `preflight` and `edit-guard` still work from runtime guardrail evidence
+5. legacy committed `state.yaml` evidence remains readable as compatibility
+   fallback
+
+## Conclusion
+
+The remaining write-boundary bug is not “a missing extra guard.”
+
+It is that the system still stores live guardrail execution evidence in the same
+versioned file that now has explicit committed-snapshot semantics.
+
+`#294` should fix that by moving latest guardrail / bootstrap persistence to a
+runtime-managed project surface under `AGENTICOS_HOME/.agent-workspace/`, while
+keeping committed `state.yaml` reserved for explicit project snapshot semantics.


### PR DESCRIPTION
## Summary

Closes #294.

This PR finishes the remaining canonical-main runtime write-boundary cleanup for guardrail state.

- move live guardrail / issue-bootstrap persistence to `AGENTICOS_HOME/.agent-workspace/projects/<project-id>/guardrail-state.yaml`
- make guardrail reads runtime-first with committed fallback
- merge committed fallback at slot granularity so partial runtime state does not hide valid committed evidence
- reap stale runtime locks and treat invalid runtime state as fallback-to-committed instead of authoritative empty state
- harden runtime path resolution by encoding project id segments
- update `switch` / `status` guardrail and bootstrap summaries to read runtime-first state, fixing stale historical display
- make canonical-main guard verification fail closed on Git inspection errors while still allowing non-Git runtime homes
- ignore `.agent-workspace/` in source worktrees
- add audit notes for the final write-boundary review

## Testing

- `npm run lint`
- `npx vitest run src/utils/__tests__/guardrail-evidence.test.ts src/tools/__tests__/preflight.test.ts src/tools/__tests__/edit-guard.test.ts src/tools/__tests__/project.test.ts src/utils/__tests__/canonical-main-guard.test.ts src/tools/__tests__/issue-bootstrap.test.ts src/tools/__tests__/pr-scope-check.test.ts src/tools/__tests__/branch-bootstrap.test.ts --coverage.enabled true --coverage.provider v8 --coverage.reporter text --coverage.include src/utils/guardrail-evidence.ts --coverage.include src/tools/preflight.ts --coverage.include src/tools/edit-guard.ts --coverage.include src/tools/project.ts --coverage.include src/utils/canonical-main-guard.ts`

## Coverage

Changed implementation surface is at 100% statement / branch / function / line coverage for:

- `src/utils/guardrail-evidence.ts`
- `src/tools/preflight.ts`
- `src/tools/edit-guard.ts`
- `src/tools/project.ts`
- `src/utils/canonical-main-guard.ts`
