### PR TITLE
fix(mcp-server): unify project resolution + add version freshness health gate

### DIFF
--- a/mcp-server/src/utils/guardrail-evidence.ts
+++ b/mcp-server/src/utils/guardrail-evidence.ts
@@ -1,9 +1,10 @@
 import { access, mkdir, readFile, rename, rm, stat, writeFile } from 'fs/promises';
-import { basename, dirname, join, resolve, sep } from 'path';
+import { dirname, join, resolve } from 'path';
 import yaml from 'yaml';
-import { getAgenticOSHome, loadRegistry } from './registry.js';
+import { getAgenticOSHome } from './registry.js';
 import { detectCanonicalMainWriteProtection } from './canonical-main-guard.js';
-import { type ProjectYamlSchema, type PreflightResult, type StateYamlSchema } from './yaml-schemas.js';
+import { type PreflightResult, type StateYamlSchema } from './yaml-schemas.js';
+import { resolveProjectTarget } from './repo-boundary.js';
 
 export type GuardrailCommand =
   | 'agenticos_preflight'
@@ -87,32 +88,9 @@ interface PersistIssueBootstrapEvidenceArgs {
   payload: IssueBootstrapRecord;
 }
 
-interface ResolvedProjectTarget {
-  id: string;
-  path: string;
-  statePath: string;
-}
-
 interface LoadLatestGuardrailStateArgs {
   project_id: string;
   committed_state_path?: string;
-}
-
-function normalizePath(path: string): string {
-  return resolve(path);
-}
-
-function resolveProjectStatePath(projectPath: string, projectYaml: ProjectYamlSchema): string {
-  const configuredStatePath = projectYaml?.agent_context?.current_state;
-  if (typeof configuredStatePath === 'string' && configuredStatePath.trim().length > 0) {
-    return join(projectPath, configuredStatePath.trim());
-  }
-  return join(projectPath, '.context', 'state.yaml');
-}
-
-function isWithinProject(repoPath: string, projectPath: string): boolean {
-  if (repoPath === projectPath) return true;
-  return repoPath.startsWith(`${projectPath}${sep}`);
 }
 
 function getCommandSlot(command: GuardrailCommand): GuardrailEvidenceSlot {
@@ -257,122 +235,6 @@ function mergeGuardrailState(runtimeState: StateYaml, committedState: StateYaml 
     guardrail_evidence: mergeGuardrailEvidenceState(runtimeState?.guardrail_evidence, committedState?.guardrail_evidence),
     issue_bootstrap: runtimeState?.issue_bootstrap ?? committedState?.issue_bootstrap,
   };
-}
-
-async function findProjectRootFromRepoPath(repoPath: string): Promise<ResolvedProjectTarget | null> {
-  let currentPath = normalizePath(repoPath);
-
-  while (true) {
-    const projectYamlPath = join(currentPath, '.project.yaml');
-    const hasProjectYaml = await pathExists(projectYamlPath);
-
-    if (hasProjectYaml) {
-      let projectYaml: ProjectYamlSchema = {};
-      let projectId = currentPath.split(sep).filter(Boolean).pop() || 'unknown-project';
-      try {
-        projectYaml = yaml.parse(await readFile(projectYamlPath, 'utf-8')) as ProjectYamlSchema || {};
-        if (projectYaml?.meta?.id) {
-          projectId = String(projectYaml.meta.id);
-        }
-      } catch {
-        // Fall back to directory-derived project id.
-      }
-
-      const statePath = resolveProjectStatePath(currentPath, projectYaml);
-      const hasState = await pathExists(statePath);
-      if (!hasState) {
-        const parentPath = dirname(currentPath);
-        if (parentPath === currentPath) {
-          return null;
-        }
-        currentPath = parentPath;
-        continue;
-      }
-
-      return {
-        id: projectId,
-        path: currentPath,
-        statePath,
-      };
-    }
-
-    const parentPath = dirname(currentPath);
-    if (parentPath === currentPath) {
-      return null;
-    }
-    currentPath = parentPath;
-  }
-}
-
-async function resolveExplicitProjectTarget(projectPath: string): Promise<ResolvedProjectTarget | null> {
-  const normalizedProjectPath = normalizePath(projectPath);
-  const projectYamlPath = join(normalizedProjectPath, '.project.yaml');
-  if (!(await pathExists(projectYamlPath))) {
-    return null;
-  }
-
-  let projectYaml: ProjectYamlSchema = {};
-  try {
-    projectYaml = yaml.parse(await readFile(projectYamlPath, 'utf-8')) as ProjectYamlSchema || {};
-  } catch {
-    projectYaml = {};
-  }
-
-  const statePath = resolveProjectStatePath(normalizedProjectPath, projectYaml);
-  if (!(await pathExists(statePath))) {
-    return null;
-  }
-
-  return {
-    id: String(projectYaml?.meta?.id || basename(normalizedProjectPath)),
-    path: normalizedProjectPath,
-    statePath,
-  };
-}
-
-async function resolveRegistryProjectTarget(projectPath: string, fallbackId: string): Promise<ResolvedProjectTarget | null> {
-  const normalizedProjectPath = normalizePath(projectPath);
-  const projectYamlPath = join(normalizedProjectPath, '.project.yaml');
-
-  let projectYaml: ProjectYamlSchema = {};
-  if (await pathExists(projectYamlPath)) {
-    try {
-      projectYaml = yaml.parse(await readFile(projectYamlPath, 'utf-8')) as ProjectYamlSchema || {};
-    } catch {
-      projectYaml = {};
-    }
-  }
-
-  const statePath = resolveProjectStatePath(normalizedProjectPath, projectYaml);
-  if (!(await pathExists(statePath))) {
-    return null;
-  }
-
-  return {
-    id: String(projectYaml?.meta?.id || fallbackId || basename(normalizedProjectPath)),
-    path: normalizedProjectPath,
-    statePath,
-  };
-}
-
-async function resolveProjectTarget(repoPath: string, projectPath?: string): Promise<ResolvedProjectTarget | null> {
-  if (projectPath) {
-    return resolveExplicitProjectTarget(projectPath);
-  }
-
-  const registry = await loadRegistry();
-  const normalizedRepoPath = normalizePath(repoPath);
-  const matchingProjects = registry.projects
-    .map((project) => ({ ...project, path: normalizePath(project.path) }))
-    .filter((project) => isWithinProject(normalizedRepoPath, project.path))
-    .sort((a, b) => b.path.length - a.path.length);
-
-  const registryProject = matchingProjects[0];
-  if (registryProject) {
-    return resolveRegistryProjectTarget(registryProject.path, registryProject.id);
-  }
-
-  return findProjectRootFromRepoPath(normalizedRepoPath);
 }
 
 export async function loadLatestGuardrailState(

--- a/mcp-server/src/utils/health.ts
+++ b/mcp-server/src/utils/health.ts
@@ -22,7 +22,7 @@ export interface HealthArgs {
 }
 
 export interface HealthGate {
-  gate: 'repo_sync' | 'entry_surface_refresh' | 'versioned_entry_surface_state' | 'guardrail_evidence' | 'issue_bootstrap_continuity' | 'worktree_topology' | 'standard_kit';
+  gate: 'repo_sync' | 'entry_surface_refresh' | 'versioned_entry_surface_state' | 'guardrail_evidence' | 'issue_bootstrap_continuity' | 'worktree_topology' | 'standard_kit' | 'version_freshness';
   status: 'PASS' | 'WARN' | 'BLOCK';
   summary: string;
 }
@@ -251,6 +251,66 @@ async function buildStandardKitGate(args: HealthArgs): Promise<HealthGate | null
   };
 }
 
