### PR TITLE
feat: split record capture from continuity writes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,13 +63,16 @@ Call the MCP tool `agenticos_record` with:
 - `outcomes`: What was accomplished
 - `pending`: What remains to be done
 - `current_task`: { title, status } to update current task
+- `project_path`: optional absolute issue worktree path when the session is operating outside the registered canonical checkout
+
+`agenticos_record` is capture-first. If tracked continuity writes are protected, it must still preserve a safe capture when possible and return `RECORDED_CAPTURE_ONLY` with next actions. Do not treat capture-only as a terminal failure; follow the returned recovery path before ending the session.
 
 ### When to Record
 
 1. After completing any meaningful unit of work
 2. Before ending the session (MANDATORY — context is lost otherwise)
 
-After recording, call `agenticos_save` to commit to Git.
+After recording, call `agenticos_save` to commit distilled continuity to Git when the current checkout is allowed to save.
 
 ### Session Start
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -345,6 +345,22 @@ List all projects with status.
 
 **Returns**: Formatted list with the current session project highlighted when one is bound
 
+### agenticos_record
+Capture session activity and, when allowed, distill it into project continuity.
+
+**Parameters**:
+- `project` (optional) - Project ID, name, or registered path. Defaults to the current session project.
+- `project_path` (optional) - Absolute project checkout path to write into. Use the issue worktree path when recording from an isolated worktree.
+- `summary` (required) - What happened in this session.
+- `decisions`, `outcomes`, `pending` (optional) - Structured continuity updates.
+- `current_task` (optional) - `{ title, status }`.
+
+**Behavior**:
+- capture is attempted first so meaningful session facts are not lost
+- when project-tree writes are allowed, record also updates distilled continuity (`state.yaml`, `CLAUDE.md`, marker, and registry metadata)
+- when tracked writes are protected, record returns `RECORDED_CAPTURE_ONLY` with recovery actions instead of treating the block as the end state
+- raw capture sidecars are runtime/private surfaces and must not be staged by `agenticos_save`
+
 ### agenticos_save
 Save state and backup to Git.
 

--- a/mcp-server/src/__tests__/mcp-regression.test.ts
+++ b/mcp-server/src/__tests__/mcp-regression.test.ts
@@ -18,6 +18,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // In compiled form, __dirname = mcp-server/build/__tests__
 const MONOREPO_ROOT = join(__dirname, '..', '..', '..');
 const SNAPSHOT_PATH = join(__dirname, 'mcp-regression-baseline.json');
+const LOCAL_SERVER_PATH = join(MONOREPO_ROOT, 'mcp-server', 'build', 'index.js');
 
 interface JsonRpcMessage {
   jsonrpc: '2.0';
@@ -73,10 +74,15 @@ async function sendMessage(
 }
 
 function spawnServer() {
-  const proc = spawn('agenticos-mcp', [], {
-    stdio: ['pipe', 'pipe', 'pipe'],
-    env: { ...process.env, AGENTICOS_HOME: MONOREPO_ROOT },
-  });
+  const useLocalBuild = existsSync(LOCAL_SERVER_PATH);
+  const proc = spawn(
+    useLocalBuild ? process.execPath : 'agenticos-mcp',
+    useLocalBuild ? [LOCAL_SERVER_PATH] : [],
+    {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, AGENTICOS_HOME: MONOREPO_ROOT },
+    },
+  );
   return proc as ReturnType<typeof spawn> & { stdin: { write: (data: string) => void }; stdout: { on: (event: string, cb: (data: Buffer) => void) => void; off: (event: string, cb: (data: Buffer) => void) => void }; kill: () => boolean; killed: boolean; exitCode: number | null };
 }
 

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -55,7 +55,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     },
     {
       name: 'agenticos_switch',
-      description: 'Bind the current MCP session to an existing AgenticOS project',
+      description: 'Bind the current MCP session to an existing AgenticOS project. When the user asks to switch, enter, or continue a project, call this before shell path discovery.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -71,11 +71,12 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     },
     {
       name: 'agenticos_record',
-      description: 'Record session activity — conversations, decisions, outcomes. Call this after completing meaningful work and before ending any session. This is how the Agent maintains project memory.',
+      description: 'Record session activity — conversations, decisions, outcomes. Capture is attempted first; tracked continuity is distilled only when the target checkout can receive project-tree writes. If the response is capture-only or blocked, follow its next actions before ending the session.',
       inputSchema: {
         type: 'object',
         properties: {
           project: { type: 'string', description: 'Optional project ID, name, or path. If omitted, uses the current session project.' },
+          project_path: { type: 'string', description: 'Optional absolute project checkout path to write/distill into. Use the issue worktree path when recording from an isolated worktree.' },
           summary: { type: 'string', description: 'What happened in this session (required)' },
           decisions: { type: 'array', items: { type: 'string' }, description: 'Key decisions made during this session' },
           outcomes: { type: 'array', items: { type: 'string' }, description: 'What was accomplished' },
@@ -94,11 +95,12 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     },
     {
       name: 'agenticos_record_case',
-      description: 'Record a structured corner case or bad case under the current project knowledge surface.',
+      description: 'Record a structured corner case or bad case under the current project knowledge surface. Tracked knowledge writes are blocked on canonical main; use an isolated worktree for durable case knowledge.',
       inputSchema: {
         type: 'object',
         properties: {
           project: { type: 'string', description: 'Optional project ID, name, or path. If omitted, uses the current session project.' },
+          project_path: { type: 'string', description: 'Optional absolute project checkout path to write case knowledge into. Use the issue worktree path when recording from an isolated worktree.' },
           type: { type: 'string', enum: ['corner', 'bad'], description: 'Case type.' },
           title: { type: 'string', description: 'Short case title.' },
           trigger: { type: 'string', description: 'What action or input triggered this case.' },

--- a/mcp-server/src/tools/__tests__/case.test.ts
+++ b/mcp-server/src/tools/__tests__/case.test.ts
@@ -1,0 +1,227 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../utils/project-target.js', () => ({
+  resolveManagedProjectTarget: vi.fn(),
+}));
+
+vi.mock('../../utils/case-knowledge.js', () => ({
+  normalizeCaseFilterType: vi.fn((value) => value || 'all'),
+  normalizeCaseType: vi.fn((value) => value),
+  parseCaseTags: vi.fn((value) => Array.isArray(value) ? value : []),
+  recordCaseKnowledge: vi.fn(),
+  listCasesAcrossProjects: vi.fn(),
+  listCasesForProject: vi.fn(),
+  renderCaseListMarkdown: vi.fn(() => '# Cases'),
+}));
+
+vi.mock('../../utils/registry.js', () => ({
+  loadRegistry: vi.fn(),
+}));
+
+vi.mock('fs/promises', () => ({
+  readFile: vi.fn(),
+}));
+
+import { runListCases, runRecordCase } from '../case.js';
+import { resolveManagedProjectTarget } from '../../utils/project-target.js';
+import {
+  listCasesAcrossProjects,
+  listCasesForProject,
+  recordCaseKnowledge,
+  renderCaseListMarkdown,
+} from '../../utils/case-knowledge.js';
+import { loadRegistry } from '../../utils/registry.js';
+import { readFile } from 'fs/promises';
+
+const resolveManagedProjectTargetMock = resolveManagedProjectTarget as unknown as ReturnType<typeof vi.fn>;
+const recordCaseKnowledgeMock = recordCaseKnowledge as unknown as ReturnType<typeof vi.fn>;
+const listCasesAcrossProjectsMock = listCasesAcrossProjects as unknown as ReturnType<typeof vi.fn>;
+const listCasesForProjectMock = listCasesForProject as unknown as ReturnType<typeof vi.fn>;
+const renderCaseListMarkdownMock = renderCaseListMarkdown as unknown as ReturnType<typeof vi.fn>;
+const loadRegistryMock = loadRegistry as unknown as ReturnType<typeof vi.fn>;
+const readFileMock = readFile as unknown as ReturnType<typeof vi.fn>;
+
+describe('case tools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resolveManagedProjectTargetMock.mockResolvedValue({
+      projectId: 'agenticos',
+      projectName: 'AgenticOS',
+      projectPath: '/project',
+      projectYaml: {},
+    });
+    recordCaseKnowledgeMock.mockResolvedValue({
+      projectId: 'agenticos',
+      projectName: 'AgenticOS',
+      projectPath: '/project',
+      type: 'bad',
+      title: 'Bad Case',
+      timestamp: '2026-05-07T10:30:00.000Z',
+      tags: ['bad-case'],
+      filePath: '/project/knowledge/bad-cases/bad.md',
+      relativePath: 'knowledge/bad-cases/bad.md',
+    });
+    listCasesAcrossProjectsMock.mockResolvedValue([]);
+    listCasesForProjectMock.mockResolvedValue([]);
+    renderCaseListMarkdownMock.mockReturnValue('# Cases');
+    loadRegistryMock.mockResolvedValue({
+      projects: [],
+    });
+    readFileMock.mockResolvedValue(JSON.stringify({
+      meta: { id: 'agenticos', name: 'AgenticOS' },
+      source_control: {
+        topology: 'github_versioned',
+        context_publication_policy: 'public_distilled',
+        github_repo: 'madlouse/AgenticOS',
+        branch_strategy: 'github_flow',
+      },
+      execution: { source_repo_roots: ['.'] },
+    }));
+  });
+
+  it('records cases against an explicit project_path override', async () => {
+    const result = await runRecordCase({
+      project: 'agenticos',
+      project_path: '/worktree',
+      type: 'bad',
+      title: 'Bad Case',
+      trigger: 'Trigger',
+      behavior: 'Behavior',
+    });
+
+    expect(resolveManagedProjectTargetMock).toHaveBeenCalledWith({
+      project: 'agenticos',
+      projectPath: '/worktree',
+      commandName: 'agenticos_record_case',
+    });
+    expect(recordCaseKnowledgeMock).toHaveBeenCalled();
+    expect(JSON.parse(result).status).toBe('RECORDED');
+  });
+
+  it('returns blocked case knowledge errors instead of throwing out of the tool', async () => {
+    recordCaseKnowledgeMock.mockRejectedValue(new Error('agenticos_record_case blocked for "AgenticOS"'));
+
+    const result = await runRecordCase({
+      type: 'bad',
+      title: 'Bad Case',
+      trigger: 'Trigger',
+      behavior: 'Behavior',
+    });
+
+    expect(result).toContain('agenticos_record_case blocked');
+  });
+
+  it('rejects record_case project=all', async () => {
+    const result = await runRecordCase({ project: 'all' });
+
+    expect(result).toContain('does not support project="all"');
+  });
+
+  it('returns project resolution errors for record_case', async () => {
+    resolveManagedProjectTargetMock.mockRejectedValue(new Error('No project provided'));
+
+    const result = await runRecordCase({
+      type: 'bad',
+      title: 'Bad Case',
+      trigger: 'Trigger',
+      behavior: 'Behavior',
+    });
+
+    expect(result).toContain('No project provided');
+  });
+
+  it('lists cases for all active normalized projects', async () => {
+    loadRegistryMock.mockResolvedValue({
+      projects: [
+        {
+          id: 'agenticos',
+          name: 'AgenticOS',
+          path: '/project',
+          status: 'active',
+        },
+        {
+          id: 'archived',
+          name: 'Archived',
+          path: '/archived',
+          status: 'archived',
+        },
+      ],
+    });
+
+    const result = await runListCases({ project: 'all', type: 'bad', tags: ['guardrail'] });
+
+    expect(listCasesAcrossProjectsMock).toHaveBeenCalledWith([
+      expect.objectContaining({ projectId: 'agenticos', projectPath: '/project' }),
+    ], { type: 'bad', tags: ['guardrail'] });
+    expect(result).toBe('# Cases');
+  });
+
+  it('skips unreadable or invalid projects when listing across all projects', async () => {
+    loadRegistryMock.mockResolvedValue({
+      projects: [
+        {
+          id: 'missing',
+          name: 'Missing',
+          path: '/missing',
+          status: 'active',
+        },
+        {
+          id: 'invalid',
+          name: 'Invalid',
+          path: '/invalid',
+          status: 'active',
+        },
+      ],
+    });
+    readFileMock.mockImplementation(async (path: string) => {
+      if (path.startsWith('/missing')) throw new Error('missing');
+      return JSON.stringify({ meta: { id: 'invalid', name: 'Invalid' } });
+    });
+
+    await runListCases({ project: 'all' });
+
+    expect(listCasesAcrossProjectsMock).toHaveBeenCalledWith([], { type: 'all', tags: [] });
+  });
+
+  it('skips projects whose yaml parses to null when listing across all projects', async () => {
+    loadRegistryMock.mockResolvedValue({
+      projects: [
+        {
+          id: 'null-yaml',
+          name: 'Null YAML',
+          path: '/null-yaml',
+          status: 'active',
+        },
+      ],
+    });
+    readFileMock.mockResolvedValue('null');
+
+    await runListCases({ project: 'all' });
+
+    expect(listCasesAcrossProjectsMock).toHaveBeenCalledWith([], { type: 'all', tags: [] });
+  });
+
+  it('lists cases for the resolved session project', async () => {
+    const result = await runListCases({ type: 'corner' });
+
+    expect(resolveManagedProjectTargetMock).toHaveBeenCalledWith({
+      project: undefined,
+      commandName: 'agenticos_list_cases',
+    });
+    expect(listCasesForProjectMock).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: 'agenticos' }),
+      { type: 'corner', tags: [] },
+    );
+    expect(renderCaseListMarkdownMock).toHaveBeenCalledWith([], 'Matching Cases for AgenticOS');
+    expect(result).toBe('# Cases');
+  });
+
+  it('returns project resolution errors for list cases', async () => {
+    resolveManagedProjectTargetMock.mockRejectedValue(new Error('No project provided'));
+
+    const result = await runListCases({});
+
+    expect(result).toContain('# Error');
+    expect(result).toContain('No project provided');
+  });
+});

