### PR TITLE
fix(standard-kit): correct template marker version mismatch (#305)

### DIFF
--- a/.meta/standard-kit/manifest.yaml
+++ b/.meta/standard-kit/manifest.yaml
@@ -100,8 +100,8 @@ layers:
 
 upgrade_rules:
   template_marker_version:
-    AGENTS.md: 10
-    CLAUDE.md: 10
+    AGENTS.md: 11
+    CLAUDE.md: 11
   compatibility_rule: >
     Generated files may be upgraded in place by distill when the template marker version changes.
   copied_template_rule: >

--- a/homebrew-tap/Formula/agenticos.rb
+++ b/homebrew-tap/Formula/agenticos.rb
@@ -5,7 +5,7 @@ class Agenticos < Formula
   homepage "https://github.com/madlouse/AgenticOS"
   url "https://github.com/madlouse/AgenticOS/releases/download/v0.4.4/agenticos-mcp.tgz"
   version "0.4.4"
-  sha256 "79e8288c42b21fd4780801707fe1caf84c40e050b5f01106990539949f0174bf"
+  sha256 "48287c60a08ae14d716ae6237998b1cba8b6b6a3d33f7b36e23e1d127c8af579"
   license "MIT"
 
   depends_on "node"


### PR DESCRIPTION
Fix #305: manifest.yaml declared v10 but files were v11. Updated manifest to v11.