### PR TITLE
chore: release v0.4.12

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenticos-mcp",
-  "version": "0.4.5",
+  "version": "0.4.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenticos-mcp",
-      "version": "0.4.5",
+      "version": "0.4.12",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-mcp",
-  "version": "0.4.10",
+  "version": "0.4.12",
   "description": "MCP Server for AgenticOS - AI-native project management system",
   "type": "module",
   "bin": {

--- a/mcp-server/src/__tests__/mcp-regression-baseline.json
+++ b/mcp-server/src/__tests__/mcp-regression-baseline.json
@@ -1,9 +1,9 @@
 {
-  "capturedAt": "2026-04-25T15:16:06.271Z",
-  "version": "0.4.10",
+  "capturedAt": "2026-05-08T04:30:06.975Z",
+  "version": "0.4.12",
   "serverInfo": {
     "name": "agenticos-mcp",
-    "version": "0.4.10"
+    "version": "0.4.12"
   },
   "protocolVersion": "2025-11-25",
   "capabilities": {


### PR DESCRIPTION
## Summary
- bump agenticos-mcp package and lockfile version to 0.4.12
- refresh MCP regression baseline to 0.4.12 so release package reports the intended runtime version

## Validation
- npm run build
- npm test (58 files / 657 tests)
- git diff --check
- agenticos_pr_scope_check PASS

Release goal: publish #363 capture-first record behavior to Homebrew-installed runtimes.