### PR TITLE
feat(#358): surface bootstrap failures in verify output and status

### DIFF
--- a/mcp-server/src/tools/project.ts
+++ b/mcp-server/src/tools/project.ts
@@ -616,5 +616,20 @@ export async function getStatus(args: any = {}): Promise<string> {
     }
   }
 
+  // Check bootstrap state for failures
+  const bootstrapStatePath = `${resolved.projectPath}/.agent-workspace/bootstrap-state.yaml`;
+  try {
+    const bootstrapContent = await readFile(bootstrapStatePath, 'utf-8');
+    const bootstrapState = yaml.parse(bootstrapContent) as any;
+    if (bootstrapState?.failed_agents?.length > 0) {
+      lines.push('');
+      lines.push('⚠️ Bootstrap Issues:');
+      for (const agent of bootstrapState.failed_agents as string[]) {
+        lines.push(`   - ${agent}: verification failed`);
+      }
+      lines.push('   Run: agenticos-bootstrap --verify');
+    }
+  } catch {}
+
   return lines.join('\n');
 }

--- a/mcp-server/src/utils/__tests__/bootstrap-cli.test.ts
+++ b/mcp-server/src/utils/__tests__/bootstrap-cli.test.ts
@@ -231,6 +231,27 @@ describe('bootstrap cli', () => {
 
     expect(exitCode).toBe(1);
     expect(harness.stdout.some((line) => line.includes('FAIL codex: env: AGENTICOS_HOME=/tmp/other-workspace'))).toBe(true);
+    expect(harness.stdout.some((line) => line.includes('Recovery: agenticos-bootstrap --agents codex'))).toBe(true);
+  });
+
+  it('shows recovery command for claude-code when verification fails', () => {
+    const harness = createDeps();
+    harness.deps.runCommand = (command: string, args: string[], failOnError: boolean) => {
+      harness.commands.push({ command, args, failOnError });
+      if ([command, ...args].join(' ') === 'claude mcp get agenticos') {
+        return { ok: false, detail: 'not registered' };
+      }
+      return { ok: true, detail: 'ok' };
+    };
+
+    const exitCode = runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'claude-code', '--verify'],
+      harness.deps,
+    );
+
+    expect(exitCode).toBe(1);
+    expect(harness.stdout.some((line) => line.includes('FAIL claude-code'))).toBe(true);
+    expect(harness.stdout.some((line) => line.includes('Recovery: claude mcp add'))).toBe(true);
   });
 
   it('fails verification when the expected shell profile export is missing', () => {

--- a/mcp-server/src/utils/bootstrap-cli.ts
+++ b/mcp-server/src/utils/bootstrap-cli.ts
@@ -323,6 +323,16 @@ export function buildDryRunLines(
   return lines;
 }
 
+function getRecoveryCommand(agentId: SupportedAgentId): string {
+  const commands: Record<SupportedAgentId, string> = {
+    'claude-code': 'claude mcp add --transport stdio --scope user agenticos -- agenticos-mcp',
+    'codex': 'agenticos-bootstrap --agents codex',
+    'cursor': 'agenticos-bootstrap --agents cursor',
+    'gemini-cli': 'agenticos-bootstrap --agents gemini-cli',
+  };
+  return commands[agentId] || '';
+}
+
 function runVerification(
   workspace: string,
   selected: SupportedAgentId[],
@@ -341,7 +351,13 @@ function runVerification(
     const result = verifyAgent(agentId, deps, workspace);
     const marker = result.ok ? 'OK' : 'FAIL';
     lines.push(`${marker} ${agentId}: ${result.detail}`);
-    if (!result.ok) ok = false;
+    if (!result.ok) {
+      ok = false;
+      const recovery = getRecoveryCommand(agentId);
+      if (recovery) {
+        lines.push(`   Recovery: ${recovery}`);
+      }
+    }
   }
 
   if (options.persistShellEnv) {


### PR DESCRIPTION
## Summary

Extend existing bootstrap verification to surface failures prominently with actionable recovery commands.

### Changes

1. **`--verify` output now shows recovery commands on FAIL:**
   ```
   FAIL claude-code: not registered
      Recovery: claude mcp add --transport stdio --scope user agenticos -- agenticos-mcp
   ```

2. **`agenticos_status` now shows bootstrap issues when failed_agents exist:**
   ```
   ⚠️ Bootstrap Issues:
      - claude-code: verification failed
      - codex: verification failed
      Run: agenticos-bootstrap --verify
   ```

### Approach

- Extend existing `--verify` and `agenticos_status` rather than building new transaction model
- Recovery commands from predefined allowlist (no user input)
- Status only shows warning when issues exist (not always)

### Test Plan
- [x] `npm run build` passes
- [x] All 659 tests pass (added 1 new test for recovery commands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)