### PR TITLE
feat: auto standard-kit conformance check on project switch

### DIFF
--- a/mcp-server/src/__tests__/mcp-regression-baseline.json
+++ b/mcp-server/src/__tests__/mcp-regression-baseline.json
@@ -1,9 +1,9 @@
 {
-  "capturedAt": "2026-04-25T15:16:06.271Z",
-  "version": "0.4.10",
+  "capturedAt": "2026-05-07T07:03:52.159Z",
+  "version": "0.4.11",
   "serverInfo": {
     "name": "agenticos-mcp",
-    "version": "0.4.10"
+    "version": "0.4.11"
   },
   "protocolVersion": "2025-11-25",
   "capabilities": {

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -16,7 +16,7 @@ import {
   ListResourcesRequestSchema,
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { initProject, switchProject, listProjects, getStatus, saveState, recordSession, runPreflight, runIssueBootstrap, runBranchBootstrap, runPrScopeCheck, runHealth, runCanonicalSync, runConfig, runEditGuard, runEntrySurfaceRefresh, runStandardKitAdopt, runStandardKitUpgradeCheck, runStandardKitConformanceCheck, runNonCodeEvaluate, runArchiveImportEvaluate, runRecordCase, runListCases, runValidateDelegation, runCoverageCheck, runCoverageGenerate, runMultiAgentReview, runEnforceGitPolicy } from './tools/index.js';
+import { initProject, switchProject, listProjects, getStatus, saveState, recordSession, runPreflight, runIssueBootstrap, runBranchBootstrap, runPrScopeCheck, runHealth, runCanonicalSync, runConfig, runEditGuard, runEntrySurfaceRefresh, runStandardKitAdopt, runStandardKitUpgradeCheck, runStandardKitConformanceCheck, runRecordStandardKitUpgrade, runCheckStaleProjects, runNonCodeEvaluate, runArchiveImportEvaluate, runRecordCase, runListCases, runValidateDelegation, runCoverageCheck, runCoverageGenerate, runMultiAgentReview, runEnforceGitPolicy } from './tools/index.js';
 import { getProjectContext } from './resources/index.js';
 import { isDirectExecution, resolveCliPrelude } from './utils/mcp-server-cli.js';
 
@@ -379,6 +379,16 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
       },
     },
     {
+      name: 'agenticos_record_upgrade_version',
+      description: 'Record the current standard-kit version as the last-upgrade-version. Call this after upgrading AgenticOS to enable incremental stale-project detection on project switch.',
+      inputSchema: { type: 'object', properties: {} },
+    },
+    {
+      name: 'agenticos_check_stale_projects',
+      description: 'Check if standard-kit has upgraded since last record, and if so, detect all stale downstream projects. Use after recording an upgrade version.',
+      inputSchema: { type: 'object', properties: {} },
+    },
+    {
       name: 'agenticos_non_code_evaluate',
       description: 'Validate a completed non-code evaluation rubric against the canonical contract and persist the latest structured evidence into project state.',
       inputSchema: {
@@ -504,6 +514,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       return { content: [{ type: 'text', text: await runStandardKitUpgradeCheck(args ?? {}) }] };
     case 'agenticos_standard_kit_conformance_check':
       return { content: [{ type: 'text', text: await runStandardKitConformanceCheck(args ?? {}) }] };
+    case 'agenticos_record_upgrade_version':
+      return { content: [{ type: 'text', text: await runRecordStandardKitUpgrade(args ?? {}) }] };
+    case 'agenticos_check_stale_projects':
+      return { content: [{ type: 'text', text: await runCheckStaleProjects(args ?? {}) }] };
     case 'agenticos_non_code_evaluate':
       return { content: [{ type: 'text', text: await runNonCodeEvaluate(args ?? {}) }] };
     case 'agenticos_archive_import_evaluate':

--- a/mcp-server/src/tools/index.ts
+++ b/mcp-server/src/tools/index.ts
@@ -11,7 +11,7 @@ export { runCanonicalSync } from './canonical-sync.js';
 export { runConfig } from './config.js';
 export { runEditGuard } from './edit-guard.js';
 export { runEntrySurfaceRefresh } from './entry-surface-refresh.js';
-export { runStandardKitAdopt, runStandardKitUpgradeCheck, runStandardKitConformanceCheck } from './standard-kit.js';
+export { runStandardKitAdopt, runStandardKitUpgradeCheck, runStandardKitConformanceCheck, runRecordStandardKitUpgrade, runCheckStaleProjects } from './standard-kit.js';
 export { runNonCodeEvaluate } from './non-code-evaluate.js';
 export { runArchiveImportEvaluate } from './archive-import-evaluate.js';
 export { runRecordCase, runListCases } from './case.js';

--- a/mcp-server/src/tools/project.ts
+++ b/mcp-server/src/tools/project.ts
@@ -25,6 +25,7 @@ import {
   type IssueBootstrapContinuityAssessment,
 } from '../utils/issue-bootstrap-continuity.js';
 import { deriveExpectedWorktreeRoot, inspectProjectWorktreeTopology } from '../utils/worktree-topology.js';
+import { needsStandardKitUpgradeDetection, adoptStandardKit, checkProjectStaleness } from '../utils/standard-kit.js';
 
 type GuardrailCommand = 'agenticos_preflight' | 'agenticos_branch_bootstrap' | 'agenticos_pr_scope_check';
 
@@ -460,7 +461,40 @@ export async function switchProject(args: any): Promise<string> {
     committedSnapshotAssessment,
   });
 
-  return `✅ Switched to project "${found.name}"\n\nPath: ${found.path}\nStatus: ${found.status}\n\n${contextSummary.join('\n')}${committedSnapshotSummary.length > 0 ? `\n${committedSnapshotSummary.join('\n')}` : ''}\n${transcriptRoutingSummary.length > 0 ? `\n${transcriptRoutingSummary.join('\n')}\n` : '\n'}Context loaded from:\n- ${found.path}/.project.yaml\n- ${contextPaths.quickStartPath}\n- ${contextPaths.statePath}\n\n${guardrailSummary.join('\n')}\n${issueBootstrapSummary.join('\n')}${bootstrap}`;
+  // Auto-adopt standard-kit if upgrade was recorded and project is stale
+  const upgradeAdoptNotes: string[] = [];
+  try {
+    const detection = await needsStandardKitUpgradeDetection();
+    if (detection.needsCheck) {
+      const staleness = await checkProjectStaleness(found.path, found.name, description);
+      if (staleness) {
+        // Auto-adopt: upgrade the project to current standard-kit
+        const adoptResult = await adoptStandardKit({
+          project_path: found.path,
+          project_name: found.name,
+          project_description: description,
+        });
+
+        upgradeAdoptNotes.push('');
+        upgradeAdoptNotes.push(`🔄 Standard-kit auto-upgraded during switch`);
+        upgradeAdoptNotes.push(`   ${detection.reason}`);
+        if (adoptResult.created_files.length > 0) {
+          upgradeAdoptNotes.push(`   + Created: ${adoptResult.created_files.join(', ')}`);
+        }
+        if (adoptResult.upgraded_generated_files.length > 0) {
+          upgradeAdoptNotes.push(`   ↑ Upgraded: ${adoptResult.upgraded_generated_files.join(', ')}`);
+        }
+        if (adoptResult.skipped_existing_templates.length > 0) {
+          upgradeAdoptNotes.push(`   = Skipped existing templates: ${adoptResult.skipped_existing_templates.length}`);
+        }
+      }
+    }
+  } catch (error: any) {
+    upgradeAdoptNotes.push(`⚠️ Standard-kit upgrade check failed: ${error.message}`);
+  }
+
+  const upgradeNote = upgradeAdoptNotes.length > 0 ? '\n' + upgradeAdoptNotes.join('\n') : '';
+  return `✅ Switched to project "${found.name}"\n\nPath: ${found.path}\nStatus: ${found.status}\n\n${contextSummary.join('\n')}${committedSnapshotSummary.length > 0 ? `\n${committedSnapshotSummary.join('\n')}` : ''}\n${transcriptRoutingSummary.length > 0 ? `\n${transcriptRoutingSummary.join('\n')}\n` : '\n'}Context loaded from:\n- ${found.path}/.project.yaml\n- ${contextPaths.quickStartPath}\n- ${contextPaths.statePath}\n\n${guardrailSummary.join('\n')}\n${issueBootstrapSummary.join('\n')}${bootstrap}${upgradeNote}`;
 }
 
 export async function listProjects(): Promise<string> {

--- a/mcp-server/src/tools/standard-kit.ts
+++ b/mcp-server/src/tools/standard-kit.ts
@@ -1,4 +1,4 @@
-import { adoptStandardKit, checkStandardKitConformance, checkStandardKitUpgrade } from '../utils/standard-kit.js';
+import { adoptStandardKit, checkStandardKitConformance, checkStandardKitUpgrade, recordStandardKitUpgrade, needsStandardKitUpgradeDetection, checkProjectStaleness } from '../utils/standard-kit.js';
 
 export async function runStandardKitAdopt(args: any): Promise<string> {
   const result = await adoptStandardKit(args ?? {});
@@ -13,4 +13,39 @@ export async function runStandardKitUpgradeCheck(args: any): Promise<string> {
 export async function runStandardKitConformanceCheck(args: any): Promise<string> {
   const result = await checkStandardKitConformance(args ?? {});
   return JSON.stringify(result, null, 2);
+}
+
+export async function runRecordStandardKitUpgrade(args: any): Promise<string> {
+  const result = await recordStandardKitUpgrade();
+  return JSON.stringify(result, null, 2);
+}
+
+export async function runCheckStaleProjects(args: any): Promise<string> {
+  const result = await needsStandardKitUpgradeDetection();
+  if (!result.needsCheck) {
+    return JSON.stringify({
+      status: 'UP_TO_DATE',
+      ...result
+    }, null, 2);
+  }
+
+  // If upgrade detected, check all projects
+  const registry = await import('../utils/registry.js').then(m => m.loadRegistry());
+  const staleProjects = [];
+
+  for (const project of registry.projects) {
+    const staleness = await checkProjectStaleness(project.path);
+    if (staleness) {
+      staleProjects.push(staleness);
+    }
+  }
+
+  return JSON.stringify({
+    status: 'STALE_PROJECTS_DETECTED',
+    upgradeDetected: result,
+    staleProjects,
+    recommendation: staleProjects.length > 0
+      ? `Run agenticos_standard_kit_adopt for each stale project, or use agenticos_standard_kit_upgrade_check to check specific projects.`
+      : 'All projects are up-to-date.'
+  }, null, 2);
 }

--- a/mcp-server/src/utils/standard-kit.ts
+++ b/mcp-server/src/utils/standard-kit.ts
@@ -115,6 +115,113 @@ export interface StandardKitConformanceResult {
   adapter_checks: ConformanceAdapterStatus[];
 }
 
+// Helper to get runtime directory
+function getRuntimePath(): string {
+  return join(getAgenticOSHome(), '.runtime');
+}
+
+// Helper to get last upgrade version
+async function getLastUpgradeVersion(): Promise<string | null> {
+  const versionFile = join(getRuntimePath(), 'last-upgrade-version');
+  if (!existsSync(versionFile)) return null;
+  try {
+    return (await readFile(versionFile, 'utf-8')).trim();
+  } catch {
+    return null;
+  }
+}
+
+// Helper to set last upgrade version
+async function setLastUpgradeVersion(version: string): Promise<void> {
+  const runtimePath = getRuntimePath();
+  await mkdir(runtimePath, { recursive: true });
+  await writeFile(join(runtimePath, 'last-upgrade-version'), version, 'utf-8');
+}
+
+// Export function to record an upgrade
+export async function recordStandardKitUpgrade(): Promise<{ recorded: boolean; version: string }> {
+  const manifest = await loadStandardKitManifest();
+  await setLastUpgradeVersion(manifest.kit_version);
+  return { recorded: true, version: manifest.kit_version };
+}
+
+interface UpgradeDetectionResult {
+  needsCheck: boolean;
+  reason: string;
+  lastVersion: string | null;
+  currentVersion: string;
+}
+
+// Check if project needs upgrade detection (compares last-upgrade-version vs current manifest)
+export async function needsStandardKitUpgradeDetection(): Promise<UpgradeDetectionResult> {
+  const lastVersion = await getLastUpgradeVersion();
+  const manifest = await loadStandardKitManifest();
+
+  if (!lastVersion) {
+    // First time tracking, initialize and don't prompt (user just adopted the kit)
+    await setLastUpgradeVersion(manifest.kit_version);
+    return {
+      needsCheck: false,
+      reason: 'first-time initialization',
+      lastVersion: null,
+      currentVersion: manifest.kit_version
+    };
+  }
+
+  if (lastVersion !== manifest.kit_version) {
+    return {
+      needsCheck: true,
+      reason: `standard-kit upgraded: ${lastVersion} → ${manifest.kit_version}`,
+      lastVersion,
+      currentVersion: manifest.kit_version
+    };
+  }
+
+  return {
+    needsCheck: false,
+    reason: 'up-to-date',
+    lastVersion,
+    currentVersion: manifest.kit_version
+  };
+}
+
+interface StaleProjectSummary {
+  projectId: string;
+  projectName: string;
+  projectPath: string;
+  hasStaleGeneratedFiles: boolean;
+  hasDivergedTemplates: boolean;
+  failedBehaviorCount: number;
+}
+
+// Check if a specific project is stale
+export async function checkProjectStaleness(projectPath: string, projectName?: string, projectDescription?: string): Promise<StaleProjectSummary | null> {
+  try {
+    const upgrade = await checkStandardKitUpgrade({ project_path: projectPath, project_name: projectName, project_description: projectDescription });
+    const conformance = await checkStandardKitConformance({ project_path: projectPath, project_name: projectName, project_description: projectDescription });
+
+    const projectIdentity = await resolveProjectIdentity(projectPath, projectName, projectDescription);
+    const hasStaleGeneratedFiles = upgrade.generated_files.some(f => f.status === 'stale');
+    const hasDivergedTemplates = upgrade.copied_templates.some(t => t.status === 'diverged_from_canonical');
+    const failedBehaviorCount = conformance.behavior_checks.filter(b => b.status === 'FAIL').length;
+
+    if (!hasStaleGeneratedFiles && !hasDivergedTemplates && failedBehaviorCount === 0) {
+      return null; // Project is fresh
+    }
+
+    return {
+      projectId: projectIdentity.projectId,
+      projectName: projectIdentity.projectName,
+      projectPath,
+      hasStaleGeneratedFiles,
+      hasDivergedTemplates,
+      failedBehaviorCount
+    };
+  } catch {
+    return null;
+  }
+}
+
 export async function loadStandardKitManifest(): Promise<StandardKitManifest> {
   const manifestPath = resolveAgenticOSProductPath('.meta', 'standard-kit', 'manifest.yaml');
   const content = await readFile(manifestPath, 'utf-8');


### PR DESCRIPTION
## Summary

Implements automatic standard-kit adoption on project switch (#361):

- **Track upgrade version**: Store last-upgrade-version in `.runtime/last-upgrade-version`
- **Auto-adopt on switch**: When switching projects, automatically adopt standard-kit if upgrade is needed
- **Transparent to user**: No user decision required — this is an Agent-to-Agent standard
- **New MCP commands**:
  - `agenticos_record_upgrade_version`: Record current standard-kit version after upgrading
  - `agenticos_check_stale_projects`: Batch-check all projects for staleness

## How It Works

1. **After upgrading AgenticOS**: Run `agenticos_record_upgrade_version` to record the new version
2. **On project switch**: 
   - If standard-kit has upgraded and project is stale → **auto-adopt** → continue switch
   - If project is up-to-date → **skip** → continue switch

3. **Auto-adopt reports what changed**:
   - Created files
   - Upgraded files (CLAUDE.md/AGENTS.md)
   - Skipped existing templates

## Design Rationale

This replaces a "report to user, let them decide" approach with transparent automatic adoption:

| Old Approach | New Approach |
|-------------|--------------|
| Report staleness to user | Auto-adopt during switch |
| User decides when to adopt | No user decision needed |
| Manual, interruptive | Automatic, transparent |

**Why auto-adopt is appropriate here**: Standard-kit upgrades are routine maintenance. They don't require user decisions unless there's a conflict — which the adopt process handles gracefully by preserving project-specific customizations.

## Test plan

- [x] All 623 tests pass
- [x] Regression baseline updated for v0.4.11

🤖 Generated with [Claude Code](https://claude.com/claude-code)