### PR TITLE
fix: correct v0.4.4 formula checksum

### DIFF
--- a/homebrew-tap/Formula/agenticos.rb
+++ b/homebrew-tap/Formula/agenticos.rb
@@ -5,7 +5,7 @@ class Agenticos < Formula
   homepage "https://github.com/madlouse/AgenticOS"
   url "https://github.com/madlouse/AgenticOS/releases/download/v0.4.4/agenticos-mcp.tgz"
   version "0.4.4"
-  sha256 "79e8288c42b21fd4780801707fe1caf84c40e050b5f01106990539949f0174bf"
+  sha256 "48287c60a08ae14d716ae6237998b1cba8b6b6a3d33f7b36e23e1d127c8af579"
   license "MIT"
 
   depends_on "node"


### PR DESCRIPTION
Follow-up for #302.

## Summary

`v0.4.4` published successfully, but the merged Homebrew formula checksum was computed from a local tarball and does not match the actual GitHub release asset.

This PR corrects `homebrew-tap/Formula/agenticos.rb` to the checksum of the live published asset:

- release asset sha256: `48287c60a08ae14d716ae6237998b1cba8b6b6a3d33f7b36e23e1d127c8af579`

## Why

Without this fix, Homebrew install/upgrade for `v0.4.4` will fail even though the release itself is published.

## Verification

- `gh release download v0.4.4 -R madlouse/AgenticOS -p agenticos-mcp.tgz`
- `shasum -a 256 agenticos-mcp.tgz`
- confirmed the checksum differs from the merged formula and matches the value in this PR
