### PR TITLE
fix(#359): prevent switch dirty canonical main by blocking writes

### DIFF
--- a/mcp-server/src/tools/__tests__/project.test.ts
+++ b/mcp-server/src/tools/__tests__/project.test.ts
@@ -61,6 +61,10 @@ vi.mock('../../utils/worktree-topology.js', () => ({
   inspectProjectWorktreeTopology: worktreeTopologyMock.inspectProjectWorktreeTopology,
 }));
 
+vi.mock('../../utils/canonical-main-guard.js', () => ({
+  detectCanonicalMainWriteProtection: vi.fn(() => ({ blocked: false })),
+}));
+
 import { switchProject, listProjects, getStatus } from '../project.js';
 import * as fsPromises from 'fs/promises';
 import * as registry from '../../utils/registry.js';
@@ -399,6 +403,73 @@ describe('switchProject', () => {
       'utf-8',
     );
     expect(fsPromisesMock.writeFile).toHaveBeenCalledWith(
+      '/test/path/AGENTS.md',
+      expect.any(String),
+      'utf-8',
+    );
+  });
+
+  it('does not write to canonical main - reports stale entry surfaces instead', async () => {
+    const canonicalMainGuardMock = await import('../../utils/canonical-main-guard.js');
+    canonicalMainGuardMock.detectCanonicalMainWriteProtection = vi.fn(() => ({
+      blocked: true,
+      reason: 'canonical main checkout is not a supported runtime workspace',
+      current_branch: 'main',
+      workspace_type: 'main' as const,
+    }));
+
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: null,
+      projects: [
+        {
+          id: 'my-project',
+          name: 'My Project',
+          path: '/test/path',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    fsPromisesMock.readFile.mockImplementation(async (path: string) => {
+      if (path.endsWith('/.project.yaml')) {
+        return JSON.stringify({
+          meta: { description: '' },
+          source_control: { topology: 'local_directory_only' },
+        });
+      }
+      if (path.endsWith('/.context/state.yaml')) {
+        return JSON.stringify({
+          working_memory: { pending: [], decisions: [] },
+        });
+      }
+      if (path.endsWith('/.context/quick-start.md')) {
+        return '# Quick Start\n\nProject summary';
+      }
+      if (path.endsWith('/CLAUDE.md')) {
+        return '# CLAUDE.md\n\n<!-- agenticos-template: v1 -->\nOld content';
+      }
+      if (path.endsWith('/AGENTS.md')) {
+        return '# AGENTS.md\n\n<!-- agenticos-template: v1 -->\nOld content';
+      }
+      return '';
+    });
+
+    const result = await switchProject({ project: 'my-project' });
+
+    // Should NOT upgrade - should report stale instead
+    expect(result).toContain('⚠️ CLAUDE.md stale');
+    expect(result).toContain('⚠️ AGENTS.md stale');
+    // writeFile should NOT be called for canonical main
+    expect(fsPromisesMock.writeFile).not.toHaveBeenCalledWith(
+      '/test/path/CLAUDE.md',
+      expect.any(String),
+      'utf-8',
+    );
+    expect(fsPromisesMock.writeFile).not.toHaveBeenCalledWith(
       '/test/path/AGENTS.md',
       expect.any(String),
       'utf-8',

--- a/mcp-server/src/tools/project.ts
+++ b/mcp-server/src/tools/project.ts
@@ -25,6 +25,7 @@ import {
   type IssueBootstrapContinuityAssessment,
 } from '../utils/issue-bootstrap-continuity.js';
 import { deriveExpectedWorktreeRoot, inspectProjectWorktreeTopology } from '../utils/worktree-topology.js';
+import { detectCanonicalMainWriteProtection } from '../utils/canonical-main-guard.js';
 
 type GuardrailCommand = 'agenticos_preflight' | 'agenticos_branch_bootstrap' | 'agenticos_pr_scope_check';
 
@@ -356,7 +357,8 @@ export async function switchProject(args: any): Promise<string> {
     projectPath: found.path,
   });
 
-  // Auto-bootstrap: generate or upgrade CLAUDE.md / AGENTS.md
+  // Check if entry surface writes are allowed in this checkout
+  const writeProtection = await detectCanonicalMainWriteProtection(found.path);
   const bootstrapNotes: string[] = [];
   try {
     await patchProjectMetadata(found.id, {
@@ -404,7 +406,13 @@ export async function switchProject(args: any): Promise<string> {
   } catch {}
 
   // CLAUDE.md: create if missing, upgrade if stale template version
-  if (!existsSync(claudeMdPath)) {
+  // Skip writes to canonical main — entry surface changes must happen in isolated worktrees
+  if (writeProtection.blocked) {
+    const existingVersion = existsSync(claudeMdPath) ? extractTemplateVersion(await readFile(claudeMdPath, 'utf-8')) : 0;
+    if (existingVersion < CURRENT_TEMPLATE_VERSION) {
+      bootstrapNotes.push(`⚠️ CLAUDE.md stale (v${existingVersion} < v${CURRENT_TEMPLATE_VERSION}) — refresh in isolated worktree`);
+    }
+  } else if (!existsSync(claudeMdPath)) {
     await writeFile(claudeMdPath, generateClaudeMd(found.name, description, state, contextDisplayPaths), 'utf-8');
     bootstrapNotes.push('📝 CLAUDE.md created');
   } else {
@@ -417,7 +425,13 @@ export async function switchProject(args: any): Promise<string> {
   }
 
   // AGENTS.md: create if missing, upgrade if stale
-  if (!existsSync(agentsMdPath)) {
+  // Skip writes to canonical main — entry surface changes must happen in isolated worktrees
+  if (writeProtection.blocked) {
+    const existingVersion = existsSync(agentsMdPath) ? extractTemplateVersion(await readFile(agentsMdPath, 'utf-8')) : 0;
+    if (existingVersion < CURRENT_TEMPLATE_VERSION) {
+      bootstrapNotes.push(`⚠️ AGENTS.md stale (v${existingVersion} < v${CURRENT_TEMPLATE_VERSION}) — refresh in isolated worktree`);
+    }
+  } else if (!existsSync(agentsMdPath)) {
     await writeFile(agentsMdPath, generateAgentsMd(found.name, description, contextDisplayPaths), 'utf-8');
     bootstrapNotes.push('📝 AGENTS.md created');
   } else {


### PR DESCRIPTION
## Summary
- Add write protection check in `switchProject` before CLAUDE.md/AGENTS.md operations
- When switching to a project on canonical main, skip writes and report stale entry surfaces instead
- This prevents dirty git state from entry surface writes during `agenticos_switch`

## Test plan
- [x] `npm run build` passes
- [x] All tests pass including new test "does not write to canonical main - reports stale entry surfaces instead"

🤖 Generated with [Claude Code](https://claude.com/claude-code)