--- a/mcp-server/src/tools/__tests__/record.test.ts
+++ b/mcp-server/src/tools/__tests__/record.test.ts
@@ -39,11 +39,15 @@ vi.mock('../../utils/distill.js', () => ({
   updateClaudeMdState: vi.fn().mockResolvedValue({ updated: true, created: false }),
 }));
 
+vi.mock('../../utils/canonical-main-guard.js', () => ({
+  detectCanonicalMainWriteProtection: vi.fn(),
+}));
 
 import { recordSession } from '../record.js';
 import * as fsPromises from 'fs/promises';
 import * as registry from '../../utils/registry.js';
 import { bindSessionProject, clearSessionProjectBinding } from '../../utils/session-context.js';
+import { detectCanonicalMainWriteProtection } from '../../utils/canonical-main-guard.js';
 const fsPromisesMock = fsPromises as typeof fsPromises & {
   readFile: ReturnType<typeof vi.fn>;
   writeFile: ReturnType<typeof vi.fn>;
@@ -53,6 +57,7 @@ const registryMock = registry as typeof registry & {
   loadRegistry: ReturnType<typeof vi.fn>;
   patchProjectMetadata: ReturnType<typeof vi.fn>;
 };
+const canonicalMainGuardMock = detectCanonicalMainWriteProtection as unknown as ReturnType<typeof vi.fn>;
 
 function buildRegistry(overrides: Record<string, unknown> = {}) {
   return {
@@ -141,6 +146,7 @@ describe('recordSession', () => {
       projects: [],
     });
     registryMock.patchProjectMetadata.mockResolvedValue(undefined);
+    canonicalMainGuardMock.mockResolvedValue({ blocked: false });
     mockProjectFiles();
   });
 
@@ -183,15 +189,37 @@ describe('recordSession', () => {
     expect(result).toContain('No project provided and no session project is bound');
   });
 
-  it('allows recordSession on canonical main checkout (no git writes, runtime-only)', async () => {
+  it('captures only on canonical main without writing tracked continuity surfaces', async () => {
     registryMock.loadRegistry.mockResolvedValue(buildRegistry());
-    // Guard is not called by recordSession — it writes runtime surfaces only, no git commits
-    const result = await recordSession({ summary: 'runtime-only record on canonical main' });
+    canonicalMainGuardMock.mockResolvedValue({
+      blocked: true,
+      reason: 'canonical main checkout is write-protected for runtime persistence: /test/path',
+    });
 
-    expect(result).toContain('Session recorded');
-    expect(fsPromisesMock.writeFile).toHaveBeenCalled();
-    expect(fsPromisesMock.mkdir).toHaveBeenCalled();
-    expect(registryMock.patchProjectMetadata).toHaveBeenCalled();
+    const result = await recordSession({ summary: 'blocked write' });
+
+    expect(result).toContain('RECORDED_CAPTURE_ONLY');
+    expect(result).toContain('canonical main checkout is write-protected for runtime persistence: /test/path');
+    expect(fsPromisesMock.mkdir).toHaveBeenCalledWith('/home/testuser/AgenticOS/.agent-workspace/projects/test-project/captures/conversations', { recursive: true });
+    expect(fsPromisesMock.writeFile).toHaveBeenCalledWith(
+      expect.stringContaining('/.agent-workspace/projects/test-project/captures/conversations/'),
+      expect.stringContaining('blocked write'),
+      'utf-8',
+    );
+    expect(fsPromisesMock.writeFile.mock.calls.some((call) => String(call[0]).endsWith('state.yaml'))).toBe(false);
+    expect(fsPromisesMock.writeFile.mock.calls.some((call) => String(call[0]).endsWith('.last_record'))).toBe(false);
+    expect(registryMock.patchProjectMetadata).not.toHaveBeenCalled();
+  });
+
+  it('captures only on canonical main even when the guard omits a reason', async () => {
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry());
+    canonicalMainGuardMock.mockResolvedValue({ blocked: true });
+
+    const result = await recordSession({ summary: 'captured without reason' });
+
+    expect(result).toContain('RECORDED_CAPTURE_ONLY');
+    expect(result).not.toContain('Reason:');
+    expect(fsPromisesMock.writeFile.mock.calls.some((call) => String(call[0]).endsWith('state.yaml'))).toBe(false);
   });
 
   it('creates conversation file with correct date-based filename', async () => {
@@ -480,6 +508,33 @@ describe('recordSession', () => {
     expect(result).toContain('Git recovery is distilled-only');
   });
 
+  it('blocks when public_distilled raw transcript routing is misconfigured', async () => {
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry());
+    mockProjectFiles({
+      projectYaml: {
+        meta: { id: 'test-project', name: 'Test Project' },
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'public_distilled',
+          github_repo: 'example/test-project',
+          branch_strategy: 'github_flow',
+        },
+        agent_context: {
+          conversations: '.private/conversations/',
+        },
+        execution: {
+          source_repo_roots: ['.'],
+        },
+      },
+      state: { session: {}, working_memory: { decisions: [], facts: [], pending: [] } },
+    });
+
+    const result = await recordSession({ summary: 'test session' });
+
+    expect(result).toContain('public transcript routing is misconfigured');
+    expect(fsPromisesMock.writeFile).not.toHaveBeenCalled();
+  });
+
   it('continues when quick-start.md is missing during enrichment', async () => {
     registryMock.loadRegistry.mockResolvedValue(buildRegistry());
     fsPromisesMock.readFile.mockImplementation(async (path: string) => {
@@ -705,6 +760,39 @@ describe('recordSession', () => {
         last_recorded: expect.any(String),
       }),
     );
+  });
+
+  it('uses project_path override as the writable checkout for explicit project records', async () => {
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry());
+    fsPromisesMock.readFile.mockImplementation(async (path: string) => {
+      if (path === '/worktree/path/.project.yaml') {
+        return JSON.stringify({
+          meta: { id: 'test-project', name: 'Test Project' },
+          source_control: { topology: 'local_directory_only', context_publication_policy: 'local_private' },
+        });
+      }
+      if (path === '/worktree/path/.context/state.yaml') {
+        return JSON.stringify({
+          session: {},
+          working_memory: { decisions: [], facts: [], pending: [] },
+        });
+      }
+      if (path.includes('/worktree/path/.context/conversations/') && path.endsWith('.md')) {
+        return '';
+      }
+      return '';
+    });
+
+    const result = await recordSession({
+      project: 'test-project',
+      project_path: '/worktree/path',
+      summary: 'worktree record',
+      decisions: ['use worktree'],
+    });
+
+    expect(result).toContain('Session recorded for "Test Project"');
+    expect(fsPromisesMock.writeFile.mock.calls.some((call) => String(call[0]).startsWith('/worktree/path/.context/conversations/'))).toBe(true);
+    expect(fsPromisesMock.writeFile.mock.calls.some((call) => String(call[0]) === '/worktree/path/.context/state.yaml')).toBe(true);
   });
 
   it('uses the session-local bound project when no explicit project is provided', async () => {

--- a/mcp-server/src/tools/case.ts
+++ b/mcp-server/src/tools/case.ts
@@ -53,24 +53,30 @@ export async function runRecordCase(args: any): Promise<string> {
   try {
     resolved = await resolveManagedProjectTarget({
       project: args?.project,
+      projectPath: args?.project_path,
       commandName: 'agenticos_record_case',
     });
   } catch (error: any) {
     return `❌ ${error.message}`;
   }
 
-  const entry = await recordCaseKnowledge(toCaseProjectTarget(resolved), {
-    type: normalizeCaseType(args?.type),
-    title: args?.title,
-    trigger: args?.trigger,
-    behavior: args?.behavior,
-    rootCause: args?.rootCause ?? args?.root_cause,
-    impact: args?.impact,
-    workaround: args?.workaround,
-    prevention: args?.prevention,
-    tags: parseCaseTags(args?.tags),
-    timestamp: args?.timestamp,
-  });
+  let entry;
+  try {
+    entry = await recordCaseKnowledge(toCaseProjectTarget(resolved), {
+      type: normalizeCaseType(args?.type),
+      title: args?.title,
+      trigger: args?.trigger,
+      behavior: args?.behavior,
+      rootCause: args?.rootCause ?? args?.root_cause,
+      impact: args?.impact,
+      workaround: args?.workaround,
+      prevention: args?.prevention,
+      tags: parseCaseTags(args?.tags),
+      timestamp: args?.timestamp,
+    });
+  } catch (error: any) {
+    return `❌ ${error.message}`;
+  }
 
   return JSON.stringify({
     command: 'agenticos_record_case',

--- a/mcp-server/src/tools/record.ts
+++ b/mcp-server/src/tools/record.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile, mkdir } from 'fs/promises';
+import { readFile, writeFile } from 'fs/promises';
 import yaml from 'yaml';
 import { patchProjectMetadata } from '../utils/registry.js';
 import { updateClaudeMdState } from '../utils/distill.js';
@@ -9,6 +9,12 @@ import {
   detectLegacyTrackedTranscriptStatus,
   resolveConversationRoutingPlan,
 } from '../utils/conversation-routing.js';
+import { resolvePersistenceWritePlan } from '../utils/persistence-write-policy.js';
+import {
+  appendRecordCapture,
+  getRuntimeCaptureConversationDir,
+  type RecordCapturePayload,
+} from '../utils/record-capture.js';
 import { type StateYamlSchema } from '../utils/yaml-schemas.js';
 
 function parseArray(val: unknown): string[] {
@@ -20,6 +26,74 @@ function parseArray(val: unknown): string[] {
     } catch {}
   }
   return [];
+}
+
+async function applyTrackedContinuityPatch(args: {
+  projectId: string;
+  projectName: string;
+  projectPath: string;
+  statePath: string;
+  markerPath: string;
+  currentTask: any;
+  now: Date;
+  decisions: string[];
+  outcomes: string[];
+  pending: string[];
+}): Promise<void> {
+  let state: StateYamlSchema = {};
+  try {
+    const stateContent = await readFile(args.statePath, 'utf-8');
+    state = yaml.parse(stateContent) as StateYamlSchema || {};
+  } catch {}
+
+  if (!state.working_memory) state.working_memory = { facts: [], decisions: [], pending: [] };
+  if (!state.session) state.session = {};
+
+  if (args.decisions.length > 0) {
+    const existing_decisions = state.working_memory.decisions || [];
+    state.working_memory.decisions = [...existing_decisions, ...args.decisions];
+  }
+  if (args.pending.length > 0) {
+    state.working_memory.pending = args.pending;
+  }
+  if (args.outcomes.length > 0) {
+    const existing_facts = state.working_memory.facts || [];
+    state.working_memory.facts = [...existing_facts, ...args.outcomes];
+  }
+  if (args.currentTask) {
+    state.current_task = {
+      ...(state.current_task || {}),
+      title: args.currentTask.title || state.current_task?.title,
+      status: args.currentTask.status || 'in_progress',
+      updated: args.now.toISOString(),
+    };
+  }
+
+  state.session.last_backup = args.now.toISOString();
+  await writeFile(args.statePath, yaml.stringify(state), 'utf-8');
+
+  const claudeMdPath = `${args.projectPath}/CLAUDE.md`;
+  await updateClaudeMdState(claudeMdPath, state, args.projectName);
+  await writeFile(args.markerPath, args.now.toISOString(), 'utf-8');
+  await patchProjectMetadata(args.projectId, {
+    last_recorded: args.now.toISOString(),
+  });
+}
+
+function renderCaptureOnlyResponse(args: {
+  projectName: string;
+  capturePath: string;
+  planReason?: string;
+  nextActions: string[];
+}): string {
+  const nextActions = `\nNext actions:\n${args.nextActions.map((action) => `- ${action}`).join('\n')}`;
+
+  return `✅ Session captured for "${args.projectName}"\n\n` +
+    'Status: RECORDED_CAPTURE_ONLY\n' +
+    `📝 Capture: ${args.capturePath}\n` +
+    '📊 Distill: skipped because tracked project writes are protected in this checkout\n' +
+    (args.planReason ? `Reason: ${args.planReason}\n` : '') +
+    nextActions;
 }
 
 export async function recordSession(args: any): Promise<string> {
@@ -36,6 +110,7 @@ export async function recordSession(args: any): Promise<string> {
   try {
     resolved = await resolveManagedProjectTarget({
       project: args.project,
+      projectPath: args.project_path,
       commandName: 'agenticos_record',
     });
   } catch (error: any) {
@@ -43,7 +118,6 @@ export async function recordSession(args: any): Promise<string> {
   }
 
   const { project, projectPath, projectYaml, statePath, markerPath } = resolved;
-
   const contextPolicyPlan = resolveContextPolicyPlan({
     projectName: project.name,
     projectPath,
@@ -54,88 +128,56 @@ export async function recordSession(args: any): Promise<string> {
   if (legacyTranscriptStatus === 'misconfigured_public_raw_target') {
     return `❌ agenticos_record blocked for "${project.name}" because public transcript routing is misconfigured. Raw transcript destination must remain sidecar-only for public_distilled projects.`;
   }
-  const convDir = conversationRoutingPlan.raw_conversations_dir;
+
+  const persistencePlan = await resolvePersistenceWritePlan({
+    command: 'agenticos_record',
+    projectPath,
+    writes: [
+      'sidecar_capture',
+      'project_tree_runtime',
+      'project_tree_continuity',
+      'runtime_registry',
+    ],
+  });
+
   const now = new Date();
   const today = now.toISOString().split('T')[0];
-  const time = now.toISOString().substring(11, 16);
+  const payload: RecordCapturePayload = {
+    summary,
+    decisions,
+    outcomes,
+    pending,
+  };
 
-  // 1. Append to conversations/YYYY-MM-DD.md
-  await mkdir(convDir, { recursive: true });
-  const convFile = `${convDir}/${today}.md`;
+  const captureDir = persistencePlan.mode === 'capture_only'
+    ? getRuntimeCaptureConversationDir(project.id)
+    : conversationRoutingPlan.raw_conversations_dir;
+  const capture = await appendRecordCapture({
+    dir: captureDir,
+    now,
+    ...payload,
+  });
 
-  let existing = '';
-  try { existing = await readFile(convFile, 'utf-8'); } catch {}
-
-  const sections: string[] = [];
-  sections.push(`### ${time} — Session Record\n`);
-  sections.push(`**Summary**: ${summary}\n`);
-  if (outcomes.length > 0) {
-    sections.push('**Outcomes**:');
-    for (const o of outcomes) sections.push(`- ${o}`);
-    sections.push('');
-  }
-  if (decisions.length > 0) {
-    sections.push('**Decisions**:');
-    for (const d of decisions) sections.push(`- ${d}`);
-    sections.push('');
-  }
-  if (pending.length > 0) {
-    sections.push('**Pending**:');
-    for (const p of pending) sections.push(`- ${p}`);
-    sections.push('');
+  if (persistencePlan.mode === 'capture_only') {
+    return renderCaptureOnlyResponse({
+      projectName: project.name,
+      capturePath: capture.filePath,
+      planReason: persistencePlan.writeProtectionReason,
+      nextActions: persistencePlan.nextActions,
+    });
   }
 
-  const entry = sections.join('\n');
-
-  if (existing) {
-    await writeFile(convFile, existing + '\n\n' + entry, 'utf-8');
-  } else {
-    await writeFile(convFile, `# Sessions — ${today}\n\n${entry}`, 'utf-8');
-  }
-
-  // 2. Update state.yaml
-  let state: StateYamlSchema = {};
-  try {
-    const stateContent = await readFile(statePath, 'utf-8');
-    state = yaml.parse(stateContent) as StateYamlSchema || {};
-  } catch {}
-
-  if (!state.working_memory) state.working_memory = { facts: [], decisions: [], pending: [] };
-  if (!state.session) state.session = {};
-
-  if (decisions.length > 0) {
-    const existing_decisions = state.working_memory.decisions || [];
-    state.working_memory.decisions = [...existing_decisions, ...decisions];
-  }
-  if (pending.length > 0) {
-    state.working_memory.pending = pending; // replace — pending is current state, not history
-  }
-  if (outcomes.length > 0) {
-    const existing_facts = state.working_memory.facts || [];
-    state.working_memory.facts = [...existing_facts, ...outcomes];
-  }
-  if (current_task) {
-    state.current_task = {
-      ...(state.current_task || {}),
-      title: current_task.title || state.current_task?.title,
-      status: current_task.status || 'in_progress',
-      updated: now.toISOString(),
-    };
-  }
-
-  state.session.last_backup = now.toISOString();
-  await writeFile(statePath, yaml.stringify(state), 'utf-8');
-
-  // 3. Sync CLAUDE.md Current State
-  const claudeMdPath = `${projectPath}/CLAUDE.md`;
-  await updateClaudeMdState(claudeMdPath, state, project.name);
-
-  // 4. Touch marker file for hook-based reminder system
-  await writeFile(markerPath, now.toISOString(), 'utf-8');
-
-  // 5. Update registry with last_recorded timestamp
-  await patchProjectMetadata(project.id, {
-    last_recorded: now.toISOString(),
+  await applyTrackedContinuityPatch({
+    projectId: project.id,
+    projectName: project.name,
+    projectPath,
+    statePath,
+    markerPath,
+    currentTask: current_task,
+    now,
+    decisions,
+    outcomes,
+    pending,
   });
 
   const routingNotes = buildConversationRoutingStatusLines(conversationRoutingPlan, legacyTranscriptStatus);

--- a/mcp-server/src/utils/__tests__/case-knowledge.test.ts
+++ b/mcp-server/src/utils/__tests__/case-knowledge.test.ts
@@ -1,7 +1,12 @@
 import { mkdtemp, mkdir, readFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../canonical-main-guard.js', () => ({
+  detectCanonicalMainWriteProtection: vi.fn(),
+}));
+
 import {
   buildCaseContextSection,
   ensureCaseKnowledgeDirectories,
@@ -18,6 +23,9 @@ import {
   renderCaseListMarkdown,
   type CaseProjectTarget,
 } from '../case-knowledge.js';
+import { detectCanonicalMainWriteProtection } from '../canonical-main-guard.js';
+
+const canonicalMainGuardMock = detectCanonicalMainWriteProtection as unknown as ReturnType<typeof vi.fn>;
 
 async function createProject(name: string, id: string): Promise<CaseProjectTarget> {
   const projectPath = await mkdtemp(join(tmpdir(), `agenticos-case-${id}-`));
@@ -35,6 +43,11 @@ async function createProject(name: string, id: string): Promise<CaseProjectTarge
 }
 
 describe('case-knowledge', () => {
+  beforeEach(() => {
+    canonicalMainGuardMock.mockReset();
+    canonicalMainGuardMock.mockResolvedValue({ blocked: false });
+  });
+
   it('creates case directories and records collision-safe case files', async () => {
     const project = await createProject('Alpha Project', 'alpha');
 
@@ -64,10 +77,18 @@ describe('case-knowledge', () => {
       tags: ['Git', 'Retry'],
       timestamp: '2026-04-14T10:10:00.000Z',
     });
+    const fallbackSlug = await recordCaseKnowledge(project, {
+      type: 'corner',
+      title: '!!!',
+      trigger: 'Punctuation-only title',
+      behavior: 'Slug fallback should still allocate a stable path',
+      timestamp: '2026-04-14T10:15:00.000Z',
+    });
 
     expect(first.relativePath).toBe('knowledge/corner-cases/2026-04-14-retry-loop.md');
     expect(second.relativePath).toBe('knowledge/corner-cases/2026-04-14-retry-loop-2.md');
     expect(third.relativePath).toBe('knowledge/corner-cases/2026-04-14-retry-loop-3.md');
+    expect(fallbackSlug.relativePath).toBe('knowledge/corner-cases/2026-04-14-untitled-case.md');
     expect(getCaseTypeLabel('corner')).toBe('corner-case');
     expect(getCaseDirectoryName('bad')).toBe('bad-cases');
 
@@ -80,6 +101,22 @@ describe('case-knowledge', () => {
     expect(parsed.tags).toEqual(['corner-case', 'git', 'retry']);
     expect(parsed.rootCause).toBeNull();
     expect(parsed.behavior).toContain('retried the same failing command');
+  });
+
+  it('blocks tracked case knowledge writes on canonical main', async () => {
+    const project = await createProject('Alpha Project', 'alpha');
+    canonicalMainGuardMock.mockResolvedValue({
+      blocked: true,
+      reason: `canonical main checkout is write-protected for runtime persistence: ${project.projectPath}`,
+    });
+
+    await expect(recordCaseKnowledge(project, {
+      type: 'bad',
+      title: 'Canonical Write',
+      trigger: 'Recording a case on main',
+      behavior: 'The tool tried to write tracked knowledge directly',
+      timestamp: '2026-04-14T10:00:00.000Z',
+    })).rejects.toThrow('agenticos_record_case blocked');
   });
 
   it('validates types, filters, tags, timestamps, and malformed case documents', async () => {
@@ -119,6 +156,12 @@ describe('case-knowledge', () => {
       behavior: 'y',
       timestamp: 'not-an-iso-date',
     })).toThrow('timestamp must be a valid ISO-8601 string when provided.');
+    expect(renderCaseDocument({
+      type: 'corner',
+      title: 'Default Timestamp',
+      trigger: 'x',
+      behavior: 'y',
+    })).toContain('# corner-case: Default Timestamp');
 
     expect(() => parseCaseDocument('## Timestamp\n2026-04-14T12:00:00.000Z\n', project, join(project.projectPath, 'broken.md')))
       .toThrow(`Case document ${join(project.projectPath, 'broken.md')} is missing the title heading.`);
@@ -239,6 +282,16 @@ describe('case-knowledge', () => {
       tags: ['router'],
       timestamp: '2026-04-13T09:00:00.000Z',
     });
+    await recordCaseKnowledge(project, {
+      type: 'bad',
+      title: 'Recovery Binding Leak',
+      trigger: 'Session recovery after a branch switch',
+      behavior: 'The wrong project binding was reused',
+      rootCause: 'Global binding leaked into the recovered session',
+      prevention: 'Prefer session-local binding during recovery',
+      tags: ['recovery'],
+      timestamp: '2026-04-09T09:00:00.000Z',
+    });
 
     const noCasesProject = await createProject('No Cases', 'nocases');
     expect(await buildCaseContextSection(noCasesProject, {})).toContain('No recorded corner or bad cases.');
@@ -272,5 +325,12 @@ describe('case-knowledge', () => {
     expect(tiedRelevantSection.indexOf('Deferred Context Load')).toBeLessThan(
       tiedRelevantSection.indexOf('Aged Session State'),
     );
+
+    const rootCauseAndPreventionSection = await buildCaseContextSection(project, {
+      current_task: { title: 'global binding session-local' },
+      working_memory: { pending: [] },
+    }, 1);
+    expect(rootCauseAndPreventionSection).toContain('## Relevant Cases');
+    expect(rootCauseAndPreventionSection).toContain('Recovery Binding Leak');
   });
 });

--- a/mcp-server/src/utils/__tests__/conversation-routing.test.ts
+++ b/mcp-server/src/utils/__tests__/conversation-routing.test.ts
@@ -31,6 +31,78 @@ describe('conversation routing', () => {
     expect(routing.is_sidecar).toBe(true);
   });
 
+  it('derives full tracked recovery for private_continuity', () => {
+    const contextPlan = resolveContextPolicyPlan({
+      projectName: 'Private Project',
+      projectPath: '/workspace/private-project',
+      repoRoot: '/workspace/private-project',
+      projectYaml: {
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'private_continuity',
+          github_repo: 'example/private-project',
+          branch_strategy: 'github_flow',
+        },
+      },
+    });
+
+    const routing = resolveConversationRoutingPlan(contextPlan);
+
+    expect(routing.raw_conversations_display_dir).toBe('.context/conversations/');
+    expect(routing.tracked_conversations_dir).toBe('/workspace/private-project/.context/conversations/');
+    expect(routing.tracked_recovery_contract).toBe('git_full');
+    expect(routing.notes).toEqual([]);
+    expect(routing.is_sidecar).toBe(false);
+  });
+
+  it('derives local-only recovery for local_private', () => {
+    const contextPlan = resolveContextPolicyPlan({
+      projectName: 'Local Project',
+      projectPath: '/workspace/local-project',
+      projectYaml: {
+        source_control: {
+          topology: 'local_directory_only',
+          context_publication_policy: 'local_private',
+        },
+      },
+    });
+
+    expect(resolveConversationRoutingPlan(contextPlan).tracked_recovery_contract).toBe('local_only');
+  });
+
+  it('fails closed when the raw conversation path escapes the project root', () => {
+    expect(() => resolveConversationRoutingPlan({
+      policy: 'local_private',
+      projectRoot: '/workspace/project',
+      repoRoot: null,
+      trackedContextPaths: {
+        projectFile: '/workspace/project/.project.yaml',
+        quickStart: '/workspace/project/.context/quick-start.md',
+        state: '/workspace/project/.context/state.yaml',
+        conversations: '/workspace/project/.context/conversations',
+        knowledge: '/workspace/project/knowledge',
+        tasks: '/workspace/project/tasks',
+        lastRecord: '/workspace/project/.context/.last_record',
+        artifacts: '/workspace/project/artifacts',
+      },
+      trackedContextDisplayPaths: {
+        projectFile: '.project.yaml',
+        quickStart: '.context/quick-start.md',
+        state: '.context/state.yaml',
+        conversations: '.context/conversations/',
+        knowledge: 'knowledge/',
+        tasks: 'tasks/',
+        lastRecord: '.context/.last_record',
+        artifacts: 'artifacts/',
+      },
+      rawConversationsDir: '/outside/conversations',
+      trackedConversationsDir: '/workspace/project/.context/conversations',
+      sidecarOnlyPaths: [],
+      projectBoundaryViolations: [],
+      repoBoundaryViolations: [],
+    })).toThrow('Path escapes project root');
+  });
+
   it('preserves the configured tracked conversation display path for public_distilled', () => {
     const contextPlan = resolveContextPolicyPlan({
       projectName: 'Public Project',
@@ -76,5 +148,164 @@ describe('conversation routing', () => {
 
     expect(status).toBe('tracked_legacy_present');
     expect(lines.join('\n')).toContain('historical tracked evidence');
+  });
+
+  it('detects nested tracked legacy transcript history for public_distilled projects', async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), 'agenticos-routing-nested-'));
+    await mkdir(join(projectRoot, '.context', 'conversations', 'nested'), { recursive: true });
+    await writeFile(join(projectRoot, '.context', 'conversations', 'nested', '2026-04-13.md'), '# legacy\n', 'utf-8');
+
+    const contextPlan = resolveContextPolicyPlan({
+      projectName: 'Public Project',
+      projectPath: projectRoot,
+      repoRoot: projectRoot,
+      projectYaml: {
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'public_distilled',
+        },
+      },
+    });
+
+    await expect(detectLegacyTrackedTranscriptStatus(contextPlan)).resolves.toBe('tracked_legacy_present');
+  });
+
+  it('returns none when public_distilled tracked legacy transcript directory is empty or missing', async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), 'agenticos-routing-empty-'));
+    await mkdir(join(projectRoot, '.context', 'conversations'), { recursive: true });
+    const contextPlan = resolveContextPolicyPlan({
+      projectName: 'Public Project',
+      projectPath: projectRoot,
+      repoRoot: projectRoot,
+      projectYaml: {
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'public_distilled',
+        },
+      },
+    });
+
+    await expect(detectLegacyTrackedTranscriptStatus(contextPlan)).resolves.toBe('none');
+  });
+
+  it('returns none when public_distilled tracked legacy transcript directory is missing', async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), 'agenticos-routing-missing-'));
+    const contextPlan = resolveContextPolicyPlan({
+      projectName: 'Public Project',
+      projectPath: projectRoot,
+      repoRoot: projectRoot,
+      projectYaml: {
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'public_distilled',
+        },
+      },
+    });
+
+    await expect(detectLegacyTrackedTranscriptStatus(contextPlan)).resolves.toBe('none');
+  });
+
+  it('returns none for non-public-distilled transcript status checks', async () => {
+    const contextPlan = resolveContextPolicyPlan({
+      projectName: 'Local Project',
+      projectPath: '/workspace/local-project',
+      projectYaml: {
+        source_control: {
+          topology: 'local_directory_only',
+          context_publication_policy: 'local_private',
+        },
+      },
+    });
+
+    await expect(detectLegacyTrackedTranscriptStatus(contextPlan, { tracked_transcript_dirty: true })).resolves.toBe('none');
+  });
+
+  it('returns tracked_legacy_dirty when public_distilled tracked transcripts are dirty', async () => {
+    const contextPlan = resolveContextPolicyPlan({
+      projectName: 'Public Project',
+      projectPath: '/workspace/public-project',
+      repoRoot: '/workspace/public-project',
+      projectYaml: {
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'public_distilled',
+        },
+      },
+    });
+
+    await expect(detectLegacyTrackedTranscriptStatus(contextPlan, { tracked_transcript_dirty: true })).resolves.toBe('tracked_legacy_dirty');
+  });
+
+  it('detects public raw routing misconfiguration even when paths differ only by trailing slash', async () => {
+    const contextPlan = resolveContextPolicyPlan({
+      projectName: 'Public Project',
+      projectPath: '/workspace/public-project',
+      repoRoot: '/workspace/public-project',
+      projectYaml: {
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'public_distilled',
+        },
+        agent_context: {
+          conversations: '.private/conversations/',
+        },
+      },
+    });
+
+    await expect(detectLegacyTrackedTranscriptStatus(contextPlan)).resolves.toBe('misconfigured_public_raw_target');
+  });
+
+  it('renders status lines for dirty and misconfigured public transcript states', () => {
+    const contextPlan = resolveContextPolicyPlan({
+      projectName: 'Public Project',
+      projectPath: '/workspace/public-project',
+      repoRoot: '/workspace/public-project',
+      projectYaml: {
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'public_distilled',
+        },
+      },
+    });
+    const routing = resolveConversationRoutingPlan(contextPlan);
+
+    expect(buildConversationRoutingStatusLines(routing, 'tracked_legacy_dirty').join('\n')).toContain('publishing them would leak');
+    expect(buildConversationRoutingStatusLines(routing, 'misconfigured_public_raw_target').join('\n')).toContain('misconfigured');
+  });
+
+  it('uses the default tracked conversation display path when status fallbacks receive none', () => {
+    const contextPlan = resolveContextPolicyPlan({
+      projectName: 'Public Project',
+      projectPath: '/workspace/public-project',
+      repoRoot: '/workspace/public-project',
+      projectYaml: {
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'public_distilled',
+        },
+      },
+    });
+    const routing = {
+      ...resolveConversationRoutingPlan(contextPlan),
+      tracked_conversations_display_dir: null,
+    };
+
+    expect(buildConversationRoutingStatusLines(routing, 'tracked_legacy_present').join('\n')).toContain('.context/conversations/');
+    expect(buildConversationRoutingStatusLines(routing, 'tracked_legacy_dirty').join('\n')).toContain('.context/conversations/');
+  });
+
+  it('renders no status lines for non-public policies', () => {
+    const contextPlan = resolveContextPolicyPlan({
+      projectName: 'Local Project',
+      projectPath: '/workspace/local-project',
+      projectYaml: {
+        source_control: {
+          topology: 'local_directory_only',
+          context_publication_policy: 'local_private',
+        },
+      },
+    });
+
+    expect(buildConversationRoutingStatusLines(resolveConversationRoutingPlan(contextPlan), 'none')).toEqual([]);
   });
 });

