### PR TITLE
feat(docs): rewrite README and add first-project tutorial (#309, #310)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,23 @@ _No unreleased changes._
 - generated `AGENTS.md` and `CLAUDE.md` adapter surfaces now ship with truthful
   `standards/.context/*` navigation for the self-hosting product project
 
+## [0.4.0] — 2026-04-06
+
+### Added
+- task intake rule: codified operator-intent recovery before treating named
+  methods or workflow fragments as the full plan
+- standard-kit adoption and upgrade-check tooling for downstream projects
+- distilled conversation surface with configurable truncation
+- `distill.ts` utility improvements: stronger truncation, word-boundary respect,
+  ellipsis placement
+
+### Changed
+- Homebrew formula updated to reflect new release artifact layout and artifact
+  naming conventions
+- standard-kit manifest updated with revised inheritance rules
+- template and documentation improvements across `issue-design-brief.md` and
+  Homebrew README
+
 ## [0.4.1] — 2026-04-07
 
 ### Fixed
@@ -73,6 +90,39 @@ _No unreleased changes._
 - CI now uses `npm install` instead of `npm ci` where lock-file drift made
   release and verification brittle
 - release workflow now matches the same install contract
+
+## [0.2.2] — 2026-04-01
+
+### Changed
+- Homebrew formula now provisions a workspace in `post_install` for a smoother
+  first-run experience; no user-facing API changes
+
+## [0.3.0] — 2026-04-01
+
+### Added
+- fail-fast `AGENTICOS_HOME` enforcement: AgenticOS now requires an explicit
+  `AGENTICOS_HOME` to be set and refuses to operate without it
+- `agenticos_edit_guard` tool: fail-closed project boundary enforcement before
+  implementation edits
+- `agenticos_standard_kit_conformance_check` and
+  `agenticos_standard_kit_upgrade_check` tools for downstream project audits
+- cross-agent policy freeze: codified boundaries between MCP-native, MCP +
+  Skills Assist, CLI Wrapper, and Skills-only guidance modes
+- `agenticos_non_code_evaluate` tool: rubric-backed non-code evaluation
+- `agenticos_health` command: canonical checkout freshness evaluation
+- `agenticos_refresh_entry_surfaces` command: deterministic quick-start and
+  state refresh from merged-work inputs
+- `agenticos_archive_import_evaluate` tool: archive import classification
+- guardrail summary now surfaces in `agenticos_status` and `agenticos_switch`
+  output
+
+### Fixed
+- `agenticos_pr_scope_check` now correctly preserves literal dots in path
+  matching instead of treating them as wildcards
+
+### Changed
+- distribution now via GitHub Releases and Homebrew
+- narrowed scope: deferred `memory.jsonl` and project-level changelog surfaces
 
 ## [0.2.0] — 2026-03-22
 

--- a/README.md
+++ b/README.md
@@ -1,46 +1,31 @@
 # AgenticOS
 
-AI-native project management that persists context across sessions for
-MCP-capable AI tools.
+AgenticOS gives AI coding assistants (Claude Code, Codex, Cursor, Gemini CLI,
+and any MCP-compatible tool) a persistent, structured memory of your
+projects. Every conversation, decision, and working state is saved so you can
+pick up exactly where you left off — even weeks later. No more re-explaining
+context at the start of every session.
 
-This directory is the canonical product-source project for AgenticOS. If you
-are changing AgenticOS itself, start here instead of treating the enclosing
-workspace root as the authoritative product repository.
+**If you use an AI coding assistant and want it to remember your project
+across sessions, you are the target user.**
 
-## Source Checkout vs Runtime Home
+## Get to `agenticos_list` in 3 Steps
 
-AgenticOS now distinguishes two different paths:
+```bash
+# 1. Install (macOS)
+brew install madlouse/tap/agenticos
 
-- `projects/agenticos/` is the canonical product-source checkout for developing AgenticOS itself
-- `AGENTICOS_HOME` is the runtime home used by installed binaries and managed projects
+# 2. Set up your workspace and bootstrap your AI tool
+export AGENTICOS_HOME=~/agenticos-workspace
+agenticos-bootstrap --workspace "$AGENTICOS_HOME" --first-run
 
-Do not treat the runtime home as the product-source root.
-In the standard layout, the runtime home contains a `projects/` directory, and
-the AgenticOS source project lives at `"$AGENTICOS_HOME/projects/agenticos"`.
+# 3. Verify — restart your AI tool, then ask it to run agenticos_list
+```
 
-## Scope
+For full documentation, agent-specific setup, and advanced configuration,
+see [mcp-server/README.md](mcp-server/README.md).
 
-`projects/agenticos/` owns:
-
-- product documentation and operator contracts
-- MCP server source under `mcp-server/`
-- standards, templates, and downstream workflow kit
-- Homebrew distribution assets under `homebrew-tap/`
-
-The enclosing workspace root may still expose compatibility entrypoints while the root-Git split is in progress, but those root files are not the long-term authority path.
-
-This project now also carries the future repository shell needed for root-Git
-exit:
-
-- `.github/`
-- `.gitignore`
-- `CLAUDE.md`
-- `CHANGELOG.md`
-- `ROADMAP.md`
-- `LICENSE`
-- `scripts/`
-
-## Quick Start
+## Quick Start (from source)
 
 Requires: node.js >= 20.0.0
 
@@ -86,46 +71,46 @@ select a workspace, does **not** edit Claude Code, Codex, Cursor, or Gemini
 CLI configuration, does **not** restart the AI tool, and does **not** prove
 activation by itself.
 
-After installation, set `AGENTICOS_HOME` explicitly, bootstrap one supported
-agent manually or with `agenticos-bootstrap`, restart the current client, and
-explicitly verify `agenticos_list` before assuming project-intent routing is
-working.
+### Recommended: One-command bootstrap
 
-`AGENTICOS_HOME` may be any valid workspace home, including a long-term
-self-hosting AgenticOS workspace, as long as it is not the repo root of a
-project such as `projects/agenticos`.
-
-If you installed via Homebrew on Apple Silicon macOS, the default runtime-home
-example is:
+After Homebrew installation, the fastest path to a working setup is:
 
 ```bash
-export AGENTICOS_HOME=/opt/homebrew/var/agenticos
+export AGENTICOS_HOME=/absolute/path/to/your/workspace   # any valid workspace home
+agenticos-bootstrap --workspace "$AGENTICOS_HOME" --first-run
 ```
 
-That path is a runtime home example, not the canonical product-source checkout.
-If you are developing AgenticOS itself, work in `projects/agenticos/` under the
-selected runtime home.
+On macOS, `--first-run` also sets up `launchctl` persistence so GUI tools
+inherit `AGENTICOS_HOME` across sessions. Then restart your AI tool and
+confirm `agenticos_list` succeeds.
 
-Requires: Node.js >= 20.0.0 for local build and packaged runtime workflows.
+Use `agenticos-bootstrap --verify` to audit the current state without
+mutating anything.
+
+### Alternative: Per-agent manual setup
+
+If you prefer to register the MCP server manually for each tool:
 
 ```bash
 export AGENTICOS_HOME=/absolute/path/to/your/workspace
 
-agenticos-bootstrap --workspace "$AGENTICOS_HOME" --first-run
-
+# Claude Code
 claude mcp add --transport stdio --scope user -e AGENTICOS_HOME="$AGENTICOS_HOME" agenticos -- agenticos-mcp
+
+# Codex
 codex mcp add --env AGENTICOS_HOME="$AGENTICOS_HOME" agenticos -- agenticos-mcp
+
+# Gemini CLI
 gemini mcp add -s user -e AGENTICOS_HOME="$AGENTICOS_HOME" agenticos agenticos-mcp
 ```
-
-Verify with `agenticos-mcp --version`, then restart the target MCP client and
-confirm `agenticos_list` succeeds.
 
 For Cursor, add `agenticos` with explicit `env.AGENTICOS_HOME` to
 `~/.cursor/mcp.json`, then restart Cursor and verify `agenticos_list`.
 
+### Repairing a stale registration
+
 If a previous registration still points at a source checkout instead of
-`agenticos-mcp`, repair it manually:
+`agenticos-mcp`, repair it with:
 
 ```bash
 claude mcp get agenticos
@@ -136,6 +121,22 @@ codex mcp get agenticos
 codex mcp remove agenticos
 codex mcp add --env AGENTICOS_HOME="$AGENTICOS_HOME" agenticos -- agenticos-mcp
 ```
+
+## Your First Project
+
+Once `agenticos_list` succeeds (after bootstrap and a restart), create your
+first managed project:
+
+1. **Create the project** — ask your AI tool to run
+   `agenticos_init` with a name and topology, e.g.
+   `agenticos_init(name: "my-project", topology: "local_directory_only")`
+2. **Switch to it** — ask the tool to run `agenticos_switch(project: "my-project")`
+3. **Do real work** — complete a task across two or more sessions
+4. **Verify persistence** — on the second session, ask the tool to run
+   `agenticos_status` and confirm it shows your previous context
+
+For a full walkthrough with `agenticos-bootstrap --first-run`, see
+[mcp-server/README.md](mcp-server/README.md).
 
 ## Canonical Documents
 
@@ -149,14 +150,6 @@ codex mcp add --env AGENTICOS_HOME="$AGENTICOS_HOME" agenticos -- agenticos-mcp
   [standards/knowledge/](standards/knowledge/)
 - product-root shell readiness:
   [standards/knowledge/product-root-shell-readiness-2026-04-07.md](standards/knowledge/product-root-shell-readiness-2026-04-07.md)
-
-## Current Boundary Rule
-
-- `projects/agenticos/` is the only canonical AgenticOS product-source project under `projects/`
-- the enclosing `AgenticOS/` path is the workspace home; product source lives under `projects/agenticos/`
-- issue worktrees live under `$AGENTICOS_HOME/worktrees/<project-id>/` as
-  helper execution checkouts, not as managed project roots
-- root-level `README.md`, `AGENTS.md`, and `CONTRIBUTING.md` currently remain as compatibility entrypoints during that migration
 
 ## Managed Project Contract
 
@@ -175,3 +168,30 @@ Current save/recovery contract:
 - `local_private`: Git is not the continuity recovery mechanism
 - `private_continuity`: `agenticos_save` is expected to persist the tracked continuity core for Git-backed restore
 - `public_distilled`: `agenticos_save` persists a distilled tracked continuity core for Git-backed restore, while raw transcripts route to a private sidecar such as `.private/conversations/`
+
+---
+
+## For Developers
+
+This directory is the canonical product-source project for AgenticOS. If you
+are changing AgenticOS itself, start here instead of treating the enclosing
+workspace root as the authoritative product repository.
+
+AgenticOS distinguishes two different paths:
+
+- `projects/agenticos/` is the canonical product-source checkout for developing AgenticOS itself
+- `AGENTICOS_HOME` is the runtime home used by installed binaries and managed projects
+
+In the standard layout, the runtime home contains a `projects/` directory, and
+the AgenticOS source project lives at `"$AGENTICOS_HOME/projects/agenticos"`.
+
+`projects/agenticos/` owns:
+
+- product documentation and operator contracts
+- MCP server source under `mcp-server/`
+- standards, templates, and downstream workflow kit
+- Homebrew distribution assets under `homebrew-tap/`
+
+This project also carries the repository shell for root-Git exit:
+
+- `.github/`, `.gitignore`, `CLAUDE.md`, `CHANGELOG.md`, `ROADMAP.md`, `LICENSE`, `scripts/`

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -231,6 +231,24 @@ It proves the current issue packet, startup surfaces, and issue-bound repo/workt
 
 ---
 
+## Your First Project
+
+Once `agenticos_list` succeeds (after bootstrap and a restart), create your
+first managed project:
+
+1. **Create the project** — ask your AI tool to run
+   `agenticos_init` with a name and topology, e.g.
+   `agenticos_init(name: "my-project", topology: "local_directory_only")`
+2. **Switch to it** — ask the tool to run `agenticos_switch(project: "my-project")`
+3. **Do real work** — complete a task across two or more sessions
+4. **Verify persistence** — on the second session, ask the tool to run
+   `agenticos_status` and confirm it shows your previous context
+
+For the recommended bootstrap walkthrough, see the Quick Start section above
+and run `agenticos-bootstrap --workspace "$AGENTICOS_HOME" --first-run` first.
+
+---
+
 ## 🛠️ Tools Reference
 
 ### agenticos_init
@@ -446,6 +464,64 @@ Get complete context for the current session project.
 - Project configuration (.project.yaml)
 - Quick start guide
 - Current session state
+
+---
+
+## Troubleshooting
+
+### `agenticos_list` returns empty
+
+1. Confirm `AGENTICOS_HOME` is set in the current shell:
+   ```bash
+   echo $AGENTICOS_HOME
+   ```
+2. Run `agenticos-bootstrap --verify` to audit the current bootstrap state
+3. If the workspace was never initialized, run:
+   ```bash
+   agenticos-bootstrap --workspace "$AGENTICOS_HOME" --first-run
+   ```
+4. Restart your AI tool, then try `agenticos_list` again
+
+### Agent started but tools don't appear
+
+1. Confirm the MCP server is registered: `claude mcp list` (or your agent's equivalent)
+2. If `agenticos` is missing, re-register it:
+   ```bash
+   claude mcp remove agenticos -s user
+   claude mcp add --transport stdio --scope user -e AGENTICOS_HOME="$AGENTICOS_HOME" agenticos -- agenticos-mcp
+   ```
+3. Restart the AI tool completely (not just the current session)
+4. Try `agenticos_list` again
+
+### `AGENTICOS_HOME` is not inherited by GUI tools
+
+GUI applications (Claude Code desktop, Cursor, etc.) run outside your shell and
+don't inherit shell profile variables. On macOS, `--first-run` sets up
+`launchctl` persistence for this:
+
+```bash
+agenticos-bootstrap --workspace "$AGENTICOS_HOME" --first-run
+```
+
+If you set `AGENTICOS_HOME` manually, also add it to your shell profile
+(`~/.zshrc` or `~/.bashrc`):
+
+```bash
+export AGENTICOS_HOME=/path/to/your/workspace
+```
+
+Then restart the GUI application.
+
+### Stale source-checkout registration
+
+If `claude mcp get agenticos` shows a path like `node /path/to/mcp-server/build/index.js`
+instead of `agenticos-mcp`, remove the stale entry and re-register:
+
+```bash
+claude mcp get agenticos
+claude mcp remove agenticos -s user
+claude mcp add --transport stdio --scope user -e AGENTICOS_HOME="$AGENTICOS_HOME" agenticos -- agenticos-mcp
+```
 
 ---
 


### PR DESCRIPTION
## Summary\nRewrote repo-root README.md and added first-project tutorial.\n\n**README rewrite:**\n- Leads with plain-language value proposition for new users\n- 3-step fastest path to working agenticos_list\n- Source Checkout vs Runtime Home moved to For Developers section\n- Promoted bootstrap --first-run as canonical path\n\n**First-project tutorial:**\n- 4-step walkthrough demonstrating context persistence across sessions\n- Added to mcp-server/README.md before Tools Reference\n\n**Troubleshooting section:**\n- 4 common failure modes with recovery steps\n- Covers empty agenticos_list, missing tools, AGENTICOS_HOME inheritance, stale registration\n\n**CHANGELOG:**\n- Filled entries for 0.2.2, 0.3.0, 0.4.0 (previously missing)\n\nFixes #309, #310.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)