### PR TITLE
fix: degrade stale issue-bootstrap paths after worktree relocation

### DIFF
--- a/mcp-server/src/tools/__tests__/edit-guard.test.ts
+++ b/mcp-server/src/tools/__tests__/edit-guard.test.ts
@@ -359,7 +359,43 @@ describe('runEditGuard', () => {
     })) as { status: string; block_reasons: string[] };
 
     expect(result.status).toBe('BLOCK');
-    expect(result.block_reasons.join(' ')).toContain('different repo_path');
+    expect(result.block_reasons.join(' ')).toContain('historical for the current checkout');
+  });
+
+  it('blocks when the latest issue bootstrap is missing repo_path continuity evidence', async () => {
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/runtime/.agent-workspace/projects/agenticos-standards/guardrail-state.yaml',
+      state: {
+        issue_bootstrap: {
+          latest: {
+            issue_id: '113',
+            repo_path: '   ',
+            current_branch: 'feat/113-fail-closed-edit-boundaries',
+          },
+        },
+        guardrail_evidence: {
+          preflight: {
+            issue_id: '113',
+            repo_path: '/workspace/source',
+            declared_target_files: ['projects/agenticos/mcp-server/src/index.ts'],
+            result: { status: 'PASS' },
+          },
+        },
+      },
+    });
+
+    const result = JSON.parse(await runEditGuard({
+      issue_id: '113',
+      task_type: 'implementation',
+      repo_path: '/workspace/source',
+      project_path: '/workspace/projects/agenticos/standards',
+      declared_target_files: ['projects/agenticos/mcp-server/src/index.ts'],
+    })) as { status: string; block_reasons: string[]; recovery_actions: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons.join(' ')).toContain('missing repo_path for the current checkout');
+    expect(result.recovery_actions).toContain('rerun agenticos_issue_bootstrap in the current checkout');
   });
 
   it('blocks when the latest issue bootstrap branch differs from the current branch', async () => {
@@ -642,7 +678,7 @@ describe('runEditGuard', () => {
       declared_target_files: ['projects/agenticos/mcp-server/src/index.ts'],
     })) as { block_reasons: string[] };
 
-    expect(result.block_reasons.join(' ')).toContain('different repo_path');
+    expect(result.block_reasons.join(' ')).toContain('missing repo_path for the current checkout');
   });
 
   it('falls back preflight evidence fields to null when metadata is not string typed', async () => {

--- a/mcp-server/src/tools/__tests__/preflight.test.ts
+++ b/mcp-server/src/tools/__tests__/preflight.test.ts
@@ -698,7 +698,52 @@ describe('runPreflight', () => {
     })) as { status: string; block_reasons: string[] };
 
     expect(result.status).toBe('BLOCK');
-    expect(result.block_reasons.join(' ')).toContain('different repo_path');
+    expect(result.block_reasons.join(' ')).toContain('historical for the current checkout');
+  });
+
+  it('returns BLOCK when the latest issue bootstrap is missing repo_path continuity evidence', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --git-common-dir': '.git\n',
+      'config --get remote.origin.url': 'git@github.com:madlouse/AgenticOS.git\n',
+      'rev-parse --abbrev-ref HEAD': 'feat/36-guardrail-preflight\n',
+      'rev-parse HEAD': 'abc123\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo\nHEAD abc123\nbranch refs/heads/feat/36-guardrail-preflight\n',
+      'log --format=%s origin/main..HEAD': '',
+    });
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/runtime/.agent-workspace/projects/agenticos/guardrail-state.yaml',
+      state: {
+        issue_bootstrap: {
+          latest: {
+            issue_id: '36',
+            repo_path: '   ',
+            current_branch: 'feat/36-guardrail-preflight',
+            startup_context_paths: ['/workspace/projects/agenticos/standards/.project.yaml'],
+            stages: {
+              context_reset_performed: true,
+              project_hot_load_performed: true,
+              issue_payload_attached: true,
+            },
+          },
+        },
+      },
+    });
+
+    const result = JSON.parse(await runPreflight({
+      issue_id: '36',
+      task_type: 'implementation',
+      repo_path: '/repo',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/preflight.ts'],
+      worktree_required: true,
+    })) as { status: string; block_reasons: string[]; redirect_actions: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons.join(' ')).toContain('missing repo_path for the current checkout');
+    expect(result.redirect_actions).toContain('rerun agenticos_issue_bootstrap in the current checkout');
   });
 
   it('returns BLOCK when the latest issue bootstrap branch differs from the current branch', async () => {
@@ -949,7 +994,7 @@ describe('runPreflight', () => {
       worktree_required: true,
     })) as { block_reasons: string[] };
 
-    expect(result.block_reasons.join(' ')).toContain('different repo_path');
+    expect(result.block_reasons.join(' ')).toContain('missing repo_path for the current checkout');
   });
 
   it('returns BLOCK for structural move without root exception or reproducibility gate', async () => {

--- a/mcp-server/src/tools/__tests__/project.test.ts
+++ b/mcp-server/src/tools/__tests__/project.test.ts
@@ -639,6 +639,7 @@ describe('switchProject', () => {
             issue_title: 'Implement bootstrap evidence',
             recorded_at: '2025-01-02T15:00:00.000Z',
             current_branch: 'feat/179-issue-start-bootstrap-evidence',
+            repo_path: '/test/path',
             startup_context_paths: ['.project.yaml', '.context/quick-start.md'],
             additional_context: [{ path: 'knowledge/issue-158.md', reason: 'design reference' }],
           },
@@ -655,6 +656,7 @@ describe('switchProject', () => {
             issue_title: 'Implement bootstrap evidence',
             recorded_at: '2025-01-02T15:00:00.000Z',
             current_branch: 'feat/179-issue-start-bootstrap-evidence',
+            repo_path: '/test/path',
             startup_context_paths: ['.project.yaml', '.context/quick-start.md'],
             additional_context: [{ path: 'knowledge/issue-158.md', reason: 'design reference' }],
           },
@@ -665,9 +667,10 @@ describe('switchProject', () => {
 
     const result = await switchProject({ project: 'my-project' });
 
-    expect(result).toContain('🧭 Latest issue bootstrap: #179 on feat/179-issue-start-bootstrap-evidence');
+    expect(result).toContain('🧭 Latest issue bootstrap record: #179 on feat/179-issue-start-bootstrap-evidence');
     expect(result).toContain('Title: Implement bootstrap evidence');
     expect(result).toContain('2 startup surface(s), 1 additional context document(s)');
+    expect(result).toContain('Status: current for this project path');
   });
 
   it('inlines actionable project context into switch output', async () => {
@@ -825,7 +828,8 @@ describe('switchProject', () => {
 
     expect(result).toContain('⚠️ Committed snapshot: stale for canonical mainline use');
     expect(result).toContain('🛡️ Latest committed guardrail snapshot: freshness not proven');
-    expect(result).toContain('🧭 Latest committed issue bootstrap snapshot: #260 on fix/260-stop-active-project-drift-and-main-state-pollution');
+    expect(result).toContain('🧭 Latest issue bootstrap record: #260 on fix/260-stop-active-project-drift-and-main-state-pollution');
+    expect(result).toContain('Status: historical for this project path');
     expect(result).toContain('🎯 Current committed task snapshot: Implement #262 concurrent runtime project resolution (in_progress)');
   });
 
@@ -1180,7 +1184,7 @@ describe('switchProject', () => {
 
     const result = await switchProject({ project: 'my-project' });
 
-    expect(result).toContain('🧭 Latest issue bootstrap: unknown issue (Unknown time)');
+    expect(result).toContain('🧭 Latest issue bootstrap record: unknown issue (Unknown time)');
   });
 
   it('surfaces a registry metadata patch warning during switch bootstrap', async () => {
@@ -2236,7 +2240,7 @@ describe('getStatus', () => {
 
     const result = await getStatus();
 
-    expect(result).toContain('🧭 Latest issue bootstrap: None recorded');
+    expect(result).toContain('🧭 Latest issue bootstrap record: None recorded');
   });
 
   it('shows the latest issue bootstrap summary in status output when evidence exists', async () => {
@@ -2278,6 +2282,7 @@ describe('getStatus', () => {
             issue_title: 'Implement bootstrap evidence',
             recorded_at: '2025-01-02T15:00:00.000Z',
             current_branch: 'feat/179-issue-start-bootstrap-evidence',
+            repo_path: '/test/path',
             startup_context_paths: ['.project.yaml', '.context/quick-start.md'],
             additional_context: [{ path: 'knowledge/issue-158.md', reason: 'design reference' }],
           },
@@ -2287,8 +2292,62 @@ describe('getStatus', () => {
 
     const result = await getStatus();
 
-    expect(result).toContain('🧭 Latest issue bootstrap: #179 on feat/179-issue-start-bootstrap-evidence');
+    expect(result).toContain('🧭 Latest issue bootstrap record: #179 on feat/179-issue-start-bootstrap-evidence');
     expect(result).toContain('Title: Implement bootstrap evidence');
+    expect(result).toContain('Status: current for this project path');
+  });
+
+  it('surfaces missing or invalid issue bootstrap continuity in status output', async () => {
+    bindSessionProject({
+      projectId: 'test-project',
+      projectName: 'Test Project',
+      projectPath: '/test/path',
+    });
+
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: 'test-project',
+      projects: [
+        {
+          id: 'test-project',
+          name: 'Test Project',
+          path: '/test/path',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    mockStatusReads(
+      {
+        meta: { id: 'test-project', name: 'Test Project' },
+        source_control: { topology: 'local_directory_only' },
+      },
+      {
+        source_control: { topology: 'local_directory_only' },
+        session: { last_backup: '2025-01-02T12:00:00.000Z' },
+        working_memory: { pending: [], decisions: [] },
+        issue_bootstrap: {
+          updated_at: '2025-01-02T15:00:00.000Z',
+          latest: {
+            issue_id: '179',
+            issue_title: 'Implement bootstrap evidence',
+            recorded_at: '2025-01-02T15:00:00.000Z',
+            current_branch: 'feat/179-issue-start-bootstrap-evidence',
+            repo_path: '   ',
+          },
+        },
+      },
+    );
+
+    const result = await getStatus();
+
+    expect(result).toContain('🧭 Latest issue bootstrap record: #179 on feat/179-issue-start-bootstrap-evidence');
+    expect(result).toContain('Status: missing or invalid for this project path');
+    expect(result).toContain('Reason: latest issue bootstrap is missing repo_path evidence');
+    expect(result).toContain('Recovery: rerun agenticos_issue_bootstrap in the current checkout');
   });
 
   it('prefers runtime guardrail and bootstrap summaries in status output', async () => {
@@ -2553,7 +2612,8 @@ describe('getStatus', () => {
 
     expect(result).toContain('⚠️ Committed snapshot: stale for canonical mainline use');
     expect(result).toContain('🛡️ Latest committed guardrail snapshot: freshness not proven');
-    expect(result).toContain('🧭 Latest committed issue bootstrap snapshot: #260 on fix/260-stop-active-project-drift-and-main-state-pollution');
+    expect(result).toContain('🧭 Latest issue bootstrap record: #260 on fix/260-stop-active-project-drift-and-main-state-pollution');
+    expect(result).toContain('Status: historical for this project path');
     expect(result).toContain('🎯 Current committed task snapshot: Implement #262 concurrent runtime project resolution (in_progress)');
   });
 

--- a/mcp-server/src/tools/edit-guard.ts
+++ b/mcp-server/src/tools/edit-guard.ts
@@ -2,6 +2,7 @@ import { exec } from 'child_process';
 import { dirname, resolve } from 'path';
 import { promisify } from 'util';
 import { extractLatestIssueBootstrap, loadLatestGuardrailState } from '../utils/guardrail-evidence.js';
+import { assessIssueBootstrapContinuity } from '../utils/issue-bootstrap-continuity.js';
 import {
   isImplementationAffectingTask,
   resolveGuardrailProjectTarget,
@@ -198,6 +199,12 @@ export async function runEditGuard(args: EditGuardArgs): Promise<string> {
     result.block_reasons.push('no issue bootstrap evidence is recorded for the target project');
     result.recovery_actions.push('record agenticos_issue_bootstrap for the current issue before rerunning preflight');
   } else {
+    const bootstrapContinuity = await assessIssueBootstrapContinuity({
+      bootstrap: latestBootstrap,
+      currentRepoPath: repo_path,
+      projectPath: result.target_project?.path,
+      checkStartupContextPaths: false,
+    });
     result.evidence.issue_bootstrap_issue_id = typeof latestBootstrap.issue_id === 'string' ? latestBootstrap.issue_id : null;
     result.evidence.issue_bootstrap_repo_path = typeof latestBootstrap.repo_path === 'string' ? latestBootstrap.repo_path : null;
     result.evidence.issue_bootstrap_branch = typeof latestBootstrap.current_branch === 'string' ? latestBootstrap.current_branch : null;
@@ -209,9 +216,9 @@ export async function runEditGuard(args: EditGuardArgs): Promise<string> {
       result.recovery_actions.push(`record agenticos_issue_bootstrap for issue #${issue_id} before rerunning preflight`);
     }
 
-    if (repo_path && resolve(latestBootstrap.repo_path || '') !== resolve(repo_path)) {
-      result.block_reasons.push('latest issue bootstrap was recorded for a different repo_path');
-      result.recovery_actions.push('record agenticos_issue_bootstrap for the current repo_path before rerunning preflight');
+    if (bootstrapContinuity.status !== 'current') {
+      result.block_reasons.push(bootstrapContinuity.summary);
+      result.recovery_actions.push(...bootstrapContinuity.recovery_actions);
     }
 
     if (result.evidence.current_branch && latestBootstrap.current_branch && latestBootstrap.current_branch !== result.evidence.current_branch) {

--- a/mcp-server/src/tools/preflight.ts
+++ b/mcp-server/src/tools/preflight.ts
@@ -7,6 +7,7 @@ import {
   persistGuardrailEvidence,
   type GuardrailPersistenceResult,
 } from '../utils/guardrail-evidence.js';
+import { assessIssueBootstrapContinuity } from '../utils/issue-bootstrap-continuity.js';
 import {
   isImplementationAffectingTask,
   resolveGuardrailProjectTarget,
@@ -330,14 +331,21 @@ export async function runPreflight(args: PreflightArgs): Promise<string> {
         if (!latestBootstrap) {
           result.block_reasons.push('no issue bootstrap evidence is recorded for the target project');
         } else {
+          const bootstrapContinuity = await assessIssueBootstrapContinuity({
+            bootstrap: latestBootstrap,
+            currentRepoPath: repo_path,
+            projectPath: projectResolution.targetProject.path,
+            checkStartupContextPaths: false,
+          });
+
           if (issue_id && latestBootstrap.issue_id !== issue_id) {
             result.block_reasons.push(
               `latest issue bootstrap issue "${latestBootstrap.issue_id || 'unknown'}" does not match requested issue "${issue_id}"`,
             );
           }
 
-          if (repo_path && resolve(latestBootstrap.repo_path || '') !== resolve(repo_path)) {
-            result.block_reasons.push('latest issue bootstrap was recorded for a different repo_path');
+          if (bootstrapContinuity.status !== 'current') {
+            result.block_reasons.push(bootstrapContinuity.summary);
           }
 
           if (latestBootstrap.current_branch && latestBootstrap.current_branch !== result.evidence.current_branch) {
@@ -358,6 +366,7 @@ export async function runPreflight(args: PreflightArgs): Promise<string> {
           if (!Array.isArray(latestBootstrap.startup_context_paths) || latestBootstrap.startup_context_paths.length === 0) {
             result.block_reasons.push('latest issue bootstrap is missing startup context evidence');
           }
+          result.redirect_actions.push(...bootstrapContinuity.recovery_actions);
         }
       } catch {
         result.block_reasons.push(`managed project guardrail state is missing or unreadable: ${projectResolution.targetProject.statePath}`);

--- a/mcp-server/src/tools/project.ts
+++ b/mcp-server/src/tools/project.ts
@@ -20,6 +20,10 @@ import {
   assessVersionedEntrySurfaceState,
   type VersionedEntrySurfaceAssessment,
 } from '../utils/versioned-entry-surface-state.js';
+import {
+  assessIssueBootstrapContinuity,
+  type IssueBootstrapContinuityAssessment,
+} from '../utils/issue-bootstrap-continuity.js';
 import { deriveExpectedWorktreeRoot, inspectProjectWorktreeTopology } from '../utils/worktree-topology.js';
 
 type GuardrailCommand = 'agenticos_preflight' | 'agenticos_branch_bootstrap' | 'agenticos_pr_scope_check';
@@ -49,7 +53,7 @@ interface GuardrailEvidenceState {
 
 interface IssueBootstrapSummaryInput {
   issueBootstrap?: IssueBootstrapState;
-  committedSnapshotAssessment?: VersionedEntrySurfaceAssessment;
+  continuity?: IssueBootstrapContinuityAssessment;
 }
 
 interface SwitchContextSummaryInput {
@@ -174,12 +178,9 @@ function summarizeIssueBootstrapDetail(entry: IssueBootstrapRecord): string | nu
 }
 
 function buildIssueBootstrapSummaryLines(input: IssueBootstrapSummaryInput): string[] {
-  const label = usesCommittedSnapshotLabels(input.committedSnapshotAssessment)
-    ? '🧭 Latest committed issue bootstrap snapshot'
-    : '🧭 Latest issue bootstrap';
   const latestBootstrap = input.issueBootstrap?.latest;
   if (!latestBootstrap) {
-    return [`${label}: ${usesCommittedSnapshotLabels(input.committedSnapshotAssessment) ? 'freshness not proven' : 'None recorded'}`];
+    return ['🧭 Latest issue bootstrap record: None recorded'];
   }
 
   const recordedAt =
@@ -188,7 +189,7 @@ function buildIssueBootstrapSummaryLines(input: IssueBootstrapSummaryInput): str
     'Unknown time';
   const issueLabel = latestBootstrap.issue_id ? `#${latestBootstrap.issue_id}` : 'unknown issue';
   const branchDetail = latestBootstrap.current_branch ? ` on ${latestBootstrap.current_branch}` : '';
-  const lines = [`${label}: ${issueLabel}${branchDetail} (${recordedAt})`];
+  const lines = [`🧭 Latest issue bootstrap record: ${issueLabel}${branchDetail} (${recordedAt})`];
 
   if (latestBootstrap.issue_title) {
     lines.push(`   Title: ${latestBootstrap.issue_title}`);
@@ -197,6 +198,24 @@ function buildIssueBootstrapSummaryLines(input: IssueBootstrapSummaryInput): str
   const detail = summarizeIssueBootstrapDetail(latestBootstrap);
   if (detail) {
     lines.push(`   Detail: ${detail}`);
+  }
+
+  const continuity = input.continuity;
+  if (continuity) {
+    const continuityLabel = continuity.status === 'current'
+      ? 'current for this project path'
+      : continuity.status === 'historical_for_current_checkout'
+        ? 'historical for this project path'
+        : 'missing or invalid for this project path';
+    lines.push(`   Status: ${continuityLabel}`);
+
+    if (continuity.reasons.length > 0) {
+      lines.push(`   Reason: ${continuity.reasons[0]}`);
+    }
+
+    if (continuity.recovery_actions.length > 0) {
+      lines.push(`   Recovery: ${continuity.recovery_actions[0]}`);
+    }
   }
 
   return lines;
@@ -421,9 +440,17 @@ export async function switchProject(args: any): Promise<string> {
     displayState?.guardrail_evidence as GuardrailEvidenceState | undefined,
     committedSnapshotAssessment,
   );
+  const latestSwitchBootstrap = displayState?.issue_bootstrap?.latest as IssueBootstrapRecord | null | undefined;
+  const bootstrapContinuity = latestSwitchBootstrap
+    ? await assessIssueBootstrapContinuity({
+        bootstrap: latestSwitchBootstrap,
+        currentRepoPath: found.path,
+        projectPath: found.path,
+      })
+    : undefined;
   const issueBootstrapSummary = buildIssueBootstrapSummaryLines({
     issueBootstrap: displayState?.issue_bootstrap as IssueBootstrapState | undefined,
-    committedSnapshotAssessment,
+    continuity: bootstrapContinuity,
   });
   const contextSummary = buildSwitchContextSummaryLines({
     description,
@@ -525,6 +552,14 @@ export async function getStatus(args: any = {}): Promise<string> {
     state,
     projectPath: resolved.projectPath,
   });
+  const latestStatusBootstrap = displayState.issue_bootstrap?.latest as IssueBootstrapRecord | null | undefined;
+  const bootstrapContinuity = latestStatusBootstrap
+    ? await assessIssueBootstrapContinuity({
+        bootstrap: latestStatusBootstrap,
+        currentRepoPath: resolved.projectPath,
+        projectPath: resolved.projectPath,
+      })
+    : undefined;
 
   lines.push(...buildCommittedSnapshotSummaryLines(committedSnapshotAssessment));
   lines.push(...buildGuardrailSummaryLines(
@@ -533,7 +568,7 @@ export async function getStatus(args: any = {}): Promise<string> {
   ));
   lines.push(...buildIssueBootstrapSummaryLines({
     issueBootstrap: displayState.issue_bootstrap as IssueBootstrapState | undefined,
-    committedSnapshotAssessment,
+    continuity: bootstrapContinuity,
   }));
   try {
     lines.push(...await buildWorktreeTopologySummaryLines(resolved.projectPath, resolved.projectYaml));

--- a/mcp-server/src/utils/__tests__/health.test.ts
+++ b/mcp-server/src/utils/__tests__/health.test.ts
@@ -90,7 +90,7 @@ describe('health command', () => {
   });
 
   it('reports PASS when the canonical checkout is clean and freshness signals are present', async () => {
-    const projectRoot = await setupProjectRoot(`session:\n  last_entry_surface_refresh: "2026-03-25T00:00:00.000Z"\nguardrail_evidence:\n  last_command: "agenticos_preflight"\nentry_surface_refresh:\n  refreshed_at: "2026-03-25T00:00:00.000Z"\n`);
+    const projectRoot = await setupProjectRoot(`session:\n  last_entry_surface_refresh: "2026-03-25T00:00:00.000Z"\nguardrail_evidence:\n  last_command: "agenticos_preflight"\nentry_surface_refresh:\n  refreshed_at: "2026-03-25T00:00:00.000Z"\nissue_bootstrap:\n  latest:\n    issue_id: "300"\n    current_branch: "main"\n    workspace_type: "main"\n    repo_path: "/repo"\n`);
     childProcessMock.exec.mockImplementation((_: string, cb: Function) => cb(null, '## main...origin/main\n', ''));
     standardKitMock.checkStandardKitUpgrade.mockResolvedValue({
       missing_required_files: [],
@@ -110,6 +110,7 @@ describe('health command', () => {
       { gate: 'entry_surface_refresh', status: 'PASS', summary: 'Entry surfaces have explicit refresh metadata.' },
       { gate: 'versioned_entry_surface_state', status: 'PASS', summary: 'Committed versioned entry surfaces look fresh for canonical mainline use.' },
       { gate: 'guardrail_evidence', status: 'PASS', summary: 'Latest guardrail evidence is present (agenticos_preflight).' },
+      { gate: 'issue_bootstrap_continuity', status: 'PASS', summary: 'Latest issue bootstrap evidence is current for this checkout.' },
       { gate: 'worktree_topology', status: 'PASS', summary: 'Worktree topology matches the derived project-scoped root.' },
       { gate: 'standard_kit', status: 'PASS', summary: 'Standard-kit files match the canonical kit.' },
     ]);
@@ -177,6 +178,11 @@ describe('health command', () => {
         summary: 'No persisted guardrail evidence is present yet.',
       },
       {
+        gate: 'issue_bootstrap_continuity',
+        status: 'BLOCK',
+        summary: 'No issue bootstrap evidence is recorded for the current checkout.',
+      },
+      {
         gate: 'worktree_topology',
         status: 'WARN',
         summary: 'Worktree topology has 1 misplaced clean worktree(s).',
@@ -194,6 +200,7 @@ describe('health command', () => {
       'discard or isolate runtime-managed drift from the canonical checkout: standards/.context/state.yaml',
       'review, move, or revert source-tree edits before trusting the canonical checkout: README.md',
       'keep new implementation work inside isolated issue worktrees rather than the canonical main checkout',
+      'run agenticos_issue_bootstrap in the current checkout',
       'recreate misplaced clean worktrees under the derived project-scoped worktree root and remove the old paths',
     ]);
   });
@@ -233,6 +240,43 @@ describe('health command', () => {
     ]);
   });
 
+  it('still evaluates issue bootstrap continuity for an explicit trusted project_path without a resolved managed target', async () => {
+    const projectRoot = await setupProjectRoot(`entry_surface_refresh:\n  refreshed_at: "2026-03-25T00:00:00.000Z"\nissue_bootstrap:\n  latest:\n    issue_id: "300"\n    current_branch: "main"\n    workspace_type: "main"\n    repo_path: "/repo"\n`);
+    repoBoundaryMock.resolveGuardrailProjectTarget.mockResolvedValue({
+      activeProjectId: null,
+      resolutionSource: null,
+      targetProject: null,
+      resolutionErrors: ['explicit project path is outside the managed registry'],
+    });
+    childProcessMock.exec.mockImplementation((_: string, cb: Function) => cb(null, '## main...origin/main\n', ''));
+
+    const result = await runHealthCheck({
+      repo_path: '/repo',
+      project_path: projectRoot,
+    });
+
+    expect(result.project_path).toBe(projectRoot);
+    expect(result.gates).toContainEqual({
+      gate: 'issue_bootstrap_continuity',
+      status: 'PASS',
+      summary: 'Latest issue bootstrap evidence is current for this checkout.',
+    });
+  });
+
+  it('skips issue bootstrap continuity for non-github_versioned projects', async () => {
+    const projectRoot = await setupProjectRoot(`entry_surface_refresh:\n  refreshed_at: "2026-03-25T00:00:00.000Z"\nissue_bootstrap:\n  latest:\n    issue_id: "300"\n    repo_path: "/repo"\n`, {
+      projectYaml: `meta:\n  id: "health-project"\n  name: "Health Project"\nsource_control:\n  topology: "local_directory_only"\nagent_context:\n  quick_start: "standards/.context/quick-start.md"\n  current_state: "standards/.context/state.yaml"\n  conversations: "standards/.context/conversations/"\n  last_record_marker: "standards/.context/.last_record"\n`,
+    });
+    childProcessMock.exec.mockImplementation((_: string, cb: Function) => cb(null, '## main...origin/main\n', ''));
+
+    const result = await runHealthCheck({
+      repo_path: '/repo',
+      project_path: projectRoot,
+    });
+
+    expect(result.gates.some((gate) => gate.gate === 'issue_bootstrap_continuity')).toBe(false);
+  });
+
   it('classifies runtime-only drift in a canonical checkout that is otherwise aligned', async () => {
     const projectRoot = await setupProjectRoot(`entry_surface_refresh:\n  refreshed_at: "2026-03-25T00:00:00.000Z"\n`);
     childProcessMock.exec.mockImplementation((_: string, cb: Function) => cb(null, '## main...origin/main\n M standards/.context/state.yaml\n M CLAUDE.md\n', ''));
@@ -249,6 +293,11 @@ describe('health command', () => {
       summary: 'Canonical checkout is blocked by runtime-managed drift: 2 path(s).',
     });
     expect(result.gates[4]).toEqual({
+      gate: 'issue_bootstrap_continuity',
+      status: 'BLOCK',
+      summary: 'No issue bootstrap evidence is recorded for the current checkout.',
+    });
+    expect(result.gates[5]).toEqual({
       gate: 'worktree_topology',
       status: 'PASS',
       summary: 'Worktree topology matches the derived project-scoped root.',
@@ -272,8 +321,27 @@ describe('health command', () => {
       { gate: 'entry_surface_refresh', status: 'PASS', summary: 'Entry surfaces have explicit refresh metadata.' },
       { gate: 'versioned_entry_surface_state', status: 'WARN', summary: 'Committed versioned entry surfaces look stale for canonical mainline use.' },
       { gate: 'guardrail_evidence', status: 'WARN', summary: 'No persisted guardrail evidence is present yet.' },
+      { gate: 'issue_bootstrap_continuity', status: 'WARN', summary: 'Latest issue bootstrap evidence is historical for the current checkout.' },
       { gate: 'worktree_topology', status: 'PASS', summary: 'Worktree topology matches the derived project-scoped root.' },
     ]);
+  });
+
+  it('surfaces invalid issue bootstrap continuity as a dedicated BLOCK gate', async () => {
+    const projectRoot = await setupProjectRoot(`session:\n  last_entry_surface_refresh: "2026-03-25T00:00:00.000Z"\nentry_surface_refresh:\n  refreshed_at: "2026-03-25T00:00:00.000Z"\nissue_bootstrap:\n  latest:\n    issue_id: "300"\n    current_branch: "main"\n    workspace_type: "main"\n    repo_path: "   "\n`);
+    childProcessMock.exec.mockImplementation((_: string, cb: Function) => cb(null, '## main...origin/main\n', ''));
+
+    const result = await runHealthCheck({
+      repo_path: '/repo',
+      project_path: projectRoot,
+    });
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.gates).toContainEqual({
+      gate: 'issue_bootstrap_continuity',
+      status: 'BLOCK',
+      summary: 'Latest issue bootstrap evidence is missing repo_path for the current checkout.',
+    });
+    expect(result.recovery_actions).toContain('rerun agenticos_issue_bootstrap in the current checkout');
   });
 
   it('normalizes managed runtime paths when agent_context uses dot-prefixed and slashless directory paths', async () => {
@@ -350,10 +418,16 @@ describe('health command', () => {
 
     expect(result.status).toBe('BLOCK');
     expect(result.gates[4]).toEqual({
+      gate: 'issue_bootstrap_continuity',
+      status: 'BLOCK',
+      summary: 'No issue bootstrap evidence is recorded for the current checkout.',
+    });
+    expect(result.gates[5]).toEqual({
       gate: 'worktree_topology',
       status: 'BLOCK',
       summary: 'Worktree topology is blocked by 1 misplaced dirty worktree(s).',
     });
+    expect(result.recovery_actions).toContain('run agenticos_issue_bootstrap in the current checkout');
     expect(result.recovery_actions).toContain('protect dirty misplaced worktrees first, then recreate them under the derived project-scoped worktree root before removing the old paths');
   });
 
@@ -370,10 +444,16 @@ describe('health command', () => {
 
     expect(result.status).toBe('BLOCK');
     expect(result.gates[4]).toEqual({
+      gate: 'issue_bootstrap_continuity',
+      status: 'BLOCK',
+      summary: 'No issue bootstrap evidence is recorded for the current checkout.',
+    });
+    expect(result.gates[5]).toEqual({
       gate: 'worktree_topology',
       status: 'BLOCK',
       summary: 'Worktree topology could not be checked because the project is missing meta.id.',
     });
+    expect(result.recovery_actions).toContain('run agenticos_issue_bootstrap in the current checkout');
     expect(result.recovery_actions).toContain('restore project meta.id before relying on derived project-scoped worktree-root checks');
   });
 
@@ -463,6 +543,7 @@ describe('health command', () => {
       'verify git repo identity before treating repo_path as a managed project: show-toplevel failed',
     );
     expect(result.gates.some((gate) => gate.gate === 'worktree_topology')).toBe(false);
+    expect(result.gates.some((gate) => gate.gate === 'issue_bootstrap_continuity')).toBe(false);
   });
 
   it('fails closed on missing repo_path, git command failure fallbacks, missing branch status, and missing project_path for standard-kit checks', async () => {
@@ -504,6 +585,11 @@ describe('health command', () => {
         summary: 'No persisted guardrail evidence is present yet.',
       },
       {
+        gate: 'issue_bootstrap_continuity',
+        status: 'BLOCK',
+        summary: 'No issue bootstrap evidence is recorded for the current checkout.',
+      },
+      {
         gate: 'worktree_topology',
         status: 'PASS',
         summary: 'Worktree topology matches the derived project-scoped root.',
@@ -518,6 +604,7 @@ describe('health command', () => {
     });
     expect(missingBranchResult.recovery_actions).toEqual([
       'inspect canonical branch status "missing branch status" and restore exact main...origin/main alignment',
+      'run agenticos_issue_bootstrap in the current checkout',
     ]);
 
     childProcessMock.exec.mockImplementation((_: string, cb: Function) => cb(null, '## main...origin/main\n', ''));
@@ -629,6 +716,7 @@ describe('health command', () => {
 
     expect(result.project_path).toBeNull();
     expect(result.gates.some((gate) => gate.gate === 'worktree_topology')).toBe(false);
+    expect(result.gates.some((gate) => gate.gate === 'issue_bootstrap_continuity')).toBe(false);
     expect(result.recovery_actions).toContain(
       'verify git repo identity before treating repo_path as a managed project: git worktree root "/workspace/worktrees/health-project/issue-1" is under the derived project worktree root "/workspace/worktrees/health-project", but git common repo root "/external" is not declared for target project "health-project"',
     );
@@ -678,6 +766,7 @@ describe('health command', () => {
 
     expect(result.project_path).toBeNull();
     expect(result.gates.some((gate) => gate.gate === 'worktree_topology')).toBe(false);
+    expect(result.gates.some((gate) => gate.gate === 'issue_bootstrap_continuity')).toBe(false);
     expect(result.recovery_actions).toContain(
       'verify git repo identity before treating repo_path as a managed project: neither git worktree root "/workspace/other-repo" nor git common repo root "/workspace/other-repo" is declared for target project "health-project"',
     );

--- a/mcp-server/src/utils/__tests__/issue-bootstrap-continuity.test.ts
+++ b/mcp-server/src/utils/__tests__/issue-bootstrap-continuity.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtemp, mkdir, rm, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { assessIssueBootstrapContinuity } from '../issue-bootstrap-continuity.js';
+
+const createdPaths: string[] = [];
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), prefix));
+  createdPaths.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  while (createdPaths.length > 0) {
+    const path = createdPaths.pop();
+    if (path) {
+      await rm(path, { recursive: true, force: true });
+    }
+  }
+});
+
+describe('assessIssueBootstrapContinuity', () => {
+  it('returns missing_or_invalid when no bootstrap evidence exists', async () => {
+    const result = await assessIssueBootstrapContinuity({
+      bootstrap: null,
+      currentRepoPath: '/repo/current',
+    });
+
+    expect(result.status).toBe('missing_or_invalid');
+    expect(result.summary).toContain('No issue bootstrap evidence');
+    expect(result.recovery_actions).toEqual(['run agenticos_issue_bootstrap in the current checkout']);
+  });
+
+  it('returns missing_or_invalid when repo_path evidence is blank', async () => {
+    const result = await assessIssueBootstrapContinuity({
+      bootstrap: {
+        repo_path: '   ',
+      },
+      currentRepoPath: '/repo/current',
+    });
+
+    expect(result.status).toBe('missing_or_invalid');
+    expect(result.reasons).toEqual(['latest issue bootstrap is missing repo_path evidence']);
+  });
+
+  it('treats a matching current checkout as current when startup path checks are disabled', async () => {
+    const repoDir = await makeTempDir('agenticos-bootstrap-current-');
+
+    const result = await assessIssueBootstrapContinuity({
+      bootstrap: {
+        repo_path: repoDir,
+        startup_context_paths: ['/missing/path/that/is/ignored'],
+      },
+      currentRepoPath: repoDir,
+      checkStartupContextPaths: false,
+    });
+
+    expect(result.status).toBe('current');
+    expect(result.details.repo_path_exists).toBe(true);
+    expect(result.details.startup_context_paths_checked).toBe(0);
+  });
+
+  it('marks a missing relocated repo_path as historical for the current checkout', async () => {
+    const currentRepoDir = await makeTempDir('agenticos-bootstrap-current-');
+
+    const result = await assessIssueBootstrapContinuity({
+      bootstrap: {
+        repo_path: '/missing/old/worktree',
+      },
+      currentRepoPath: currentRepoDir,
+      checkStartupContextPaths: false,
+    });
+
+    expect(result.status).toBe('historical_for_current_checkout');
+    expect(result.reasons).toEqual([
+      `recorded repo_path points at "${'/missing/old/worktree'}" instead of the current checkout "${currentRepoDir}"`,
+      'recorded repo_path "/missing/old/worktree" no longer exists',
+    ]);
+  });
+
+  it('resolves relative startup context paths against projectPath and reports missing historical paths', async () => {
+    const repoDir = await makeTempDir('agenticos-bootstrap-project-');
+    const projectDir = await makeTempDir('agenticos-bootstrap-context-');
+    await mkdir(join(projectDir, '.context'), { recursive: true });
+    await writeFile(join(projectDir, '.context', 'quick-start.md'), '# quick start\n', 'utf-8');
+
+    const result = await assessIssueBootstrapContinuity({
+      bootstrap: {
+        repo_path: repoDir,
+        startup_context_paths: ['.context/quick-start.md', '.context/missing.md'],
+      },
+      currentRepoPath: repoDir,
+      projectPath: projectDir,
+    });
+
+    expect(result.status).toBe('historical_for_current_checkout');
+    expect(result.details.startup_context_paths_checked).toBe(2);
+    expect(result.details.missing_startup_context_paths).toEqual([
+      join(projectDir, '.context', 'missing.md'),
+    ]);
+  });
+
+  it('accepts existing absolute startup context paths', async () => {
+    const repoDir = await makeTempDir('agenticos-bootstrap-project-');
+    const contextFile = join(repoDir, 'startup.md');
+    await writeFile(contextFile, 'startup\n', 'utf-8');
+
+    const result = await assessIssueBootstrapContinuity({
+      bootstrap: {
+        repo_path: repoDir,
+        startup_context_paths: [contextFile],
+      },
+      currentRepoPath: repoDir,
+    });
+
+    expect(result.status).toBe('current');
+    expect(result.details.startup_context_paths_checked).toBe(1);
+  });
+
+  it('ignores unresolved relative startup context paths when no projectPath is available', async () => {
+    const repoDir = await makeTempDir('agenticos-bootstrap-project-');
+
+    const result = await assessIssueBootstrapContinuity({
+      bootstrap: {
+        repo_path: repoDir,
+        startup_context_paths: ['relative/path.md'],
+      },
+      currentRepoPath: repoDir,
+    });
+
+    expect(result.status).toBe('current');
+    expect(result.details.startup_context_paths_checked).toBe(0);
+  });
+});

--- a/mcp-server/src/utils/__tests__/versioned-entry-surface-state.test.ts
+++ b/mcp-server/src/utils/__tests__/versioned-entry-surface-state.test.ts
@@ -47,7 +47,6 @@ describe('assessVersionedEntrySurfaceState', () => {
       'entry_surface_refresh still reports in_progress in committed state',
       'issue bootstrap still points at non-main branch "fix/260-stop-active-project-drift-and-main-state-pollution"',
       'issue bootstrap still points at an isolated worktree snapshot',
-      'issue bootstrap repo_path still points at "/tmp/worktrees/issue-260" instead of the canonical project root',
     ]);
   });
 

--- a/mcp-server/src/utils/health.ts
+++ b/mcp-server/src/utils/health.ts
@@ -8,7 +8,9 @@ import { resolveManagedProjectContextDisplayPaths, resolveManagedProjectContextP
 import { resolveGuardrailProjectTarget, type GuardrailProjectTarget } from './repo-boundary.js';
 import { validateGuardrailRepoIdentity } from './guardrail-repo-identity.js';
 import { assessVersionedEntrySurfaceState } from './versioned-entry-surface-state.js';
+import { extractLatestIssueBootstrap, loadLatestGuardrailState } from './guardrail-evidence.js';
 import { getAgenticOSHome } from './registry.js';
+import { assessIssueBootstrapContinuity, type IssueBootstrapContinuityAssessment } from './issue-bootstrap-continuity.js';
 import { deriveExpectedWorktreeRoot, inspectProjectWorktreeTopology, type WorktreeTopologyInspection } from './worktree-topology.js';
 
 export interface HealthArgs {
@@ -20,7 +22,7 @@ export interface HealthArgs {
 }
 
 export interface HealthGate {
-  gate: 'repo_sync' | 'entry_surface_refresh' | 'versioned_entry_surface_state' | 'guardrail_evidence' | 'worktree_topology' | 'standard_kit';
+  gate: 'repo_sync' | 'entry_surface_refresh' | 'versioned_entry_surface_state' | 'guardrail_evidence' | 'issue_bootstrap_continuity' | 'worktree_topology' | 'standard_kit';
   status: 'PASS' | 'WARN' | 'BLOCK';
   summary: string;
 }
@@ -36,6 +38,7 @@ export interface HealthResult {
   gates: HealthGate[];
   repo_sync?: CanonicalRepoSyncDetails;
   worktree_topology?: WorktreeTopologyInspection;
+  issue_bootstrap_continuity?: IssueBootstrapContinuityAssessment;
   recovery_actions?: string[];
 }
 
@@ -143,6 +146,33 @@ function buildGuardrailGate(state: any | null): HealthGate {
     gate: 'guardrail_evidence',
     status: 'WARN',
     summary: 'No persisted guardrail evidence is present yet.',
+  };
+}
+
+async function buildIssueBootstrapContinuityGate(args: HealthArgs, projectYaml: any | null, state: any | null): Promise<{ gate: HealthGate; continuity: IssueBootstrapContinuityAssessment } | null> {
+  if (!args.project_path || state === null) return null;
+  if (projectYaml?.source_control?.topology !== 'github_versioned') return null;
+
+  const latestBootstrap = extractLatestIssueBootstrap(state);
+  const continuity = await assessIssueBootstrapContinuity({
+    bootstrap: latestBootstrap,
+    currentRepoPath: args.repo_path,
+    projectPath: args.project_path,
+  });
+
+  const gateStatus = continuity.status === 'current'
+    ? 'PASS'
+    : continuity.status === 'historical_for_current_checkout'
+      ? 'WARN'
+      : 'BLOCK';
+
+  return {
+    gate: {
+      gate: 'issue_bootstrap_continuity',
+      status: gateStatus,
+      summary: continuity.summary,
+    },
+    continuity,
   };
 }
 
@@ -298,6 +328,12 @@ export async function runHealthCheck(args: HealthArgs): Promise<HealthResult> {
   const resolvedProjectPath = effectiveProjectPath ?? undefined;
   const projectYaml = await readProjectYaml(resolvedProjectPath);
   const state = await readState(resolvedProjectPath, projectYaml);
+  const displayState = effectiveProjectPath && projectResolution.targetProject?.statePath
+    ? await loadLatestGuardrailState({
+        project_id: projectResolution.targetProject.id,
+        committed_state_path: projectResolution.targetProject.statePath,
+      }).then((loaded) => loaded.state).catch(() => state)
+    : state;
   const repoSync = analyzeCanonicalRepoSync({
     statusOutput: repoStatus,
     remoteBaseBranch,
@@ -313,6 +349,11 @@ export async function runHealthCheck(args: HealthArgs): Promise<HealthResult> {
     project_path: resolvedProjectPath,
   };
   const worktreeTopologyGate = await buildWorktreeTopologyGate(effectiveArgs, projectYaml);
+  const bootstrapContinuityGate = await buildIssueBootstrapContinuityGate(
+    effectiveArgs,
+    effectiveProjectPath ? projectYaml : null,
+    displayState,
+  );
 
   const gates: HealthGate[] = [
     {
@@ -335,6 +376,10 @@ export async function runHealthCheck(args: HealthArgs): Promise<HealthResult> {
     buildGuardrailGate(state),
   );
 
+  if (bootstrapContinuityGate) {
+    gates.push(bootstrapContinuityGate.gate);
+  }
+
   if (worktreeTopologyGate) {
     gates.push(worktreeTopologyGate.gate);
   }
@@ -355,10 +400,14 @@ export async function runHealthCheck(args: HealthArgs): Promise<HealthResult> {
     gates,
     repo_sync: repoSync.details,
     worktree_topology: worktreeTopologyGate?.topology,
+    issue_bootstrap_continuity: bootstrapContinuityGate?.continuity,
     recovery_actions: [
       ...repoSync.recovery_actions,
       ...(trustedProject.repoIdentityError
         ? [`verify git repo identity before treating repo_path as a managed project: ${trustedProject.repoIdentityError}`]
+        : []),
+      ...(bootstrapContinuityGate?.continuity.status && bootstrapContinuityGate.continuity.status !== 'current'
+        ? bootstrapContinuityGate.continuity.recovery_actions
         : []),
       ...(worktreeTopologyGate?.topology.status === 'WARN' && worktreeTopologyGate.topology.counts.misplaced_clean > 0
         ? ['recreate misplaced clean worktrees under the derived project-scoped worktree root and remove the old paths']

--- a/mcp-server/src/utils/issue-bootstrap-continuity.ts
+++ b/mcp-server/src/utils/issue-bootstrap-continuity.ts
@@ -1,0 +1,164 @@
+import { access } from 'fs/promises';
+import { isAbsolute, resolve } from 'path';
+import type { IssueBootstrapRecord } from './guardrail-evidence.js';
+
+export type IssueBootstrapContinuityStatus =
+  | 'current'
+  | 'historical_for_current_checkout'
+  | 'missing_or_invalid';
+
+export interface IssueBootstrapContinuityAssessment {
+  status: IssueBootstrapContinuityStatus;
+  summary: string;
+  reasons: string[];
+  recovery_actions: string[];
+  details: {
+    recorded_repo_path: string | null;
+    current_repo_path: string | null;
+    repo_path_exists: boolean | null;
+    startup_context_paths_checked: number;
+    missing_startup_context_paths: string[];
+  };
+}
+
+function normalizedString(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolveStartupContextPath(path: string, projectPath?: string | null): string | null {
+  if (isAbsolute(path)) {
+    return resolve(path);
+  }
+
+  const normalizedProjectPath = normalizedString(projectPath);
+  if (!normalizedProjectPath) {
+    return null;
+  }
+
+  return resolve(normalizedProjectPath, path);
+}
+
+export async function assessIssueBootstrapContinuity(args: {
+  bootstrap?: IssueBootstrapRecord | null;
+  currentRepoPath?: string | null;
+  projectPath?: string | null;
+  checkStartupContextPaths?: boolean;
+}): Promise<IssueBootstrapContinuityAssessment> {
+  const bootstrap = args.bootstrap || null;
+  const currentRepoPath = normalizedString(args.currentRepoPath);
+
+  if (!bootstrap) {
+    return {
+      status: 'missing_or_invalid',
+      summary: 'No issue bootstrap evidence is recorded for the current checkout.',
+      reasons: ['no issue bootstrap evidence is recorded'],
+      recovery_actions: ['run agenticos_issue_bootstrap in the current checkout'],
+      details: {
+        recorded_repo_path: null,
+        current_repo_path: currentRepoPath,
+        repo_path_exists: null,
+        startup_context_paths_checked: 0,
+        missing_startup_context_paths: [],
+      },
+    };
+  }
+
+  const recordedRepoPath = normalizedString(bootstrap.repo_path);
+  if (!recordedRepoPath) {
+    return {
+      status: 'missing_or_invalid',
+      summary: 'Latest issue bootstrap evidence is missing repo_path for the current checkout.',
+      reasons: ['latest issue bootstrap is missing repo_path evidence'],
+      recovery_actions: ['rerun agenticos_issue_bootstrap in the current checkout'],
+      details: {
+        recorded_repo_path: null,
+        current_repo_path: currentRepoPath,
+        repo_path_exists: null,
+        startup_context_paths_checked: 0,
+        missing_startup_context_paths: [],
+      },
+    };
+  }
+
+  const normalizedRecordedRepoPath = resolve(recordedRepoPath);
+  const normalizedCurrentRepoPath = currentRepoPath ? resolve(currentRepoPath) : null;
+  const repoPathMatchesCurrentCheckout = normalizedCurrentRepoPath !== null
+    && normalizedRecordedRepoPath === normalizedCurrentRepoPath;
+  const repoPathExists = repoPathMatchesCurrentCheckout
+    ? true
+    : await pathExists(normalizedRecordedRepoPath);
+  const missingStartupContextPaths: string[] = [];
+  let startupContextPathsChecked = 0;
+
+  if (args.checkStartupContextPaths !== false) {
+    const startupContextPaths = Array.isArray(bootstrap.startup_context_paths)
+      ? bootstrap.startup_context_paths
+          .map((path) => normalizedString(path))
+          .filter((path): path is string => path !== null)
+      : [];
+    const resolvedStartupContextPaths = startupContextPaths
+      .map((path) => resolveStartupContextPath(path, args.projectPath))
+      .filter((path): path is string => path !== null);
+
+    startupContextPathsChecked = resolvedStartupContextPaths.length;
+    for (const path of resolvedStartupContextPaths) {
+      if (!(await pathExists(path))) {
+        missingStartupContextPaths.push(path);
+      }
+    }
+  }
+
+  const reasons: string[] = [];
+  if (normalizedCurrentRepoPath && normalizedRecordedRepoPath !== normalizedCurrentRepoPath) {
+    reasons.push(`recorded repo_path points at "${normalizedRecordedRepoPath}" instead of the current checkout "${normalizedCurrentRepoPath}"`);
+  }
+
+  if (!repoPathExists) {
+    reasons.push(`recorded repo_path "${normalizedRecordedRepoPath}" no longer exists`);
+  }
+
+  if (missingStartupContextPaths.length > 0) {
+    reasons.push(`startup context paths include ${missingStartupContextPaths.length} missing historical path(s)`);
+  }
+
+  if (reasons.length === 0) {
+    return {
+      status: 'current',
+      summary: 'Latest issue bootstrap evidence is current for this checkout.',
+      reasons: [],
+      recovery_actions: [],
+      details: {
+        recorded_repo_path: normalizedRecordedRepoPath,
+        current_repo_path: normalizedCurrentRepoPath,
+        repo_path_exists: repoPathExists,
+        startup_context_paths_checked: startupContextPathsChecked,
+        missing_startup_context_paths: [],
+      },
+    };
+  }
+
+  return {
+    status: 'historical_for_current_checkout',
+    summary: 'Latest issue bootstrap evidence is historical for the current checkout.',
+    reasons,
+    recovery_actions: ['rerun agenticos_issue_bootstrap in the current checkout'],
+    details: {
+      recorded_repo_path: normalizedRecordedRepoPath,
+      current_repo_path: normalizedCurrentRepoPath,
+      repo_path_exists: repoPathExists,
+      startup_context_paths_checked: startupContextPathsChecked,
+      missing_startup_context_paths: missingStartupContextPaths,
+    },
+  };
+}

--- a/mcp-server/src/utils/versioned-entry-surface-state.ts
+++ b/mcp-server/src/utils/versioned-entry-surface-state.ts
@@ -81,10 +81,6 @@ export function assessVersionedEntrySurfaceState(args: {
     reasons.push('issue bootstrap still points at an isolated worktree snapshot');
   }
 
-  if (args.projectPath && issueBootstrapRepoPath && resolve(issueBootstrapRepoPath) !== resolve(args.projectPath)) {
-    reasons.push(`issue bootstrap repo_path still points at "${issueBootstrapRepoPath}" instead of the canonical project root`);
-  }
-
   if (reasons.length > 0) {
     return {
       applies: true,

--- a/tasks/issue-300-stale-issue-bootstrap-relocation-design.md
+++ b/tasks/issue-300-stale-issue-bootstrap-relocation-design.md
@@ -1,0 +1,418 @@
+# Issue #300 Design Review: Stale Issue-Bootstrap Paths After Worktree Relocation
+
+## Summary
+
+`#297` fixed where issue worktrees are allowed to live.
+
+`#300` is about what happens **after** a worktree is manually relocated or
+normalized.
+
+Today, `issue_bootstrap.latest.repo_path` is still treated in two incompatible
+ways:
+
+1. as a historical record of the checkout where bootstrap was recorded
+2. as if it were still current-path proof for every later status/freshness read
+
+That is the core design error.
+
+The correct V1 model is:
+
+- persisted bootstrap paths stay immutable as historical evidence
+- status/health must explicitly evaluate whether that evidence is still valid
+  for the **current checkout**
+- live guardrail commands must still require an explicit rerun of
+  `agenticos_issue_bootstrap` in the new checkout instead of silently
+  reconciling history
+
+## Current Evidence
+
+The current gap was reproduced after normalizing `360teams` worktrees under the
+project-scoped root:
+
+- worktree topology now reports `PASS`
+- expected root is `/Users/jeking/dev/AgenticOS/worktrees/360teams`
+- the old misplaced worktree paths were removed or moved
+- but the latest bootstrap record still points at the old checkout path
+
+So the system ends up saying two different things at once:
+
+- topology is correct
+- latest bootstrap path still looks stale or mismatched
+
+That is confusing because the first problem has been fixed while the second is
+just a historical-evidence continuity problem.
+
+## Current Semantics In Code
+
+### `versioned-entry-surface-state.ts`
+
+`assessVersionedEntrySurfaceState(...)` currently hard-codes this stale reason:
+
+- `issue bootstrap repo_path still points at "<path>" instead of the canonical project root`
+
+That means a historical worktree path is incorrectly treated as a canonical
+freshness invariant.
+
+### `project.ts`
+
+`status` / `switch` currently render the latest bootstrap record directly and do
+not distinguish:
+
+- latest recorded bootstrap evidence
+- bootstrap evidence that is still valid for the current checkout
+
+The label logic is also tied to committed-snapshot freshness, so a runtime
+bootstrap record can be shown under a “committed snapshot” label.
+
+### `health.ts`
+
+`health` has a `guardrail_evidence` presence gate and a committed entry-surface
+freshness gate, but no dedicated bootstrap-continuity signal for the current
+checkout.
+
+### `preflight.ts` and `edit-guard.ts`
+
+These tools currently do the right thing from a safety perspective:
+
+- they fail closed when `latestBootstrap.repo_path !== current repo_path`
+
+But their messaging is too generic. They do not distinguish:
+
+- historical bootstrap recorded in an older checkout
+- operator has relocated the worktree and simply needs to rerun bootstrap
+- truly wrong checkout / wrong branch / wrong issue context
+
+## Design Goal
+
+Keep historical bootstrap evidence immutable, but stop treating historical paths
+as if they were still current live proof for any later checkout.
+
+The system should:
+
+1. preserve `issue_bootstrap.latest.repo_path` as the original recorded path
+2. explicitly evaluate whether that record is still valid for the current
+   checkout
+3. surface that evaluation in `status` and `health`
+4. keep live guardrail enforcement fail-closed and require rerunning
+   `agenticos_issue_bootstrap` in the current checkout
+
+## Non-Goals
+
+This issue should not:
+
+- reopen `#297` worktree-root placement enforcement
+- automatically move worktrees
+- silently rewrite persisted historical bootstrap paths
+- auto-reconcile old and new checkouts based only on branch name or HEAD
+- expand into append-only bootstrap history
+- change the guardrail trust model so that relocated worktrees become trusted
+  without rerunning `agenticos_issue_bootstrap`
+
+## Design Options
+
+### Option A: Narrow Freshness Fix Only
+
+Remove the canonical-root `repo_path` stale reason from
+`versioned-entry-surface-state.ts`, and keep all other behavior unchanged.
+
+Pros:
+
+- smallest implementation
+- fixes the most obviously wrong stale reason
+
+Cons:
+
+- `status` still does not explain whether the latest bootstrap is current or
+  only historical
+- `health` still has no machine-checkable bootstrap continuity signal
+- relocation still looks like a generic mismatch in live guardrail commands
+
+### Option B: Add Bootstrap Continuity As A First-Class Evaluation Layer
+
+Introduce an explicit current-checkout evaluation for the latest bootstrap
+record, and use it in `status`, `health`, and live guardrail recovery
+messaging.
+
+Pros:
+
+- separates historical evidence from current-checkout validity
+- keeps immutable history and fail-closed rerun semantics
+- resolves the status/health ambiguity directly
+
+Cons:
+
+- slightly larger implementation slice
+- requires new tests across multiple surfaces
+
+## Recommendation
+
+Recommend **Option B**.
+
+Option A is too narrow for the issue statement and acceptance criteria.
+
+`#300` is not just “remove one stale reason.” It is about defining the semantic
+boundary between:
+
+- the latest recorded bootstrap
+- bootstrap evidence that is still valid for the current checkout
+
+## Proposed V1 Contract
+
+### 1. Historical bootstrap evidence stays immutable
+
+`issue_bootstrap.latest` remains a point-in-time record.
+
+In particular:
+
+- `repo_path` remains the checkout path where bootstrap was recorded
+- `startup_context_paths` remain the paths recorded at bootstrap time
+- no status/health read is allowed to rewrite those paths
+
+### 2. Add explicit bootstrap continuity evaluation
+
+Add a shared helper, preferably in a new utility such as:
+
+- `mcp-server/src/utils/issue-bootstrap-continuity.ts`
+
+Suggested output shape:
+
+```ts
+type IssueBootstrapContinuityStatus =
+  | 'current'
+  | 'historical_for_current_checkout'
+  | 'missing_or_invalid';
+
+interface IssueBootstrapContinuityAssessment {
+  status: IssueBootstrapContinuityStatus;
+  summary: string;
+  reasons: string[];
+  recovery_actions: string[];
+  details: {
+    recorded_repo_path: string | null;
+    current_repo_path: string | null;
+    repo_path_exists: boolean | null;
+    startup_context_paths_checked: number;
+    missing_startup_context_paths: string[];
+  };
+}
+```
+
+### 3. Continuity rules
+
+For V1, continuity is only about whether the latest bootstrap record still
+counts as proof for the **current checkout path**.
+
+Suggested rules:
+
+- `current`
+  - latest bootstrap exists
+  - `repo_path` matches the current checkout path
+  - any absolute `startup_context_paths` that are expected to exist still exist
+
+- `historical_for_current_checkout`
+  - latest bootstrap exists
+  - but `repo_path` differs from the current checkout path, or
+  - recorded startup context paths are missing / historical
+
+- `missing_or_invalid`
+  - no bootstrap exists, or
+  - required bootstrap fields are missing / malformed
+
+Important:
+
+- this helper should **not** auto-upgrade `historical_for_current_checkout` to
+  `current` by inspecting same-branch or same-HEAD heuristics
+- explicit rerun remains required
+
+### 4. Committed freshness semantics
+
+`versioned-entry-surface-state.ts` should stop treating
+`issue_bootstrap.latest.repo_path` as a canonical-root invariant.
+
+Keep stale committed-snapshot signals that are genuinely about stale issue
+context:
+
+- `current_task.status === in_progress`
+- `entry_surface_refresh.status === in_progress`
+- `issue_bootstrap.current_branch !== main`
+- `issue_bootstrap.workspace_type === isolated_worktree`
+
+Remove the direct canonical-root mismatch reason:
+
+- `issue bootstrap repo_path still points at "<path>" instead of the canonical project root`
+
+Then, if needed, append a **path-aware** stale reason only through the new
+continuity helper, not through a raw canonical-root string comparison.
+
+### 5. `status` / `switch` rendering
+
+`project.ts` should render bootstrap continuity explicitly.
+
+Suggested output pattern:
+
+- `🧭 Latest issue bootstrap record: #300 on fix/...`
+- `   Status: current for this checkout`
+
+or
+
+- `🧭 Latest issue bootstrap record: #18 on feat/...`
+- `   Status: historical for current checkout`
+- `   Reason: recorded repo_path points at an older checkout path`
+- `   Recovery: rerun agenticos_issue_bootstrap in the current checkout`
+
+Two important rendering rules:
+
+1. stop using committed-snapshot freshness to rename the bootstrap label as if
+   the bootstrap line itself were a committed snapshot
+2. keep “committed snapshot freshness” and “bootstrap continuity” as separate
+   lines so users can see when both are true at once
+
+### 6. `health` semantics
+
+Add a dedicated gate:
+
+- `issue_bootstrap_continuity`
+
+Recommended statuses:
+
+- `PASS` when bootstrap continuity is `current`
+- `WARN` when it is `historical_for_current_checkout`
+- `BLOCK` when it is `missing_or_invalid`
+
+This keeps the issue separate from:
+
+- `worktree_topology`
+- `repo_sync`
+- committed `versioned_entry_surface_state`
+
+Suggested recovery actions:
+
+- historical:
+  - `rerun agenticos_issue_bootstrap in the current checkout before trusting current-checkout bootstrap evidence`
+- missing/invalid:
+  - `record agenticos_issue_bootstrap in the current verified checkout before continuing`
+
+### 7. Live guardrail enforcement
+
+Do **not** weaken `preflight` / `edit_guard`.
+
+Instead:
+
+- keep exact current-checkout mismatch as a fail-closed condition
+- replace generic mismatch wording with relocation-aware recovery wording
+
+Example:
+
+- current: `latest issue bootstrap was recorded for a different repo_path`
+- proposed V1: `latest issue bootstrap is historical for this checkout; rerun agenticos_issue_bootstrap in the current checkout before continuing`
+
+This preserves safety while making the operator action obvious.
+
+### 8. `startup_context_paths`
+
+For V1:
+
+- inspect only paths that can be evaluated deterministically
+- absolute paths are checked directly
+- relative paths may be resolved against `project_path` when available
+- missing historical startup paths should contribute to
+  `historical_for_current_checkout`, not trigger silent rewriting
+
+This matters mainly for older records and compatibility cases.
+
+## Affected Files
+
+Primary implementation slice:
+
+- `mcp-server/src/utils/versioned-entry-surface-state.ts`
+- `mcp-server/src/tools/project.ts`
+- `mcp-server/src/utils/health.ts`
+- `mcp-server/src/tools/preflight.ts`
+- `mcp-server/src/tools/edit-guard.ts`
+
+New shared helper:
+
+- `mcp-server/src/utils/issue-bootstrap-continuity.ts`
+
+Likely unchanged persistence/write behavior:
+
+- `mcp-server/src/utils/guardrail-evidence.ts`
+- `mcp-server/src/tools/issue-bootstrap.ts`
+
+V1 out of scope unless review finds a hard requirement:
+
+- `mcp-server/src/resources/context.ts`
+
+Reason:
+
+- it is a raw context surface, not the main operator-facing health/status flow
+- including it now would widen the issue without changing the core contract
+
+## Test Plan
+
+### `versioned-entry-surface-state.test.ts`
+
+Add / update cases for:
+
+- historical relocated `repo_path` alone no longer causes the canonical-root
+  stale reason
+- non-main branch still causes stale
+- isolated worktree still causes stale
+- fresh canonical-main snapshot remains PASS
+
+### `health.test.ts`
+
+Add cases for:
+
+- `issue_bootstrap_continuity = PASS` when repo_path matches current checkout
+- `issue_bootstrap_continuity = WARN` when repo_path points at an older moved
+  checkout path
+- `issue_bootstrap_continuity = BLOCK` when bootstrap is missing or invalid
+- recovery action tells the operator to rerun `agenticos_issue_bootstrap`
+
+### `project.test.ts`
+
+Add cases for:
+
+- status renders `Latest issue bootstrap record`
+- status distinguishes current vs historical bootstrap continuity
+- historical bootstrap continuity shows recovery guidance
+- committed snapshot stale lines remain separate from bootstrap continuity lines
+
+### `preflight.test.ts` and `edit-guard.test.ts`
+
+Add cases for:
+
+- relocated old bootstrap path still blocks
+- block reason says bootstrap is historical for the current checkout
+- recovery action says rerun bootstrap in the current checkout
+- truly missing bootstrap still blocks as missing, not historical
+
+## Acceptance Criteria
+
+`#300` is complete when:
+
+1. historical `issue_bootstrap.repo_path` is no longer treated as a canonical
+   freshness invariant by itself
+2. `status` distinguishes latest recorded bootstrap evidence from bootstrap
+   evidence that is valid for the current checkout
+3. `health` exposes bootstrap continuity as its own machine-checkable signal
+4. relocated historical bootstrap evidence yields rerun guidance instead of a
+   generic mismatch message
+5. `preflight` and `edit_guard` still fail closed until bootstrap is rerun in
+   the current checkout
+6. no status/health evaluation silently rewrites historical bootstrap paths
+
+## Implementation Notes
+
+The most important scope control for V1 is:
+
+- do not try to infer continuity from same branch or same HEAD alone
+- do not implement automatic path reconciliation
+- do not widen into generic historical-path rewriting
+
+The safe contract is:
+
+- immutable record
+- explicit continuity assessment
+- explicit rerun to restore current-checkout proof


### PR DESCRIPTION
## Summary
- add explicit issue-bootstrap continuity assessment for current, historical, and missing/invalid states
- surface continuity separately in status/switch/health while keeping historical bootstrap provenance immutable
- keep preflight/edit-guard fail-closed and improve recovery messaging after worktree relocation

## Verification
- npm run build
- npm test
- npx vitest run --coverage

Closes #300