--- a/mcp-server/src/utils/__tests__/persistence-write-policy.test.ts
+++ b/mcp-server/src/utils/__tests__/persistence-write-policy.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../canonical-main-guard.js', () => ({
+  detectCanonicalMainWriteProtection: vi.fn(),
+}));
+
+import {
+  formatBlockedProjectTreeWrite,
+  resolvePersistenceWritePlan,
+} from '../persistence-write-policy.js';
+import { detectCanonicalMainWriteProtection } from '../canonical-main-guard.js';
+
+const canonicalMainGuardMock = detectCanonicalMainWriteProtection as unknown as ReturnType<typeof vi.fn>;
+
+describe('persistence-write-policy', () => {
+  beforeEach(() => {
+    canonicalMainGuardMock.mockReset();
+    canonicalMainGuardMock.mockResolvedValue({ blocked: false });
+  });
+
+  it('allows full writes when canonical-main protection is not active', async () => {
+    const plan = await resolvePersistenceWritePlan({
+      command: 'agenticos_record',
+      projectPath: '/project',
+      writes: ['sidecar_capture', 'project_tree_runtime', 'runtime_registry'],
+    });
+
+    expect(plan.mode).toBe('full');
+    expect(plan.writes.every((write) => write.allowed)).toBe(true);
+    expect(plan.nextActions).toEqual([]);
+  });
+
+  it('allows sidecar-only writes as full mode when nothing is blocked', async () => {
+    const plan = await resolvePersistenceWritePlan({
+      command: 'agenticos_record',
+      projectPath: '/project',
+      writes: ['sidecar_capture'],
+    });
+
+    expect(plan.mode).toBe('full');
+    expect(plan.writes).toEqual([{ kind: 'sidecar_capture', allowed: true }]);
+  });
+
+  it('allows capture-only while blocking project-tree writes on canonical main', async () => {
+    canonicalMainGuardMock.mockResolvedValue({
+      blocked: true,
+      reason: 'canonical main checkout is write-protected for runtime persistence: /project',
+    });
+
+    const plan = await resolvePersistenceWritePlan({
+      command: 'agenticos_record',
+      projectPath: '/project',
+      writes: ['sidecar_capture', 'project_tree_runtime', 'runtime_registry'],
+    });
+
+    expect(plan.mode).toBe('capture_only');
+    expect(plan.writeProtectionReason).toContain('/project');
+    expect(plan.writes.find((write) => write.kind === 'sidecar_capture')?.allowed).toBe(true);
+    expect(plan.writes.find((write) => write.kind === 'project_tree_runtime')?.allowed).toBe(false);
+    expect(plan.writes.find((write) => write.kind === 'runtime_registry')?.allowed).toBe(true);
+    expect(plan.nextActions).toContain('create or enter an isolated issue worktree before distilling tracked continuity');
+  });
+
+  it('blocks when canonical main would only receive project-tree writes', async () => {
+    canonicalMainGuardMock.mockResolvedValue({
+      blocked: true,
+      reason: 'canonical main checkout is write-protected for runtime persistence: /project',
+    });
+
+    const plan = await resolvePersistenceWritePlan({
+      command: 'agenticos_record_case',
+      projectPath: '/project',
+      writes: ['project_tree_knowledge'],
+    });
+
+    expect(plan.mode).toBe('blocked');
+    expect(plan.writes).toEqual([{
+      kind: 'project_tree_knowledge',
+      allowed: false,
+      reason: 'canonical main checkout is write-protected for runtime persistence: /project',
+    }]);
+  });
+
+  it('formats blocked project-tree write messages with recovery guidance', () => {
+    const message = formatBlockedProjectTreeWrite({
+      command: 'agenticos_record_case',
+      projectName: 'AgenticOS',
+      writeKind: 'project_tree_knowledge',
+      reason: 'canonical main checkout is write-protected',
+    });
+
+    expect(message).toContain('agenticos_record_case blocked for "AgenticOS"');
+    expect(message).toContain('project_tree_knowledge');
+    expect(message).toContain('isolated issue worktree');
+  });
+
+  it('formats blocked project-tree write messages with a default reason', () => {
+    const message = formatBlockedProjectTreeWrite({
+      command: 'agenticos_record_case',
+      projectName: 'AgenticOS',
+      writeKind: 'project_tree_knowledge',
+    });
+
+    expect(message).toContain('canonical main checkout is write-protected');
+  });
+});

