### PR TITLE
release: prepare v0.4.4 for runtime parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No unreleased changes._
 
+## [0.4.4] — 2026-04-19
+
+### Fixed
+- installed/runtime AgenticOS now includes the merged `private_continuity`
+  tracked-save behavior from `#244` / PR `#270`, so Git-backed private projects
+  can persist their tracked continuity surface instead of falling back to the
+  older narrow runtime-only save behavior
+- installed/runtime AgenticOS now includes the merged `public_distilled`
+  transcript-isolation behavior from `#245` / PR `#278`, so raw transcripts no
+  longer rely on tracked public conversation paths in the shipped runtime
+- Homebrew formula metadata is now aligned with the shipped release artifact
+  instead of pointing at the stale `v0.4.2` package
+
+### Changed
+- release artifact packaging is now prepared from `0.4.4`, which is the first
+  shipped version expected to carry the post-`0.4.3` continuity and transcript
+  behavior already merged on `main`
+
 ## [0.4.3] — 2026-04-10
 
 ### Fixed

--- a/homebrew-tap/Formula/agenticos.rb
+++ b/homebrew-tap/Formula/agenticos.rb
@@ -3,9 +3,9 @@ require "language/node"
 class Agenticos < Formula
   desc "AI-native project management MCP server for coding agents"
   homepage "https://github.com/madlouse/AgenticOS"
-  url "https://github.com/madlouse/AgenticOS/releases/download/v0.4.2/agenticos-mcp.tgz"
-  version "0.4.2"
-  sha256 "9ccc0051cbf11ec4731d57c3765cb548e092a344520bc733e89d149a7ad27cc8"
+  url "https://github.com/madlouse/AgenticOS/releases/download/v0.4.4/agenticos-mcp.tgz"
+  version "0.4.4"
+  sha256 "79e8288c42b21fd4780801707fe1caf84c40e050b5f01106990539949f0174bf"
   license "MIT"
 
   depends_on "node"

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenticos-mcp",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenticos-mcp",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-mcp",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "MCP Server for AgenticOS - AI-native project management system",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Closes #302.

## Summary

This PR prepares the next AgenticOS patch release so the shipped/installable runtime catches up with the continuity and transcript behavior already merged on `main` after `v0.4.3`.

This tranche is release-prep only:

1. bump `mcp-server` from `0.4.3` to `0.4.4`
2. add the `0.4.4` changelog entry for the continuity/transcript install-time behavior
3. update the Homebrew formula to the matching `v0.4.4` release asset URL and checksum

No new runtime semantics are introduced here. This only ships behavior already merged via PR `#270` and PR `#278`.

## What Changed

- bumped `mcp-server/package.json` to `0.4.4`
- bumped `mcp-server/package-lock.json` to `0.4.4`
- added `CHANGELOG.md` entry for `0.4.4`
- updated `homebrew-tap/Formula/agenticos.rb` to `v0.4.4`
- computed the `sha256` from a locally generated tarball that matches the release workflow shape (`npm pack` -> `agenticos-mcp.tgz`)

## Verification

- `cd mcp-server && npm run lint`
- `cd mcp-server && npm test -- src/tools/__tests__/save.test.ts src/tools/__tests__/record.test.ts src/utils/__tests__/context-policy-plan.test.ts src/utils/__tests__/continuity-surface.test.ts`
- `cd mcp-server && node build/index.js --version`

Result:

- lint passed
- `64` tests passed
- build output reports `0.4.4`

## Follow-Ups After Merge

- create and push tag `v0.4.4`
- wait for the GitHub release workflow to publish `agenticos-mcp.tgz`
- verify the release asset checksum matches the formula
- upgrade/reinstall the installed runtime and verify live parity
