### PR TITLE
fix: relax issue-marker guardrails and exclude last_record (#296)

### DIFF
--- a/mcp-server/src/tools/__tests__/pr-scope-check.test.ts
+++ b/mcp-server/src/tools/__tests__/pr-scope-check.test.ts
@@ -135,6 +135,31 @@ describe('runPrScopeCheck', () => {
     expect(result.unexpected_files).toEqual([]);
   });
 
+  it('returns PASS when a clean issue branch commit omits the issue marker in the subject', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --git-common-dir': '/repo/.git\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'log --format=%s origin/main..HEAD': 'feat: preserve teams session and hotel booking guardrails\n',
+      'diff --name-only origin/main...HEAD': 'README.md\nprojects/agenticos/mcp-server/src/tools/pr-scope-check.ts\n',
+    });
+
+    const result = JSON.parse(await runPrScopeCheck({
+      issue_id: '296',
+      repo_path: '/repo',
+      declared_target_files: [
+        'README.md',
+        'projects/agenticos/mcp-server/src/tools/pr-scope-check.ts',
+      ],
+      expected_issue_scope: 'clean_release_branch',
+    })) as { status: string; unrelated_commit_subjects: string[]; unexpected_files: string[] };
+
+    expect(result.status).toBe('PASS');
+    expect(result.unrelated_commit_subjects).toEqual([]);
+    expect(result.unexpected_files).toEqual([]);
+  });
+
   it('returns BLOCK when commit subjects do not match the current issue', async () => {
     mockGitResponses({
       'rev-parse --show-toplevel': '/repo\n',

--- a/mcp-server/src/tools/__tests__/preflight.test.ts
+++ b/mcp-server/src/tools/__tests__/preflight.test.ts
@@ -428,7 +428,52 @@ describe('runPreflight', () => {
     expect(result.branch_based_on_intended_remote).toBe(true);
   });
 
-  it('treats missing issue id as an empty issue marker when scanning commit subjects', async () => {
+  it('accepts a clean issue branch commit even when the subject omits the issue marker', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --git-common-dir': '.git\n',
+      'config --get remote.origin.url': 'git@github.com:madlouse/AgenticOS.git\n',
+      'rev-parse --abbrev-ref HEAD': 'fix/296-save-pr-scope-guardrail-release-flow\n',
+      'rev-parse HEAD': 'abc123\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo\nHEAD abc123\nbranch refs/heads/fix/296-save-pr-scope-guardrail-release-flow\n',
+      'log --format=%s origin/main..HEAD': 'fix: preserve teams session and hotel booking guardrails\n',
+    });
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/runtime/.agent-workspace/projects/agenticos/guardrail-state.yaml',
+      state: {
+        issue_bootstrap: {
+          latest: {
+            issue_id: '296',
+            repo_path: '/repo',
+            current_branch: 'fix/296-save-pr-scope-guardrail-release-flow',
+            startup_context_paths: ['/workspace/projects/agenticos/standards/.project.yaml'],
+            stages: {
+              context_reset_performed: true,
+              project_hot_load_performed: true,
+              issue_payload_attached: true,
+            },
+          },
+        },
+      },
+    });
+
+    const result = JSON.parse(await runPreflight({
+      issue_id: '296',
+      task_type: 'implementation',
+      repo_path: '/repo',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/pr-scope-check.ts'],
+      worktree_required: true,
+    })) as { status: string; branch_based_on_intended_remote: boolean; block_reasons: string[] };
+
+    expect(result.status).toBe('PASS');
+    expect(result.branch_based_on_intended_remote).toBe(true);
+    expect(result.block_reasons).toEqual([]);
+  });
+
+  it('treats neutral commit subjects as in-scope even when issue_id is missing', async () => {
     mockGitResponses({
       'rev-parse --show-toplevel': '/repo\n',
       'rev-parse --git-common-dir': '.git\n',
@@ -467,8 +512,8 @@ describe('runPreflight', () => {
     })) as { block_reasons: string[]; branch_based_on_intended_remote: boolean };
 
     expect(result.block_reasons).toContain('issue_id is required for implementation work');
-    expect(result.block_reasons.join(' ')).toContain('unrelated commits');
-    expect(result.branch_based_on_intended_remote).toBe(false);
+    expect(result.block_reasons.join(' ')).not.toContain('unrelated commits');
+    expect(result.branch_based_on_intended_remote).toBe(true);
   });
 
   it('returns BLOCK and persists evidence when git repository resolution fails', async () => {

--- a/mcp-server/src/tools/__tests__/save.test.ts
+++ b/mcp-server/src/tools/__tests__/save.test.ts
@@ -246,7 +246,7 @@ describe('saveState', () => {
     const addCommand = commands.find((cmd) => cmd.includes(' add -A -- '));
     expect(addCommand).toBeDefined();
     expect(addCommand).toContain('/test/path/.context/state.yaml');
-    expect(addCommand).toContain('/test/path/.context/.last_record');
+    expect(addCommand).not.toContain('/test/path/.context/.last_record');
     expect(addCommand).toContain('/test/path/.context/conversations');
     expect(addCommand).toContain('/test/path/CLAUDE.md');
     expect(addCommand).not.toContain('add "/test/path/"');

--- a/mcp-server/src/tools/pr-scope-check.ts
+++ b/mcp-server/src/tools/pr-scope-check.ts
@@ -7,6 +7,7 @@ import { persistGuardrailEvidence, type GuardrailPersistenceResult } from '../ut
 import { resolveGuardrailProjectTarget } from '../utils/repo-boundary.js';
 import { matchesRuntimeReviewExcludedPath, resolveRuntimeReviewSurfacePaths } from '../utils/runtime-review-surface.js';
 import { validateGuardrailRepoIdentity } from '../utils/guardrail-repo-identity.js';
+import { classifyUnrelatedCommitSubjects } from '../utils/issue-commit-scope.js';
 
 const execAsync = promisify(exec);
 
@@ -296,7 +297,7 @@ export async function runPrScopeCheck(args: PrScopeCheckArgs): Promise<string> {
   result.changed_files = changedFiles;
   result.runtime_managed_files = changedFiles.filter((file) => matchesRuntimeReviewExcludedPath(file, runtimeTrackedPaths));
   result.private_raw_transcript_files = changedFiles.filter((file) => matchesRuntimeReviewExcludedPath(file, privateTranscriptPaths));
-  result.unrelated_commit_subjects = subjects.filter((subject) => !subject.includes(`#${issue_id}`));
+  result.unrelated_commit_subjects = classifyUnrelatedCommitSubjects(subjects, issue_id);
   const productReviewFiles = changedFiles.filter((file) =>
     !matchesRuntimeReviewExcludedPath(file, runtimeTrackedPaths)
     && !matchesRuntimeReviewExcludedPath(file, privateTranscriptPaths));

--- a/mcp-server/src/tools/preflight.ts
+++ b/mcp-server/src/tools/preflight.ts
@@ -13,6 +13,7 @@ import {
   type GuardrailTaskType,
 } from '../utils/repo-boundary.js';
 import { validateGuardrailRepoIdentity } from '../utils/guardrail-repo-identity.js';
+import { classifyUnrelatedCommitSubjects } from '../utils/issue-commit-scope.js';
 
 const execAsync = promisify(exec);
 
@@ -282,8 +283,7 @@ export async function runPreflight(args: PreflightArgs): Promise<string> {
     result.evidence.commit_subjects_since_base = subjects;
 
     if (subjects.length > 0) {
-      const issueMarker = issue_id ? `#${issue_id}` : '';
-      const unrelatedSubjects = subjects.filter((subject) => !issueMarker || !subject.includes(issueMarker));
+      const unrelatedSubjects = classifyUnrelatedCommitSubjects(subjects, issue_id);
       if (unrelatedSubjects.length > 0) {
         result.block_reasons.push(`branch includes unrelated commits relative to ${remote_base_branch}`);
       } else {

--- a/mcp-server/src/tools/save.ts
+++ b/mcp-server/src/tools/save.ts
@@ -54,6 +54,14 @@ function normalizePath(value: string): string {
   return resolve(value);
 }
 
+function normalizeTrackedPath(value: string): string {
+  return value.replace(/\\/g, '/').replace(/\/$/, '');
+}
+
+function isLastRecordMarkerPath(pathValue: string): boolean {
+  return normalizeTrackedPath(pathValue).endsWith('/.last_record');
+}
+
 function toGitRelativePath(gitWorktreeRoot: string, absolutePath: string, options?: { directory?: boolean }): string {
   const relativePath = relative(normalizePath(gitWorktreeRoot), normalizePath(absolutePath)).replace(/\\/g, '/');
   if (!relativePath || relativePath.startsWith('..')) {
@@ -287,7 +295,8 @@ export async function saveState(args: any): Promise<string> {
       : resolveRuntimeReviewSurfacePaths(projectPath, projectYaml, {
         include_claude_state_mirror: true,
       }).tracked_review_excluded_paths;
-    const stageTargets = stagePaths
+    const filteredStagePaths = stagePaths.filter((trackedPath) => !isLastRecordMarkerPath(trackedPath));
+    const stageTargets = filteredStagePaths
       .map((trackedPath) => continuityPlan
         ? `"${trackedPath}"`
         : `"${toProjectAbsoluteRuntimePath(projectPath, trackedPath)}"`)

--- a/mcp-server/src/utils/issue-commit-scope.ts
+++ b/mcp-server/src/utils/issue-commit-scope.ts
@@ -1,0 +1,29 @@
+function normalizeIssueId(issueId: string | undefined | null): string {
+  return (issueId || '').trim();
+}
+
+export function extractIssueReferences(subject: string): string[] {
+  const matches = subject.matchAll(/(^|[^\w])#(\d+)\b/g);
+  const refs = new Set<string>();
+  for (const match of matches) {
+    if (match[2]) refs.add(match[2]);
+  }
+  return Array.from(refs);
+}
+
+export function commitSubjectTargetsDifferentIssue(subject: string, issueId: string | undefined | null): boolean {
+  const normalizedIssueId = normalizeIssueId(issueId);
+  if (!normalizedIssueId) return false;
+
+  const refs = extractIssueReferences(subject);
+  if (refs.length === 0) return false;
+
+  return !refs.includes(normalizedIssueId);
+}
+
+export function classifyUnrelatedCommitSubjects(
+  subjects: string[],
+  issueId: string | undefined | null,
+): string[] {
+  return subjects.filter((subject) => commitSubjectTargetsDifferentIssue(subject, issueId));
+}


### PR DESCRIPTION
## Summary
- treat commit subjects without any explicit issue reference as neutral in preflight and pr-scope-check
- centralize commit-subject issue parsing in a shared utility and cover the clean-branch case in tests
- stop agenticos_save from staging .last_record even for runtime-only saves

## Testing
- npm test

Closes #296