--- a/mcp-server/src/utils/__tests__/record-capture.test.ts
+++ b/mcp-server/src/utils/__tests__/record-capture.test.ts
@@ -1,0 +1,74 @@
+import { mkdtemp, readFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../registry.js', () => ({
+  getAgenticOSHome: vi.fn(() => '/runtime/home'),
+}));
+
+import {
+  appendRecordCapture,
+  buildRecordCaptureEntry,
+  getRuntimeCaptureConversationDir,
+} from '../record-capture.js';
+
+describe('record-capture', () => {
+  const now = new Date('2026-05-07T10:30:00.000Z');
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('derives runtime capture paths from encoded project ids', () => {
+    expect(getRuntimeCaptureConversationDir('agenticos/core')).toBe(
+      '/runtime/home/.agent-workspace/projects/agenticos%2Fcore/captures/conversations',
+    );
+  });
+
+  it('builds a markdown capture entry with structured sections', () => {
+    const entry = buildRecordCaptureEntry({
+      now,
+      summary: 'Did work',
+      decisions: ['Decision'],
+      outcomes: ['Outcome'],
+      pending: ['Pending'],
+    });
+
+    expect(entry.date).toBe('2026-05-07');
+    expect(entry.time).toBe('10:30');
+    expect(entry.entry).toContain('### 10:30 - Session Record');
+    expect(entry.entry).toContain('**Summary**: Did work');
+    expect(entry.entry).toContain('- Decision');
+    expect(entry.entry).toContain('- Outcome');
+    expect(entry.entry).toContain('- Pending');
+  });
+
+  it('creates and appends daily capture files', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'agenticos-capture-'));
+
+    const first = await appendRecordCapture({
+      dir,
+      now,
+      summary: 'First record',
+      decisions: [],
+      outcomes: [],
+      pending: [],
+    });
+    const second = await appendRecordCapture({
+      dir,
+      now: new Date('2026-05-07T10:35:00.000Z'),
+      summary: 'Second record',
+      decisions: ['Keep going'],
+      outcomes: [],
+      pending: [],
+    });
+
+    expect(first.filePath).toBe(second.filePath);
+    const content = await readFile(first.filePath, 'utf-8');
+    expect(content).toContain('# Sessions - 2026-05-07');
+    expect(content).toContain('First record');
+    expect(content).toContain('Second record');
+    expect(content).toContain('Keep going');
+  });
+});

