### PR TITLE
feat(ci): add symlink installation path test for Homebrew install coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,9 @@ jobs:
       - name: Create symlink directory (simulates Homebrew bin/ install)
         run: |
           mkdir -p /tmp/agenticos-symlink-test/bin
+          # ln -s creates symlink; chmod +x ensures shebang execution works
           ln -s "$(pwd)/mcp-server/build/index.js" /tmp/agenticos-symlink-test/bin/agenticos-mcp
+          chmod +x /tmp/agenticos-symlink-test/bin/agenticos-mcp
           ls -la /tmp/agenticos-symlink-test/bin/
       - name: Run MCP handshake test via symlink
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,63 @@ jobs:
       - name: Run tests
         run: npm test
         working-directory: mcp-server
+
+  mcp-symlink-integration:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Install dependencies
+        run: npm install
+        working-directory: mcp-server
+      - name: Build
+        run: npm run build
+        working-directory: mcp-server
+      - name: Create symlink directory (simulates Homebrew bin/ install)
+        run: |
+          mkdir -p /tmp/agenticos-symlink-test/bin
+          ln -s "$(pwd)/mcp-server/build/index.js" /tmp/agenticos-symlink-test/bin/agenticos-mcp
+          ls -la /tmp/agenticos-symlink-test/bin/
+      - name: Run MCP handshake test via symlink
+        run: |
+          node -e "
+            const { spawn } = require('child_process');
+            const path = '/tmp/agenticos-symlink-test/bin/agenticos-mcp';
+            const proc = spawn(path, [], { stdio: ['pipe', 'pipe', 'pipe'] });
+            let timedOut = false;
+            const timer = setTimeout(() => {
+              timedOut = true;
+              console.error('TIMEOUT: server did not respond to initialize in 10s');
+              proc.kill();
+              process.exit(1);
+            }, 10000);
+            proc.stdout.on('data', (d) => {
+              const line = d.toString().trim();
+              if (!line) return;
+              try {
+                const msg = JSON.parse(line);
+                if (msg.result && msg.result.serverInfo) {
+                  clearTimeout(timer);
+                  console.log('SUCCESS: server responded via symlink path');
+                  console.log('Server:', JSON.stringify(msg.result.serverInfo));
+                  proc.kill();
+                }
+              } catch {}
+            });
+            proc.on('exit', (code) => {
+              if (!timedOut && code !== null) {
+                console.error('UNEXPECTED EXIT: server exited with code', code);
+                process.exit(1);
+              }
+            });
+            proc.stdin.write(JSON.stringify({
+              jsonrpc: '2.0',
+              id: 1,
+              method: 'initialize',
+              params: { protocolVersion: '2025-11-25', capabilities: {}, clientInfo: { name: 'ci-test', version: '1.0.0' } }
+            }) + '\n');
+          "

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -515,9 +515,9 @@ export async function main(
 }
 
 if (isDirectExecution(process.argv, import.meta.url)) {
-  main().then((exitCode) => {
-    process.exit(exitCode);
-  }).catch((error) => {
+  // Keep process alive — main() blocks until transport closes.
+  // Only exit on unrecoverable errors.
+  main().catch((error) => {
     console.error(error);
     process.exit(1);
   });


### PR DESCRIPTION
## Summary
- Add `mcp-symlink-integration` job to CI that creates a real symlink at `/tmp/agenticos-symlink-test/bin/agenticos-mcp` (simulates Homebrew `bin.install_symlink` behavior)
- Tests full MCP handshake (initialize → serverInfo response) through the symlink path
- Catches both `isDirectExecution` symlink resolution bugs and premature `process.exit` bugs
- Also applies Bug #333 fix in this branch (removes `.then(process.exit)` from index.ts)
- Job runs only after `build` passes; fails fast if server exits before responding

## Test plan
- [x] Symlink path MCP handshake tested locally
- [x] CI YAML syntax validated (well-formed YAML)

🤖 Generated with [Claude Code](https://claude.com/claude-code)