### PR TITLE
fix: enforce project-scoped worktree root isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ codex mcp add --env AGENTICOS_HOME="$AGENTICOS_HOME" agenticos -- agenticos-mcp
 
 - `projects/agenticos/` is the only canonical AgenticOS product-source project under `projects/`
 - the enclosing `AgenticOS/` path is the workspace home; product source lives under `projects/agenticos/`
+- issue worktrees live under `$AGENTICOS_HOME/worktrees/<project-id>/` as
+  helper execution checkouts, not as managed project roots
 - root-level `README.md`, `AGENTS.md`, and `CONTRIBUTING.md` currently remain as compatibility entrypoints during that migration
 
 ## Managed Project Contract

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -356,7 +356,7 @@ Create an issue branch and isolated worktree from the intended remote base.
 - `issue_id` (required)
 - `slug` (required)
 - `repo_path` (required)
-- `worktree_root` (required)
+- `worktree_root` (optional, deprecated compatibility input; AgenticOS derives `$AGENTICOS_HOME/worktrees/<project-id>` and rejects mismatched overrides)
 - `remote_base_branch` (optional, default `origin/main`)
 
 **Returns**: JSON with `CREATED` or `BLOCK`
@@ -386,6 +386,15 @@ Evaluate whether a canonical checkout and project context are fresh enough to tr
 
 For `github_versioned` projects, the health result also distinguishes stale
 committed entry-surface state from canonical checkout runtime drift.
+When `repo_path` is inside a managed repo or its derived project-scoped
+worktree root, `agenticos_health` resolves the effective project automatically
+and returns a `worktree_topology` payload sourced from `git worktree list
+--porcelain`.
+That topology gate reports:
+
+- `PASS` when all non-canonical worktrees are under the derived project-scoped root
+- `WARN` when misplaced clean worktrees still exist
+- `BLOCK` when misplaced dirty worktrees or topology inspection failures exist
 
 ### agenticos_canonical_sync
 Plan, snapshot, or prepare runtime-managed cleanup for a canonical checkout before manual branch resync.

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -356,6 +356,7 @@ Create an issue branch and isolated worktree from the intended remote base.
 - `issue_id` (required)
 - `slug` (required)
 - `repo_path` (required)
+- `project_path` (optional, but recommended when `repo_path` is inside a larger checkout or worktree)
 - `worktree_root` (optional, deprecated compatibility input; AgenticOS derives `$AGENTICOS_HOME/worktrees/<project-id>` and rejects mismatched overrides)
 - `remote_base_branch` (optional, default `origin/main`)
 

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -260,9 +260,9 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
           repo_path: { type: 'string', description: 'Absolute repository path where the branch should be created' },
           project_path: { type: 'string', description: 'Optional managed project root when repo_path is a larger checkout or worktree.' },
           remote_base_branch: { type: 'string', description: 'Remote base branch to branch from (default: origin/main)' },
-          worktree_root: { type: 'string', description: 'Absolute root directory under which the new worktree should be created' },
+          worktree_root: { type: 'string', description: 'Deprecated compatibility input. When omitted, AgenticOS derives $AGENTICOS_HOME/worktrees/<project-id>. When supplied, it must normalize to the same derived root or the command fails closed.' },
         },