--- a/mcp-server/src/utils/case-knowledge.ts
+++ b/mcp-server/src/utils/case-knowledge.ts
@@ -1,6 +1,7 @@
 import { mkdir, readdir, readFile, writeFile } from 'fs/promises';
 import { join, relative } from 'path';
 import { resolveManagedProjectContextPaths } from './agent-context-paths.js';
+import { formatBlockedProjectTreeWrite, resolvePersistenceWritePlan } from './persistence-write-policy.js';
 
 export type CaseType = 'corner' | 'bad';
 export type CaseFilterType = CaseType | 'all';
@@ -203,8 +204,6 @@ function parseRequiredSection(value: string | undefined, label: string): string 
 }
 
 function scoreCaseAgainstKeywords(entry: CaseEntry, keywords: string[]): number {
-  if (keywords.length === 0) return 0;
-
   let score = 0;
   for (const keyword of keywords) {
     if (entry.tags.some((tag) => tag.includes(keyword))) score += 3;
@@ -377,6 +376,20 @@ export async function recordCaseKnowledge(
   input: CaseRecordInput,
 ): Promise<CaseEntry> {
   const type = normalizeCaseType(input.type);
+  const persistencePlan = await resolvePersistenceWritePlan({
+    command: 'agenticos_record_case',
+    projectPath: project.projectPath,
+    writes: ['project_tree_knowledge'],
+  });
+  if (persistencePlan.mode === 'blocked') {
+    throw new Error(formatBlockedProjectTreeWrite({
+      command: 'agenticos_record_case',
+      projectName: project.projectName,
+      writeKind: 'project_tree_knowledge',
+      reason: persistencePlan.writeProtectionReason,
+    }));
+  }
+
   await ensureCaseKnowledgeDirectories(project.projectPath, project.projectYaml);
 
   const content = renderCaseDocument({ ...input, type });

--- a/mcp-server/src/utils/conversation-routing.ts
+++ b/mcp-server/src/utils/conversation-routing.ts
@@ -1,5 +1,5 @@
 import { readdir } from 'fs/promises';
-import { relative } from 'path';
+import { relative, resolve } from 'path';
 import { type ContextPolicyPlan } from './context-policy-plan.js';
 
 export type TrackedRecoveryContract = 'local_only' | 'git_full' | 'git_distilled';
@@ -24,12 +24,16 @@ interface DetectLegacyTrackedTranscriptStatusOptions {
   tracked_transcript_dirty?: boolean;
 }
 
-function toProjectRelativePath(projectRoot: string, absolutePath: string, directory = false): string {
+function toProjectRelativeDirectoryPath(projectRoot: string, absolutePath: string): string {
   const relativePath = relative(projectRoot, absolutePath).replace(/\\/g, '/');
   if (!relativePath || relativePath.startsWith('..')) {
     throw new Error(`Path escapes project root: ${absolutePath}`);
   }
-  return directory && !relativePath.endsWith('/') ? `${relativePath}/` : relativePath;
+  return `${relativePath}/`;
+}
+
+function samePath(left: string, right: string): boolean {
+  return resolve(left) === resolve(right);
 }
 
 async function directoryContainsTranscriptFiles(path: string): Promise<boolean> {
@@ -50,7 +54,7 @@ async function directoryContainsTranscriptFiles(path: string): Promise<boolean> 
 }
 
 export function resolveConversationRoutingPlan(plan: ContextPolicyPlan): ConversationRoutingPlan {
-  const rawDisplayDir = toProjectRelativePath(plan.projectRoot, plan.rawConversationsDir, true);
+  const rawDisplayDir = toProjectRelativeDirectoryPath(plan.projectRoot, plan.rawConversationsDir);
   const trackedDisplayDir = plan.trackedContextDisplayPaths.conversations;
   const trackedRecoveryContract: TrackedRecoveryContract = plan.policy === 'private_continuity'
     ? 'git_full'
@@ -88,7 +92,7 @@ export async function detectLegacyTrackedTranscriptStatus(
 
   const rawRelative = relative(plan.projectRoot, plan.rawConversationsDir).replace(/\\/g, '/');
   if (!rawRelative || rawRelative.startsWith('..')
-    || plan.rawConversationsDir === plan.trackedContextPaths.conversations) {
+    || samePath(plan.rawConversationsDir, plan.trackedContextPaths.conversations)) {
     return 'misconfigured_public_raw_target';
   }
 

--- a/mcp-server/src/utils/persistence-write-policy.ts
+++ b/mcp-server/src/utils/persistence-write-policy.ts
@@ -1,0 +1,92 @@
+import { detectCanonicalMainWriteProtection } from './canonical-main-guard.js';
+
+export type PersistenceWriteKind =
+  | 'sidecar_capture'
+  | 'project_tree_runtime'
+  | 'project_tree_knowledge'
+  | 'project_tree_continuity'
+  | 'runtime_registry';
+
+export type PersistenceMode = 'full' | 'capture_only' | 'blocked';
+
+export interface PersistenceWriteDecision {
+  kind: PersistenceWriteKind;
+  allowed: boolean;
+  reason?: string;
+}
+
+export interface PersistenceWritePlan {
+  command: string;
+  mode: PersistenceMode;
+  writeProtectionReason?: string;
+  writes: PersistenceWriteDecision[];
+  nextActions: string[];
+}
+
+const PROJECT_TREE_WRITE_KINDS = new Set<PersistenceWriteKind>([
+  'project_tree_runtime',
+  'project_tree_knowledge',
+  'project_tree_continuity',
+]);
+
+function isProjectTreeWrite(kind: PersistenceWriteKind): boolean {
+  return PROJECT_TREE_WRITE_KINDS.has(kind);
+}
+
+export async function resolvePersistenceWritePlan(args: {
+  command: string;
+  projectPath: string;
+  writes: PersistenceWriteKind[];
+}): Promise<PersistenceWritePlan> {
+  const writeProtection = await detectCanonicalMainWriteProtection(args.projectPath);
+  const writeProtectionReason = writeProtection.blocked ? writeProtection.reason : undefined;
+
+  const writes = args.writes.map((kind) => {
+    if (writeProtection.blocked && isProjectTreeWrite(kind)) {
+      return {
+        kind,
+        allowed: false,
+        reason: writeProtection.reason,
+      };
+    }
+
+    return {
+      kind,
+      allowed: true,
+    };
+  });
+
+  const hasBlockedWrite = writes.some((write) => !write.allowed);
+  const hasAllowedCapture = writes.some((write) => write.kind === 'sidecar_capture' && write.allowed);
+  const mode: PersistenceMode = hasBlockedWrite
+    ? hasAllowedCapture ? 'capture_only' : 'blocked'
+    : 'full';
+
+  const nextActions = mode === 'capture_only' || mode === 'blocked'
+    ? [
+        'create or enter an isolated issue worktree before distilling tracked continuity',
+        'rerun agenticos_record after worktree alignment to apply tracked continuity updates',
+        'run agenticos_status to verify session binding and pending capture context',
+      ]
+    : [];
+
+  return {
+    command: args.command,
+    mode,
+    writeProtectionReason,
+    writes,
+    nextActions,
+  };
+}
+
+export function formatBlockedProjectTreeWrite(args: {
+  command: string;
+  projectName: string;
+  writeKind: PersistenceWriteKind;
+  reason?: string;
+}): string {
+  return `❌ ${args.command} blocked for "${args.projectName}" because canonical main checkout project-tree writes are protected.\n\n` +
+    `- blocked write kind: ${args.writeKind}\n` +
+    `- ${args.reason || 'canonical main checkout is write-protected'}\n` +
+    '- create or enter an isolated issue worktree before writing tracked project continuity or knowledge';
+}

--- a/mcp-server/src/utils/project-target.ts
+++ b/mcp-server/src/utils/project-target.ts
@@ -27,6 +27,7 @@ export interface ResolvedManagedProjectTarget {
 
 interface ResolveManagedProjectTargetArgs {
   project?: string;
+  projectPath?: string;
   commandName: string;
 }
 
@@ -68,7 +69,7 @@ export async function resolveManagedProjectTarget(args: ResolveManagedProjectTar
     throw new Error(`No project provided and no session project is bound. Use agenticos_switch first or pass project to ${args.commandName}.`);
   }
 
-  let project: Project | null = null;
+  let project: Project;
   if (requestedProject) {
     const matches = registry.projects.filter((candidate) =>
       candidate.id === requestedProject ||
@@ -80,23 +81,23 @@ export async function resolveManagedProjectTarget(args: ResolveManagedProjectTar
       `Project "${requestedProject}" not found in registry.`,
       `Project "${requestedProject}" is ambiguous in registry.`
     );
-  } else if (sessionProject) {
+  } else {
+    const boundProject = sessionProject!;
     project = uniqueMatch(
       registry.projects.filter((candidate) =>
-        candidate.id === sessionProject.projectId || candidate.path === sessionProject.projectPath
+        candidate.id === boundProject.projectId || candidate.path === boundProject.projectPath
       ),
-      `Session project "${sessionProject.projectId}" not found in registry.`,
-      `Session project "${sessionProject.projectId}" is ambiguous in registry.`,
+      `Session project "${boundProject.projectId}" not found in registry.`,
+      `Session project "${boundProject.projectId}" is ambiguous in registry.`,
     );
-  }
-
-  if (!project) {
-    throw new Error(`No project provided and no session project is bound. Use agenticos_switch first or pass project to ${args.commandName}.`);
   }
 
   assertRegistryUniqueness(registry, project, requestedProject || undefined);
 
-  const projectYamlPath = join(project.path, '.project.yaml');
+  const targetProjectPath = typeof args.projectPath === 'string' && args.projectPath.trim().length > 0
+    ? args.projectPath.trim()
+    : project.path;
+  const projectYamlPath = join(targetProjectPath, '.project.yaml');
   let projectYaml: any;
   try {
     projectYaml = yaml.parse(await readFile(projectYamlPath, 'utf-8')) || {};
@@ -132,7 +133,7 @@ export async function resolveManagedProjectTarget(args: ResolveManagedProjectTar
     throw new Error(`${topologyValidation.message} ${args.commandName} only works with normalized managed projects.`);
   }
 
-  const contextPaths = resolveManagedProjectContextPaths(project.path, projectYaml);
+  const contextPaths = resolveManagedProjectContextPaths(targetProjectPath, projectYaml);
 
   return {
     registry,
@@ -140,7 +141,7 @@ export async function resolveManagedProjectTarget(args: ResolveManagedProjectTar
     projectYaml,
     projectId: project.id,
     projectName: project.name,
-    projectPath: project.path,
+    projectPath: targetProjectPath,
     projectYamlPath,
     quickStartPath: contextPaths.quickStartPath,
     statePath: contextPaths.statePath,

--- a/mcp-server/src/utils/record-capture.ts
+++ b/mcp-server/src/utils/record-capture.ts
@@ -1,0 +1,87 @@
+import { mkdir, readFile, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { getAgenticOSHome } from './registry.js';
+
+export interface RecordCapturePayload {
+  summary: string;
+  decisions: string[];
+  outcomes: string[];
+  pending: string[];
+}
+
+export interface AppendRecordCaptureArgs extends RecordCapturePayload {
+  dir: string;
+  now: Date;
+}
+
+export interface AppendedRecordCapture {
+  filePath: string;
+  date: string;
+  time: string;
+  entry: string;
+}
+
+export function getRuntimeCaptureConversationDir(projectId: string): string {
+  return join(
+    getAgenticOSHome(),
+    '.agent-workspace',
+    'projects',
+    encodeURIComponent(projectId),
+    'captures',
+    'conversations',
+  );
+}
+
+export function buildRecordCaptureEntry(args: RecordCapturePayload & { now: Date }): AppendedRecordCapture {
+  const date = args.now.toISOString().split('T')[0];
+  const time = args.now.toISOString().substring(11, 16);
+  const sections: string[] = [];
+
+  sections.push(`### ${time} - Session Record\n`);
+  sections.push(`**Summary**: ${args.summary}\n`);
+  if (args.outcomes.length > 0) {
+    sections.push('**Outcomes**:');
+    for (const outcome of args.outcomes) sections.push(`- ${outcome}`);
+    sections.push('');
+  }
+  if (args.decisions.length > 0) {
+    sections.push('**Decisions**:');
+    for (const decision of args.decisions) sections.push(`- ${decision}`);
+    sections.push('');
+  }
+  if (args.pending.length > 0) {
+    sections.push('**Pending**:');
+    for (const item of args.pending) sections.push(`- ${item}`);
+    sections.push('');
+  }
+
+  return {
+    filePath: '',
+    date,
+    time,
+    entry: sections.join('\n'),
+  };
+}
+
+export async function appendRecordCapture(args: AppendRecordCaptureArgs): Promise<AppendedRecordCapture> {
+  await mkdir(args.dir, { recursive: true });
+
+  const built = buildRecordCaptureEntry(args);
+  const filePath = join(args.dir, `${built.date}.md`);
+
+  let existing = '';
+  try {
+    existing = await readFile(filePath, 'utf-8');
+  } catch {}
+
+  const content = existing
+    ? `${existing}\n\n${built.entry}`
+    : `# Sessions - ${built.date}\n\n${built.entry}`;
+
+  await writeFile(filePath, content, 'utf-8');
+
+  return {
+    ...built,
+    filePath,
+  };
+}


### PR DESCRIPTION
## Summary

Closes #363.

This PR implements the capture-first record architecture for AgenticOS:

- `agenticos_record` now captures session facts before attempting tracked continuity writes.
- canonical-main project-tree write protection now yields `RECORDED_CAPTURE_ONLY` instead of losing the record.
- tracked continuity distillation still only happens when the target checkout can receive project-tree writes.
- `agenticos_record_case` now uses the same project-tree write protection before writing tracked `knowledge/` case docs.
- `project_path` can be passed to record/case tools so isolated issue worktrees do not write back to the registered canonical checkout.
- conversation routing now normalizes paths before deciding whether public raw transcript routing is misconfigured.

## Flow Evidence

### 1. Design review

Posted design review on #363:

- https://github.com/madlouse/AgenticOS/issues/363#issuecomment-4396228692

Design decision:

- capture first
- distill tracked continuity only when allowed
- block tracked case knowledge writes on canonical main
- keep #359 entry-surface auto-upgrade as related but separate work unless sharing small helpers

### 2. Development and tests

Targeted tests:

```text
npx vitest run \
  src/tools/__tests__/record.test.ts \
  src/tools/__tests__/case.test.ts \
  src/utils/__tests__/case-knowledge.test.ts \
  src/utils/__tests__/persistence-write-policy.test.ts \
  src/utils/__tests__/record-capture.test.ts \
  src/utils/__tests__/conversation-routing.test.ts
```

Result:

```text
Test Files  6 passed (6)
Tests       66 passed (66)
```

Coverage for changed executable files:

```text
All included files: 100% statements, 100% functions, 100% lines
record.ts: 100% statements/functions/lines
case.ts: 100% statements/functions/lines
persistence-write-policy.ts: 100% statements/functions/lines
record-capture.ts: 100% statements/functions/lines
case-knowledge.ts: 100% statements/functions/lines
conversation-routing.ts: 100% statements/functions/lines
```

Full test suite:

```text
npm test
Test Files  54 passed (54)
Tests       605 passed (605)
```

Note: full suite initially exposed an existing MCP regression baseline drift from installed runtime `0.4.8` vs baseline `0.4.7`; this PR updates the baseline to the currently installed runtime version.

### 3. Merge review

Guardrails:

- `agenticos_preflight`: PASS in isolated #363 worktree
- `agenticos_issue_bootstrap`: recorded for #363
- `agenticos_edit_guard`: PASS before implementation edits
- `agenticos_pr_scope_check`: PASS after commit

Residual risk:

- capture-only mode deliberately does not write tracked `.last_record`, so reminder surfaces may still report that tracked continuity was not distilled. That is consistent with the design boundary; a future runtime marker can improve this UX without polluting canonical main.

## Testing

- [x] targeted vitest suite for changed behavior
- [x] targeted coverage report for changed executable files
- [x] full `npm test`
- [x] `git diff --check`
- [x] AgenticOS PR scope check