+async function buildVersionFreshnessGate(args: HealthArgs): Promise<HealthGate | null> {
+  // Gate is only meaningful for canonical checkout role on github_versioned projects
+  if (args.checkout_role !== 'canonical') return null;
+
+  const lookupPath = args.project_path || args.repo_path;
+  if (!lookupPath) {
+    return {
+      gate: 'version_freshness',
+      status: 'WARN',
+      summary: 'Version freshness could not be checked because no project_path or repo_path was provided.',
+    };
+  }
+
+  let installedVersion: string | null = null;
+  let sourceVersion: string | null = null;
+
+  // 1. Installed runtime version — query npm registry for the published agenticos-mcp version
+  try {
+    const npmOutput = await execCommand('npm show agenticos-mcp version');
+    installedVersion = npmOutput.trim();
+  } catch {
+    // npm show fails when the package is installed from a local path (dev mode, not published)
+    installedVersion = null;
+  }
+
+  // 2. Source checkout version — read version from package.json at the project or repo root
+  const packageJsonPath = join(lookupPath, 'package.json');
+  try {
+    const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf-8'));
+    sourceVersion = typeof packageJson.version === 'string' ? packageJson.version.trim() : null;
+  } catch {
+    sourceVersion = null;
+  }
+
+  // Determine status
+  if (installedVersion === null || sourceVersion === null) {
+    // Dev mode or missing package.json — cannot determine freshness
+    return {
+      gate: 'version_freshness',
+      status: 'WARN',
+      summary: 'Version freshness could not be determined (runtime may be in dev mode or package.json is missing).',
+    };
+  }
+
+  if (installedVersion === sourceVersion) {
+    return {
+      gate: 'version_freshness',
+      status: 'PASS',
+      summary: `Installed runtime (${installedVersion}) matches source checkout version (${sourceVersion}).`,
+    };
+  }
+
+  // Versions differ — installed runtime may be stale or source is newer
+  return {
+    gate: 'version_freshness',
+    status: 'BLOCK',
+    summary: `Installed runtime (${installedVersion}) differs from source checkout version (${sourceVersion}).`,
+  };
+}
+
 async function resolveTrustedProjectPath(args: {
   repoPath: string;
   explicitProjectPath?: string;
@@ -389,6 +449,11 @@ export async function runHealthCheck(args: HealthArgs): Promise<HealthResult> {
     gates.push(standardKitGate);
   }
 
+  const versionFreshnessGate = await buildVersionFreshnessGate(effectiveArgs);
+  if (versionFreshnessGate) {
+    gates.push(versionFreshnessGate);
+  }
+
   return {
     command: 'agenticos_health',
     status: combineHealthStatus(gates),
@@ -425,6 +490,9 @@ export async function runHealthCheck(args: HealthArgs): Promise<HealthResult> {
         && worktreeTopologyGate.topology.inspection_errors.length > 0
         && !worktreeTopologyGate.topology.inspection_errors.some((error) => error.includes('missing meta.id'))
         ? ['inspect git worktree topology failures and restore accurate worktree visibility before trusting this checkout']
+        : []),
+      ...(versionFreshnessGate?.status === 'BLOCK'
+        ? ['upgrade agenticos-mcp to match the source checkout version, or pin the source checkout to match the installed runtime']
         : []),
     ],
   };

--- a/mcp-server/src/utils/repo-boundary.ts
+++ b/mcp-server/src/utils/repo-boundary.ts
@@ -301,3 +301,38 @@ export async function resolveGuardrailProjectTarget(args: {
       : [`No project_path, repo_path proof, or session binding is available for ${commandName}.`],
   };
 }
+
+/**
+ * Canonical unified project resolution for guardrail commands.
+ *
+ * Resolves by:
+ *   1. explicit projectPath — resolves against the filesystem, validates topology
+ *   2. repoPath containment match — searches registry projects by path containment,
+ *      considering project path, declared source repo roots, and expected worktree root
+ *   3. session project binding — uses the current session's bound project
+ *
+ * Returns the same flat {id, path, statePath} shape used by guardrail-evidence.ts so that
+ * callers that only need those three fields can use this directly without a type adaptation step.
+ * For callers that need GuardrailProjectTarget fields (githubRepo, sourceRepoRoots,
+ * expectedWorktreeRoot, topology, etc.), use resolveGuardrailProjectTarget instead.
+ */
+export async function resolveProjectTarget(
+  repoPath: string,
+  projectPath?: string,
+): Promise<{ id: string; path: string; statePath: string } | null> {
+  const resolution = await resolveGuardrailProjectTarget({
+    commandName: 'resolveProjectTarget',
+    repoPath,
+    projectPath,
+  });
+
+  if (!resolution.targetProject) {
+    return null;
+  }
+
+  return {
+    id: resolution.targetProject.id,
+    path: resolution.targetProject.path,
+    statePath: resolution.targetProject.statePath,
+  };
+}


### PR DESCRIPTION
## Summary
- repo-boundary.ts: new resolveProjectTarget() canonical function returning flat {id,path,statePath} — used by guardrail-evidence.ts instead of its own 120-line duplicate
- guardrail-evidence.ts: replaces inline findProjectRootFromRepoPath with imported resolveProjectTarget, net -120 lines
- health.ts: new version_freshness gate — compares npm show agenticos-mcp version vs package.json version; WARN in dev mode, BLOCK if installed runtime is stale

## Test plan
- npm run build passes
- agenticos_health shows version_freshness gate in output
- Health returns WARN when runtime is in dev mode (no npm package)
- Health returns BLOCK when installed version ≠ source version

🤖 Generated with Claude Code