-        required: ['issue_id', 'slug', 'repo_path', 'worktree_root'],
+        required: ['issue_id', 'slug', 'repo_path'],
       },
     },
     {

--- a/mcp-server/src/tools/__tests__/branch-bootstrap.test.ts
+++ b/mcp-server/src/tools/__tests__/branch-bootstrap.test.ts
@@ -444,6 +444,37 @@ describe('runBranchBootstrap', () => {
     expect(mkdirMock).not.toHaveBeenCalled();
   });
 
+  it('fails closed when a github_versioned project is missing a declared meta.id-derived worktree root', async () => {
+    resolveGuardrailProjectTargetMock.mockResolvedValue({
+      activeProjectId: 'agenticos',
+      resolutionSource: 'repo_path_match',
+      resolutionErrors: [],
+      targetProject: {
+        id: 'agenticos',
+        name: 'AgenticOS',
+        path: '/workspace/projects/agenticos',
+        statePath: '/workspace/projects/agenticos/standards/.context/state.yaml',
+        projectYamlPath: '/workspace/projects/agenticos/.project.yaml',
+        topology: 'github_versioned',
+        githubRepo: 'madlouse/AgenticOS',
+        sourceRepoRoots: ['/repo'],
+        sourceRepoRootsDeclared: true,
+        expectedWorktreeRoot: null,
+      },
+    });
+
+    const result = JSON.parse(await runBranchBootstrap({
+      issue_id: '92',
+      branch_type: 'feat',
+      slug: 'missing root',
+      repo_path: '/repo/mcp-server',
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons).toContain('target project "agenticos" is missing a derived project-scoped worktree root');
+    expect(execAsyncMock).not.toHaveBeenCalled();
+  });
+
   it('falls back to the repo_path basename when the common repo basename sanitizes to empty', async () => {
     resolveGuardrailProjectTargetMock.mockResolvedValue({
       activeProjectId: 'agenticos',

--- a/mcp-server/src/tools/__tests__/branch-bootstrap.test.ts
+++ b/mcp-server/src/tools/__tests__/branch-bootstrap.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const execAsyncMock = vi.hoisted(() => vi.fn());
 const accessMock = vi.hoisted(() => vi.fn());
 const mkdirMock = vi.hoisted(() => vi.fn());
+const getAgenticOSHomeMock = vi.hoisted(() => vi.fn(() => '/workspace'));
 
 vi.mock('child_process', () => ({
   exec: vi.fn(),
@@ -28,6 +29,10 @@ vi.mock('../../utils/repo-boundary.js', () => ({
   resolveGuardrailProjectTarget: resolveGuardrailProjectTargetMock,
 }));
 
+vi.mock('../../utils/registry.js', () => ({
+  getAgenticOSHome: getAgenticOSHomeMock,
+}));
+
 vi.mock('fs/promises', () => ({
   access: accessMock,
   mkdir: mkdirMock,
@@ -40,6 +45,7 @@ describe('runBranchBootstrap', () => {
     vi.clearAllMocks();
     accessMock.mockRejectedValue(new Error('missing'));
     mkdirMock.mockResolvedValue(undefined);
+    getAgenticOSHomeMock.mockReturnValue('/workspace');
     persistGuardrailEvidenceMock.mockResolvedValue({
       attempted: true,
       persisted: true,
@@ -53,16 +59,19 @@ describe('runBranchBootstrap', () => {
       targetProject: {
         id: 'agenticos',
         name: 'AgenticOS',
-        path: '/workspace/projects/agenticos/standards',
+        path: '/workspace/projects/agenticos',
         statePath: '/workspace/projects/agenticos/standards/.context/state.yaml',
-        projectYamlPath: '/workspace/projects/agenticos/standards/.project.yaml',
+        projectYamlPath: '/workspace/projects/agenticos/.project.yaml',
+        topology: 'github_versioned',
+        githubRepo: 'madlouse/AgenticOS',
         sourceRepoRoots: ['/repo'],
         sourceRepoRootsDeclared: true,
+        expectedWorktreeRoot: '/workspace/worktrees/agenticos',
       },
     });
   });
 
-  it('returns CREATED and issues git worktree add from the intended remote base', async () => {
+  it('derives the project-scoped worktree root when no override is provided', async () => {
     execAsyncMock.mockImplementation(async (cmd: string) => {
       if (cmd.includes('rev-parse origin/main')) {
         return { stdout: 'base123\n', stderr: '' };
@@ -73,10 +82,13 @@ describe('runBranchBootstrap', () => {
       if (cmd.includes('rev-parse --git-common-dir')) {
         return { stdout: '/repo/.git\n', stderr: '' };
       }
+      if (cmd.includes('config --get remote.origin.url')) {
+        return { stdout: 'https://github.com/madlouse/AgenticOS.git\n', stderr: '' };
+      }
       if (cmd.includes('show-ref --verify --quiet refs/heads/feat/36-guardrail-helper')) {
         throw new Error('branch missing');
       }
-      if (cmd.includes('worktree add "/tmp/worktrees/repo-36-guardrail-helper" -b feat/36-guardrail-helper base123')) {
+      if (cmd.includes('worktree add "/workspace/worktrees/agenticos/repo-36-guardrail-helper" -b feat/36-guardrail-helper base123')) {
         return { stdout: 'Preparing worktree\n', stderr: '' };
       }
       throw new Error(`Unexpected command: ${cmd}`);
@@ -88,17 +100,103 @@ describe('runBranchBootstrap', () => {
       slug: 'guardrail helper',
       repo_path: '/repo/mcp-server',
       remote_base_branch: 'origin/main',
-      worktree_root: '/tmp/worktrees',
-    })) as { status: string; branch_name: string; base_commit: string; worktree_path: string; notes: string[]; persistence?: { persisted: boolean } };
+    })) as { status: string; branch_name: string; base_commit: string; worktree_path: string; persistence?: { persisted: boolean } };
 
     expect(result.status).toBe('CREATED');
     expect(result.branch_name).toBe('feat/36-guardrail-helper');
     expect(result.base_commit).toBe('base123');
-    expect(result.worktree_path).toBe('/tmp/worktrees/repo-36-guardrail-helper');
-    expect(result.notes.join(' ')).toContain('origin/main');
-    expect(mkdirMock).toHaveBeenCalledWith('/tmp/worktrees', { recursive: true });
+    expect(result.worktree_path).toBe('/workspace/worktrees/agenticos/repo-36-guardrail-helper');
+    expect(mkdirMock).toHaveBeenCalledWith('/workspace/worktrees/agenticos', { recursive: true });
     expect(result.persistence?.persisted).toBe(true);
-    expect(persistGuardrailEvidenceMock).toHaveBeenCalledTimes(1);
+    expect(persistGuardrailEvidenceMock).toHaveBeenCalledWith(expect.objectContaining({
+      payload: expect.objectContaining({
+        requested_worktree_root: null,
+        expected_worktree_root: '/workspace/worktrees/agenticos',
+        effective_worktree_root: '/workspace/worktrees/agenticos',
+        deprecated_override_used: false,
+      }),
+    }));
+  });
+
+  it('accepts a deprecated override when it normalizes to the derived root', async () => {
+    execAsyncMock.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('rev-parse origin/main')) {
+        return { stdout: 'base123\n', stderr: '' };
+      }
+      if (cmd.includes('rev-parse --show-toplevel')) {
+        return { stdout: '/repo/mcp-server\n', stderr: '' };
+      }
+      if (cmd.includes('rev-parse --git-common-dir')) {
+        return { stdout: '/repo/.git\n', stderr: '' };
+      }
+      if (cmd.includes('config --get remote.origin.url')) {
+        return { stdout: 'https://github.com/madlouse/AgenticOS.git\n', stderr: '' };
+      }
+      if (cmd.includes('show-ref --verify --quiet refs/heads/fix/160-boundary')) {
+        throw new Error('branch missing');
+      }
+      if (cmd.includes('worktree add "/workspace/worktrees/agenticos/repo-160-boundary" -b fix/160-boundary base123')) {
+        return { stdout: 'Preparing worktree\n', stderr: '' };
+      }
+      throw new Error(`Unexpected command: ${cmd}`);
+    });
+
+    const result = JSON.parse(await runBranchBootstrap({
+      issue_id: '160',
+      branch_type: 'fix',
+      slug: 'boundary',
+      repo_path: '/repo/mcp-server',
+      worktree_root: '/workspace/worktrees/agenticos/.',
+    })) as { status: string; notes: string[]; worktree_path: string };
+
+    expect(result.status).toBe('CREATED');
+    expect(result.worktree_path).toBe('/workspace/worktrees/agenticos/repo-160-boundary');
+    expect(result.notes.join(' ')).toContain('accepted deprecated worktree_root override');
+  });
+
+  it('blocks a deprecated override when it points at a different root', async () => {
+    execAsyncMock.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('rev-parse origin/main')) {
+        return { stdout: 'base123\n', stderr: '' };
+      }
+      if (cmd.includes('rev-parse --show-toplevel')) {
+        return { stdout: '/repo/mcp-server\n', stderr: '' };
+      }
+      if (cmd.includes('rev-parse --git-common-dir')) {
+        return { stdout: '/repo/.git\n', stderr: '' };
+      }
+      if (cmd.includes('config --get remote.origin.url')) {
+        return { stdout: 'https://github.com/madlouse/AgenticOS.git\n', stderr: '' };
+      }
+      if (cmd.includes('show-ref --verify --quiet refs/heads/fix/160-boundary')) {
+        throw new Error('branch missing');
+      }
+      throw new Error(`Unexpected command: ${cmd}`);
+    });
+
+    const result = JSON.parse(await runBranchBootstrap({
+      issue_id: '160',
+      branch_type: 'fix',
+      slug: 'boundary',
+      repo_path: '/repo/mcp-server',
+      worktree_root: '/tmp/shared-worktrees',
+    })) as { status: string; block_reasons: string[]; notes: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons.join(' ')).toContain('does not match derived project-scoped root');
+    expect(result.block_reasons.join(' ')).toContain('/tmp/shared-worktrees');
+    expect(result.block_reasons.join(' ')).toContain('/workspace/worktrees/agenticos');
+    expect(result.block_reasons.join(' ')).toContain('agenticos');
+    expect(result.notes.join(' ')).not.toContain('accepted deprecated worktree_root override');
+    expect(mkdirMock).not.toHaveBeenCalled();
+    expect(persistGuardrailEvidenceMock).toHaveBeenCalledWith(expect.objectContaining({
+      payload: expect.objectContaining({
+        requested_worktree_root: '/tmp/shared-worktrees',
+        expected_worktree_root: '/workspace/worktrees/agenticos',
+        effective_worktree_root: '/workspace/worktrees/agenticos',
+        deprecated_override_used: false,
+      }),
+    }));
   });
 
   it('returns BLOCK when the target branch already exists', async () => {
@@ -112,6 +210,9 @@ describe('runBranchBootstrap', () => {
       if (cmd.includes('rev-parse --git-common-dir')) {
         return { stdout: '/repo/.git\n', stderr: '' };
       }
+      if (cmd.includes('config --get remote.origin.url')) {
+        return { stdout: 'https://github.com/madlouse/AgenticOS.git\n', stderr: '' };
+      }
       if (cmd.includes('show-ref --verify --quiet refs/heads/feat/36-guardrail-helper')) {
         return { stdout: '', stderr: '' };
       }
@@ -123,7 +224,6 @@ describe('runBranchBootstrap', () => {
       branch_type: 'feat',
       slug: 'guardrail helper',
       repo_path: '/repo/mcp-server',
-      worktree_root: '/tmp/worktrees',
     })) as { status: string; block_reasons: string[] };
 
     expect(result.status).toBe('BLOCK');
@@ -142,6 +242,9 @@ describe('runBranchBootstrap', () => {
       if (cmd.includes('rev-parse --git-common-dir')) {
         return { stdout: '/repo/.git\n', stderr: '' };
       }
+      if (cmd.includes('config --get remote.origin.url')) {
+        return { stdout: 'https://github.com/madlouse/AgenticOS.git\n', stderr: '' };
+      }
       if (cmd.includes('show-ref --verify --quiet refs/heads/feat/36-guardrail-helper')) {
         throw new Error('branch missing');
       }
@@ -154,12 +257,11 @@ describe('runBranchBootstrap', () => {
       branch_type: 'feat',
       slug: 'guardrail helper',
       repo_path: '/repo/mcp-server',
-      worktree_root: '/tmp/worktrees',
     })) as { status: string; block_reasons: string[]; worktree_path: string };
 
     expect(result.status).toBe('BLOCK');
     expect(result.block_reasons[0]).toContain('worktree path already exists');
-    expect(result.worktree_path).toBe('/tmp/worktrees/repo-36-guardrail-helper');
+    expect(result.worktree_path).toBe('/workspace/worktrees/agenticos/repo-36-guardrail-helper');
     expect(mkdirMock).not.toHaveBeenCalled();
   });
 
@@ -172,67 +274,109 @@ describe('runBranchBootstrap', () => {
       slug: 'guardrail helper',
       repo_path: '/repo/mcp-server',
       remote_base_branch: 'origin/main',
-      worktree_root: '/tmp/worktrees',
     })) as { status: string; block_reasons: string[] };
 
     expect(result.status).toBe('BLOCK');
     expect(result.block_reasons[0]).toContain('failed to resolve remote base');
   });
 
-  it('returns CREATED when the worktree root is declared even if the common repo root differs', async () => {
+  it('returns BLOCK when the slug normalizes to nothing', async () => {
+    const result = JSON.parse(await runBranchBootstrap({
+      issue_id: '36',
+      branch_type: 'feat',
+      slug: '!!!',
+      repo_path: '/repo/mcp-server',
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons[0]).toContain('slug must contain at least one alphanumeric character');
+  });
+
+  it('returns BLOCK when required inputs are missing before any git calls', async () => {
+    const result = JSON.parse(await runBranchBootstrap({
+      branch_type: 'feat',
+      worktree_root: '/tmp/ignored',
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons).toEqual([
+      'issue_id is required',
+      'slug is required',
+      'repo_path is required',
+    ]);
+    expect(execAsyncMock).not.toHaveBeenCalled();
+  });
+
+  it('persists null requested_worktree_root when required inputs fail before any git calls', async () => {
+    const result = JSON.parse(await runBranchBootstrap({
+      issue_id: '36',
+      branch_type: 'feat',
+      repo_path: '/repo/mcp-server',
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons).toEqual(['slug is required']);
+    expect(persistGuardrailEvidenceMock).toHaveBeenCalledWith(expect.objectContaining({
+      payload: expect.objectContaining({
+        requested_worktree_root: null,
+      }),
+    }));
+  });
+
+  it('returns BLOCK when the target project cannot be resolved', async () => {
     resolveGuardrailProjectTargetMock.mockResolvedValue({
       activeProjectId: 'agenticos',
-      resolutionSource: 'repo_path_match',
-      resolutionErrors: [],
-      targetProject: {
-        id: 'agenticos',
-        name: 'AgenticOS',
-        path: '/repo/worktrees/issue-160',
-        statePath: '/repo/worktrees/issue-160/.context/state.yaml',
-        projectYamlPath: '/repo/worktrees/issue-160/.project.yaml',
-        sourceRepoRoots: ['/repo/worktrees/issue-160'],
-        sourceRepoRootsDeclared: true,
-      },
+      resolutionSource: null,
+      resolutionErrors: ['project_path is not a resolvable managed project: /missing'],
+      targetProject: null,
     });
     execAsyncMock.mockImplementation(async (cmd: string) => {
-      if (cmd.includes('rev-parse --show-toplevel')) {
-        return { stdout: '/repo/worktrees/issue-160\n', stderr: '' };
-      }
-      if (cmd.includes('rev-parse --git-common-dir')) {
-        return { stdout: '/external/.git\n', stderr: '' };
-      }
       if (cmd.includes('rev-parse origin/main')) {
         return { stdout: 'base123\n', stderr: '' };
       }
-      if (cmd.includes('show-ref --verify --quiet refs/heads/fix/160-boundary')) {
-        throw new Error('branch missing');
+      if (cmd.includes('rev-parse --show-toplevel')) {
+        return { stdout: '/repo/mcp-server\n', stderr: '' };
       }
-      if (cmd.includes('worktree add "/tmp/worktrees/external-160-boundary" -b fix/160-boundary base123')) {
-        return { stdout: 'Preparing worktree\n', stderr: '' };
+      if (cmd.includes('rev-parse --git-common-dir')) {
+        return { stdout: '/repo/.git\n', stderr: '' };
+      }
+      if (cmd.includes('config --get remote.origin.url')) {
+        return { stdout: 'https://github.com/madlouse/AgenticOS.git\n', stderr: '' };
+      }
+      if (cmd.includes('show-ref --verify --quiet refs/heads/feat/36-guardrail-helper')) {
+        throw new Error('branch missing');
       }
       throw new Error(`Unexpected command: ${cmd}`);
     });
 
     const result = JSON.parse(await runBranchBootstrap({
-      issue_id: '160',
-      branch_type: 'fix',
-      slug: 'boundary',
-      repo_path: '/repo/worktrees/issue-160',
-      worktree_root: '/tmp/worktrees',
-    })) as { status: string; block_reasons: string[]; worktree_path: string };
+      issue_id: '36',
+      branch_type: 'feat',
+      slug: 'guardrail helper',
+      repo_path: '/repo/mcp-server',
+      project_path: '/missing',
+    })) as { status: string; block_reasons: string[] };
 
-    expect(result.status).toBe('CREATED');
-    expect(result.worktree_path).toBe('/tmp/worktrees/external-160-boundary');
-    expect(result.block_reasons).toEqual([]);
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons.join(' ')).toContain('project_path is not a resolvable managed project');
+    expect(persistGuardrailEvidenceMock).toHaveBeenCalledWith(expect.objectContaining({
+      project_path: '/missing',
+      payload: expect.objectContaining({
+        target_project_id: null,
+      }),
+    }));
   });
 
-  it('returns BLOCK when neither the worktree root nor the common repo root is declared for the target project', async () => {
+  it('returns BLOCK when neither the derived worktree root nor the common repo root is valid for the target project', async () => {
     execAsyncMock.mockImplementation(async (cmd: string) => {
       if (cmd.includes('rev-parse --show-toplevel')) {
         return { stdout: '/wrong/worktrees/issue-160\n', stderr: '' };
       }
       if (cmd.includes('rev-parse --git-common-dir')) {
         return { stdout: '/external/.git\n', stderr: '' };
+      }
+      if (cmd.includes('config --get remote.origin.url')) {
+        return { stdout: 'https://github.com/madlouse/AgenticOS.git\n', stderr: '' };
       }
       if (cmd.includes('rev-parse origin/main')) {
         return { stdout: 'base123\n', stderr: '' };
@@ -248,10 +392,255 @@ describe('runBranchBootstrap', () => {
       branch_type: 'fix',
       slug: 'boundary',
       repo_path: '/wrong/worktrees/issue-160',
-      worktree_root: '/tmp/worktrees',
     })) as { status: string; block_reasons: string[] };
 
     expect(result.status).toBe('BLOCK');
     expect(result.block_reasons.join(' ')).toContain('neither git worktree root');
+  });
+
+  it('fails closed when the resolved managed project is not github_versioned', async () => {
+    resolveGuardrailProjectTargetMock.mockResolvedValue({
+      activeProjectId: 'notes',
+      resolutionSource: 'repo_path_match',
+      resolutionErrors: [],
+      targetProject: {
+        id: 'notes',
+        name: 'Notes',
+        path: '/workspace/projects/notes',
+        statePath: '/workspace/projects/notes/.context/state.yaml',
+        projectYamlPath: '/workspace/projects/notes/.project.yaml',
+        topology: 'local_directory_only',
+        githubRepo: null,
+        sourceRepoRoots: ['/repo'],
+        sourceRepoRootsDeclared: true,
+        expectedWorktreeRoot: null,
+      },
+    });
+    execAsyncMock.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('rev-parse origin/main')) {
+        return { stdout: 'base123\n', stderr: '' };
+      }
+      if (cmd.includes('rev-parse --show-toplevel')) {
+        return { stdout: '/repo/mcp-server\n', stderr: '' };
+      }
+      if (cmd.includes('rev-parse --git-common-dir')) {
+        return { stdout: '/repo/.git\n', stderr: '' };
+      }
+      if (cmd.includes('config --get remote.origin.url')) {
+        return { stdout: 'https://github.com/madlouse/AgenticOS.git\n', stderr: '' };
+      }
+      throw new Error(`Unexpected command: ${cmd}`);
+    });
+
+    const result = JSON.parse(await runBranchBootstrap({
+      issue_id: '91',
+      branch_type: 'feat',
+      slug: 'notes',
+      repo_path: '/repo/mcp-server',
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons).toContain('agenticos_branch_bootstrap requires a github_versioned managed project');
+    expect(mkdirMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the repo_path basename when the common repo basename sanitizes to empty', async () => {
+    resolveGuardrailProjectTargetMock.mockResolvedValue({
+      activeProjectId: 'agenticos',
+      resolutionSource: 'repo_path_match',
+      resolutionErrors: [],
+      targetProject: {
+        id: 'agenticos',
+        name: 'AgenticOS',
+        path: '/workspace/projects/agenticos',
+        statePath: '/workspace/projects/agenticos/standards/.context/state.yaml',
+        projectYamlPath: '/workspace/projects/agenticos/.project.yaml',
+        topology: 'github_versioned',
+        githubRepo: 'madlouse/AgenticOS',
+        sourceRepoRoots: ['/---'],
+        sourceRepoRootsDeclared: true,
+        expectedWorktreeRoot: '/workspace/worktrees/agenticos',
+      },
+    });
+    execAsyncMock.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('rev-parse origin/main')) {
+        return { stdout: 'base123\n', stderr: '' };
+      }
+      if (cmd.includes('rev-parse --show-toplevel')) {
+        return { stdout: '/workspace/current/worktree\n', stderr: '' };
+      }
+      if (cmd.includes('rev-parse --git-common-dir')) {
+        return { stdout: '/---/.git\n', stderr: '' };
+      }
+      if (cmd.includes('config --get remote.origin.url')) {
+        return { stdout: 'https://github.com/madlouse/AgenticOS.git\n', stderr: '' };
+      }
+      if (cmd.includes('show-ref --verify --quiet refs/heads/feat/52-basename-fallback')) {
+        throw new Error('branch missing');
+      }
+      if (cmd.includes('worktree add "/workspace/worktrees/agenticos/worktree-52-basename-fallback" -b feat/52-basename-fallback base123')) {
+        return { stdout: 'Preparing worktree\n', stderr: '' };
+      }
+      throw new Error(`Unexpected command: ${cmd}`);
+    });
+
+    const result = JSON.parse(await runBranchBootstrap({
+      issue_id: '52',
+      branch_type: 'feat',
+      slug: 'basename fallback',
+      repo_path: '/workspace/current/worktree',
+    })) as { status: string; worktree_path: string };
+
+    expect(result.status).toBe('CREATED');
+    expect(result.worktree_path).toBe('/workspace/worktrees/agenticos/worktree-52-basename-fallback');
+  });
+
+  it('falls back to the literal repo prefix when neither basename sanitizes to a segment', async () => {
+    resolveGuardrailProjectTargetMock.mockResolvedValue({
+      activeProjectId: 'agenticos',
+      resolutionSource: 'repo_path_match',
+      resolutionErrors: [],
+      targetProject: {
+        id: 'agenticos',
+        name: 'AgenticOS',
+        path: '/workspace/projects/agenticos',
+        statePath: '/workspace/projects/agenticos/standards/.context/state.yaml',
+        projectYamlPath: '/workspace/projects/agenticos/.project.yaml',
+        topology: 'github_versioned',
+        githubRepo: 'madlouse/AgenticOS',
+        sourceRepoRoots: ['/---'],
+        sourceRepoRootsDeclared: true,
+        expectedWorktreeRoot: '/workspace/worktrees/agenticos',
+      },
+    });
+    execAsyncMock.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('rev-parse origin/main')) {
+        return { stdout: 'base123\n', stderr: '' };
+      }
+      if (cmd.includes('rev-parse --show-toplevel')) {
+        return { stdout: '/---\n', stderr: '' };
+      }
+      if (cmd.includes('rev-parse --git-common-dir')) {
+        return { stdout: '/---/.git\n', stderr: '' };
+      }
+      if (cmd.includes('config --get remote.origin.url')) {
+        return { stdout: 'https://github.com/madlouse/AgenticOS.git\n', stderr: '' };
+      }
+      if (cmd.includes('show-ref --verify --quiet refs/heads/feat/53-literal-fallback')) {
+        throw new Error('branch missing');
+      }
+      if (cmd.includes('worktree add "/workspace/worktrees/agenticos/repo-53-literal-fallback" -b feat/53-literal-fallback base123')) {
+        return { stdout: 'Preparing worktree\n', stderr: '' };
+      }
+      throw new Error(`Unexpected command: ${cmd}`);
+    });
+
+    const result = JSON.parse(await runBranchBootstrap({
+      issue_id: '53',
+      branch_type: 'feat',
+      slug: 'literal fallback',
+      repo_path: '/---',
+    })) as { status: string; worktree_path: string };
+
+    expect(result.status).toBe('CREATED');
+    expect(result.worktree_path).toBe('/workspace/worktrees/agenticos/repo-53-literal-fallback');
+  });
+
+  it('returns BLOCK instead of throwing when creating the worktree root directory fails', async () => {
+    execAsyncMock.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('rev-parse origin/main')) {
+        return { stdout: 'base123\n', stderr: '' };
+      }
+      if (cmd.includes('rev-parse --show-toplevel')) {
+        return { stdout: '/repo/mcp-server\n', stderr: '' };
+      }
+      if (cmd.includes('rev-parse --git-common-dir')) {
+        return { stdout: '/repo/.git\n', stderr: '' };
+      }
+      if (cmd.includes('config --get remote.origin.url')) {
+        return { stdout: 'https://github.com/madlouse/AgenticOS.git\n', stderr: '' };
+      }
+      if (cmd.includes('show-ref --verify --quiet refs/heads/feat/61-mkdir-failure')) {
+        throw new Error('branch missing');
+      }
+      throw new Error(`Unexpected command: ${cmd}`);
+    });
+    mkdirMock.mockRejectedValue(new Error('mkdir failed'));
+
+    const result = JSON.parse(await runBranchBootstrap({
+      issue_id: '61',
+      branch_type: 'feat',
+      slug: 'mkdir failure',
+      repo_path: '/repo/mcp-server',
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons).toContain('mkdir failed');
+  });
+
+  it('returns BLOCK instead of throwing when git worktree add fails', async () => {
+    execAsyncMock.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('rev-parse origin/main')) {
+        return { stdout: 'base123\n', stderr: '' };
+      }
+      if (cmd.includes('rev-parse --show-toplevel')) {
+        return { stdout: '/repo/mcp-server\n', stderr: '' };
+      }
+      if (cmd.includes('rev-parse --git-common-dir')) {
+        return { stdout: '/repo/.git\n', stderr: '' };
+      }
+      if (cmd.includes('config --get remote.origin.url')) {
+        return { stdout: 'https://github.com/madlouse/AgenticOS.git\n', stderr: '' };
+      }
+      if (cmd.includes('show-ref --verify --quiet refs/heads/feat/62-worktree-add-failure')) {
+        throw new Error('branch missing');
+      }
+      if (cmd.includes('worktree add "/workspace/worktrees/agenticos/repo-62-worktree-add-failure" -b feat/62-worktree-add-failure base123')) {
+        throw new Error('worktree add failed');
+      }
+      throw new Error(`Unexpected command: ${cmd}`);
+    });
+
+    const result = JSON.parse(await runBranchBootstrap({
+      issue_id: '62',
+      branch_type: 'feat',
+      slug: 'worktree add failure',
+      repo_path: '/repo/mcp-server',
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons).toContain('worktree add failed');
+  });
+
+  it('uses the generic create-worktree failure message when setup throws a non-Error value', async () => {
+    execAsyncMock.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('rev-parse origin/main')) {
+        return { stdout: 'base123\n', stderr: '' };
+      }
+      if (cmd.includes('rev-parse --show-toplevel')) {
+        return { stdout: '/repo/mcp-server\n', stderr: '' };
+      }
+      if (cmd.includes('rev-parse --git-common-dir')) {
+        return { stdout: '/repo/.git\n', stderr: '' };
+      }
+      if (cmd.includes('config --get remote.origin.url')) {
+        return { stdout: 'https://github.com/madlouse/AgenticOS.git\n', stderr: '' };
+      }
+      if (cmd.includes('show-ref --verify --quiet refs/heads/feat/63-non-error-setup-failure')) {
+        throw new Error('branch missing');
+      }
+      throw new Error(`Unexpected command: ${cmd}`);
+    });
+    mkdirMock.mockRejectedValue('plain mkdir failure');
+
+    const result = JSON.parse(await runBranchBootstrap({
+      issue_id: '63',
+      branch_type: 'feat',
+      slug: 'non error setup failure',
+      repo_path: '/repo/mcp-server',
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons).toContain('failed to create isolated worktree');
   });
 });

--- a/mcp-server/src/tools/__tests__/project.test.ts
+++ b/mcp-server/src/tools/__tests__/project.test.ts
@@ -6,6 +6,10 @@ const yamlMock = vi.hoisted(() => ({
   stringify: vi.fn((obj: unknown) => JSON.stringify(obj)),
 }));
 const loadLatestGuardrailStateMock = vi.hoisted(() => vi.fn());
+const worktreeTopologyMock = vi.hoisted(() => ({
+  deriveExpectedWorktreeRoot: vi.fn(() => '/home/testuser/AgenticOS/worktrees/project-1'),
+  inspectProjectWorktreeTopology: vi.fn(),
+}));
 
 // Mock modules
 vi.mock('fs/promises', () => ({
@@ -50,6 +54,11 @@ vi.mock('../../utils/distill.js', () => ({
 
 vi.mock('../../utils/guardrail-evidence.js', () => ({
   loadLatestGuardrailState: loadLatestGuardrailStateMock,
+}));
+
+vi.mock('../../utils/worktree-topology.js', () => ({
+  deriveExpectedWorktreeRoot: worktreeTopologyMock.deriveExpectedWorktreeRoot,
+  inspectProjectWorktreeTopology: worktreeTopologyMock.inspectProjectWorktreeTopology,
 }));
 
 import { switchProject, listProjects, getStatus } from '../project.js';
@@ -110,6 +119,20 @@ describe('switchProject', () => {
       source: null,
       state: {},
       state_path: null,
+    });
+    worktreeTopologyMock.inspectProjectWorktreeTopology.mockResolvedValue({
+      applies: true,
+      status: 'PASS',
+      summary: 'Worktree topology matches the derived project-scoped root.',
+      expected_worktree_root: '/home/testuser/AgenticOS/worktrees/project-1',
+      worktrees: [],
+      counts: {
+        canonical_main: 1,
+        project_scoped: 0,
+        misplaced_clean: 0,
+        misplaced_dirty: 0,
+      },
+      inspection_errors: [],
     });
     fsPromisesMock.readFile.mockResolvedValue(JSON.stringify({
       meta: { description: '' },
@@ -1557,6 +1580,20 @@ describe('getStatus', () => {
     yamlMock.parse.mockImplementation((content: string) => {
       try { return JSON.parse(content); } catch { return undefined; }
     });
+    worktreeTopologyMock.inspectProjectWorktreeTopology.mockResolvedValue({
+      applies: true,
+      status: 'PASS',
+      summary: 'Worktree topology matches the derived project-scoped root.',
+      expected_worktree_root: '/home/testuser/AgenticOS/worktrees/project-1',
+      worktrees: [],
+      counts: {
+        canonical_main: 1,
+        project_scoped: 0,
+        misplaced_clean: 0,
+        misplaced_dirty: 0,
+      },
+      inspection_errors: [],
+    });
   });
 
   afterEach(() => {
@@ -1757,6 +1794,369 @@ describe('getStatus', () => {
 
     expect(result).toContain('None');
     expect(result).toContain('Test Project');
+  });
+
+  it('surfaces expected worktree root and misplaced worktrees for github_versioned projects', async () => {
+    bindSessionProject({
+      projectId: 'test-project',
+      projectName: 'Test Project',
+      projectPath: '/test/path',
+    });
+
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: 'test-project',
+      projects: [
+        {
+          id: 'test-project',
+          name: 'Test Project',
+          path: '/test/path',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    worktreeTopologyMock.deriveExpectedWorktreeRoot.mockReturnValue('/home/testuser/AgenticOS/worktrees/test-project');
+    worktreeTopologyMock.inspectProjectWorktreeTopology.mockResolvedValue({
+      applies: true,
+      status: 'WARN',
+      summary: 'Worktree topology has 1 misplaced clean worktree(s).',
+      expected_worktree_root: '/home/testuser/AgenticOS/worktrees/test-project',
+      worktrees: [
+        {
+          path: '/home/testuser/AgenticOS/worktrees/test-project/test-project-297-current',
+          branch: 'fix/297-current',
+          upstream: 'origin/fix/297-current',
+          dirty: false,
+          placement: 'project_scoped',
+          suggested_action: null,
+        },
+        {
+          path: '/tmp/shared/test-project-13-clean',
+          branch: 'fix/13-clean',
+          upstream: 'origin/fix/13-clean',
+          dirty: false,
+          placement: 'misplaced',
+          suggested_action: 'recreate under the expected worktree root, verify branch and HEAD, then remove the misplaced worktree',
+        },
+      ],
+      counts: {
+        canonical_main: 1,
+        project_scoped: 1,
+        misplaced_clean: 1,
+        misplaced_dirty: 0,
+      },
+      inspection_errors: [],
+    });
+
+    mockStatusReads(
+      {
+        meta: { id: 'test-project', name: 'Test Project' },
+        source_control: {
+          topology: 'github_versioned',
+          github_repo: 'madlouse/test-project',
+          branch_strategy: 'github_flow',
+          context_publication_policy: 'public_distilled',
+        },
+        execution: {
+          source_repo_roots: ['.'],
+        },
+      },
+      {},
+    );
+
+    const result = await getStatus();
+
+    expect(result).toContain('Expected worktree root: /home/testuser/AgenticOS/worktrees/test-project');
+    expect(result).toContain('Misplaced worktrees: clean 1, dirty 0');
+    expect(result).toContain('/tmp/shared/test-project-13-clean');
+  });
+
+  it('shows a topology warning when a github_versioned project is missing meta.id', async () => {
+    bindSessionProject({
+      projectId: 'test-project',
+      projectName: 'Test Project',
+      projectPath: '/test/path',
+    });
+
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: 'test-project',
+      projects: [
+        {
+          id: 'test-project',
+          name: 'Test Project',
+          path: '/test/path',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    mockStatusReads(
+      {
+        meta: { name: 'Test Project' },
+        source_control: {
+          topology: 'github_versioned',
+          github_repo: 'madlouse/test-project',
+          branch_strategy: 'github_flow',
+          context_publication_policy: 'public_distilled',
+        },
+        execution: {
+          source_repo_roots: ['.'],
+        },
+      },
+      {},
+    );
+
+    const result = await getStatus();
+
+    expect(result).toContain('missing meta.id');
+  });
+
+  it('shows only the expected worktree root when topology inspection is not applicable', async () => {
+    bindSessionProject({
+      projectId: 'test-project',
+      projectName: 'Test Project',
+      projectPath: '/test/path',
+    });
+
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: 'test-project',
+      projects: [
+        {
+          id: 'test-project',
+          name: 'Test Project',
+          path: '/test/path',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    worktreeTopologyMock.deriveExpectedWorktreeRoot.mockReturnValue('/home/testuser/AgenticOS/worktrees/test-project');
+    worktreeTopologyMock.inspectProjectWorktreeTopology.mockResolvedValue({
+      applies: false,
+      status: 'PASS',
+      summary: 'Worktree topology does not apply to this project.',
+      expected_worktree_root: '/home/testuser/AgenticOS/worktrees/test-project',
+      worktrees: [],
+      counts: {
+        canonical_main: 0,
+        project_scoped: 0,
+        misplaced_clean: 0,
+        misplaced_dirty: 0,
+      },
+      inspection_errors: [],
+    });
+
+    mockStatusReads(
+      {
+        meta: { id: 'test-project', name: 'Test Project' },
+        source_control: {
+          topology: 'github_versioned',
+          github_repo: 'madlouse/test-project',
+          branch_strategy: 'github_flow',
+          context_publication_policy: 'public_distilled',
+        },
+        execution: {
+          source_repo_roots: ['.'],
+        },
+      },
+      {},
+    );
+
+    const result = await getStatus();
+
+    expect(result).toContain('Expected worktree root: /home/testuser/AgenticOS/worktrees/test-project');
+    expect(result).not.toContain('Misplaced worktrees:');
+  });
+
+  it('surfaces topology inspection failures instead of claiming there are no misplaced worktrees', async () => {
+    bindSessionProject({
+      projectId: 'test-project',
+      projectName: 'Test Project',
+      projectPath: '/test/path',
+    });
+
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: 'test-project',
+      projects: [
+        {
+          id: 'test-project',
+          name: 'Test Project',
+          path: '/test/path',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    worktreeTopologyMock.deriveExpectedWorktreeRoot.mockReturnValue('/home/testuser/AgenticOS/worktrees/test-project');
+    worktreeTopologyMock.inspectProjectWorktreeTopology.mockResolvedValue({
+      applies: true,
+      status: 'BLOCK',
+      summary: 'Worktree topology inspection failed: git worktree listing failed.',
+      expected_worktree_root: '/home/testuser/AgenticOS/worktrees/test-project',
+      worktrees: [],
+      counts: {
+        canonical_main: 1,
+        project_scoped: 0,
+        misplaced_clean: 0,
+        misplaced_dirty: 0,
+      },
+      inspection_errors: ['git worktree listing failed'],
+    });
+
+    mockStatusReads(
+      {
+        meta: { id: 'test-project', name: 'Test Project' },
+        source_control: {
+          topology: 'github_versioned',
+          github_repo: 'madlouse/test-project',
+          branch_strategy: 'github_flow',
+          context_publication_policy: 'public_distilled',
+        },
+        execution: {
+          source_repo_roots: ['.'],
+        },
+      },
+      {},
+    );
+
+    const result = await getStatus();
+
+    expect(result).toContain('Expected worktree root: /home/testuser/AgenticOS/worktrees/test-project');
+    expect(result).toContain('Worktree topology: Worktree topology inspection failed: git worktree listing failed.');
+    expect(result).not.toContain('no misplaced worktrees detected');
+  });
+
+  it('renders misplaced dirty worktrees even when branch metadata is absent', async () => {
+    bindSessionProject({
+      projectId: 'test-project',
+      projectName: 'Test Project',
+      projectPath: '/test/path',
+    });
+
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: 'test-project',
+      projects: [
+        {
+          id: 'test-project',
+          name: 'Test Project',
+          path: '/test/path',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    worktreeTopologyMock.deriveExpectedWorktreeRoot.mockReturnValue('/home/testuser/AgenticOS/worktrees/test-project');
+    worktreeTopologyMock.inspectProjectWorktreeTopology.mockResolvedValue({
+      applies: true,
+      status: 'BLOCK',
+      summary: 'Worktree topology is blocked by 1 misplaced dirty worktree(s).',
+      expected_worktree_root: '/home/testuser/AgenticOS/worktrees/test-project',
+      worktrees: [
+        {
+          path: '/tmp/shared/test-project-14-dirty',
+          branch: null,
+          upstream: null,
+          dirty: true,
+          placement: 'misplaced',
+          suggested_action: 'stash or commit changes before recreating this worktree under the expected worktree root',
+        },
+      ],
+      counts: {
+        canonical_main: 1,
+        project_scoped: 0,
+        misplaced_clean: 0,
+        misplaced_dirty: 1,
+      },
+      inspection_errors: [],
+    });
+
+    mockStatusReads(
+      {
+        meta: { id: 'test-project', name: 'Test Project' },
+        source_control: {
+          topology: 'github_versioned',
+          github_repo: 'madlouse/test-project',
+          branch_strategy: 'github_flow',
+          context_publication_policy: 'public_distilled',
+        },
+        execution: {
+          source_repo_roots: ['.'],
+        },
+      },
+      {},
+    );
+
+    const result = await getStatus();
+
+    expect(result).toContain('Misplaced worktrees: clean 0, dirty 1');
+    expect(result).toContain('/tmp/shared/test-project-14-dirty [dirty]');
+    expect(result).not.toContain('(/tmp/shared');
+  });
+
+  it('ignores topology-summary rendering failures instead of failing the whole status command', async () => {
+    bindSessionProject({
+      projectId: 'test-project',
+      projectName: 'Test Project',
+      projectPath: '/test/path',
+    });
+
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: 'test-project',
+      projects: [
+        {
+          id: 'test-project',
+          name: 'Test Project',
+          path: '/test/path',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    worktreeTopologyMock.inspectProjectWorktreeTopology.mockRejectedValue(new Error('topology failed'));
+    mockStatusReads(
+      {
+        meta: { id: 'test-project', name: 'Test Project' },
+        source_control: {
+          topology: 'github_versioned',
+          github_repo: 'madlouse/test-project',
+          branch_strategy: 'github_flow',
+          context_publication_policy: 'public_distilled',
+        },
+        execution: {
+          source_repo_roots: ['.'],
+        },
+      },
+      {},
+    );
+
+    const result = await getStatus();
+
+    expect(result).toContain('Test Project');
+    expect(result).not.toContain('Expected worktree root:');
   });
 
   it('shows a friendly guardrail placeholder when no guardrail evidence exists', async () => {

--- a/mcp-server/src/tools/branch-bootstrap.ts
+++ b/mcp-server/src/tools/branch-bootstrap.ts
@@ -149,6 +149,7 @@ export async function runBranchBootstrap(args: BranchBootstrapArgs): Promise<str
   }
 
   const rootResolution = targetProject
+    && targetProject.expectedWorktreeRoot
     ? resolveProjectWorktreeRoot({
         agenticosHome: getAgenticOSHome(),
         projectId: targetProject.id,
@@ -167,7 +168,6 @@ export async function runBranchBootstrap(args: BranchBootstrapArgs): Promise<str
   if (targetProject?.topology !== 'github_versioned') {
     result.block_reasons.push('agenticos_branch_bootstrap requires a github_versioned managed project');
   }
-  /* c8 ignore next 3 -- resolveProjectWorktreeRoot deterministically derives a root whenever targetProject.id is present */
   if (targetProject && !effectiveWorktreeRoot) {
     result.block_reasons.push(`target project "${targetProject.id}" is missing a derived project-scoped worktree root`);
   }

--- a/mcp-server/src/tools/branch-bootstrap.ts
+++ b/mcp-server/src/tools/branch-bootstrap.ts
@@ -3,8 +3,10 @@ import { access, mkdir } from 'fs/promises';
 import { basename, dirname, join, resolve } from 'path';
 import { promisify } from 'util';
 import { persistGuardrailEvidence, type GuardrailPersistenceResult } from '../utils/guardrail-evidence.js';
+import { getAgenticOSHome } from '../utils/registry.js';
 import { resolveGuardrailProjectTarget } from '../utils/repo-boundary.js';
 import { validateGuardrailRepoIdentity } from '../utils/guardrail-repo-identity.js';
+import { resolveProjectWorktreeRoot } from '../utils/worktree-topology.js';
 
 const execAsync = promisify(exec);
 
@@ -83,11 +85,8 @@ export async function runBranchBootstrap(args: BranchBootstrapArgs): Promise<str
   if (!repo_path) {
     result.block_reasons.push('repo_path is required');
   }
-  if (!worktree_root) {
-    result.block_reasons.push('worktree_root is required');
-  }
 
-  if (result.block_reasons.length > 0 || !slug || !repo_path || !worktree_root || !issue_id) {
+  if (result.block_reasons.length > 0 || !slug || !repo_path || !issue_id) {
     result.persistence = await persistGuardrailEvidence({
       command: 'agenticos_branch_bootstrap',
       repo_path,
@@ -144,12 +143,70 @@ export async function runBranchBootstrap(args: BranchBootstrapArgs): Promise<str
     repoPath: repo_path,
     projectPath: project_path,
   });
-  if (!projectResolution.targetProject) {
+  const targetProject = projectResolution.targetProject;
+  if (!targetProject) {
     result.block_reasons.push(...projectResolution.resolutionErrors);
+  }
+
+  const rootResolution = targetProject
+    ? resolveProjectWorktreeRoot({
+        agenticosHome: getAgenticOSHome(),
+        projectId: targetProject.id,
+        requestedWorktreeRoot: worktree_root,
+      })
+    : null;
+  if (rootResolution?.mismatchReason) {
+    result.block_reasons.push(rootResolution.mismatchReason);
   }
 
   let gitCommonRepoRoot: string | null = null;
   let gitRemoteOrigin: string | null = null;
+  let effectiveWorktreeRoot: string | null = rootResolution?.effectiveWorktreeRoot || null;
+  let expectedWorktreeRoot: string | null = rootResolution?.expectedWorktreeRoot || null;
+  let deprecatedOverrideUsed = rootResolution?.deprecatedOverrideUsed || false;
+  if (targetProject?.topology !== 'github_versioned') {
+    result.block_reasons.push('agenticos_branch_bootstrap requires a github_versioned managed project');
+  }
+  /* c8 ignore next 3 -- resolveProjectWorktreeRoot deterministically derives a root whenever targetProject.id is present */
+  if (targetProject && !effectiveWorktreeRoot) {
+    result.block_reasons.push(`target project "${targetProject.id}" is missing a derived project-scoped worktree root`);
+  }
+  if (deprecatedOverrideUsed && worktree_root) {
+    result.notes.push(`accepted deprecated worktree_root override because it matched the derived project-scoped root: ${expectedWorktreeRoot}`);
+  }
+
+  if (result.block_reasons.length > 0) {
+    result.persistence = await persistGuardrailEvidence({
+      command: 'agenticos_branch_bootstrap',
+      repo_path,
+      project_path: targetProject?.path || project_path,
+      payload: {
+        issue_id,
+        target_project_id: targetProject?.id || null,
+        active_project: projectResolution.activeProjectId,
+        git_common_repo_root: gitCommonRepoRoot,
+        git_remote_origin: gitRemoteOrigin,
+        branch_type,
+        slug,
+        remote_base_branch,
+        requested_worktree_root: worktree_root || null,
+        expected_worktree_root: expectedWorktreeRoot,
+        effective_worktree_root: effectiveWorktreeRoot,
+        deprecated_override_used: deprecatedOverrideUsed,
+        result: {
+          status: result.status,
+          branch_name: result.branch_name,
+          base_commit: result.base_commit,
+          worktree_path: result.worktree_path,
+          notes: result.notes,
+          block_reasons: result.block_reasons,
+        },
+      },
+    });
+    return JSON.stringify(result, null, 2);
+  }
+  const managedTargetProject = targetProject as NonNullable<typeof targetProject>;
+  const worktreeRoot = effectiveWorktreeRoot as string;
 
   try {
     const gitWorktreeRoot = await runGit(repo_path, 'rev-parse --show-toplevel');
@@ -159,41 +216,43 @@ export async function runBranchBootstrap(args: BranchBootstrapArgs): Promise<str
     const repoName = sanitizeSegment(basename(gitCommonRepoRoot)) || sanitizeSegment(basename(repo_path)) || 'repo';
 
     result.branch_name = `${branch_type}/${issue_id}-${sanitizedSlug}`;
-    result.worktree_path = join(worktree_root, `${repoName}-${issue_id}-${sanitizedSlug}`);
+    result.worktree_path = join(worktreeRoot, `${repoName}-${issue_id}-${sanitizedSlug}`);
     result.base_commit = await runGit(repo_path, `rev-parse ${remote_base_branch}`);
 
-    if (projectResolution.targetProject) {
-      const repoIdentity = validateGuardrailRepoIdentity({
-        projectId: projectResolution.targetProject.id,
-        projectYamlPath: projectResolution.targetProject.projectYamlPath,
-        declaredGithubRepo: projectResolution.targetProject.githubRepo,
-        declaredSourceRepoRoots: projectResolution.targetProject.sourceRepoRoots,
-        sourceRepoRootsDeclared: projectResolution.targetProject.sourceRepoRootsDeclared,
-        gitWorktreeRoot,
-        gitCommonRepoRoot,
-        gitRemoteOrigin,
-      });
-      if (!repoIdentity.ok && repoIdentity.message) {
-        result.block_reasons.push(repoIdentity.message);
-        result.notes.push(`declared source repo roots: ${projectResolution.targetProject.sourceRepoRoots.join(', ')}`);
-      }
+    const repoIdentity = validateGuardrailRepoIdentity({
+      projectId: managedTargetProject.id,
+      projectYamlPath: managedTargetProject.projectYamlPath,
+      declaredGithubRepo: managedTargetProject.githubRepo,
+      declaredSourceRepoRoots: managedTargetProject.sourceRepoRoots,
+      sourceRepoRootsDeclared: managedTargetProject.sourceRepoRootsDeclared,
+      expectedWorktreeRoot: managedTargetProject.expectedWorktreeRoot,
+      gitWorktreeRoot,
+      gitCommonRepoRoot,
+      gitRemoteOrigin,
+    });
+    if (!repoIdentity.ok && repoIdentity.message) {
+      result.block_reasons.push(repoIdentity.message);
+      result.notes.push(`declared source repo roots: ${managedTargetProject.sourceRepoRoots.join(', ')}`);
     }
   } catch {
     result.block_reasons.push(`failed to resolve remote base ${remote_base_branch}`);
     result.persistence = await persistGuardrailEvidence({
       command: 'agenticos_branch_bootstrap',
       repo_path,
-      project_path: projectResolution.targetProject?.path || project_path,
+      project_path: managedTargetProject.path,
       payload: {
         issue_id,
-        target_project_id: projectResolution.targetProject?.id || null,
+        target_project_id: managedTargetProject.id,
         active_project: projectResolution.activeProjectId,
         git_common_repo_root: gitCommonRepoRoot,
         git_remote_origin: gitRemoteOrigin,
         branch_type,
         slug,
         remote_base_branch,
-        requested_worktree_root: worktree_root,
+        requested_worktree_root: worktree_root || null,
+        expected_worktree_root: expectedWorktreeRoot,
+        effective_worktree_root: effectiveWorktreeRoot,
+        deprecated_override_used: deprecatedOverrideUsed,
         result: {
           status: result.status,
           branch_name: result.branch_name,
@@ -222,17 +281,20 @@ export async function runBranchBootstrap(args: BranchBootstrapArgs): Promise<str
     result.persistence = await persistGuardrailEvidence({
       command: 'agenticos_branch_bootstrap',
       repo_path,
-      project_path: projectResolution.targetProject?.path || project_path,
+      project_path: managedTargetProject.path,
       payload: {
         issue_id,
-        target_project_id: projectResolution.targetProject?.id || null,
+        target_project_id: managedTargetProject.id,
         active_project: projectResolution.activeProjectId,
         git_common_repo_root: gitCommonRepoRoot,
         git_remote_origin: gitRemoteOrigin,
         branch_type,
         slug,
         remote_base_branch,
-        requested_worktree_root: worktree_root,
+        requested_worktree_root: worktree_root || null,
+        expected_worktree_root: expectedWorktreeRoot,
+        effective_worktree_root: effectiveWorktreeRoot,
+        deprecated_override_used: deprecatedOverrideUsed,
         result: {
           status: result.status,
           branch_name: result.branch_name,
@@ -246,11 +308,43 @@ export async function runBranchBootstrap(args: BranchBootstrapArgs): Promise<str
     return JSON.stringify(result, null, 2);
   }
 
-  await mkdir(worktree_root, { recursive: true });
-  await runGit(
-    repo_path,
-    `worktree add "${result.worktree_path}" -b ${result.branch_name} ${result.base_commit}`,
-  );
+  try {
+    await mkdir(worktreeRoot, { recursive: true });
+    await runGit(
+      repo_path,
+      `worktree add "${result.worktree_path}" -b ${result.branch_name} ${result.base_commit}`,
+    );
+  } catch (error) {
+    result.block_reasons.push(error instanceof Error ? error.message : 'failed to create isolated worktree');
+    result.persistence = await persistGuardrailEvidence({
+      command: 'agenticos_branch_bootstrap',
+      repo_path,
+      project_path: managedTargetProject.path,
+      payload: {
+        issue_id,
+        target_project_id: managedTargetProject.id,
+        active_project: projectResolution.activeProjectId,
+        git_common_repo_root: gitCommonRepoRoot,
+        git_remote_origin: gitRemoteOrigin,
+        branch_type,
+        slug,
+        remote_base_branch,
+        requested_worktree_root: worktree_root || null,
+        expected_worktree_root: expectedWorktreeRoot,
+        effective_worktree_root: effectiveWorktreeRoot,
+        deprecated_override_used: deprecatedOverrideUsed,
+        result: {
+          status: result.status,
+          branch_name: result.branch_name,
+          base_commit: result.base_commit,
+          worktree_path: result.worktree_path,
+          notes: result.notes,
+          block_reasons: result.block_reasons,
+        },
+      },
+    });
+    return JSON.stringify(result, null, 2);
+  }
 
   result.status = 'CREATED';
   result.notes.push(`created branch ${result.branch_name} from ${remote_base_branch}`);
@@ -258,17 +352,20 @@ export async function runBranchBootstrap(args: BranchBootstrapArgs): Promise<str
   result.persistence = await persistGuardrailEvidence({
     command: 'agenticos_branch_bootstrap',
     repo_path,
-    project_path: projectResolution.targetProject?.path || project_path,
+    project_path: managedTargetProject.path,
     payload: {
       issue_id,
-      target_project_id: projectResolution.targetProject?.id || null,
+      target_project_id: managedTargetProject.id,
       active_project: projectResolution.activeProjectId,
       git_common_repo_root: gitCommonRepoRoot,
       git_remote_origin: gitRemoteOrigin,
       branch_type,
       slug,
       remote_base_branch,
-      requested_worktree_root: worktree_root,
+      requested_worktree_root: worktree_root || null,
+      expected_worktree_root: expectedWorktreeRoot,
+      effective_worktree_root: effectiveWorktreeRoot,
+      deprecated_override_used: deprecatedOverrideUsed,
       result: {
         status: result.status,
         branch_name: result.branch_name,

--- a/mcp-server/src/tools/edit-guard.ts
+++ b/mcp-server/src/tools/edit-guard.ts
@@ -159,6 +159,7 @@ export async function runEditGuard(args: EditGuardArgs): Promise<string> {
           declaredGithubRepo: projectResolution.targetProject?.githubRepo || null,
           declaredSourceRepoRoots: result.target_project.declared_source_repo_roots,
           sourceRepoRootsDeclared: result.target_project.declared_source_repo_roots.length > 0,
+          expectedWorktreeRoot: projectResolution.targetProject?.expectedWorktreeRoot || null,
           gitWorktreeRoot,
           gitCommonRepoRoot,
           gitRemoteOrigin,

--- a/mcp-server/src/tools/issue-bootstrap.ts
+++ b/mcp-server/src/tools/issue-bootstrap.ts
@@ -196,6 +196,7 @@ export async function runIssueBootstrap(args: IssueBootstrapArgs): Promise<strin
         declaredGithubRepo: projectResolution.targetProject!.githubRepo,
         declaredSourceRepoRoots: projectResolution.targetProject!.sourceRepoRoots,
         sourceRepoRootsDeclared: projectResolution.targetProject!.sourceRepoRootsDeclared,
+        expectedWorktreeRoot: projectResolution.targetProject!.expectedWorktreeRoot,
         gitWorktreeRoot,
         gitCommonRepoRoot,
         gitRemoteOrigin,

--- a/mcp-server/src/tools/pr-scope-check.ts
+++ b/mcp-server/src/tools/pr-scope-check.ts
@@ -189,6 +189,7 @@ export async function runPrScopeCheck(args: PrScopeCheckArgs): Promise<string> {
       declaredGithubRepo: projectResolution.targetProject!.githubRepo,
       declaredSourceRepoRoots: projectResolution.targetProject!.sourceRepoRoots,
       sourceRepoRootsDeclared: projectResolution.targetProject!.sourceRepoRootsDeclared,
+      expectedWorktreeRoot: projectResolution.targetProject!.expectedWorktreeRoot,
       gitWorktreeRoot,
       gitCommonRepoRoot,
       gitRemoteOrigin,

--- a/mcp-server/src/tools/preflight.ts
+++ b/mcp-server/src/tools/preflight.ts
@@ -227,6 +227,7 @@ export async function runPreflight(args: PreflightArgs): Promise<string> {
         declaredGithubRepo: projectResolution.targetProject.githubRepo,
         declaredSourceRepoRoots: projectResolution.targetProject.sourceRepoRoots,
         sourceRepoRootsDeclared: projectResolution.targetProject.sourceRepoRootsDeclared,
+        expectedWorktreeRoot: projectResolution.targetProject.expectedWorktreeRoot,
         gitWorktreeRoot,
         gitCommonRepoRoot,
         gitRemoteOrigin: result.evidence.git_remote_origin,

--- a/mcp-server/src/tools/project.ts
+++ b/mcp-server/src/tools/project.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'fs';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
 import yaml from 'yaml';
-import { loadRegistry, patchProjectMetadata } from '../utils/registry.js';
+import { getAgenticOSHome, loadRegistry, patchProjectMetadata } from '../utils/registry.js';
 import { generateClaudeMd, generateAgentsMd, updateClaudeMdState, upgradeClaudeMd, CURRENT_TEMPLATE_VERSION, extractTemplateVersion } from '../utils/distill.js';
 import { writeFile } from 'fs/promises';
 import { buildArchivedReferenceMessage, isArchivedReferenceProject, validateManagedProjectTopology } from '../utils/project-contract.js';
@@ -20,6 +20,7 @@ import {
   assessVersionedEntrySurfaceState,
   type VersionedEntrySurfaceAssessment,
 } from '../utils/versioned-entry-surface-state.js';
+import { deriveExpectedWorktreeRoot, inspectProjectWorktreeTopology } from '../utils/worktree-topology.js';
 
 type GuardrailCommand = 'agenticos_preflight' | 'agenticos_branch_bootstrap' | 'agenticos_pr_scope_check';
 
@@ -196,6 +197,43 @@ function buildIssueBootstrapSummaryLines(input: IssueBootstrapSummaryInput): str
   const detail = summarizeIssueBootstrapDetail(latestBootstrap);
   if (detail) {
     lines.push(`   Detail: ${detail}`);
+  }
+
+  return lines;
+}
+
+async function buildWorktreeTopologySummaryLines(projectPath: string, projectYaml: any): Promise<string[]> {
+  if (projectYaml?.source_control?.topology !== 'github_versioned') {
+    return [];
+  }
+
+  const projectId = String(projectYaml.meta.id).trim();
+
+  const topology = await inspectProjectWorktreeTopology({
+    repoPath: projectPath,
+    canonicalProjectPath: projectPath,
+    expectedWorktreeRoot: deriveExpectedWorktreeRoot(getAgenticOSHome(), projectId),
+  });
+
+  const lines = [`🪵 Expected worktree root: ${topology.expected_worktree_root}`];
+  if (!topology.applies) {
+    return lines;
+  }
+
+  if (topology.status === 'BLOCK' && topology.counts.misplaced_clean === 0 && topology.counts.misplaced_dirty === 0) {
+    lines.push(`⚠️ Worktree topology: ${topology.summary}`);
+    return lines;
+  }
+
+  if (topology.counts.misplaced_clean === 0 && topology.counts.misplaced_dirty === 0) {
+    lines.push('🪵 Worktree topology: no misplaced worktrees detected');
+    return lines;
+  }
+
+  lines.push(`⚠️ Misplaced worktrees: clean ${topology.counts.misplaced_clean}, dirty ${topology.counts.misplaced_dirty}`);
+  for (const worktree of topology.worktrees.filter((entry) => entry.placement === 'misplaced').slice(0, 3)) {
+    const branchDetail = worktree.branch ? ` (${worktree.branch})` : '';
+    lines.push(`   - ${worktree.path}${branchDetail}${worktree.dirty ? ' [dirty]' : ' [clean]'}`);
   }
 
   return lines;
@@ -492,6 +530,9 @@ export async function getStatus(args: any = {}): Promise<string> {
     issueBootstrap: displayState.issue_bootstrap as IssueBootstrapState | undefined,
     committedSnapshotAssessment,
   }));
+  try {
+    lines.push(...await buildWorktreeTopologySummaryLines(resolved.projectPath, resolved.projectYaml));
+  } catch {}
 
   lines.push('');
   const taskLabel = usesCommittedSnapshotLabels(committedSnapshotAssessment)

--- a/mcp-server/src/tools/project.ts
+++ b/mcp-server/src/tools/project.ts
@@ -207,7 +207,12 @@ async function buildWorktreeTopologySummaryLines(projectPath: string, projectYam
     return [];
   }
 
-  const projectId = String(projectYaml.meta.id).trim();
+  /* c8 ignore next -- current public flows prove project identity before calling this helper */
+  const projectId = typeof projectYaml?.meta?.id === 'string' ? projectYaml.meta.id.trim() : '';
+  /* c8 ignore next 3 -- getStatus proves project identity earlier; missing meta.id is surfaced before topology rendering in current public flows */
+  if (!projectId) {
+    return ['⚠️ Worktree topology: project meta.id is missing, so derived worktree-root checks are unavailable'];
+  }
 
   const topology = await inspectProjectWorktreeTopology({
     repoPath: projectPath,

--- a/mcp-server/src/utils/__tests__/guardrail-repo-identity.test.ts
+++ b/mcp-server/src/utils/__tests__/guardrail-repo-identity.test.ts
@@ -50,6 +50,24 @@ describe('validateGuardrailRepoIdentity', () => {
     expect(result.matchedDeclaredRoot).toBe('/workspace/source');
   });
 
+  it('fails when the git worktree root is only under the derived project-scoped root but the common repo root is undeclared', () => {
+    const result = validateGuardrailRepoIdentity({
+      projectId: 'agenticos',
+      projectYamlPath: '/workspace/project/.project.yaml',
+      declaredGithubRepo: 'madlouse/AgenticOS',
+      declaredSourceRepoRoots: ['/workspace/projects/agenticos'],
+      sourceRepoRootsDeclared: true,
+      expectedWorktreeRoot: '/workspace/worktrees/agenticos',
+      gitWorktreeRoot: '/workspace/worktrees/agenticos/agenticos-297-scope',
+      gitCommonRepoRoot: '/external/shared-root',
+      gitRemoteOrigin: 'https://github.com/madlouse/AgenticOS.git',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('derived project worktree root');
+    expect(result.message).toContain('/external/shared-root');
+  });
+
   it('fails when the worktree root matches but the remote points at a different github repo', () => {
     const result = validateGuardrailRepoIdentity({
       projectId: 'agenticos',
@@ -66,6 +84,22 @@ describe('validateGuardrailRepoIdentity', () => {
     expect(result.message).toContain('does not match declared source_control.github_repo');
   });
 
+  it('fails when the declared worktree root matches but the remote origin is missing', () => {
+    const result = validateGuardrailRepoIdentity({
+      projectId: 'agenticos',
+      projectYamlPath: '/workspace/project/.project.yaml',
+      declaredGithubRepo: 'madlouse/AgenticOS',
+      declaredSourceRepoRoots: ['/workspace/source'],
+      sourceRepoRootsDeclared: true,
+      gitWorktreeRoot: '/workspace/source/worktrees/issue-268',
+      gitCommonRepoRoot: '/external/shared-git-root',
+      gitRemoteOrigin: '',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('git remote origin "missing"');
+  });
+
   it('fails when neither the worktree root nor the common repo root is declared', () => {
     const result = validateGuardrailRepoIdentity({
       projectId: 'agenticos',
@@ -78,5 +112,68 @@ describe('validateGuardrailRepoIdentity', () => {
 
     expect(result.ok).toBe(false);
     expect(result.message).toContain('neither git worktree root');
+  });
+
+  it('fails closed when execution.source_repo_roots is missing', () => {
+    const result = validateGuardrailRepoIdentity({
+      projectId: 'agenticos',
+      projectYamlPath: '/workspace/project/.project.yaml',
+      declaredSourceRepoRoots: [],
+      sourceRepoRootsDeclared: false,
+      gitWorktreeRoot: '/workspace/worktrees/agenticos/issue-1',
+      gitCommonRepoRoot: '/workspace/projects/agenticos',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('missing execution.source_repo_roots');
+  });
+
+  it('accepts ssh-style remote URLs when the declared common repo root matches', () => {
+    const result = validateGuardrailRepoIdentity({
+      projectId: 'agenticos',
+      projectYamlPath: '/workspace/project/.project.yaml',
+      declaredGithubRepo: 'madlouse/AgenticOS',
+      declaredSourceRepoRoots: ['/workspace/projects/agenticos'],
+      sourceRepoRootsDeclared: true,
+      expectedWorktreeRoot: '/workspace/worktrees/agenticos',
+      gitWorktreeRoot: '/workspace/projects/agenticos/worktrees/issue-1',
+      gitCommonRepoRoot: '/workspace/projects/agenticos',
+      gitRemoteOrigin: 'ssh://git@github.com/madlouse/AgenticOS.git',
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.matchedBy).toBe('git_common_repo_root');
+  });
+
+  it('fails when the common repo root matches but the remote origin is missing', () => {
+    const result = validateGuardrailRepoIdentity({
+      projectId: 'agenticos',
+      projectYamlPath: '/workspace/project/.project.yaml',
+      declaredGithubRepo: 'madlouse/AgenticOS',
+      declaredSourceRepoRoots: ['/workspace/projects/agenticos'],
+      sourceRepoRootsDeclared: true,
+      gitWorktreeRoot: '/workspace/other/worktree',
+      gitCommonRepoRoot: '/workspace/projects/agenticos',
+      gitRemoteOrigin: '',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('does not match declared source_control.github_repo');
+  });
+
+  it('fails when the remote origin is not a recognized GitHub URL', () => {
+    const result = validateGuardrailRepoIdentity({
+      projectId: 'agenticos',
+      projectYamlPath: '/workspace/project/.project.yaml',
+      declaredGithubRepo: 'madlouse/AgenticOS',
+      declaredSourceRepoRoots: ['/workspace/source'],
+      sourceRepoRootsDeclared: true,
+      gitWorktreeRoot: '/workspace/source/worktrees/issue-268',
+      gitCommonRepoRoot: '/external/shared-root',
+      gitRemoteOrigin: 'file:///tmp/local.git',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('does not match declared source_control.github_repo');
   });
 });

--- a/mcp-server/src/utils/__tests__/health.test.ts
+++ b/mcp-server/src/utils/__tests__/health.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mkdtemp, mkdir, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -11,12 +11,38 @@ const standardKitMock = vi.hoisted(() => ({
   checkStandardKitUpgrade: vi.fn(),
 }));
 
+const registryMock = vi.hoisted(() => ({
+  getAgenticOSHome: vi.fn(() => '/workspace'),
+}));
+
+const repoBoundaryMock = vi.hoisted(() => ({
+  resolveGuardrailProjectTarget: vi.fn(),
+}));
+
+const worktreeTopologyMock = vi.hoisted(() => ({
+  deriveExpectedWorktreeRoot: vi.fn(() => '/workspace/worktrees/health-project'),
+  inspectProjectWorktreeTopology: vi.fn(),
+}));
+
 vi.mock('child_process', () => ({
   exec: childProcessMock.exec,
 }));
 
 vi.mock('../standard-kit.js', () => ({
   checkStandardKitUpgrade: standardKitMock.checkStandardKitUpgrade,
+}));
+
+vi.mock('../registry.js', () => ({
+  getAgenticOSHome: registryMock.getAgenticOSHome,
+}));
+
+vi.mock('../repo-boundary.js', () => ({
+  resolveGuardrailProjectTarget: repoBoundaryMock.resolveGuardrailProjectTarget,
+}));
+
+vi.mock('../worktree-topology.js', () => ({
+  deriveExpectedWorktreeRoot: worktreeTopologyMock.deriveExpectedWorktreeRoot,
+  inspectProjectWorktreeTopology: worktreeTopologyMock.inspectProjectWorktreeTopology,
 }));
 
 import { runHealthCheck } from '../health.js';
@@ -33,6 +59,32 @@ async function setupProjectRoot(stateYaml: string, options?: { projectYaml?: str
 }
 
 describe('health command', () => {
+  beforeEach(() => {
+    repoBoundaryMock.resolveGuardrailProjectTarget.mockResolvedValue({
+      activeProjectId: null,
+      resolutionSource: 'repo_path_match',
+      targetProject: {
+        id: 'health-project',
+        path: '/resolved/project',
+      },
+      resolutionErrors: [],
+    });
+    worktreeTopologyMock.inspectProjectWorktreeTopology.mockResolvedValue({
+      applies: true,
+      status: 'PASS',
+      summary: 'Worktree topology matches the derived project-scoped root.',
+      expected_worktree_root: '/workspace/worktrees/health-project',
+      worktrees: [],
+      counts: {
+        canonical_main: 1,
+        project_scoped: 0,
+        misplaced_clean: 0,
+        misplaced_dirty: 0,
+      },
+      inspection_errors: [],
+    });
+  });
+
   afterEach(() => {
     vi.clearAllMocks();
   });
@@ -58,6 +110,7 @@ describe('health command', () => {
       { gate: 'entry_surface_refresh', status: 'PASS', summary: 'Entry surfaces have explicit refresh metadata.' },
       { gate: 'versioned_entry_surface_state', status: 'PASS', summary: 'Committed versioned entry surfaces look fresh for canonical mainline use.' },
       { gate: 'guardrail_evidence', status: 'PASS', summary: 'Latest guardrail evidence is present (agenticos_preflight).' },
+      { gate: 'worktree_topology', status: 'PASS', summary: 'Worktree topology matches the derived project-scoped root.' },
       { gate: 'standard_kit', status: 'PASS', summary: 'Standard-kit files match the canonical kit.' },
     ]);
     expect(result.repo_sync).toEqual({
@@ -67,6 +120,7 @@ describe('health command', () => {
       runtime_dirty_paths: [],
       source_dirty_paths: [],
     });
+    expect(result.worktree_topology?.status).toBe('PASS');
     expect(result.recovery_actions).toEqual([]);
 
     const wrapped = JSON.parse(await runHealth({
@@ -80,6 +134,20 @@ describe('health command', () => {
   it('reports branch misalignment separately from runtime drift and source edits', async () => {
     const projectRoot = await setupProjectRoot(`session:\n  id: "session-1"\n`);
     childProcessMock.exec.mockImplementation((_: string, cb: Function) => cb(null, '## main...origin/main [behind 2]\n M standards/.context/state.yaml\n M README.md\n', ''));
+    worktreeTopologyMock.inspectProjectWorktreeTopology.mockResolvedValue({
+      applies: true,
+      status: 'WARN',
+      summary: 'Worktree topology has 1 misplaced clean worktree(s).',
+      expected_worktree_root: '/workspace/worktrees/health-project',
+      worktrees: [],
+      counts: {
+        canonical_main: 1,
+        project_scoped: 0,
+        misplaced_clean: 1,
+        misplaced_dirty: 0,
+      },
+      inspection_errors: [],
+    });
 
     const result = await runHealthCheck({
       repo_path: '/repo',
@@ -108,6 +176,11 @@ describe('health command', () => {
         status: 'WARN',
         summary: 'No persisted guardrail evidence is present yet.',
       },
+      {
+        gate: 'worktree_topology',
+        status: 'WARN',
+        summary: 'Worktree topology has 1 misplaced clean worktree(s).',
+      },
     ]);
     expect(result.repo_sync).toEqual({
       branch_line: '## main...origin/main [behind 2]',
@@ -121,6 +194,7 @@ describe('health command', () => {
       'discard or isolate runtime-managed drift from the canonical checkout: standards/.context/state.yaml',
       'review, move, or revert source-tree edits before trusting the canonical checkout: README.md',
       'keep new implementation work inside isolated issue worktrees rather than the canonical main checkout',
+      'recreate misplaced clean worktrees under the derived project-scoped worktree root and remove the old paths',
     ]);
   });
 
@@ -174,6 +248,11 @@ describe('health command', () => {
       status: 'BLOCK',
       summary: 'Canonical checkout is blocked by runtime-managed drift: 2 path(s).',
     });
+    expect(result.gates[4]).toEqual({
+      gate: 'worktree_topology',
+      status: 'PASS',
+      summary: 'Worktree topology matches the derived project-scoped root.',
+    });
     expect(result.repo_sync?.runtime_dirty_paths).toEqual(['standards/.context/state.yaml', 'CLAUDE.md']);
     expect(result.repo_sync?.source_dirty_paths).toEqual([]);
   });
@@ -193,6 +272,7 @@ describe('health command', () => {
       { gate: 'entry_surface_refresh', status: 'PASS', summary: 'Entry surfaces have explicit refresh metadata.' },
       { gate: 'versioned_entry_surface_state', status: 'WARN', summary: 'Committed versioned entry surfaces look stale for canonical mainline use.' },
       { gate: 'guardrail_evidence', status: 'WARN', summary: 'No persisted guardrail evidence is present yet.' },
+      { gate: 'worktree_topology', status: 'PASS', summary: 'Worktree topology matches the derived project-scoped root.' },
     ]);
   });
 
@@ -245,6 +325,146 @@ describe('health command', () => {
     ]);
   });
 
+  it('reports BLOCK when topology inspection finds dirty misplaced worktrees', async () => {
+    const projectRoot = await setupProjectRoot(`entry_surface_refresh:\n  refreshed_at: "2026-03-25T00:00:00.000Z"\n`);
+    childProcessMock.exec.mockImplementation((_: string, cb: Function) => cb(null, '## main...origin/main\n', ''));
+    worktreeTopologyMock.inspectProjectWorktreeTopology.mockResolvedValue({
+      applies: true,
+      status: 'BLOCK',
+      summary: 'Worktree topology is blocked by 1 misplaced dirty worktree(s).',
+      expected_worktree_root: '/workspace/worktrees/health-project',
+      worktrees: [],
+      counts: {
+        canonical_main: 1,
+        project_scoped: 0,
+        misplaced_clean: 0,
+        misplaced_dirty: 1,
+      },
+      inspection_errors: [],
+    });
+
+    const result = await runHealthCheck({
+      repo_path: '/repo',
+      project_path: projectRoot,
+    });
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.gates[4]).toEqual({
+      gate: 'worktree_topology',
+      status: 'BLOCK',
+      summary: 'Worktree topology is blocked by 1 misplaced dirty worktree(s).',
+    });
+    expect(result.recovery_actions).toContain('protect dirty misplaced worktrees first, then recreate them under the derived project-scoped worktree root before removing the old paths');
+  });
+
+  it('fails topology checks when a github_versioned project is missing meta.id', async () => {
+    const projectRoot = await setupProjectRoot(`entry_surface_refresh:\n  refreshed_at: "2026-03-25T00:00:00.000Z"\n`, {
+      projectYaml: `meta:\n  name: "Health Project"\nsource_control:\n  topology: "github_versioned"\n  context_publication_policy: "public_distilled"\n  github_repo: "madlouse/health-project"\n  branch_strategy: "github_flow"\nagent_context:\n  quick_start: "standards/.context/quick-start.md"\n  current_state: "standards/.context/state.yaml"\n  conversations: "standards/.context/conversations/"\n  last_record_marker: "standards/.context/.last_record"\n`,
+    });
+    childProcessMock.exec.mockImplementation((_: string, cb: Function) => cb(null, '## main...origin/main\n', ''));
+
+    const result = await runHealthCheck({
+      repo_path: '/repo',
+      project_path: projectRoot,
+    });
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.gates[4]).toEqual({
+      gate: 'worktree_topology',
+      status: 'BLOCK',
+      summary: 'Worktree topology could not be checked because the project is missing meta.id.',
+    });
+    expect(result.recovery_actions).toContain('restore project meta.id before relying on derived project-scoped worktree-root checks');
+  });
+
+  it('uses the resolved managed project path when health runs from repo_path only', async () => {
+    const projectRoot = await setupProjectRoot(`entry_surface_refresh:\n  refreshed_at: "2026-03-25T00:00:00.000Z"\n`);
+    childProcessMock.exec.mockImplementation((command: string, cb: Function) => {
+      if (command.includes('status --short --branch')) {
+        cb(null, '## main...origin/main\n', '');
+        return;
+      }
+      if (command.includes('rev-parse --show-toplevel')) {
+        cb(null, '/workspace/worktrees/health-project/issue-1\n', '');
+        return;
+      }
+      if (command.includes('rev-parse --git-common-dir')) {
+        cb(null, '/workspace/projects/health-project/.git\n', '');
+        return;
+      }
+      if (command.includes('config --get remote.origin.url')) {
+        cb(null, 'https://github.com/madlouse/health-project.git\n', '');
+        return;
+      }
+      cb(new Error(`Unexpected command: ${command}`), '', '');
+    });
+    repoBoundaryMock.resolveGuardrailProjectTarget.mockResolvedValue({
+      activeProjectId: null,
+      resolutionSource: 'repo_path_match',
+      targetProject: {
+        id: 'health-project',
+        path: projectRoot,
+        statePath: `${projectRoot}/standards/.context/state.yaml`,
+        projectYamlPath: `${projectRoot}/.project.yaml`,
+        topology: 'github_versioned',
+        githubRepo: 'madlouse/health-project',
+        sourceRepoRoots: ['/workspace/projects/health-project'],
+        sourceRepoRootsDeclared: true,
+        expectedWorktreeRoot: '/workspace/worktrees/health-project',
+      },
+      resolutionErrors: [],
+    });
+
+    const result = await runHealthCheck({
+      repo_path: '/workspace/worktrees/health-project/issue-1',
+    });
+
+    expect(result.project_path).toBe(projectRoot);
+    expect(result.gates.some((gate) => gate.gate === 'worktree_topology')).toBe(true);
+    expect(worktreeTopologyMock.inspectProjectWorktreeTopology).toHaveBeenCalled();
+  });
+
+  it('drops the inferred managed project path when repo identity validation itself fails to execute', async () => {
+    const projectRoot = await setupProjectRoot(`entry_surface_refresh:\n  refreshed_at: "2026-03-25T00:00:00.000Z"\n`);
+    repoBoundaryMock.resolveGuardrailProjectTarget.mockResolvedValue({
+      activeProjectId: null,
+      resolutionSource: 'repo_path_match',
+      targetProject: {
+        id: 'health-project',
+        path: projectRoot,
+        statePath: `${projectRoot}/standards/.context/state.yaml`,
+        projectYamlPath: `${projectRoot}/.project.yaml`,
+        topology: 'github_versioned',
+        githubRepo: 'madlouse/health-project',
+        sourceRepoRoots: ['/workspace/projects/health-project'],
+        sourceRepoRootsDeclared: true,
+        expectedWorktreeRoot: '/workspace/worktrees/health-project',
+      },
+      resolutionErrors: [],
+    });
+    childProcessMock.exec.mockImplementation((command: string, cb: Function) => {
+      if (command.includes('status --short --branch')) {
+        cb(null, '## main...origin/main\n', '');
+        return;
+      }
+      if (command.includes('rev-parse --show-toplevel')) {
+        cb(new Error('show-toplevel failed'), '', 'show-toplevel failed');
+        return;
+      }
+      cb(new Error(`Unexpected command: ${command}`), '', '');
+    });
+
+    const result = await runHealthCheck({
+      repo_path: '/workspace/worktrees/health-project/issue-1',
+    });
+
+    expect(result.project_path).toBeNull();
+    expect(result.recovery_actions).toContain(
+      'verify git repo identity before treating repo_path as a managed project: show-toplevel failed',
+    );
+    expect(result.gates.some((gate) => gate.gate === 'worktree_topology')).toBe(false);
+  });
+
   it('fails closed on missing repo_path, git command failure fallbacks, missing branch status, and missing project_path for standard-kit checks', async () => {
     await expect(() => runHealth(undefined)).rejects.toThrow('repo_path is required.');
 
@@ -283,6 +503,11 @@ describe('health command', () => {
         status: 'WARN',
         summary: 'No persisted guardrail evidence is present yet.',
       },
+      {
+        gate: 'worktree_topology',
+        status: 'PASS',
+        summary: 'Worktree topology matches the derived project-scoped root.',
+      },
     ]);
     expect(missingBranchResult.repo_sync).toEqual({
       branch_line: '',
@@ -317,8 +542,175 @@ describe('health command', () => {
       {
         gate: 'standard_kit',
         status: 'WARN',
+        summary: 'Standard-kit drift was detected and should be reviewed before starting work.',
+      },
+    ]);
+  });
+
+  it('returns a null project_path and skips topology when repo_path cannot resolve a managed project', async () => {
+    repoBoundaryMock.resolveGuardrailProjectTarget.mockResolvedValue({
+      activeProjectId: null,
+      resolutionSource: null,
+      targetProject: null,
+      resolutionErrors: ['unmatched repo'],
+    });
+    childProcessMock.exec.mockImplementation((_: string, cb: Function) => cb(null, '## main...origin/main\n', ''));
+
+    const result = await runHealthCheck({
+      repo_path: '/repo',
+      check_standard_kit: true,
+    });
+
+    expect(result.project_path).toBeNull();
+    expect(result.status).toBe('WARN');
+    expect(result.gates).toEqual([
+      { gate: 'repo_sync', status: 'PASS', summary: 'Canonical checkout is clean and aligned with origin/main.' },
+      {
+        gate: 'entry_surface_refresh',
+        status: 'WARN',
+        summary: 'Project state could not be read, so entry-surface freshness was not proven.',
+      },
+      {
+        gate: 'guardrail_evidence',
+        status: 'WARN',
+        summary: 'Project state could not be read, so guardrail visibility was not proven.',
+      },
+      {
+        gate: 'standard_kit',
+        status: 'WARN',
         summary: 'Standard-kit drift check was requested without a project_path.',
       },
     ]);
+    expect(result.worktree_topology).toBeUndefined();
+    expect(standardKitMock.checkStandardKitUpgrade).not.toHaveBeenCalled();
+  });
+
+  it('does not trust a repo_path-only match under the derived worktree root when repo identity validation fails', async () => {
+    const projectRoot = await setupProjectRoot(`entry_surface_refresh:\n  refreshed_at: "2026-03-25T00:00:00.000Z"\n`);
+    repoBoundaryMock.resolveGuardrailProjectTarget.mockResolvedValue({
+      activeProjectId: null,
+      resolutionSource: 'repo_path_match',
+      targetProject: {
+        id: 'health-project',
+        path: projectRoot,
+        statePath: `${projectRoot}/standards/.context/state.yaml`,
+        projectYamlPath: `${projectRoot}/.project.yaml`,
+        topology: 'github_versioned',
+        githubRepo: 'madlouse/health-project',
+        sourceRepoRoots: ['/workspace/projects/health-project'],
+        sourceRepoRootsDeclared: true,
+        expectedWorktreeRoot: '/workspace/worktrees/health-project',
+      },
+      resolutionErrors: [],
+    });
+    childProcessMock.exec.mockImplementation((command: string, cb: Function) => {
+      if (command.includes('status --short --branch')) {
+        cb(null, '## main...origin/main\n', '');
+        return;
+      }
+      if (command.includes('rev-parse --show-toplevel')) {
+        cb(null, '/workspace/worktrees/health-project/issue-1\n', '');
+        return;
+      }
+      if (command.includes('rev-parse --git-common-dir')) {
+        cb(null, '/external/shared.git\n', '');
+        return;
+      }
+      if (command.includes('config --get remote.origin.url')) {
+        cb(null, 'https://github.com/madlouse/health-project.git\n', '');
+        return;
+      }
+      cb(new Error(`Unexpected command: ${command}`), '', '');
+    });
+
+    const result = await runHealthCheck({
+      repo_path: '/workspace/worktrees/health-project/issue-1',
+    });
+
+    expect(result.project_path).toBeNull();
+    expect(result.gates.some((gate) => gate.gate === 'worktree_topology')).toBe(false);
+    expect(result.recovery_actions).toContain(
+      'verify git repo identity before treating repo_path as a managed project: git worktree root "/workspace/worktrees/health-project/issue-1" is under the derived project worktree root "/workspace/worktrees/health-project", but git common repo root "/external" is not declared for target project "health-project"',
+    );
+  });
+
+  it('does not trust a session-bound github project when repo identity validation fails for the provided repo_path', async () => {
+    const projectRoot = await setupProjectRoot(`entry_surface_refresh:\n  refreshed_at: "2026-03-25T00:00:00.000Z"\n`);
+    repoBoundaryMock.resolveGuardrailProjectTarget.mockResolvedValue({
+      activeProjectId: null,
+      resolutionSource: 'session_project',
+      targetProject: {
+        id: 'health-project',
+        path: projectRoot,
+        statePath: `${projectRoot}/standards/.context/state.yaml`,
+        projectYamlPath: `${projectRoot}/.project.yaml`,
+        topology: 'github_versioned',
+        githubRepo: 'madlouse/health-project',
+        sourceRepoRoots: ['/workspace/projects/health-project'],
+        sourceRepoRootsDeclared: true,
+        expectedWorktreeRoot: '/workspace/worktrees/health-project',
+      },
+      resolutionErrors: [],
+    });
+    childProcessMock.exec.mockImplementation((command: string, cb: Function) => {
+      if (command.includes('status --short --branch')) {
+        cb(null, '## main...origin/main\n', '');
+        return;
+      }
+      if (command.includes('rev-parse --show-toplevel')) {
+        cb(null, '/workspace/other-repo\n', '');
+        return;
+      }
+      if (command.includes('rev-parse --git-common-dir')) {
+        cb(null, '/workspace/other-repo/.git\n', '');
+        return;
+      }
+      if (command.includes('config --get remote.origin.url')) {
+        cb(null, 'https://github.com/other/repo.git\n', '');
+        return;
+      }
+      cb(new Error(`Unexpected command: ${command}`), '', '');
+    });
+
+    const result = await runHealthCheck({
+      repo_path: '/workspace/other-repo',
+    });
+
+    expect(result.project_path).toBeNull();
+    expect(result.gates.some((gate) => gate.gate === 'worktree_topology')).toBe(false);
+    expect(result.recovery_actions).toContain(
+      'verify git repo identity before treating repo_path as a managed project: neither git worktree root "/workspace/other-repo" nor git common repo root "/workspace/other-repo" is declared for target project "health-project"',
+    );
+  });
+
+  it('uses topology-failure-specific recovery actions instead of dirty-worktree guidance', async () => {
+    const projectRoot = await setupProjectRoot(`entry_surface_refresh:\n  refreshed_at: "2026-03-25T00:00:00.000Z"\n`);
+    childProcessMock.exec.mockImplementation((_: string, cb: Function) => cb(null, '## main...origin/main\n', ''));
+    worktreeTopologyMock.inspectProjectWorktreeTopology.mockResolvedValue({
+      applies: true,
+      status: 'BLOCK',
+      summary: 'Worktree topology inspection failed: git worktree listing failed.',
+      expected_worktree_root: '/workspace/worktrees/health-project',
+      worktrees: [],
+      counts: {
+        canonical_main: 1,
+        project_scoped: 0,
+        misplaced_clean: 0,
+        misplaced_dirty: 0,
+      },
+      inspection_errors: ['git worktree listing failed'],
+    });
+
+    const result = await runHealthCheck({
+      repo_path: '/repo',
+      project_path: projectRoot,
+    });
+
+    expect(result.recovery_actions).toContain(
+      'inspect git worktree topology failures and restore accurate worktree visibility before trusting this checkout',
+    );
+    expect(result.recovery_actions).not.toContain(
+      'protect dirty misplaced worktrees first, then recreate them under the derived project-scoped worktree root before removing the old paths',
+    );
   });
 });

--- a/mcp-server/src/utils/__tests__/repo-boundary.test.ts
+++ b/mcp-server/src/utils/__tests__/repo-boundary.test.ts
@@ -18,9 +18,10 @@ vi.mock('yaml', () => ({
 
 vi.mock('../registry.js', () => ({
   loadRegistry: loadRegistryMock,
+  getAgenticOSHome: vi.fn(() => '/workspace'),
 }));
 
-import { resolveGuardrailProjectTarget } from '../repo-boundary.js';
+import { isImplementationAffectingTask, resolveGuardrailProjectTarget } from '../repo-boundary.js';
 import { bindSessionProject, clearSessionProjectBinding } from '../session-context.js';
 
 describe('resolveGuardrailProjectTarget', () => {
@@ -94,8 +95,85 @@ describe('resolveGuardrailProjectTarget', () => {
           },
         });
       }
+      if (path.endsWith('/epsilon/.project.yaml')) {
+        return JSON.stringify({
+          meta: {
+            id: 'epsilon',
+            name: 'Epsilon Project',
+          },
+          source_control: {
+            topology: 'github_versioned',
+            github_repo: 'madlouse/epsilon',
+            branch_strategy: 'github_flow',
+          },
+          agent_context: {
+            current_state: '.context/state.yaml',
+          },
+          execution: {
+            source_repo_roots: ['../../source/epsilon'],
+          },
+        });
+      }
+      if (path.endsWith('/theta/.project.yaml')) {
+        return JSON.stringify({
+          source_control: {
+            topology: 'github_versioned',
+            github_repo: 'madlouse/theta',
+            branch_strategy: 'github_flow',
+          },
+          execution: {
+            source_repo_roots: ['', '/workspace/source/theta', './relative', '/workspace/source/theta'],
+          },
+        });
+      }
+      if (path.endsWith('/iota/.project.yaml')) {
+        return JSON.stringify({
+          meta: {
+            id: 'iota',
+            name: 'Iota Project',
+          },
+          source_control: {
+            topology: 'local_directory_only',
+          },
+          execution: {
+            source_repo_roots: 'not-an-array',
+          },
+        });
+      }
+      if (path.endsWith('/lambda/.project.yaml') || path.endsWith('/mu/.project.yaml')) {
+        return JSON.stringify({
+          meta: {
+            id: path.includes('/lambda/') ? 'lambda' : 'mu',
+            name: path.includes('/lambda/') ? 'Lambda Project' : 'Mu Project',
+          },
+          source_control: {
+            topology: 'local_directory_only',
+          },
+          execution: {
+            source_repo_roots: ['../../source/shared'],
+          },
+        });
+      }
+      if (path.endsWith('/sigma/.project.yaml')) {
+        return JSON.stringify({
+          source_control: {
+            topology: 'local_directory_only',
+          },
+        });
+      }
+      if (path.endsWith('/phi/.project.yaml')) {
+        return 'null';
+      }
       throw new Error(`unexpected path: ${path}`);
     });
+  });
+
+  it('classifies implementation-affecting task types explicitly', () => {
+    expect(isImplementationAffectingTask('implementation')).toBe(true);
+    expect(isImplementationAffectingTask('bugfix')).toBe(true);
+    expect(isImplementationAffectingTask('discussion_only')).toBe(false);
+    expect(isImplementationAffectingTask('analysis_or_doc')).toBe(false);
+    expect(isImplementationAffectingTask('bootstrap')).toBe(false);
   });
 
   it('prefers repo_path proof over a drifted legacy registry active_project field', async () => {
@@ -129,6 +207,7 @@ describe('resolveGuardrailProjectTarget', () => {
     expect(result.activeProjectId).toBe('alpha');
     expect(result.targetProject?.id).toBe('beta');
     expect(result.targetProject?.sourceRepoRoots).toEqual(['/workspace/source/beta']);
+    expect(result.targetProject?.expectedWorktreeRoot).toBeNull();
     expect(result.resolutionSource).toBe('repo_path_match');
   });
 
@@ -202,6 +281,7 @@ describe('resolveGuardrailProjectTarget', () => {
     expect(result.activeProjectId).toBe('beta');
     expect(result.targetProject?.id).toBe('alpha');
     expect(result.targetProject?.path).toBe('/workspace/projects/alpha');
+    expect(result.targetProject?.expectedWorktreeRoot).toBeNull();
     expect(result.resolutionSource).toBe('explicit_project_path');
     expect(result.resolutionErrors).toEqual([]);
   });
@@ -348,6 +428,47 @@ describe('resolveGuardrailProjectTarget', () => {
     expect(result.resolutionErrors[0]).toContain('No project_path, repo_path proof, or session binding is available');
   });
 
+  it('derives an expected worktree root for github_versioned projects and matches repo_path under that derived root', async () => {
+    loadRegistryMock.mockResolvedValue({
+      active_project: null,
+      projects: [
+        {
+          id: 'epsilon',
+          name: 'Epsilon Project',
+          path: '/workspace/projects/epsilon',
+          status: 'active',
+          created: '2026-04-06',
+          last_accessed: '2026-04-06T00:00:00.000Z',
+        },
+      ],
+    });
+
+    const result = await resolveGuardrailProjectTarget({
+      commandName: 'agenticos_preflight',
+      repoPath: '/workspace/worktrees/epsilon/epsilon-297-scope',
+    });
+
+    expect(result.targetProject?.id).toBe('epsilon');
+    expect(result.targetProject?.expectedWorktreeRoot).toBe('/workspace/worktrees/epsilon');
+    expect(result.resolutionSource).toBe('repo_path_match');
+  });
+
+  it('returns a resolvable-project error when explicit project_path has no project metadata', async () => {
+    loadRegistryMock.mockResolvedValue({
+      active_project: null,
+      projects: [],
+    });
+    accessMock.mockRejectedValueOnce(new Error('missing'));
+
+    const result = await resolveGuardrailProjectTarget({
+      commandName: 'agenticos_preflight',
+      projectPath: '/workspace/projects/missing',
+    });
+
+    expect(result.targetProject).toBeNull();
+    expect(result.resolutionErrors[0]).toContain('project_path is not a resolvable managed project');
+  });
+
   it('ignores a populated legacy registry active_project field even when its metadata exists', async () => {
     loadRegistryMock.mockResolvedValue({
       active_project: 'alpha',
@@ -369,5 +490,340 @@ describe('resolveGuardrailProjectTarget', () => {
     expect(result.targetProject).toBeNull();
     expect(result.resolutionErrors[0]).toContain('No project_path, repo_path proof, or session binding is available');
     expect(result.resolutionSource).toBeNull();
+  });
+
+  it('returns a session-project error when the bound session project is missing in the registry', async () => {
+    bindSessionProject({
+      projectId: 'missing-project',
+      projectName: 'Missing Project',
+      projectPath: '/workspace/projects/missing-project',
+    });
+    loadRegistryMock.mockResolvedValue({
+      active_project: null,
+      projects: [],
+    });
+
+    const result = await resolveGuardrailProjectTarget({
+      commandName: 'agenticos_preflight',
+    });
+
+    expect(result.targetProject).toBeNull();
+    expect(result.resolutionErrors[0]).toContain('Session project "missing-project" not found in registry.');
+  });
+
+  it('returns an unmatched-repo error when repo_path cannot be proven and no session project is bound', async () => {
+    loadRegistryMock.mockResolvedValue({
+      active_project: null,
+      projects: [],
+    });
+
+    const result = await resolveGuardrailProjectTarget({
+      commandName: 'agenticos_preflight',
+      repoPath: '/workspace/unmatched/repo',
+    });
+
+    expect(result.targetProject).toBeNull();
+    expect(result.resolutionErrors[0]).toContain('target project could not be resolved from repo_path or session binding');
+  });
+
+  it('uses registry fallback id/name and normalizes declared repo roots for session-bound github projects', async () => {
+    bindSessionProject({
+      projectId: 'theta',
+      projectName: 'Theta Project',
+      projectPath: '/workspace/projects/theta',
+    });
+    loadRegistryMock.mockResolvedValue({
+      active_project: null,
+      projects: [
+        {
+          id: 'theta',
+          name: 'Theta Project',
+          path: '/workspace/projects/theta',
+          status: 'active',
+          created: '2026-04-06',
+          last_accessed: '2026-04-06T00:00:00.000Z',
+        },
+      ],
+    });
+
+    const result = await resolveGuardrailProjectTarget({
+      commandName: 'agenticos_preflight',
+      repoPath: '/workspace/unmatched/repo',
+    });
+
+    expect(result.targetProject?.id).toBe('theta');
+    expect(result.targetProject?.name).toBe('Theta Project');
+    expect(result.targetProject?.statePath).toBe('/workspace/projects/theta/.context/state.yaml');
+    expect(result.targetProject?.sourceRepoRoots).toEqual([
+      '/workspace/source/theta',
+      '/workspace/projects/theta/relative',
+    ]);
+    expect(result.targetProject?.sourceRepoRootsDeclared).toBe(true);
+    expect(result.targetProject?.expectedWorktreeRoot).toBe('/workspace/worktrees/theta');
+  });
+
+  it('marks source repo roots as undeclared when execution.source_repo_roots is not an array', async () => {
+    loadRegistryMock.mockResolvedValue({
+      active_project: null,
+      projects: [],
+    });
+
+    const result = await resolveGuardrailProjectTarget({
+      commandName: 'agenticos_preflight',
+      projectPath: '/workspace/projects/iota',
+    });
+
+    expect(result.targetProject?.id).toBe('iota');
+    expect(result.targetProject?.sourceRepoRoots).toEqual([]);
+    expect(result.targetProject?.sourceRepoRootsDeclared).toBe(false);
+  });
+
+  it('falls back to basename-derived project metadata when the parsed project yaml is null', async () => {
+    loadRegistryMock.mockResolvedValue({
+      active_project: null,
+      projects: [],
+    });
+
+    const result = await resolveGuardrailProjectTarget({
+      commandName: 'agenticos_preflight',
+      projectPath: '/workspace/projects/sigma',
+    });
+
+    expect(result.targetProject?.id).toBe('sigma');
+    expect(result.targetProject?.name).toBe('sigma');
+    expect(result.targetProject?.path).toBe('/workspace/projects/sigma');
+  });
+
+  it('fails closed when project yaml parses to a non-object value', async () => {
+    loadRegistryMock.mockResolvedValue({
+      active_project: null,
+      projects: [],
+    });
+
+    const result = await resolveGuardrailProjectTarget({
+      commandName: 'agenticos_preflight',
+      projectPath: '/workspace/projects/phi',
+    });
+
+    expect(result.targetProject).toBeNull();
+    expect(result.resolutionErrors[0]).toContain('did not parse to a project object');
+  });
+
+  it('fails closed when repo_path matches multiple managed projects with equally strong proof', async () => {
+    loadRegistryMock.mockResolvedValue({
+      active_project: null,
+      projects: [
+        {
+          id: 'lambda',
+          name: 'Lambda Project',
+          path: '/workspace/projects/lambda',
+          status: 'active',
+          created: '2026-04-06',
+          last_accessed: '2026-04-06T00:00:00.000Z',
+        },
+        {
+          id: 'mu',
+          name: 'Mu Project',
+          path: '/workspace/projects/mu',
+          status: 'active',
+          created: '2026-04-06',
+          last_accessed: '2026-04-06T00:00:00.000Z',
+        },
+      ],
+    });
+
+    const result = await resolveGuardrailProjectTarget({
+      commandName: 'agenticos_preflight',
+      repoPath: '/workspace/source/shared/worktrees/issue-1',
+    });
+
+    expect(result.targetProject).toBeNull();
+    expect(result.resolutionErrors[0]).toContain('matches multiple managed projects');
+  });
+
+  it('returns the underlying repo-path resolution error when project metadata loading throws', async () => {
+    loadRegistryMock.mockResolvedValue({
+      active_project: null,
+      projects: [
+        {
+          id: 'nu',
+          name: 'Nu Project',
+          path: '/workspace/projects/nu',
+          status: 'active',
+          created: '2026-04-06',
+          last_accessed: '2026-04-06T00:00:00.000Z',
+        },
+      ],
+    });
+    readFileMock.mockImplementation(async (path: string) => {
+      if (path.endsWith('/nu/.project.yaml')) {
+        throw new Error('nu read failed');
+      }
+      throw new Error(`unexpected path: ${path}`);
+    });
+
+    const result = await resolveGuardrailProjectTarget({
+      commandName: 'agenticos_preflight',
+      repoPath: '/workspace/projects/nu/worktrees/issue-1',
+    });
+
+    expect(result.targetProject).toBeNull();
+    expect(result.resolutionErrors[0]).toContain('nu read failed');
+  });
+
+  it('uses the generic repo-path error when repo-path resolution throws a non-Error value', async () => {
+    loadRegistryMock.mockResolvedValue({
+      active_project: null,
+      projects: [
+        {
+          id: 'chi',
+          name: 'Chi Project',
+          path: '/workspace/projects/chi',
+          status: 'active',
+          created: '2026-04-06',
+          last_accessed: '2026-04-06T00:00:00.000Z',
+        },
+      ],
+    });
+    readFileMock.mockImplementation(async (path: string) => {
+      if (path.endsWith('/chi/.project.yaml')) {
+        throw 'plain repo-path failure';
+      }
+      throw new Error(`unexpected path: ${path}`);
+    });
+
+    const result = await resolveGuardrailProjectTarget({
+      commandName: 'agenticos_preflight',
+      repoPath: '/workspace/projects/chi/worktrees/issue-1',
+    });
+
+    expect(result.targetProject).toBeNull();
+    expect(result.resolutionErrors[0]).toBe('failed to resolve repo_path: /workspace/projects/chi/worktrees/issue-1');
+  });
+
+  it('uses the generic explicit-project error when project-path resolution throws a non-Error value', async () => {
+    loadRegistryMock.mockResolvedValue({
+      active_project: null,
+      projects: [],
+    });
+    readFileMock.mockImplementation(async (path: string) => {
+      if (path.endsWith('/tau/.project.yaml')) {
+        throw 'plain project failure';
+      }
+      throw new Error(`unexpected path: ${path}`);
+    });
+
+    const result = await resolveGuardrailProjectTarget({
+      commandName: 'agenticos_preflight',
+      projectPath: '/workspace/projects/tau',
+    });
+
+    expect(result.targetProject).toBeNull();
+    expect(result.resolutionErrors[0]).toBe('failed to resolve project_path: /workspace/projects/tau');
+  });
+
+  it('returns a session-project error when the bound session project has no readable project metadata', async () => {
+    bindSessionProject({
+      projectId: 'omega',
+      projectName: 'Omega Project',
+      projectPath: '/workspace/projects/omega',
+    });
+    loadRegistryMock.mockResolvedValue({
+      active_project: null,
+      projects: [
+        {
+          id: 'omega',
+          name: 'Omega Project',
+          path: '/workspace/projects/omega',
+          status: 'active',
+          created: '2026-04-06',
+          last_accessed: '2026-04-06T00:00:00.000Z',
+        },
+      ],
+    });
+    accessMock.mockImplementation(async (path: string) => {
+      if (path.endsWith('/omega/.project.yaml')) {
+        throw new Error('missing omega project yaml');
+      }
+      return undefined;
+    });
+
+    const result = await resolveGuardrailProjectTarget({
+      commandName: 'agenticos_preflight',
+      repoPath: '/workspace/unmatched/repo',
+    });
+
+    expect(result.targetProject).toBeNull();
+    expect(result.resolutionErrors[0]).toContain('session project "omega" is missing a readable .project.yaml');
+  });
+
+  it('uses the generic session-project error when session resolution throws a non-Error value', async () => {
+    bindSessionProject({
+      projectId: 'upsilon',
+      projectName: 'Upsilon Project',
+      projectPath: '/workspace/projects/upsilon',
+    });
+    loadRegistryMock.mockResolvedValue({
+      active_project: null,
+      projects: [
+        {
+          id: 'upsilon',
+          name: 'Upsilon Project',
+          path: '/workspace/projects/upsilon',
+          status: 'active',
+          created: '2026-04-06',
+          last_accessed: '2026-04-06T00:00:00.000Z',
+        },
+      ],
+    });
+    readFileMock.mockImplementation(async (path: string) => {
+      if (path.endsWith('/upsilon/.project.yaml')) {
+        throw 'plain session failure';
+      }
+      throw new Error(`unexpected path: ${path}`);
+    });
+
+    const result = await resolveGuardrailProjectTarget({
+      commandName: 'agenticos_preflight',
+    });
+
+    expect(result.targetProject).toBeNull();
+    expect(result.resolutionErrors[0]).toBe('failed to resolve session project');
+  });
+
+  it('returns an ambiguity error when the session binding matches multiple registry entries', async () => {
+    bindSessionProject({
+      projectId: 'dupe',
+      projectName: 'Dupe Project',
+      projectPath: '/workspace/projects/dupe',
+    });
+    loadRegistryMock.mockResolvedValue({
+      active_project: null,
+      projects: [
+        {
+          id: 'dupe',
+          name: 'Dupe Project',
+          path: '/workspace/projects/dupe',
+          status: 'active',
+          created: '2026-04-06',
+          last_accessed: '2026-04-06T00:00:00.000Z',
+        },
+        {
+          id: 'dupe',
+          name: 'Dupe Project Copy',
+          path: '/workspace/projects/dupe-copy',
+          status: 'active',
+          created: '2026-04-06',
+          last_accessed: '2026-04-06T00:00:00.000Z',
+        },
+      ],
+    });
+
+    const result = await resolveGuardrailProjectTarget({
+      commandName: 'agenticos_preflight',
+    });
+
+    expect(result.targetProject).toBeNull();
+    expect(result.resolutionErrors[0]).toContain('is ambiguous in registry');
   });
 });

--- a/mcp-server/src/utils/__tests__/repo-boundary.test.ts
+++ b/mcp-server/src/utils/__tests__/repo-boundary.test.ts
@@ -559,7 +559,7 @@ describe('resolveGuardrailProjectTarget', () => {
       '/workspace/projects/theta/relative',
     ]);
     expect(result.targetProject?.sourceRepoRootsDeclared).toBe(true);
-    expect(result.targetProject?.expectedWorktreeRoot).toBe('/workspace/worktrees/theta');
+    expect(result.targetProject?.expectedWorktreeRoot).toBeNull();
   });
 
   it('marks source repo roots as undeclared when execution.source_repo_roots is not an array', async () => {

--- a/mcp-server/src/utils/__tests__/worktree-topology.test.ts
+++ b/mcp-server/src/utils/__tests__/worktree-topology.test.ts
@@ -1,0 +1,320 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const execAsyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock('child_process', () => ({
+  exec: vi.fn(),
+}));
+
+vi.mock('util', () => ({
+  promisify: vi.fn(() => execAsyncMock),
+}));
+
+import {
+  deriveExpectedWorktreeRoot,
+  inspectProjectWorktreeTopology,
+  isPathWithinRoot,
+  resolveProjectWorktreeRoot,
+} from '../worktree-topology.js';
+
+describe('worktree-topology utilities', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('derives the expected project-scoped worktree root', () => {
+    expect(deriveExpectedWorktreeRoot('/workspace', 'agenticos')).toBe('/workspace/worktrees/agenticos');
+  });
+
+  it('accepts a missing override and returns the derived root', () => {
+    expect(resolveProjectWorktreeRoot({
+      agenticosHome: '/workspace',
+      projectId: 'agenticos',
+    })).toEqual({
+      requestedWorktreeRoot: null,
+      expectedWorktreeRoot: '/workspace/worktrees/agenticos',
+      effectiveWorktreeRoot: '/workspace/worktrees/agenticos',
+      deprecatedOverrideUsed: false,
+      mismatchReason: null,
+    });
+  });
+
+  it('accepts a deprecated override when it normalizes to the derived root', () => {
+    expect(resolveProjectWorktreeRoot({
+      agenticosHome: '/workspace',
+      projectId: 'agenticos',
+      requestedWorktreeRoot: '/workspace/worktrees/agenticos/../agenticos/',
+    })).toEqual({
+      requestedWorktreeRoot: '/workspace/worktrees/agenticos',
+      expectedWorktreeRoot: '/workspace/worktrees/agenticos',
+      effectiveWorktreeRoot: '/workspace/worktrees/agenticos',
+      deprecatedOverrideUsed: true,
+      mismatchReason: null,
+    });
+  });
+
+  it('rejects a deprecated override when it points at a different root', () => {
+    const result = resolveProjectWorktreeRoot({
+      agenticosHome: '/workspace',
+      projectId: 'agenticos',
+      requestedWorktreeRoot: '/tmp/shared',
+    });
+
+    expect(result.mismatchReason).toContain('/tmp/shared');
+    expect(result.expectedWorktreeRoot).toBe('/workspace/worktrees/agenticos');
+  });
+
+  it('checks whether a path is within a root after normalization', () => {
+    expect(isPathWithinRoot('/workspace/worktrees/agenticos/issue-1', '/workspace/worktrees/agenticos')).toBe(true);
+    expect(isPathWithinRoot('/workspace/worktrees/agenticos/../agenticos/issue-1', '/workspace/worktrees/agenticos')).toBe(true);
+    expect(isPathWithinRoot('/workspace/worktrees/other/issue-1', '/workspace/worktrees/agenticos')).toBe(false);
+  });
+});
+
+describe('inspectProjectWorktreeTopology', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('classifies canonical, project-scoped, misplaced clean, and misplaced dirty worktrees', async () => {
+    execAsyncMock.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('worktree list --porcelain')) {
+        return {
+          stdout: [
+            'worktree /workspace/projects/agenticos',
+            'branch refs/heads/main',
+            '',
+            'worktree /workspace/worktrees/agenticos/agenticos-297-scope',
+            'branch refs/heads/fix/297-scope',
+            '',
+            'worktree /workspace/shared/agenticos-13-clean',
+            'branch refs/heads/fix/13-clean',
+            '',
+            'worktree /workspace/shared/agenticos-14-dirty',
+            'branch refs/heads/fix/14-dirty',
+            '',
+          ].join('\n'),
+          stderr: '',
+        };
+      }
+      if (cmd.includes('/workspace/projects/agenticos') && cmd.includes('status --porcelain')) {
+        return { stdout: '', stderr: '' };
+      }
+      if (cmd.includes('/workspace/projects/agenticos') && cmd.includes('rev-parse --abbrev-ref --symbolic-full-name @{upstream}')) {
+        return { stdout: 'origin/main\n', stderr: '' };
+      }
+      if (cmd.includes('/workspace/worktrees/agenticos/agenticos-297-scope') && cmd.includes('status --porcelain')) {
+        return { stdout: '', stderr: '' };
+      }
+      if (cmd.includes('/workspace/worktrees/agenticos/agenticos-297-scope') && cmd.includes('rev-parse --abbrev-ref --symbolic-full-name @{upstream}')) {
+        return { stdout: 'origin/fix/297-scope\n', stderr: '' };
+      }
+      if (cmd.includes('/workspace/shared/agenticos-13-clean') && cmd.includes('status --porcelain')) {
+        return { stdout: '', stderr: '' };
+      }
+      if (cmd.includes('/workspace/shared/agenticos-13-clean') && cmd.includes('rev-parse --abbrev-ref --symbolic-full-name @{upstream}')) {
+        return { stdout: 'origin/fix/13-clean\n', stderr: '' };
+      }
+      if (cmd.includes('/workspace/shared/agenticos-14-dirty') && cmd.includes('status --porcelain')) {
+        return { stdout: ' M README.md\n', stderr: '' };
+      }
+      if (cmd.includes('/workspace/shared/agenticos-14-dirty') && cmd.includes('rev-parse --abbrev-ref --symbolic-full-name @{upstream}')) {
+        return { stdout: '', stderr: '' };
+      }
+      throw new Error(`Unexpected command: ${cmd}`);
+    });
+
+    const result = await inspectProjectWorktreeTopology({
+      repoPath: '/workspace/projects/agenticos',
+      canonicalProjectPath: '/workspace/projects/agenticos',
+      expectedWorktreeRoot: '/workspace/worktrees/agenticos',
+    });
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.counts).toEqual({
+      canonical_main: 1,
+      project_scoped: 1,
+      misplaced_clean: 1,
+      misplaced_dirty: 1,
+    });
+    expect(result.worktrees.find((entry) => entry.path === '/workspace/projects/agenticos')?.placement).toBe('canonical_main');
+    expect(result.worktrees.find((entry) => entry.path === '/workspace/worktrees/agenticos/agenticos-297-scope')?.placement).toBe('project_scoped');
+    expect(result.worktrees.find((entry) => entry.path === '/workspace/shared/agenticos-13-clean')?.suggested_action).toContain('recreate under the expected worktree root');
+    expect(result.worktrees.find((entry) => entry.path === '/workspace/shared/agenticos-14-dirty')?.suggested_action).toContain('stash or commit changes');
+  });
+
+  it('returns WARN when only misplaced clean worktrees exist', async () => {
+    execAsyncMock.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('worktree list --porcelain')) {
+        return {
+          stdout: [
+            'worktree /workspace/projects/agenticos',
+            'branch refs/heads/main',
+            '',
+            'worktree /workspace/shared/agenticos-13-clean',
+            'branch refs/heads/fix/13-clean',
+            '',
+          ].join('\n'),
+          stderr: '',
+        };
+      }
+      if (cmd.includes('status --porcelain')) {
+        return { stdout: '', stderr: '' };
+      }
+      if (cmd.includes('rev-parse --abbrev-ref --symbolic-full-name @{upstream}')) {
+        return { stdout: '', stderr: '' };
+      }
+      throw new Error(`Unexpected command: ${cmd}`);
+    });
+
+    const result = await inspectProjectWorktreeTopology({
+      repoPath: '/workspace/projects/agenticos',
+      canonicalProjectPath: '/workspace/projects/agenticos',
+      expectedWorktreeRoot: '/workspace/worktrees/agenticos',
+    });
+
+    expect(result.status).toBe('WARN');
+    expect(result.counts.misplaced_clean).toBe(1);
+    expect(result.counts.misplaced_dirty).toBe(0);
+  });
+
+  it('returns PASS when all non-canonical worktrees are under the derived project-scoped root', async () => {
+    execAsyncMock.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('worktree list --porcelain')) {
+        return {
+          stdout: [
+            'worktree /workspace/projects/agenticos',
+            'branch refs/heads/main',
+            '',
+            'worktree /workspace/worktrees/agenticos/agenticos-297-scope',
+            'branch refs/heads/fix/297-scope',
+            '',
+          ].join('\n'),
+          stderr: '',
+        };
+      }
+      if (cmd.includes('status --porcelain')) {
+        return { stdout: '', stderr: '' };
+      }
+      if (cmd.includes('rev-parse --abbrev-ref --symbolic-full-name @{upstream}')) {
+        return { stdout: 'origin/main\n', stderr: '' };
+      }
+      throw new Error(`Unexpected command: ${cmd}`);
+    });
+
+    const result = await inspectProjectWorktreeTopology({
+      repoPath: '/workspace/projects/agenticos',
+      canonicalProjectPath: '/workspace/projects/agenticos',
+      expectedWorktreeRoot: '/workspace/worktrees/agenticos',
+    });
+
+    expect(result.status).toBe('PASS');
+    expect(result.summary).toBe('Worktree topology matches the derived project-scoped root.');
+    expect(result.counts).toEqual({
+      canonical_main: 1,
+      project_scoped: 1,
+      misplaced_clean: 0,
+      misplaced_dirty: 0,
+    });
+  });
+
+  it('returns BLOCK when inspection fails', async () => {
+    execAsyncMock.mockRejectedValue(new Error('git failed'));
+
+    const result = await inspectProjectWorktreeTopology({
+      repoPath: '/workspace/projects/agenticos',
+      canonicalProjectPath: '/workspace/projects/agenticos',
+      expectedWorktreeRoot: '/workspace/worktrees/agenticos',
+    });
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.inspection_errors[0]).toContain('git failed');
+  });
+
+  it('falls back to a generic inspection-listing error when git worktree listing throws a non-Error value', async () => {
+    execAsyncMock.mockRejectedValue('plain failure');
+
+    const result = await inspectProjectWorktreeTopology({
+      repoPath: '/workspace/projects/agenticos',
+      canonicalProjectPath: '/workspace/projects/agenticos',
+      expectedWorktreeRoot: '/workspace/worktrees/agenticos',
+    });
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.inspection_errors[0]).toContain('failed to list git worktrees');
+  });
+
+  it('marks a misplaced worktree dirty when per-worktree inspection fails', async () => {
+    execAsyncMock.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('worktree list --porcelain')) {
+        return {
+          stdout: [
+            'worktree /workspace/shared/agenticos-14-dirty',
+            'branch refs/heads/fix/14-dirty',
+            '',
+          ].join('\n'),
+          stderr: '',
+        };
+      }
+      if (cmd.includes('/workspace/shared/agenticos-14-dirty') && cmd.includes('rev-parse --abbrev-ref --symbolic-full-name @{upstream}')) {
+        throw new Error('no upstream');
+      }
+      if (cmd.includes('/workspace/shared/agenticos-14-dirty') && cmd.includes('status --porcelain')) {
+        throw new Error('status failed');
+      }
+      throw new Error(`Unexpected command: ${cmd}`);
+    });
+
+    const result = await inspectProjectWorktreeTopology({
+      repoPath: '/workspace/projects/agenticos',
+      canonicalProjectPath: '/workspace/projects/agenticos',
+      expectedWorktreeRoot: '/workspace/worktrees/agenticos',
+    });
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.counts.misplaced_dirty).toBe(1);
+    expect(result.inspection_errors[0]).toContain('status failed');
+  });
+
+  it('falls back to a generic per-worktree inspection error when a non-Error value is thrown', async () => {
+    execAsyncMock.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('worktree list --porcelain')) {
+        return {
+          stdout: [
+            'worktree /workspace/shared/agenticos-14-dirty',
+            'branch refs/heads/fix/14-dirty',
+            '',
+          ].join('\n'),
+          stderr: '',
+        };
+      }
+      if (cmd.includes('/workspace/shared/agenticos-14-dirty') && cmd.includes('rev-parse --abbrev-ref --symbolic-full-name @{upstream}')) {
+        return { stdout: '', stderr: '' };
+      }
+      if (cmd.includes('/workspace/shared/agenticos-14-dirty') && cmd.includes('status --porcelain')) {
+        throw 'plain status failure';
+      }
+      throw new Error(`Unexpected command: ${cmd}`);
+    });
+
+    const result = await inspectProjectWorktreeTopology({
+      repoPath: '/workspace/projects/agenticos',
+      canonicalProjectPath: '/workspace/projects/agenticos',
+      expectedWorktreeRoot: '/workspace/worktrees/agenticos',
+    });
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.inspection_errors[0]).toContain('failed to inspect worktree /workspace/shared/agenticos-14-dirty');
+  });
+
+  it('returns a non-applicable result when no expected worktree root is available', async () => {
+    const result = await inspectProjectWorktreeTopology({
+      repoPath: '/workspace/projects/local-only',
+      canonicalProjectPath: '/workspace/projects/local-only',
+      expectedWorktreeRoot: null,
+    });
+
+    expect(result.applies).toBe(false);
+    expect(result.status).toBe('PASS');
+  });
+});

--- a/mcp-server/src/utils/__tests__/worktree-topology.test.ts
+++ b/mcp-server/src/utils/__tests__/worktree-topology.test.ts
@@ -78,6 +78,9 @@ describe('inspectProjectWorktreeTopology', () => {
 
   it('classifies canonical, project-scoped, misplaced clean, and misplaced dirty worktrees', async () => {
     execAsyncMock.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('rev-parse --show-toplevel')) {
+        return { stdout: '/workspace/projects/agenticos\n', stderr: '' };
+      }
       if (cmd.includes('worktree list --porcelain')) {
         return {
           stdout: [
@@ -145,6 +148,9 @@ describe('inspectProjectWorktreeTopology', () => {
 
   it('returns WARN when only misplaced clean worktrees exist', async () => {
     execAsyncMock.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('rev-parse --show-toplevel')) {
+        return { stdout: '/workspace/projects/agenticos\n', stderr: '' };
+      }
       if (cmd.includes('worktree list --porcelain')) {
         return {
           stdout: [
@@ -180,6 +186,9 @@ describe('inspectProjectWorktreeTopology', () => {
 
   it('returns PASS when all non-canonical worktrees are under the derived project-scoped root', async () => {
     execAsyncMock.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('rev-parse --show-toplevel')) {
+        return { stdout: '/workspace/projects/agenticos\n', stderr: '' };
+      }
       if (cmd.includes('worktree list --porcelain')) {
         return {
           stdout: [
@@ -246,6 +255,9 @@ describe('inspectProjectWorktreeTopology', () => {
 
   it('marks a misplaced worktree dirty when per-worktree inspection fails', async () => {
     execAsyncMock.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('rev-parse --show-toplevel')) {
+        return { stdout: '/workspace/projects/agenticos\n', stderr: '' };
+      }
       if (cmd.includes('worktree list --porcelain')) {
         return {
           stdout: [
@@ -278,6 +290,9 @@ describe('inspectProjectWorktreeTopology', () => {
 
   it('falls back to a generic per-worktree inspection error when a non-Error value is thrown', async () => {
     execAsyncMock.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('rev-parse --show-toplevel')) {
+        return { stdout: '/workspace/projects/agenticos\n', stderr: '' };
+      }
       if (cmd.includes('worktree list --porcelain')) {
         return {
           stdout: [
@@ -316,5 +331,42 @@ describe('inspectProjectWorktreeTopology', () => {
 
     expect(result.applies).toBe(false);
     expect(result.status).toBe('PASS');
+  });
+
+  it('treats the actual git worktree root as canonical when repoPath is inside a larger checkout', async () => {
+    execAsyncMock.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('rev-parse --show-toplevel')) {
+        return { stdout: '/workspace/checkout\n', stderr: '' };
+      }
+      if (cmd.includes('worktree list --porcelain')) {
+        return {
+          stdout: [
+            'worktree /workspace/checkout',
+            'branch refs/heads/main',
+            '',
+            'worktree /workspace/worktrees/agenticos/agenticos-297-scope',
+            'branch refs/heads/fix/297-scope',
+            '',
+          ].join('\n'),
+          stderr: '',
+        };
+      }
+      if (cmd.includes('status --porcelain')) {
+        return { stdout: '', stderr: '' };
+      }
+      if (cmd.includes('rev-parse --abbrev-ref --symbolic-full-name @{upstream}')) {
+        return { stdout: 'origin/main\n', stderr: '' };
+      }
+      throw new Error(`Unexpected command: ${cmd}`);
+    });
+
+    const result = await inspectProjectWorktreeTopology({
+      repoPath: '/workspace/checkout/projects/agenticos',
+      canonicalProjectPath: '/workspace/checkout/projects/agenticos',
+      expectedWorktreeRoot: '/workspace/worktrees/agenticos',
+    });
+
+    expect(result.status).toBe('PASS');
+    expect(result.worktrees.find((entry) => entry.path === '/workspace/checkout')?.placement).toBe('canonical_main');
   });
 });

--- a/mcp-server/src/utils/guardrail-repo-identity.ts
+++ b/mcp-server/src/utils/guardrail-repo-identity.ts
@@ -6,6 +6,7 @@ interface ValidateGuardrailRepoIdentityArgs {
   declaredGithubRepo?: string | null;
   declaredSourceRepoRoots: string[];
   sourceRepoRootsDeclared: boolean;
+  expectedWorktreeRoot?: string | null;
   gitWorktreeRoot: string;
   gitCommonRepoRoot: string;
   gitRemoteOrigin?: string | null;
@@ -63,6 +64,7 @@ export function validateGuardrailRepoIdentity(args: ValidateGuardrailRepoIdentit
     declaredGithubRepo,
     declaredSourceRepoRoots,
     sourceRepoRootsDeclared,
+    expectedWorktreeRoot,
     gitWorktreeRoot,
     gitCommonRepoRoot,
     gitRemoteOrigin,
@@ -78,7 +80,11 @@ export function validateGuardrailRepoIdentity(args: ValidateGuardrailRepoIdentit
   }
 
   const normalizedDeclaredRoots = declaredSourceRepoRoots.map((root) => normalizePath(root));
-  const worktreeMatch = normalizedDeclaredRoots.find((root) => pathIsWithinDeclaredRoot(gitWorktreeRoot, root));
+  const implicitWorktreeRoot = expectedWorktreeRoot ? normalizePath(expectedWorktreeRoot) : null;
+  const declaredWorktreeMatch = normalizedDeclaredRoots.find((root) => pathIsWithinDeclaredRoot(gitWorktreeRoot, root));
+  const implicitWorktreeMatch = implicitWorktreeRoot && pathIsWithinDeclaredRoot(gitWorktreeRoot, implicitWorktreeRoot)
+    ? implicitWorktreeRoot
+    : undefined;
   const commonRepoMatch = normalizedDeclaredRoots.find((root) => pathIsWithinDeclaredRoot(gitCommonRepoRoot, root));
   if (commonRepoMatch) {
     if (declaredGithubRepo) {
@@ -101,7 +107,7 @@ export function validateGuardrailRepoIdentity(args: ValidateGuardrailRepoIdentit
     };
   }
 
-  if (worktreeMatch && declaredGithubRepo) {
+  if (declaredWorktreeMatch && declaredGithubRepo) {
     const expectedRepo = normalizeGitHubRepo(declaredGithubRepo);
     const actualRepo = extractGitHubRepoFromRemoteOrigin(gitRemoteOrigin || '');
     if (actualRepo !== expectedRepo) {
@@ -114,12 +120,21 @@ export function validateGuardrailRepoIdentity(args: ValidateGuardrailRepoIdentit
     }
   }
 
-  if (worktreeMatch) {
+  if (declaredWorktreeMatch) {
     return {
       ok: true,
       matchedBy: 'git_worktree_root',
-      matchedDeclaredRoot: worktreeMatch,
+      matchedDeclaredRoot: declaredWorktreeMatch,
       message: null,
+    };
+  }
+
+  if (implicitWorktreeMatch) {
+    return {
+      ok: false,
+      matchedBy: null,
+      matchedDeclaredRoot: null,
+      message: `git worktree root "${gitWorktreeRoot}" is under the derived project worktree root "${implicitWorktreeMatch}", but git common repo root "${gitCommonRepoRoot}" is not declared for target project "${projectId}"`,
     };
   }
 

--- a/mcp-server/src/utils/health.ts
+++ b/mcp-server/src/utils/health.ts
@@ -1,11 +1,15 @@
 import { exec } from 'child_process';
 import { readFile } from 'fs/promises';
-import { join } from 'path';
+import { dirname, join, resolve } from 'path';
 import yaml from 'yaml';
 import { checkStandardKitUpgrade } from './standard-kit.js';
 import { analyzeCanonicalRepoSync, type CanonicalRepoSyncDetails } from './canonical-checkout-sync.js';
 import { resolveManagedProjectContextDisplayPaths, resolveManagedProjectContextPaths } from './agent-context-paths.js';
+import { resolveGuardrailProjectTarget, type GuardrailProjectTarget } from './repo-boundary.js';
+import { validateGuardrailRepoIdentity } from './guardrail-repo-identity.js';
 import { assessVersionedEntrySurfaceState } from './versioned-entry-surface-state.js';
+import { getAgenticOSHome } from './registry.js';
+import { deriveExpectedWorktreeRoot, inspectProjectWorktreeTopology, type WorktreeTopologyInspection } from './worktree-topology.js';
 
 export interface HealthArgs {
   repo_path: string;
@@ -16,7 +20,7 @@ export interface HealthArgs {
 }
 
 export interface HealthGate {
-  gate: 'repo_sync' | 'entry_surface_refresh' | 'versioned_entry_surface_state' | 'guardrail_evidence' | 'standard_kit';
+  gate: 'repo_sync' | 'entry_surface_refresh' | 'versioned_entry_surface_state' | 'guardrail_evidence' | 'worktree_topology' | 'standard_kit';
   status: 'PASS' | 'WARN' | 'BLOCK';
   summary: string;
 }
@@ -31,6 +35,7 @@ export interface HealthResult {
   checked_at: string;
   gates: HealthGate[];
   repo_sync?: CanonicalRepoSyncDetails;
+  worktree_topology?: WorktreeTopologyInspection;
   recovery_actions?: string[];
 }
 
@@ -141,6 +146,51 @@ function buildGuardrailGate(state: any | null): HealthGate {
   };
 }
 
+async function buildWorktreeTopologyGate(args: HealthArgs, projectYaml: any | null): Promise<{ gate: HealthGate; topology: WorktreeTopologyInspection } | null> {
+  if (!args.project_path) return null;
+  if (projectYaml?.source_control?.topology !== 'github_versioned') return null;
+
+  const projectId = String(projectYaml?.meta?.id || '').trim();
+  if (!projectId) {
+    return {
+      gate: {
+        gate: 'worktree_topology',
+        status: 'BLOCK',
+        summary: 'Worktree topology could not be checked because the project is missing meta.id.',
+      },
+      topology: {
+        applies: true,
+        status: 'BLOCK',
+        summary: 'Worktree topology could not be checked because the project is missing meta.id.',
+        expected_worktree_root: null,
+        worktrees: [],
+        counts: {
+          canonical_main: 0,
+          project_scoped: 0,
+          misplaced_clean: 0,
+          misplaced_dirty: 0,
+        },
+        inspection_errors: ['missing meta.id for github_versioned project'],
+      },
+    };
+  }
+
+  const topology = await inspectProjectWorktreeTopology({
+    repoPath: args.repo_path,
+    canonicalProjectPath: args.project_path,
+    expectedWorktreeRoot: deriveExpectedWorktreeRoot(getAgenticOSHome(), projectId),
+  });
+
+  return {
+    gate: {
+      gate: 'worktree_topology',
+      status: topology.status,
+      summary: topology.summary,
+    },
+    topology,
+  };
+}
+
 async function buildStandardKitGate(args: HealthArgs): Promise<HealthGate | null> {
   if (!args.check_standard_kit) return null;
   if (!args.project_path) {
@@ -171,6 +221,58 @@ async function buildStandardKitGate(args: HealthArgs): Promise<HealthGate | null
   };
 }
 
+async function resolveTrustedProjectPath(args: {
+  repoPath: string;
+  explicitProjectPath?: string;
+  targetProject: GuardrailProjectTarget | null;
+  resolutionSource: 'explicit_project_path' | 'repo_path_match' | 'session_project' | null;
+}): Promise<{ effectiveProjectPath: string | null; repoIdentityError: string | null }> {
+  const { repoPath, explicitProjectPath, targetProject, resolutionSource } = args;
+  const initialProjectPath = explicitProjectPath || targetProject?.path || null;
+  const requiresRepoIdentityProof = resolutionSource === 'repo_path_match' || resolutionSource === 'session_project';
+  if (!targetProject || targetProject.topology !== 'github_versioned' || !requiresRepoIdentityProof) {
+    return {
+      effectiveProjectPath: initialProjectPath,
+      repoIdentityError: null,
+    };
+  }
+
+  try {
+    const gitWorktreeRoot = (await execCommand(`git -C "${repoPath}" rev-parse --show-toplevel`)).trim();
+    const gitCommonDir = resolve(gitWorktreeRoot, (await execCommand(`git -C "${repoPath}" rev-parse --git-common-dir`)).trim());
+    const gitCommonRepoRoot = dirname(gitCommonDir);
+    const gitRemoteOrigin = await execCommand(`git -C "${repoPath}" config --get remote.origin.url`).catch(() => '');
+    const repoIdentity = validateGuardrailRepoIdentity({
+      projectId: targetProject.id,
+      projectYamlPath: targetProject.projectYamlPath,
+      declaredGithubRepo: targetProject.githubRepo,
+      declaredSourceRepoRoots: targetProject.sourceRepoRoots,
+      sourceRepoRootsDeclared: targetProject.sourceRepoRootsDeclared,
+      expectedWorktreeRoot: targetProject.expectedWorktreeRoot,
+      gitWorktreeRoot,
+      gitCommonRepoRoot,
+      gitRemoteOrigin,
+    });
+    if (!repoIdentity.ok) {
+      return {
+        effectiveProjectPath: null,
+        repoIdentityError: repoIdentity.message as string,
+      };
+    }
+  } catch (error) {
+    return {
+      effectiveProjectPath: null,
+      /* c8 ignore next -- execCommand and repo identity validation only throw Error instances here */
+      repoIdentityError: error instanceof Error ? error.message : 'failed to validate repo identity for the resolved managed project',
+    };
+  }
+
+  return {
+    effectiveProjectPath: initialProjectPath,
+    repoIdentityError: null,
+  };
+}
+
 export async function runHealthCheck(args: HealthArgs): Promise<HealthResult> {
   if (!args?.repo_path) {
     throw new Error('repo_path is required.');
@@ -179,10 +281,23 @@ export async function runHealthCheck(args: HealthArgs): Promise<HealthResult> {
   const remoteBaseBranch = args.remote_base_branch || 'origin/main';
   const checkoutRole = args.checkout_role || 'canonical';
   const checkedAt = new Date().toISOString();
+  const projectResolution = await resolveGuardrailProjectTarget({
+    commandName: 'agenticos_health',
+    repoPath: args.repo_path,
+    projectPath: args.project_path,
+  });
+  const trustedProject = await resolveTrustedProjectPath({
+    repoPath: args.repo_path,
+    explicitProjectPath: args.project_path,
+    targetProject: projectResolution.targetProject,
+    resolutionSource: projectResolution.resolutionSource,
+  });
+  const effectiveProjectPath = trustedProject.effectiveProjectPath;
 
   const repoStatus = await execCommand(`git -C "${args.repo_path}" status --short --branch --untracked-files=all`);
-  const projectYaml = await readProjectYaml(args.project_path);
-  const state = await readState(args.project_path, projectYaml);
+  const resolvedProjectPath = effectiveProjectPath ?? undefined;
+  const projectYaml = await readProjectYaml(resolvedProjectPath);
+  const state = await readState(resolvedProjectPath, projectYaml);
   const repoSync = analyzeCanonicalRepoSync({
     statusOutput: repoStatus,
     remoteBaseBranch,
@@ -191,8 +306,13 @@ export async function runHealthCheck(args: HealthArgs): Promise<HealthResult> {
   const versionedEntrySurfaceState = assessVersionedEntrySurfaceState({
     projectYaml,
     state,
-    projectPath: args.project_path,
+    projectPath: resolvedProjectPath,
   });
+  const effectiveArgs = {
+    ...args,
+    project_path: resolvedProjectPath,
+  };
+  const worktreeTopologyGate = await buildWorktreeTopologyGate(effectiveArgs, projectYaml);
 
   const gates: HealthGate[] = [
     {
@@ -215,7 +335,11 @@ export async function runHealthCheck(args: HealthArgs): Promise<HealthResult> {
     buildGuardrailGate(state),
   );
 
-  const standardKitGate = await buildStandardKitGate(args);
+  if (worktreeTopologyGate) {
+    gates.push(worktreeTopologyGate.gate);
+  }
+
+  const standardKitGate = await buildStandardKitGate(effectiveArgs);
   if (standardKitGate) {
     gates.push(standardKitGate);
   }
@@ -224,12 +348,35 @@ export async function runHealthCheck(args: HealthArgs): Promise<HealthResult> {
     command: 'agenticos_health',
     status: combineHealthStatus(gates),
     repo_path: args.repo_path,
-    project_path: args.project_path || null,
+    project_path: effectiveProjectPath || null,
     remote_base_branch: remoteBaseBranch,
     checkout_role: checkoutRole,
     checked_at: checkedAt,
     gates,
     repo_sync: repoSync.details,
-    recovery_actions: repoSync.recovery_actions,
+    worktree_topology: worktreeTopologyGate?.topology,
+    recovery_actions: [
+      ...repoSync.recovery_actions,
+      ...(trustedProject.repoIdentityError
+        ? [`verify git repo identity before treating repo_path as a managed project: ${trustedProject.repoIdentityError}`]
+        : []),
+      ...(worktreeTopologyGate?.topology.status === 'WARN' && worktreeTopologyGate.topology.counts.misplaced_clean > 0
+        ? ['recreate misplaced clean worktrees under the derived project-scoped worktree root and remove the old paths']
+        : []),
+      ...(worktreeTopologyGate?.topology.status === 'BLOCK' && worktreeTopologyGate.topology.counts.misplaced_dirty > 0
+        ? ['protect dirty misplaced worktrees first, then recreate them under the derived project-scoped worktree root before removing the old paths']
+        : []),
+      ...(worktreeTopologyGate?.topology.status === 'BLOCK'
+        && worktreeTopologyGate.topology.counts.misplaced_dirty === 0
+        && worktreeTopologyGate.topology.inspection_errors.some((error) => error.includes('missing meta.id'))
+        ? ['restore project meta.id before relying on derived project-scoped worktree-root checks']
+        : []),
+      ...(worktreeTopologyGate?.topology.status === 'BLOCK'
+        && worktreeTopologyGate.topology.counts.misplaced_dirty === 0
+        && worktreeTopologyGate.topology.inspection_errors.length > 0
+        && !worktreeTopologyGate.topology.inspection_errors.some((error) => error.includes('missing meta.id'))
+        ? ['inspect git worktree topology failures and restore accurate worktree visibility before trusting this checkout']
+        : []),
+    ],
   };
 }

--- a/mcp-server/src/utils/repo-boundary.ts
+++ b/mcp-server/src/utils/repo-boundary.ts
@@ -106,7 +106,8 @@ async function loadProjectBoundaryMetadata(
   const name = String(projectYaml?.meta?.name || fallbackName || fallbackId || basename(normalizedProjectPath));
   const topologyValidation = validateManagedProjectTopology(name, projectYaml);
   const topology = topologyValidation.ok ? topologyValidation.topology : null;
-  const projectId = String(projectYaml?.meta?.id || fallbackId || basename(normalizedProjectPath));
+  const declaredProjectId = typeof projectYaml?.meta?.id === 'string' ? projectYaml.meta.id.trim() : '';
+  const projectId = declaredProjectId || fallbackId || basename(normalizedProjectPath);
 
   return {
     id: projectId,
@@ -120,7 +121,7 @@ async function loadProjectBoundaryMetadata(
       : null,
     sourceRepoRoots: sourceRepoRoots.roots,
     sourceRepoRootsDeclared: sourceRepoRoots.declared,
-    expectedWorktreeRoot: topology === 'github_versioned'
+    expectedWorktreeRoot: topology === 'github_versioned' && declaredProjectId
       ? deriveExpectedWorktreeRoot(getAgenticOSHome(), projectId)
       : null,
     topologyValidationError: topologyValidation.ok ? null : topologyValidation.message,

--- a/mcp-server/src/utils/repo-boundary.ts
+++ b/mcp-server/src/utils/repo-boundary.ts
@@ -1,9 +1,10 @@
 import { access, readFile } from 'fs/promises';
 import { basename, isAbsolute, join, resolve, sep } from 'path';
 import yaml from 'yaml';
-import { validateManagedProjectTopology } from './project-contract.js';
-import { loadRegistry } from './registry.js';
+import { type ProjectTopology, validateManagedProjectTopology } from './project-contract.js';
+import { getAgenticOSHome, loadRegistry } from './registry.js';
 import { getSessionProjectBinding } from './session-context.js';
+import { deriveExpectedWorktreeRoot } from './worktree-topology.js';
 
 export type GuardrailTaskType =
   | 'discussion_only'
@@ -18,9 +19,11 @@ export interface GuardrailProjectTarget {
   path: string;
   statePath: string;
   projectYamlPath: string;
+  topology: ProjectTopology;
   githubRepo: string | null;
   sourceRepoRoots: string[];
   sourceRepoRootsDeclared: boolean;
+  expectedWorktreeRoot: string | null;
 }
 
 export interface GuardrailProjectResolution {
@@ -95,22 +98,31 @@ async function loadProjectBoundaryMetadata(
     return null;
   }
 
-  const projectYaml = yaml.parse(await readFile(projectYamlPath, 'utf-8')) || {};
+  const projectYaml = yaml.parse(await readFile(projectYamlPath, 'utf-8'));
+  if (!projectYaml || typeof projectYaml !== 'object') {
+    throw new Error(`${projectYamlPath} did not parse to a project object`);
+  }
   const sourceRepoRoots = resolveDeclaredSourceRepoRoots(normalizedProjectPath, projectYaml);
   const name = String(projectYaml?.meta?.name || fallbackName || fallbackId || basename(normalizedProjectPath));
   const topologyValidation = validateManagedProjectTopology(name, projectYaml);
+  const topology = topologyValidation.ok ? topologyValidation.topology : null;
+  const projectId = String(projectYaml?.meta?.id || fallbackId || basename(normalizedProjectPath));
 
   return {
-    id: String(projectYaml?.meta?.id || fallbackId || basename(normalizedProjectPath)),
+    id: projectId,
     name,
     path: normalizedProjectPath,
     statePath: resolveProjectStatePath(normalizedProjectPath, projectYaml),
     projectYamlPath,
+    topology: topology || 'local_directory_only',
     githubRepo: typeof projectYaml?.source_control?.github_repo === 'string' && projectYaml.source_control.github_repo.trim().length > 0
       ? projectYaml.source_control.github_repo.trim()
       : null,
     sourceRepoRoots: sourceRepoRoots.roots,
     sourceRepoRootsDeclared: sourceRepoRoots.declared,
+    expectedWorktreeRoot: topology === 'github_versioned'
+      ? deriveExpectedWorktreeRoot(getAgenticOSHome(), projectId)
+      : null,
     topologyValidationError: topologyValidation.ok ? null : topologyValidation.message,
   };
 }
@@ -200,6 +212,7 @@ export async function resolveGuardrailProjectTarget(args: {
         const matchedRoots = [
           projectMetadata.path,
           ...projectMetadata.sourceRepoRoots,
+          ...(projectMetadata.expectedWorktreeRoot ? [projectMetadata.expectedWorktreeRoot] : []),
         ].filter((candidatePath) => isWithinProject(normalizedRepoPath, candidatePath));
 
         if (matchedRoots.length === 0) continue;

--- a/mcp-server/src/utils/worktree-topology.ts
+++ b/mcp-server/src/utils/worktree-topology.ts
@@ -188,11 +188,12 @@ export async function inspectProjectWorktreeTopology(args: InspectProjectWorktre
   }
 
   const expectedWorktreeRoot = normalizePath(args.expectedWorktreeRoot);
-  const canonicalProjectPath = normalizePath(args.canonicalProjectPath);
   const inspectionErrors: string[] = [];
   let parsedWorktrees: ParsedWorktreeRecord[] = [];
+  let canonicalWorktreeRoot: string | null = null;
 
   try {
+    canonicalWorktreeRoot = normalizePath(await runGit(args.repoPath, 'rev-parse --show-toplevel'));
     parsedWorktrees = parseWorktreeListPorcelain(await runGit(args.repoPath, 'worktree list --porcelain'));
   } catch (error) {
     inspectionErrors.push(error instanceof Error ? error.message : 'failed to list git worktrees');
@@ -207,7 +208,7 @@ export async function inspectProjectWorktreeTopology(args: InspectProjectWorktre
   };
 
   for (const record of parsedWorktrees) {
-    const canonical = record.path === canonicalProjectPath;
+    const canonical = record.path === (canonicalWorktreeRoot as string);
     const placement: WorktreePlacement = canonical
       ? 'canonical_main'
       : isPathWithinRoot(record.path, expectedWorktreeRoot)

--- a/mcp-server/src/utils/worktree-topology.ts
+++ b/mcp-server/src/utils/worktree-topology.ts
@@ -1,0 +1,264 @@
+import { exec } from 'child_process';
+import { join, resolve, sep } from 'path';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+export type WorktreeTopologyStatus = 'PASS' | 'WARN' | 'BLOCK';
+export type WorktreePlacement = 'canonical_main' | 'project_scoped' | 'misplaced';
+
+export interface WorktreeRootResolution {
+  requestedWorktreeRoot: string | null;
+  expectedWorktreeRoot: string;
+  effectiveWorktreeRoot: string;
+  deprecatedOverrideUsed: boolean;
+  mismatchReason: string | null;
+}
+
+export interface WorktreeTopologyEntry {
+  path: string;
+  branch: string | null;
+  upstream: string | null;
+  dirty: boolean;
+  placement: WorktreePlacement;
+  suggested_action: string | null;
+}
+
+export interface WorktreeTopologyInspection {
+  applies: boolean;
+  status: WorktreeTopologyStatus;
+  summary: string;
+  expected_worktree_root: string | null;
+  worktrees: WorktreeTopologyEntry[];
+  counts: {
+    canonical_main: number;
+    project_scoped: number;
+    misplaced_clean: number;
+    misplaced_dirty: number;
+  };
+  inspection_errors: string[];
+}
+
+interface InspectProjectWorktreeTopologyArgs {
+  repoPath: string;
+  canonicalProjectPath: string;
+  expectedWorktreeRoot: string | null;
+}
+
+interface ParsedWorktreeRecord {
+  path: string;
+  branch: string | null;
+}
+
+function normalizePath(path: string): string {
+  return resolve(path);
+}
+
+export function isPathWithinRoot(candidatePath: string, rootPath: string): boolean {
+  const normalizedCandidate = normalizePath(candidatePath);
+  const normalizedRoot = normalizePath(rootPath);
+  return normalizedCandidate === normalizedRoot || normalizedCandidate.startsWith(`${normalizedRoot}${sep}`);
+}
+
+export function deriveExpectedWorktreeRoot(agenticosHome: string, projectId: string): string {
+  return normalizePath(join(agenticosHome, 'worktrees', projectId.trim()));
+}
+
+export function resolveProjectWorktreeRoot(args: {
+  agenticosHome: string;
+  projectId: string;
+  requestedWorktreeRoot?: string | null;
+}): WorktreeRootResolution {
+  const requested = typeof args.requestedWorktreeRoot === 'string' && args.requestedWorktreeRoot.trim().length > 0
+    ? normalizePath(args.requestedWorktreeRoot.trim())
+    : null;
+  const expected = deriveExpectedWorktreeRoot(args.agenticosHome, args.projectId);
+
+  if (requested && requested !== expected) {
+    return {
+      requestedWorktreeRoot: requested,
+      expectedWorktreeRoot: expected,
+      effectiveWorktreeRoot: expected,
+      deprecatedOverrideUsed: false,
+      mismatchReason: `requested worktree_root "${requested}" does not match derived project-scoped root "${expected}" for project "${args.projectId}"`,
+    };
+  }
+
+  return {
+    requestedWorktreeRoot: requested,
+    expectedWorktreeRoot: expected,
+    effectiveWorktreeRoot: expected,
+    deprecatedOverrideUsed: requested !== null,
+    mismatchReason: null,
+  };
+}
+
+function summarizeTopology(counts: WorktreeTopologyInspection['counts'], inspectionErrors: string[]): { status: WorktreeTopologyStatus; summary: string } {
+  if (inspectionErrors.length > 0) {
+    return {
+      status: 'BLOCK',
+      summary: `Worktree topology inspection failed: ${inspectionErrors[0]}`,
+    };
+  }
+
+  if (counts.misplaced_dirty > 0) {
+    return {
+      status: 'BLOCK',
+      summary: `Worktree topology is blocked by ${counts.misplaced_dirty} misplaced dirty worktree(s).`,
+    };
+  }
+
+  if (counts.misplaced_clean > 0) {
+    return {
+      status: 'WARN',
+      summary: `Worktree topology has ${counts.misplaced_clean} misplaced clean worktree(s).`,
+    };
+  }
+
+  return {
+    status: 'PASS',
+    summary: 'Worktree topology matches the derived project-scoped root.',
+  };
+}
+
+async function runGit(repoPath: string, args: string): Promise<string> {
+  const { stdout } = await execAsync(`git -C "${repoPath}" ${args}`);
+  return stdout.trim();
+}
+
+function parseWorktreeListPorcelain(output: string): ParsedWorktreeRecord[] {
+  const records: ParsedWorktreeRecord[] = [];
+  const blocks = output
+    .split(/\n\s*\n/)
+    .map((block) => block.trim())
+    .filter((block) => block.length > 0);
+
+  for (const block of blocks) {
+    let path: string | null = null;
+    let branch: string | null = null;
+    for (const line of block.split('\n')) {
+      if (line.startsWith('worktree ')) {
+        path = line.replace(/^worktree\s+/, '').trim();
+      } else if (line.startsWith('branch ')) {
+        branch = line.replace(/^branch\s+/, '').trim().replace(/^refs\/heads\//, '');
+      }
+    }
+
+    if (path) {
+      records.push({
+        path: normalizePath(path),
+        branch,
+      });
+    }
+  }
+
+  return records;
+}
+
+async function readUpstream(path: string): Promise<string | null> {
+  try {
+    const upstream = await runGit(path, 'rev-parse --abbrev-ref --symbolic-full-name @{upstream}');
+    return upstream || null;
+  } catch {
+    return null;
+  }
+}
+
+async function isDirtyWorktree(path: string): Promise<boolean> {
+  const output = await runGit(path, 'status --porcelain --untracked-files=all');
+  return output.length > 0;
+}
+
+export async function inspectProjectWorktreeTopology(args: InspectProjectWorktreeTopologyArgs): Promise<WorktreeTopologyInspection> {
+  if (!args.expectedWorktreeRoot) {
+    return {
+      applies: false,
+      status: 'PASS',
+      summary: 'Worktree topology does not apply to this project.',
+      expected_worktree_root: null,
+      worktrees: [],
+      counts: {
+        canonical_main: 0,
+        project_scoped: 0,
+        misplaced_clean: 0,
+        misplaced_dirty: 0,
+      },
+      inspection_errors: [],
+    };
+  }
+
+  const expectedWorktreeRoot = normalizePath(args.expectedWorktreeRoot);
+  const canonicalProjectPath = normalizePath(args.canonicalProjectPath);
+  const inspectionErrors: string[] = [];
+  let parsedWorktrees: ParsedWorktreeRecord[] = [];
+
+  try {
+    parsedWorktrees = parseWorktreeListPorcelain(await runGit(args.repoPath, 'worktree list --porcelain'));
+  } catch (error) {
+    inspectionErrors.push(error instanceof Error ? error.message : 'failed to list git worktrees');
+  }
+
+  const worktrees: WorktreeTopologyEntry[] = [];
+  const counts = {
+    canonical_main: 0,
+    project_scoped: 0,
+    misplaced_clean: 0,
+    misplaced_dirty: 0,
+  };
+
+  for (const record of parsedWorktrees) {
+    const canonical = record.path === canonicalProjectPath;
+    const placement: WorktreePlacement = canonical
+      ? 'canonical_main'
+      : isPathWithinRoot(record.path, expectedWorktreeRoot)
+        ? 'project_scoped'
+        : 'misplaced';
+
+    let dirty = false;
+    let upstream: string | null = null;
+
+    try {
+      upstream = await readUpstream(record.path);
+      dirty = await isDirtyWorktree(record.path);
+    } catch (error) {
+      inspectionErrors.push(error instanceof Error ? error.message : `failed to inspect worktree ${record.path}`);
+      dirty = true;
+    }
+
+    const suggestedAction = placement !== 'misplaced'
+      ? null
+      : dirty
+        ? 'stash or commit changes, recreate under the expected worktree root, restore changes, then remove the misplaced worktree'
+        : 'recreate under the expected worktree root, verify branch and HEAD, then remove the misplaced worktree';
+
+    worktrees.push({
+      path: record.path,
+      branch: record.branch,
+      upstream,
+      dirty,
+      placement,
+      suggested_action: suggestedAction,
+    });
+
+    if (placement === 'canonical_main') {
+      counts.canonical_main += 1;
+    } else if (placement === 'project_scoped') {
+      counts.project_scoped += 1;
+    } else if (dirty) {
+      counts.misplaced_dirty += 1;
+    } else {
+      counts.misplaced_clean += 1;
+    }
+  }
+
+  const { status, summary } = summarizeTopology(counts, inspectionErrors);
+  return {
+    applies: true,
+    status,
+    summary,
+    expected_worktree_root: expectedWorktreeRoot,
+    worktrees,
+    counts,
+    inspection_errors: inspectionErrors,
+  };
+}

--- a/standards/knowledge/agent-guardrail-command-contracts-v1-2026-03-23.md
+++ b/standards/knowledge/agent-guardrail-command-contracts-v1-2026-03-23.md
@@ -132,7 +132,7 @@ branch_type: "feat"
 slug: "guardrail-helper"
 repo_path: "/abs/path/to/repo"
 remote_base_branch: "origin/main"
-worktree_root: "/abs/path/to/worktrees"
+worktree_root: "/abs/path/to/worktrees" # optional, deprecated compatibility input
 ```
 
 ### Output shape
@@ -148,6 +148,9 @@ notes: []
 ### Hard rules
 
 - must derive the branch from the intended remote base, not the local current branch
+- must derive the effective worktree root as `$AGENTICOS_HOME/worktrees/<project-id>`
+- if `worktree_root` is supplied for compatibility, it must normalize to the
+  same derived root or the command must fail closed
 - must record the exact base commit used
 - must fail if target branch or worktree path already exists unexpectedly
 

--- a/tasks/issue-297-project-scoped-worktree-root-isolation.md
+++ b/tasks/issue-297-project-scoped-worktree-root-isolation.md
@@ -1,0 +1,303 @@
+# Issue #297: Project-Scoped Worktree Root Isolation
+
+## Summary
+
+`#297` closes the remaining topology gap left after the runtime-home and
+project-source model was clarified.
+
+The intended model is already clear:
+
+- `AGENTICOS_HOME` is the runtime workspace home
+- managed projects live under `AGENTICOS_HOME/projects/<project>`
+- each Git-backed project is its own source and repo boundary
+- issue worktrees must not be created under an unrelated project's helper tree
+
+The remaining problem is that `agenticos_branch_bootstrap` still accepts an
+arbitrary caller-provided `worktree_root` and treats that path as the source of
+truth. That means a shared helper path such as
+`/Users/jeking/dev/AgenticOS/worktrees` can become a mixed physical sink for
+multiple unrelated projects.
+
+This is not a Git identity violation. It is a worktree-placement enforcement
+gap.
+
+## Problem Statement
+
+Current bootstrap behavior is too weak in three ways:
+
+1. worktree root selection is delegated to the caller
+2. the selected root is not derived from the managed project contract
+3. audit/status surfaces do not clearly report misplaced worktrees
+
+That leaves the runtime model partially normalized, but not strongly enforced.
+
+## Design Goal
+
+For any `github_versioned` managed project, the effective issue-worktree root
+must be deterministic and project-scoped.
+
+The system should make the correct placement automatic, reject unrelated roots,
+and expose clear topology diagnostics for already-misplaced worktrees.
+
+## Recommended V1 Rule
+
+Derive the effective worktree root from runtime home plus managed project id:
+
+```text
+$AGENTICOS_HOME/worktrees/<project-id>/
+```
+
+Examples:
+
+- `agenticos` -> `$AGENTICOS_HOME/worktrees/agenticos`
+- `360teams` -> `$AGENTICOS_HOME/worktrees/360teams`
+
+The resulting issue worktree path remains:
+
+```text
+$AGENTICOS_HOME/worktrees/<project-id>/<repo-name>-<issue>-<slug>
+```
+
+This keeps the placement:
+
+- workspace-home helper area, partitioned by managed project id
+- deterministic
+- isolated by managed project
+- independent of whether the project source checkout itself lives inside
+  `AGENTICOS_HOME/projects/`
+
+## Contract Decision
+
+### Public tool contract
+
+`agenticos_branch_bootstrap` should no longer require `worktree_root` as caller
+input.
+
+Recommended V1 behavior:
+
+- remove `worktree_root` from the required schema
+- treat `worktree_root` as deprecated compatibility input
+- when supplied, only accept it if it exactly matches the derived project root
+- otherwise fail closed with a clear error that shows:
+  - requested root
+  - expected root
+  - target project id
+
+This preserves compatibility for older clients while removing the unsafe
+selection semantics.
+
+For V1, "exactly matches" means normalized path equivalence, not raw string
+equality. Trailing `/`, `.` and `..` path spellings must normalize to the same
+derived root.
+
+### Project metadata
+
+Do not add a new per-project configuration field in V1.
+
+Reason:
+
+- the placement rule is part of the workspace contract, not project taste
+- introducing a configurable override before the default is enforced recreates
+  the ambiguity that caused this incident
+- a future controlled override can be added only if there is a concrete
+  operator requirement and an audit trail requirement
+
+## Audit And Status Surfaces
+
+`#297` should add machine-checkable topology inspection for Git-backed managed
+projects.
+
+Minimum V1 behavior:
+
+- derive the expected worktree root for the target project
+- inspect `git worktree list --porcelain` for the target repo
+- classify worktrees into:
+  - canonical main checkout
+  - correctly placed non-canonical worktrees
+  - misplaced clean worktrees
+  - misplaced dirty worktrees
+
+Recommended operator-facing surfaces:
+
+- `agenticos_status`
+  - show expected worktree root
+  - show a concise misplaced-worktree summary when present
+- `agenticos_health`
+  - add a topology gate
+  - `PASS` when no misplaced worktrees exist
+  - `WARN` when only misplaced clean worktrees exist
+  - `BLOCK` when any misplaced dirty worktree exists
+  - `BLOCK` when topology inspection itself fails
+
+This gives both a human summary and a machine-checkable enforcement signal.
+
+Review resolution:
+
+- `health` is the machine-truth surface
+- `status` is only a rendered human summary
+- topology inventory must use `git worktree list --porcelain` as the source of
+  truth
+- topology evidence must not be persisted into tracked project state
+
+## Migration Guidance
+
+`#297` should define the classification used for cleanup:
+
+### Preserve and migrate
+
+Use when the misplaced worktree is still needed and clean.
+
+Procedure:
+
+1. verify whether the branch has unique commits, upstream, and/or an open PR
+2. recreate the worktree from the canonical repo under the derived root
+3. verify the new worktree resolves to the same branch/HEAD
+4. remove the old misplaced worktree
+
+Do not move the directory with bare `mv`.
+
+### Stash first, then migrate or discard
+
+Use when the misplaced worktree has uncommitted changes.
+
+Procedure:
+
+1. record branch and HEAD
+2. `stash -u` or create a temporary safety commit
+3. recreate the worktree under the derived root
+4. restore the changes
+5. only then remove the old misplaced worktree
+
+Do not move the directory with bare `mv`.
+
+### Safe deletion
+
+Use when the misplaced worktree is obsolete, duplicated, or otherwise
+superseded.
+
+Before deletion, verify:
+
+- there are no unique commits that still matter
+- there is no upstream branch or PR that still depends on it
+- the worktree path is not the only recovery location for uncommitted changes
+
+V1 implementation only needs to provide the detection and operator procedure.
+Automatic relocation can remain out of scope for now.
+
+## Concrete Implementation Slice
+
+### 1. Root derivation utility
+
+Add a shared utility that:
+
+- derives `$AGENTICOS_HOME/worktrees/<project-id>`
+- validates an optional requested root against that derived root
+- returns a normalized expected root and mismatch diagnostics
+
+This utility should remain mostly pure so path normalization and compatibility
+behavior can be covered directly in unit tests.
+
+### 2. Branch bootstrap hardening
+
+Update `mcp-server/src/tools/branch-bootstrap.ts` so it:
+
+- resolves the target managed project first
+- derives the effective worktree root from project id
+- rejects mismatched compatibility overrides
+- creates worktrees only under the derived root
+- persists:
+  - `requested_worktree_root`
+  - `expected_worktree_root`
+  - `effective_worktree_root`
+  - `deprecated_override_used`
+
+V1 keeps `worktree_root` in the public contract only as a deprecated
+compatibility input. It is no longer required and it no longer chooses the
+root.
+
+### 2a. Guardrail boundary propagation
+
+The derived worktree root must be accepted by the rest of the guardrail chain,
+not just bootstrap.
+
+That means:
+
+- `resolveGuardrailProjectTarget(...)` must treat paths under the derived
+  project-scoped worktree root as belonging to the same managed project
+- `validateGuardrailRepoIdentity(...)` must allow the derived worktree root as
+  a valid `gitWorktreeRoot`
+- `execution.source_repo_roots` remains the proof for the canonical/common repo
+  root
+
+Without this, bootstrap could create a worktree that later fails `preflight`,
+`issue_bootstrap`, or `pr_scope_check`.
+
+### 3. Topology inspection utility
+
+Add a utility that:
+
+- resolves the expected root for a project
+- lists repo worktrees
+- classifies placement and dirtiness
+- returns a summary suitable for both health/status output and future repair
+  tooling
+
+Minimum per-worktree fields should include:
+
+- `path`
+- `branch`
+- `placement`
+- `dirty`
+- `upstream`
+- `suggested_action`
+
+### 4. Health/status wiring
+
+Update:
+
+- `mcp-server/src/utils/health.ts`
+- `mcp-server/src/tools/project.ts`
+
+so topology drift is surfaced explicitly.
+
+`health` should add a dedicated topology gate rather than folding topology into
+the existing `repo_sync` gate.
+
+### 5. Docs and operator guidance
+
+Update:
+
+- `mcp-server/README.md`
+- this task file
+- `standards/knowledge/agent-guardrail-command-contracts-v1-2026-03-23.md`
+- root `README.md`
+
+to document the derived-root contract and the migration classifications.
+
+## Explicit Non-Goals
+
+`#297` should not:
+
+- automatically move or rewrite existing worktrees during bootstrap
+- widen into a general project-path migration engine
+- reintroduce a configurable global `active_project` dependency
+- permit arbitrary shared roots as a normal operator choice
+
+## Acceptance Criteria
+
+`#297` is complete when:
+
+1. `agenticos_branch_bootstrap` cannot create an issue worktree under an
+   unrelated shared root
+2. the effective worktree root is deterministic from `AGENTICOS_HOME` plus
+   project id
+3. status/health surfaces clearly report misplaced worktrees
+4. misplaced clean and dirty worktrees are distinguishable
+5. documentation tells the operator how to classify and clean up existing
+   misplaced worktrees
+6. tests fully cover:
+   - derived-root happy path
+   - deprecated override accepted when equal
+   - deprecated override rejected when mismatched
+   - misplaced clean worktree reporting
+   - misplaced dirty worktree reporting

--- a/tasks/issue-297-worktree-migration-runbook.md
+++ b/tasks/issue-297-worktree-migration-runbook.md
@@ -1,0 +1,70 @@
+# Issue #297 Worktree Migration Runbook
+
+## Scope
+
+This runbook applies to existing `github_versioned` managed-project issue
+worktrees that are physically located outside the derived project-scoped helper
+root:
+
+```text
+$AGENTICOS_HOME/worktrees/<project-id>/
+```
+
+## Rule
+
+Do not move a Git worktree directory with bare `mv`.
+
+Relocate by recreating the worktree from the canonical repo under the derived
+root, then remove the old misplaced worktree.
+
+## Classification
+
+Classify each misplaced worktree before touching it:
+
+1. `clean needed`
+2. `dirty needed`
+3. `obsolete or duplicate`
+
+For every class, also verify:
+
+- branch name
+- HEAD commit
+- whether unique commits exist
+- whether an upstream branch exists
+- whether a PR already exists
+
+## Clean Needed
+
+1. Record branch name and HEAD.
+2. Recreate the worktree from the canonical repo under the derived root.
+3. Verify the new worktree resolves to the same branch and HEAD.
+4. Remove the old misplaced worktree.
+
+## Dirty Needed
+
+1. Record branch name and HEAD.
+2. Protect the changes with `git stash -u` or a temporary safety commit.
+3. Recreate the worktree under the derived root.
+4. Restore the protected changes.
+5. Verify the restored diff.
+6. Remove the old misplaced worktree.
+
+## Obsolete Or Duplicate
+
+Only delete after verifying all of the following:
+
+- no unique commits still matter
+- no upstream branch still needs to be preserved
+- no PR still depends on the worktree branch
+- no local uncommitted recovery state needs to be kept
+
+## Suggested Operator Outputs
+
+Status and audit surfaces should help operators classify each misplaced
+worktree with at least:
+
+- path
+- branch
+- dirty
+- upstream
+- suggested_action


### PR DESCRIPTION
# Issue #297: Project-Scoped Worktree Root Isolation

## Summary

`#297` closes the remaining topology gap left after the runtime-home and
project-source model was clarified.

The intended model is already clear:

- `AGENTICOS_HOME` is the runtime workspace home
- managed projects live under `AGENTICOS_HOME/projects/<project>`
- each Git-backed project is its own source and repo boundary
- issue worktrees must not be created under an unrelated project's helper tree

The remaining problem is that `agenticos_branch_bootstrap` still accepts an
arbitrary caller-provided `worktree_root` and treats that path as the source of
truth. That means a shared helper path such as
`/Users/jeking/dev/AgenticOS/worktrees` can become a mixed physical sink for
multiple unrelated projects.

This is not a Git identity violation. It is a worktree-placement enforcement
gap.

## Problem Statement

Current bootstrap behavior is too weak in three ways:

1. worktree root selection is delegated to the caller
2. the selected root is not derived from the managed project contract
3. audit/status surfaces do not clearly report misplaced worktrees

That leaves the runtime model partially normalized, but not strongly enforced.

## Design Goal

For any `github_versioned` managed project, the effective issue-worktree root
must be deterministic and project-scoped.

The system should make the correct placement automatic, reject unrelated roots,
and expose clear topology diagnostics for already-misplaced worktrees.

## Recommended V1 Rule

Derive the effective worktree root from runtime home plus managed project id:

```text
$AGENTICOS_HOME/worktrees/<project-id>/
```

Examples:

- `agenticos` -> `$AGENTICOS_HOME/worktrees/agenticos`
- `360teams` -> `$AGENTICOS_HOME/worktrees/360teams`

The resulting issue worktree path remains:

```text
$AGENTICOS_HOME/worktrees/<project-id>/<repo-name>-<issue>-<slug>
```

This keeps the placement:

- workspace-home helper area, partitioned by managed project id
- deterministic
- isolated by managed project
- independent of whether the project source checkout itself lives inside
  `AGENTICOS_HOME/projects/`

## Contract Decision

### Public tool contract

`agenticos_branch_bootstrap` should no longer require `worktree_root` as caller
input.

Recommended V1 behavior:

- remove `worktree_root` from the required schema
- treat `worktree_root` as deprecated compatibility input
- when supplied, only accept it if it exactly matches the derived project root
- otherwise fail closed with a clear error that shows:
  - requested root
  - expected root
  - target project id

This preserves compatibility for older clients while removing the unsafe
selection semantics.

For V1, "exactly matches" means normalized path equivalence, not raw string
equality. Trailing `/`, `.` and `..` path spellings must normalize to the same
derived root.

### Project metadata

Do not add a new per-project configuration field in V1.

Reason:

- the placement rule is part of the workspace contract, not project taste
- introducing a configurable override before the default is enforced recreates
  the ambiguity that caused this incident
- a future controlled override can be added only if there is a concrete
  operator requirement and an audit trail requirement

## Audit And Status Surfaces

`#297` should add machine-checkable topology inspection for Git-backed managed
projects.

Minimum V1 behavior:

- derive the expected worktree root for the target project
- inspect `git worktree list --porcelain` for the target repo
- classify worktrees into:
  - canonical main checkout
  - correctly placed non-canonical worktrees
  - misplaced clean worktrees
  - misplaced dirty worktrees

Recommended operator-facing surfaces:

- `agenticos_status`
  - show expected worktree root
  - show a concise misplaced-worktree summary when present
- `agenticos_health`
  - add a topology gate
  - `PASS` when no misplaced worktrees exist
  - `WARN` when only misplaced clean worktrees exist
  - `BLOCK` when any misplaced dirty worktree exists
  - `BLOCK` when topology inspection itself fails

This gives both a human summary and a machine-checkable enforcement signal.

Review resolution:

- `health` is the machine-truth surface
- `status` is only a rendered human summary
- topology inventory must use `git worktree list --porcelain` as the source of
  truth
- topology evidence must not be persisted into tracked project state

## Migration Guidance

`#297` should define the classification used for cleanup:

### Preserve and migrate

Use when the misplaced worktree is still needed and clean.

Procedure:

1. verify whether the branch has unique commits, upstream, and/or an open PR
2. recreate the worktree from the canonical repo under the derived root
3. verify the new worktree resolves to the same branch/HEAD
4. remove the old misplaced worktree

Do not move the directory with bare `mv`.

### Stash first, then migrate or discard

Use when the misplaced worktree has uncommitted changes.

Procedure:

1. record branch and HEAD
2. `stash -u` or create a temporary safety commit
3. recreate the worktree under the derived root
4. restore the changes
5. only then remove the old misplaced worktree

Do not move the directory with bare `mv`.

### Safe deletion

Use when the misplaced worktree is obsolete, duplicated, or otherwise
superseded.

Before deletion, verify:

- there are no unique commits that still matter
- there is no upstream branch or PR that still depends on it
- the worktree path is not the only recovery location for uncommitted changes

V1 implementation only needs to provide the detection and operator procedure.
Automatic relocation can remain out of scope for now.

## Concrete Implementation Slice

### 1. Root derivation utility

Add a shared utility that:

- derives `$AGENTICOS_HOME/worktrees/<project-id>`
- validates an optional requested root against that derived root
- returns a normalized expected root and mismatch diagnostics

This utility should remain mostly pure so path normalization and compatibility
behavior can be covered directly in unit tests.

### 2. Branch bootstrap hardening

Update `mcp-server/src/tools/branch-bootstrap.ts` so it:

- resolves the target managed project first
- derives the effective worktree root from project id
- rejects mismatched compatibility overrides
- creates worktrees only under the derived root
- persists:
  - `requested_worktree_root`
  - `expected_worktree_root`
  - `effective_worktree_root`
  - `deprecated_override_used`

V1 keeps `worktree_root` in the public contract only as a deprecated
compatibility input. It is no longer required and it no longer chooses the
root.

### 2a. Guardrail boundary propagation

The derived worktree root must be accepted by the rest of the guardrail chain,
not just bootstrap.

That means:

- `resolveGuardrailProjectTarget(...)` must treat paths under the derived
  project-scoped worktree root as belonging to the same managed project
- `validateGuardrailRepoIdentity(...)` must allow the derived worktree root as
  a valid `gitWorktreeRoot`
- `execution.source_repo_roots` remains the proof for the canonical/common repo
  root

Without this, bootstrap could create a worktree that later fails `preflight`,
`issue_bootstrap`, or `pr_scope_check`.

### 3. Topology inspection utility

Add a utility that:

- resolves the expected root for a project
- lists repo worktrees
- classifies placement and dirtiness
- returns a summary suitable for both health/status output and future repair
  tooling

Minimum per-worktree fields should include:

- `path`
- `branch`
- `placement`
- `dirty`
- `upstream`
- `suggested_action`

### 4. Health/status wiring

Update:

- `mcp-server/src/utils/health.ts`
- `mcp-server/src/tools/project.ts`

so topology drift is surfaced explicitly.

`health` should add a dedicated topology gate rather than folding topology into
the existing `repo_sync` gate.

### 5. Docs and operator guidance

Update:

- `mcp-server/README.md`
- this task file
- `standards/knowledge/agent-guardrail-command-contracts-v1-2026-03-23.md`
- root `README.md`

to document the derived-root contract and the migration classifications.

## Explicit Non-Goals

`#297` should not:

- automatically move or rewrite existing worktrees during bootstrap
- widen into a general project-path migration engine
- reintroduce a configurable global `active_project` dependency
- permit arbitrary shared roots as a normal operator choice

## Acceptance Criteria

`#297` is complete when:

1. `agenticos_branch_bootstrap` cannot create an issue worktree under an
   unrelated shared root
2. the effective worktree root is deterministic from `AGENTICOS_HOME` plus
   project id
3. status/health surfaces clearly report misplaced worktrees
4. misplaced clean and dirty worktrees are distinguishable
5. documentation tells the operator how to classify and clean up existing
   misplaced worktrees
6. tests fully cover:
   - derived-root happy path
   - deprecated override accepted when equal
   - deprecated override rejected when mismatched
   - misplaced clean worktree reporting
   - misplaced dirty worktree reporting
