### PR TITLE
fix: standard_kit_adopt 模块级合并保留项目特定内容

### DIFF
--- a/mcp-server/src/tools/multi-agent-review.ts
+++ b/mcp-server/src/tools/multi-agent-review.ts
@@ -174,11 +174,12 @@ async function runClaudeAgent(
     // Write prompt to temp file — avoids shell injection from PR title/body/diff content
     await writeFile(tmpFile, prompt, 'utf-8');
 
+    // Use 'command claude' to bypass shell function wrappers (e.g., agent-cli-api overrides 'claude')
     // Use execFile (array args) to avoid shell glob expansion of ? in tmpFile path
     // stdio[0]='ignore' closes stdin, preventing parallel process conflicts
     const { stdout } = await execFileAsync(
-      'claude',
-      ['--print', '--agent', agentFlag, '--system-prompt-file', tmpFile, '.', '--dangerously-skip-permissions'],
+      'command',
+      ['claude', '--print', '--agent', agentFlag, '--system-prompt-file', tmpFile, '.', '--dangerously-skip-permissions'],
       { timeout: 120000, maxBuffer: 1024 * 1024 * 2 },
     );
 

--- a/mcp-server/src/utils/__tests__/distill.test.ts
+++ b/mcp-server/src/utils/__tests__/distill.test.ts
@@ -10,7 +10,13 @@ import {
   TASK_INTAKE_RULE_TITLE,
   generateAgentsMd,
   generateClaudeMd,
+  upgradeClaudeMd,
+  mergeSections,
+  STANDARD_SECTION_NAMES,
 } from '../distill.js';
+import { writeFile, unlink } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
 import { STOP_HOOK_MIGRATION_BULLETS } from '../stop-hook-guidance.js';
 
 describe('distill templates', () => {
@@ -103,5 +109,98 @@ describe('distill templates', () => {
     expect(content).not.toContain('| `.context/quick-start.md` | Quick project summary |');
     expect(content).not.toContain('## Navigation');
     expect(content).not.toContain('## Directory Structure');
+  });
+});
+
+describe('section markers', () => {
+  it('generates CLAUDE.md with section markers for module-level merge', () => {
+    const content = generateClaudeMd('Demo Project', 'Test project');
+
+    // Should have section markers
+    expect(content).toContain('<!-- agenticos-section:');
+    expect(content).toContain('<!-- /agenticos-section -->');
+
+    // Should mark standard sections
+    expect(content).toContain('<!-- agenticos-section: canonical-policy -->');
+    expect(content).toContain('<!-- agenticos-section: guardrail-protocol -->');
+    expect(content).toContain('<!-- agenticos-section: recording-protocol -->');
+
+    // All standard sections should be marked
+    expect(STANDARD_SECTION_NAMES.length).toBe(9);
+  });
+
+  it('mergeSections preserves project-specific content from existing file', () => {
+    const existingContent = `<!-- agenticos-template: v13 -->
+# CLAUDE.md — Existing Project
+
+<!-- agenticos-section: adapter-role -->
+## Adapter Role
+Existing adapter role content
+<!-- /agenticos-section -->
+
+## Command Contract
+
+- Project-specific command contract content that should be preserved
+- More project-specific rules
+
+<!-- agenticos-section: canonical-policy -->
+## Canonical Policy (Shared Across Agents)
+Old canonical policy
+<!-- /agenticos-section -->
+`;
+
+    const templateContent = generateClaudeMd('Existing Project', '');
+
+    // Existing file has old canonical policy, new template has new
+    // The standard section should be replaced
+    expect(mergeSections(templateContent, existingContent)).toContain('This project has one canonical AgenticOS execution policy');
+  });
+
+  it('upgradeClaudeMd preserves project-specific content from existing file', async () => {
+    const existingContent = `<!-- agenticos-template: v13 -->
+# CLAUDE.md — Agent-CLI-API
+
+## Adapter Role
+
+Adapter role for agent-cli-api
+
+## Canonical Policy (Shared Across Agents)
+
+- Old policy text
+
+## Design Rules
+
+### Command Contract
+
+- 用户入口保持小写。
+- \`cxb\` 对应 Codex。
+- \`ccb\` 对应 Claude Code。
+
+### Secret Contract
+
+- 1Password 是唯一事实源。
+- system-level env persistence 是禁止项
+
+## Guardrail Protocol (MANDATORY)
+
+Old guardrail text
+`;
+
+    // Write to temp file
+    const tempPath = join(tmpdir(), 'test-claude-md-upgrade.md');
+    await writeFile(tempPath, existingContent, 'utf-8');
+
+    try {
+      const result = upgradeClaudeMd(tempPath, 'Agent-CLI-API', 'CLI API project');
+
+      // Should have new canonical policy from template
+      expect(result).toContain('This project has one canonical AgenticOS execution policy');
+
+      // Should preserve project-specific content
+      expect(result).toContain('用户入口保持小写');
+      expect(result).toContain('1Password 是唯一事实源');
+    } finally {
+      await unlink(tempPath);
+    }
   });
 });

--- a/mcp-server/src/utils/__tests__/distill.test.ts
+++ b/mcp-server/src/utils/__tests__/distill.test.ts
@@ -11,10 +11,11 @@ import {
   generateAgentsMd,
   generateClaudeMd,
   upgradeClaudeMd,
+  upgradeAgentsMd,
   mergeSections,
   STANDARD_SECTION_NAMES,
 } from '../distill.js';
-import { writeFile, unlink } from 'fs/promises';
+import { writeFile, unlink, mkdir, rm } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { STOP_HOOK_MIGRATION_BULLETS } from '../stop-hook-guidance.js';
@@ -126,7 +127,7 @@ describe('section markers', () => {
     expect(content).toContain('<!-- agenticos-section: recording-protocol -->');
 
     // All standard sections should be marked
-    expect(STANDARD_SECTION_NAMES.length).toBe(9);
+    expect(STANDARD_SECTION_NAMES.length).toBe(8);
   });
 
   it('mergeSections preserves project-specific content from existing file', () => {
@@ -138,10 +139,12 @@ describe('section markers', () => {
 Existing adapter role content
 <!-- /agenticos-section -->
 
+<!-- agenticos-section: custom-command-contract -->
 ## Command Contract
 
 - Project-specific command contract content that should be preserved
 - More project-specific rules
+<!-- /agenticos-section -->
 
 <!-- agenticos-section: canonical-policy -->
 ## Canonical Policy (Shared Across Agents)
@@ -154,6 +157,9 @@ Old canonical policy
     // Existing file has old canonical policy, new template has new
     // The standard section should be replaced
     expect(mergeSections(templateContent, existingContent)).toContain('This project has one canonical AgenticOS execution policy');
+
+    // The non-standard section should be preserved
+    expect(mergeSections(templateContent, existingContent)).toContain('Project-specific command contract');
   });
 
   it('upgradeClaudeMd preserves project-specific content from existing file', async () => {
@@ -199,8 +205,279 @@ Old guardrail text
       // Should preserve project-specific content
       expect(result).toContain('用户入口保持小写');
       expect(result).toContain('1Password 是唯一事实源');
+
+      // Should have v14 marker
+      expect(result).toContain('v14');
     } finally {
       await unlink(tempPath);
     }
+  });
+});
+
+describe('merge sections edge cases', () => {
+  it('mergeSections with null existing content returns template', () => {
+    const template = generateClaudeMd('Test', '');
+    const result = mergeSections(template, null);
+    expect(result).toBe(template);
+  });
+
+  it('mergeSections with empty string returns template', () => {
+    const template = generateClaudeMd('Test', '');
+    const result = mergeSections(template, '');
+    expect(result).toBe(template);
+  });
+
+  it('mergeSections with existing section markers preserves project-specific sections', () => {
+    const template = generateClaudeMd('Test', '');
+    const existing = `<!-- agenticos-template: v13 -->
+# CLAUDE.md — Test
+
+<!-- agenticos-section: canonical-policy -->
+## Canonical Policy
+Old policy content
+<!-- /agenticos-section -->
+
+<!-- agenticos-section: custom-project-section -->
+## Custom Project Section
+
+- Project-specific bullet
+- Another bullet
+<!-- /agenticos-section -->
+
+<!-- agenticos-section: runtime-notes -->
+## Claude Runtime Notes
+Old runtime notes
+<!-- /agenticos-section -->
+`;
+
+    const result = mergeSections(template, existing);
+
+    // Standard section should be replaced from template
+    expect(result).toContain('This project has one canonical AgenticOS execution policy');
+    expect(result).not.toContain('Old policy content');
+    expect(result).not.toContain('Old runtime notes');
+
+    // Non-standard section should be preserved
+    expect(result).toContain('Custom Project Section');
+    expect(result).toContain('Project-specific bullet');
+  });
+
+  it('mergeSections replaces all standard sections', () => {
+    const template = generateClaudeMd('Test', '');
+    const existing = `<!-- agenticos-template: v13 -->
+# CLAUDE.md — Test
+
+<!-- agenticos-section: canonical-policy -->
+## Canonical Policy
+Old canonical
+<!-- /agenticos-section -->
+
+<!-- agenticos-section: guardrail-protocol -->
+## Guardrail Protocol
+Old guardrail
+<!-- /agenticos-section -->
+
+<!-- agenticos-section: recording-protocol -->
+## Recording Protocol
+Old recording
+<!-- /agenticos-section -->
+`;
+
+    const result = mergeSections(template, existing);
+
+    // All standard sections should be replaced
+    expect(result).toContain('This project has one canonical AgenticOS execution policy');
+    expect(result).not.toContain('Old canonical');
+    expect(result).not.toContain('Old guardrail');
+    expect(result).not.toContain('Old recording');
+  });
+
+  it('mergeSections preserves non-standard sections from existing', () => {
+    const template = generateClaudeMd('Test', '');
+    const existing = `<!-- agenticos-template: v13 -->
+# CLAUDE.md — Test
+
+<!-- agenticos-section: custom-project-section -->
+## Custom Project Section
+
+- Project-specific bullet
+- Another bullet
+<!-- /agenticos-section -->
+`;
+
+    const result = mergeSections(template, existing);
+
+    // Should have template sections
+    expect(result).toContain('This project has one canonical AgenticOS execution policy');
+
+    // Should preserve non-standard section from existing
+    expect(result).toContain('Custom Project Section');
+    expect(result).toContain('Project-specific bullet');
+  });
+});
+
+describe('upgrade functions edge cases', () => {
+  it('upgradeClaudeMd with non-existent file generates fresh template', () => {
+    const nonExistentPath = join(tmpdir(), 'non-existent-' + Date.now() + '.md');
+    const result = upgradeClaudeMd(nonExistentPath, 'Test', 'Test desc');
+
+    // Should generate template without errors
+    expect(result).toContain('<!-- agenticos-template: v14 -->');
+    expect(result).toContain('## Adapter Role');
+  });
+
+  it('upgradeClaudeMd with file without markers preserves project sections', async () => {
+    const existingContent = `<!-- agenticos-template: v13 -->
+# CLAUDE.md — Legacy Project
+
+## Adapter Role
+
+Legacy adapter role
+
+## Canonical Policy
+
+Old canonical policy
+
+## Custom Design Section
+
+- Custom design rules
+
+## Another Custom Section
+
+More custom content
+`;
+
+    const tempPath = join(tmpdir(), 'test-legacy-claude.md');
+    await writeFile(tempPath, existingContent, 'utf-8');
+
+    try {
+      const result = upgradeClaudeMd(tempPath, 'Legacy Project', '');
+
+      // Should have new template content
+      expect(result).toContain('v14');
+      expect(result).toContain('This project has one canonical AgenticOS execution policy');
+
+      // Should preserve custom sections
+      expect(result).toContain('Custom Design Section');
+      expect(result).toContain('Custom design rules');
+      expect(result).toContain('Another Custom Section');
+    } finally {
+      await unlink(tempPath);
+    }
+  });
+
+  it('upgradeAgentsMd preserves project-specific content', async () => {
+    const existingContent = `<!-- agenticos-template: v13 -->
+# AGENTS.md — CLI Project
+
+## Adapter Role
+
+CLI adapter role
+
+## Command Contract
+
+- Command 1
+- Command 2
+
+## Secret Contract
+
+- Secret 1
+`;
+
+    const tempPath = join(tmpdir(), 'test-agents-upgrade.md');
+    await writeFile(tempPath, existingContent, 'utf-8');
+
+    try {
+      const result = upgradeAgentsMd(tempPath, 'CLI Project', '');
+
+      // Should have new template content
+      expect(result).toContain('v14');
+      expect(result).toContain('This project has one canonical AgenticOS execution policy');
+
+      // Should preserve project-specific sections
+      expect(result).toContain('Command Contract');
+      expect(result).toContain('Command 1');
+      expect(result).toContain('Secret Contract');
+      expect(result).toContain('Secret 1');
+    } finally {
+      await unlink(tempPath);
+    }
+  });
+
+  it('upgradeClaudeMd with section markers uses mergeSections', async () => {
+    const existingContent = `<!-- agenticos-template: v13 -->
+# CLAUDE.md — Marked Project
+
+<!-- agenticos-section: canonical-policy -->
+## Canonical Policy
+Old canonical
+<!-- /agenticos-section -->
+
+<!-- agenticos-section: custom-project-content -->
+## Custom Project Content
+
+- Project bullet
+<!-- /agenticos-section -->
+`;
+
+    const tempPath = join(tmpdir(), 'test-marked-claude.md');
+    await writeFile(tempPath, existingContent, 'utf-8');
+
+    try {
+      const result = upgradeClaudeMd(tempPath, 'Marked Project', '');
+
+      // Should have section markers from template
+      expect(result).toContain('<!-- agenticos-section:');
+      expect(result).toContain('<!-- /agenticos-section -->');
+
+      // Should have new canonical policy
+      expect(result).toContain('This project has one canonical AgenticOS execution policy');
+      expect(result).not.toContain('Old canonical');
+
+      // Should preserve custom content
+      expect(result).toContain('Custom Project Content');
+      expect(result).toContain('Project bullet');
+    } finally {
+      await unlink(tempPath);
+    }
+  });
+});
+
+describe('section markers format consistency', () => {
+  it('generateClaudeMd produces consistent marker format', () => {
+    const content = generateClaudeMd('Test', '');
+
+    // Check marker format
+    expect(content).toMatch(/<!-- agenticos-section: [a-z-]+ -->/g);
+    expect(content).toContain('<!-- /agenticos-section -->');
+
+    // All standard sections should be marked
+    for (const sectionName of STANDARD_SECTION_NAMES) {
+      expect(content).toContain(`<!-- agenticos-section: ${sectionName} -->`);
+    }
+  });
+
+  it('generateAgentsMd produces consistent marker format', () => {
+    const content = generateAgentsMd('Test', '');
+
+    // Check marker format
+    expect(content).toMatch(/<!-- agenticos-section: [a-z-]+ -->/g);
+    expect(content).toContain('<!-- /agenticos-section -->');
+
+    // All standard sections should be marked
+    for (const sectionName of STANDARD_SECTION_NAMES) {
+      expect(content).toContain(`<!-- agenticos-section: ${sectionName} -->`);
+    }
+  });
+
+  it('STANDARD_SECTION_NAMES has expected sections', () => {
+    expect(STANDARD_SECTION_NAMES).toContain('adapter-role');
+    expect(STANDARD_SECTION_NAMES).toContain('canonical-policy');
+    expect(STANDARD_SECTION_NAMES).toContain('guardrail-protocol');
+    expect(STANDARD_SECTION_NAMES).toContain('recording-protocol');
+    expect(STANDARD_SECTION_NAMES).toContain('session-start-protocol');
+    expect(STANDARD_SECTION_NAMES).toContain('runtime-notes');
+    expect(STANDARD_SECTION_NAMES).toContain('stop-hook');
+    expect(STANDARD_SECTION_NAMES).toContain('task-intake-rule');
   });
 });

--- a/mcp-server/src/utils/distill.ts
+++ b/mcp-server/src/utils/distill.ts
@@ -232,7 +232,6 @@ const SECTION_END_MARKER = '<!-- /agenticos-section -->';
 export const STANDARD_SECTION_NAMES = [
   'adapter-role',
   'canonical-policy',
-  'continuity-contract',
   'runtime-notes',
   'stop-hook',
   'task-intake-rule',
@@ -240,6 +239,9 @@ export const STANDARD_SECTION_NAMES = [
   'recording-protocol',
   'session-start-protocol',
 ] as const;
+
+/** Additional standard sections for AGENTS.md only */
+const AGENTS_ONLY_STANDARD_SECTIONS = ['continuity-contract'] as const;
 
 /**
  * Map section names to human-readable titles for template generation.
@@ -498,6 +500,7 @@ export function mergeSections(
   const templateSections = parseSections(templateContent);
 
   const resultLines: string[] = [];
+  const processedSectionNames = new Set<string>();
 
   // Process template sections: replace standard ones, keep project-specific
   const templateEntries = Array.from(templateSections.entries());
@@ -508,8 +511,18 @@ export function mergeSections(
     if (isStandard) {
       // Replace with template content
       resultLines.push(wrapStandardSection(sectionName, templateSection.content));
+      processedSectionNames.add(sectionName);
     } else if (existingSection) {
-      // Preserve project-specific content
+      // Preserve non-standard section from existing
+      resultLines.push(wrapStandardSection(sectionName, existingSection.content));
+      processedSectionNames.add(sectionName);
+    }
+  }
+
+  // Also preserve non-standard sections from existing that are not in template
+  for (const [sectionName, existingSection] of existingSections.entries()) {
+    if (!processedSectionNames.has(sectionName)) {
+      // This is a project-specific section from existing file, preserve it
       resultLines.push(wrapStandardSection(sectionName, existingSection.content));
     }
   }

--- a/mcp-server/src/utils/distill.ts
+++ b/mcp-server/src/utils/distill.ts
@@ -156,31 +156,22 @@ export function generateAgentsMd(
 ): string {
   const contextPaths = normalizeAgentContextPaths(paths);
 
-  const sessionStartProtocol = `## Session Start Protocol
-
-On session start:
-
-1. Call \`agenticos_status\` to confirm current project and task
-2. If not on \`${name}\` project, call \`agenticos_switch\`
-3. Read \`.project.yaml\`, \`${contextPaths.quickStartPath}\`, and \`${contextPaths.statePath}\`
-4. If implementation work requested, enter Guardrail Protocol before editing
-5. Greet with: project name, last progress, pending items, suggested next step`;
-
-  return `${VERSION_MARKER}
-# AGENTS.md — ${name}
-
-## Adapter Role
-
-${AGENTS_ADAPTER_LINES[0]}
-${AGENTS_ADAPTER_LINES[1]}
-
-${renderSharedPolicySection()}${renderRuntimeGuidanceSection(AGENTS_RUNTIME_GUIDANCE_TITLE, AGENTS_RUNTIME_GUIDANCE_BULLETS)}${STOP_HOOK_SECTION}
-
-## ${TASK_INTAKE_RULE_TITLE}
-
-${TASK_INTAKE_RULE_CONTENT}
-
-## Guardrail Protocol (MANDATORY)
+  const sections = [
+    {
+      name: 'adapter-role',
+      content: `## Adapter Role\n\n${AGENTS_ADAPTER_LINES[0]}\n${AGENTS_ADAPTER_LINES[1]}`
+    },
+    { name: 'canonical-policy', content: renderSharedPolicySection() },
+    { name: 'continuity-contract', content: renderContinuityContractSection() },
+    { name: 'runtime-notes', content: renderRuntimeGuidanceSection(AGENTS_RUNTIME_GUIDANCE_TITLE, AGENTS_RUNTIME_GUIDANCE_BULLETS) },
+    { name: 'stop-hook', content: STOP_HOOK_SECTION },
+    {
+      name: 'task-intake-rule',
+      content: `## ${TASK_INTAKE_RULE_TITLE}\n\n${TASK_INTAKE_RULE_CONTENT}`
+    },
+    {
+      name: 'guardrail-protocol',
+      content: `## Guardrail Protocol (MANDATORY)
 
 Before implementation edits, confirm session/project alignment with \`agenticos_status\`; if no session project is bound or the bound project is not the intended one, call \`agenticos_switch\`.
 
@@ -192,17 +183,122 @@ For implementation-affecting work:
 4. call \`agenticos_edit_guard\` immediately before implementation edits
 5. before PR creation or merge, call \`agenticos_pr_scope_check\`
 
-If any guardrail command returns \`BLOCK\`, stop and resolve the blocking reason before continuing.
+If any guardrail command returns \`BLOCK\`, stop and resolve the blocking reason before continuing.`
+    },
+    { name: 'recording-protocol', content: RECORDING_PROTOCOL },
+    {
+      name: 'session-start-protocol',
+      content: `## Session Start Protocol
 
-${RECORDING_PROTOCOL}
+On session start:
 
-${sessionStartProtocol}
+1. Call \`agenticos_status\` to confirm current project and task
+2. If not on \`${name}\` project, call \`agenticos_switch\`
+3. Read \`.project.yaml\`, \`${contextPaths.quickStartPath}\`, and \`${contextPaths.statePath}\`
+4. If implementation work requested, enter Guardrail Protocol before editing
+5. Greet with: project name, last progress, pending items, suggested next step`
+    },
+  ];
+
+  const markedContent = sections
+    .map(({ name, content }) => wrapStandardSection(name, content))
+    .join('\n');
+
+  return `${VERSION_MARKER}
+# AGENTS.md — ${name}
+
+${markedContent}
 `;
+}
+
+// ---------------------------------------------------------------------------
+// Section markers for module-level merge
+// ---------------------------------------------------------------------------
+
+/**
+ * Section marker format for module-level merge.
+ * Sections marked as "replace" get updated from template on upgrade.
+ * Sections marked as "preserve" are kept from existing file on upgrade.
+ */
+const SECTION_MARKER_PREFIX = '<!-- agenticos-section: ';
+const SECTION_MARKER_SUFFIX = ' -->';
+const SECTION_END_MARKER = '<!-- /agenticos-section -->';
+
+/**
+ * Define which sections are standard (replace on upgrade) vs project-specific (preserve).
+ * Standard sections: protocol-related, should be kept up-to-date with canonical policy.
+ * Project-specific sections: domain knowledge, user entry contracts, project rules.
+ */
+export const STANDARD_SECTION_NAMES = [
+  'adapter-role',
+  'canonical-policy',
+  'continuity-contract',
+  'runtime-notes',
+  'stop-hook',
+  'task-intake-rule',
+  'guardrail-protocol',
+  'recording-protocol',
+  'session-start-protocol',
+] as const;
+
+/**
+ * Map section names to human-readable titles for template generation.
+ * Standard sections use canonical titles.
+ */
+const SECTION_TITLES: Record<string, string> = {
+  'adapter-role': 'Adapter Role',
+  'canonical-policy': 'Canonical Policy (Shared Across Agents)',
+  'continuity-contract': 'Continuity Contract',
+  'runtime-notes': 'Claude Runtime Notes',
+  'stop-hook': 'Stop-Hook (Optional)',
+  'task-intake-rule': 'Task Intake Rule',
+  'guardrail-protocol': 'Guardrail Protocol (MANDATORY)',
+  'recording-protocol': 'MANDATORY: Recording Protocol',
+  'session-start-protocol': 'Session Start Protocol',
+};
+
+/** Parse section markers from existing content */
+function parseSections(content: string): Map<string, { marker: string; title: string; content: string }> {
+  const sections = new Map<string, { marker: string; title: string; content: string }>();
+  const regex = new RegExp(
+    `${SECTION_MARKER_PREFIX}([a-z-]+)\\s*-->\n(.*?)${SECTION_END_MARKER}`,
+    'gs'
+  );
+  let match;
+  while ((match = regex.exec(content)) !== null) {
+    const [, sectionName, body] = match;
+    const titleMatch = body.match(/^## (.+)\n/);
+    const title = titleMatch ? titleMatch[1] : sectionName;
+    sections.set(sectionName, {
+      marker: SECTION_MARKER_PREFIX + sectionName + SECTION_MARKER_SUFFIX,
+      title,
+      content: body.trim(),
+    });
+  }
+  return sections;
+}
+
+/** Wrap content with section markers for standard sections */
+function wrapStandardSection(sectionName: string, content: string): string {
+  return `${SECTION_MARKER_PREFIX}${sectionName}${SECTION_MARKER_SUFFIX}\n${content}\n${SECTION_END_MARKER}`;
 }
 
 // ---------------------------------------------------------------------------
 // CLAUDE.md template
 // ---------------------------------------------------------------------------
+
+function buildAdapterRoleSection(): string {
+  return `## Adapter Role
+
+${CLAUDE_ADAPTER_LINES[0]}
+${CLAUDE_ADAPTER_LINES[1]}`;
+}
+
+function buildStopHookSection(): string {
+  return `## Stop-Hook (Optional)
+
+If your runtime supports local stop hooks, configure \`agenticos-record-reminder\` as a local reminder. This is optional, not a canonical guardrail.`;
+}
 
 export function generateClaudeMd(
   name: string,
@@ -213,21 +309,18 @@ export function generateClaudeMd(
 ): string {
   const contextPaths = normalizeAgentContextPaths(paths);
 
-  return `${VERSION_MARKER}
-# CLAUDE.md — ${name}
-
-## Adapter Role
-
-${CLAUDE_ADAPTER_LINES[0]}
-${CLAUDE_ADAPTER_LINES[1]}
-
-${renderSharedPolicySection()}${renderRuntimeGuidanceSection(CLAUDE_RUNTIME_GUIDANCE_TITLE, CLAUDE_RUNTIME_GUIDANCE_BULLETS)}${STOP_HOOK_SECTION}
-
-## ${TASK_INTAKE_RULE_TITLE}
-
-${TASK_INTAKE_RULE_CONTENT}
-
-## Guardrail Protocol (MANDATORY)
+  const sections = [
+    { name: 'adapter-role', content: buildAdapterRoleSection() },
+    { name: 'canonical-policy', content: renderSharedPolicySection() },
+    { name: 'runtime-notes', content: renderRuntimeGuidanceSection(CLAUDE_RUNTIME_GUIDANCE_TITLE, CLAUDE_RUNTIME_GUIDANCE_BULLETS) },
+    { name: 'stop-hook', content: buildStopHookSection() },
+    {
+      name: 'task-intake-rule',
+      content: `## ${TASK_INTAKE_RULE_TITLE}\n\n${TASK_INTAKE_RULE_CONTENT}`
+    },
+    {
+      name: 'guardrail-protocol',
+      content: `## Guardrail Protocol (MANDATORY)
 
 Before implementation edits, confirm session/project alignment with \`agenticos_status\`; if no session project is bound or the bound project is not the intended one, call \`agenticos_switch\`.
 
@@ -239,11 +332,21 @@ For implementation-affecting work:
 4. call \`agenticos_edit_guard\` immediately before implementation edits
 5. before PR creation or merge, call \`agenticos_pr_scope_check\`
 
-If any guardrail command returns \`BLOCK\`, stop and resolve the blocking reason before continuing.
+If any guardrail command returns \`BLOCK\`, stop and resolve the blocking reason before continuing.`
+    },
+    {
+      name: 'recording-protocol',
+      content: `## MANDATORY: Recording Protocol
 
-${RECORDING_PROTOCOL}
+> All session activity MUST be recorded. If you skip this, context is lost forever.
 
-## Session Start Protocol
+**During session**: After completing any meaningful unit of work, call \`agenticos_record\` with summary, decisions, outcomes, pending, and current_task.
+
+**Before session ends**: Call \`agenticos_record\` with complete summary, then \`agenticos_save\` to commit to Git.`
+    },
+    {
+      name: 'session-start-protocol',
+      content: `## Session Start Protocol
 
 On session start:
 
@@ -251,7 +354,18 @@ On session start:
 2. If not on \`${name}\` project, call \`agenticos_switch\`
 3. Read \`.project.yaml\`, \`${contextPaths.quickStartPath}\`, and \`${contextPaths.statePath}\`
 4. If implementation work requested, enter Guardrail Protocol before editing
-5. Greet with: project name, last progress, pending items, suggested next step
+5. Greet with: project name, last progress, pending items, suggested next step`
+    },
+  ];
+
+  const markedContent = sections
+    .map(({ name, content }) => wrapStandardSection(name, content))
+    .join('\n');
+
+  return `${VERSION_MARKER}
+# CLAUDE.md — ${name}
+
+${markedContent}
 `;
 }
 
@@ -262,16 +376,230 @@ export interface StateYaml {
   working_memory?: { facts?: string[]; decisions?: string[]; pending?: string[] };
 }
 
-/** @deprecated Use generateClaudeMd instead. State is now in .context/state.yaml */
+// Known project-specific section titles that should be preserved from existing files
+const PROJECT_SPECIFIC_TITLES = [
+  'Purpose',
+  'Read Order',
+  'Command Contract',
+  'Secret Contract',
+  'Resume Contract',
+  'Compatibility Contract',
+  'Install Contract',
+  'Provider Lifecycle Contract',
+  'Design Rules',
+  'Cross-Agent Handoff',
+  'GitHub Development Protocol',
+  'Editing Scope',
+  'Session Recording',
+  'What Must Stay True',
+  'Implementation Policy',
+  'Verification',
+  'Navigation',
+];
+
+/** Extract project-specific sections from existing file content.
+ * Sections that are NOT in STANDARD_SECTION_NAMES and match PROJECT_SPECIFIC_TITLES
+ * should be preserved from existing content.
+ */
+function extractProjectSpecificSections(existingContent: string): string[] {
+  const preservedSections: string[] = [];
+  const lines = existingContent.split('\n');
+  let currentSection: string[] = [];
+  let inProjectSection = false;
+
+  for (const line of lines) {
+    // Check if this is a section header (## but not standard section)
+    const sectionMatch = line.match(/^## ([^`]+)$/);
+    if (sectionMatch) {
+      const title = sectionMatch[1].trim();
+
+      // Check if this is a standard section (should be replaced)
+      const isStandard = STANDARD_SECTION_NAMES.some(name => {
+        // Map section names to possible titles
+        const standardTitles: Record<string, string[]> = {
+          'adapter-role': ['Adapter Role'],
+          'canonical-policy': ['Canonical Policy (Shared Across Agents)', 'Canonical Policy'],
+          'continuity-contract': ['Continuity Contract'],
+          'runtime-notes': ['Claude Runtime Notes', 'Codex / Generic Runtime Notes'],
+          'stop-hook': ['Stop-Hook (Optional)'],
+          'task-intake-rule': ['Task Intake Rule'],
+          'guardrail-protocol': ['Guardrail Protocol (MANDATORY)'],
+          'recording-protocol': ['MANDATORY: Recording Protocol', 'Recording Protocol (MANDATORY)'],
+          'session-start-protocol': ['Session Start Protocol'],
+        };
+        return standardTitles[name]?.includes(title);
+      });
+
+      // Check if this is a known project-specific section (should be preserved)
+      const isProjectSpecific = PROJECT_SPECIFIC_TITLES.some(
+        psTitle => title.includes(psTitle) || psTitle.includes(title)
+      );
+
+      if (isStandard) {
+        // Skip standard sections
+        inProjectSection = false;
+        if (currentSection.length > 0) {
+          preservedSections.push(currentSection.join('\n'));
+          currentSection = [];
+        }
+      } else if (isProjectSpecific) {
+        // Keep project-specific sections
+        inProjectSection = true;
+        if (currentSection.length > 0) {
+          preservedSections.push(currentSection.join('\n'));
+          currentSection = [];
+        }
+        currentSection.push(line);
+      } else {
+        // Unknown section - treat as project-specific for safety
+        if (!line.includes('Guardrail Protocol') && !line.includes('Recording Protocol')) {
+          inProjectSection = true;
+          if (currentSection.length > 0 && currentSection[currentSection.length - 1].startsWith('## ')) {
+            preservedSections.push(currentSection.join('\n'));
+            currentSection = [];
+          }
+          currentSection.push(line);
+        } else {
+          inProjectSection = false;
+          if (currentSection.length > 0) {
+            preservedSections.push(currentSection.join('\n'));
+            currentSection = [];
+          }
+        }
+      }
+    } else if (inProjectSection) {
+      currentSection.push(line);
+    }
+  }
+
+  // Don't forget the last section
+  if (currentSection.length > 0) {
+    preservedSections.push(currentSection.join('\n'));
+  }
+
+  return preservedSections;
+}
+
+/** Merge template and existing content at section level.
+ * Standard sections are replaced from template.
+ * Project-specific sections are preserved from existing file.
+ */
+export function mergeSections(
+  templateContent: string,
+  existingContent: string | null,
+): string {
+  // If no existing content, use template
+  if (!existingContent) {
+    return templateContent;
+  }
+
+  // Parse sections from existing content
+  const existingSections = parseSections(existingContent);
+  const templateSections = parseSections(templateContent);
+
+  const resultLines: string[] = [];
+
+  // Process template sections: replace standard ones, keep project-specific
+  const templateEntries = Array.from(templateSections.entries());
+  for (const [sectionName, templateSection] of templateEntries) {
+    const existingSection = existingSections.get(sectionName);
+    const isStandard = (STANDARD_SECTION_NAMES as readonly string[]).includes(sectionName);
+
+    if (isStandard) {
+      // Replace with template content
+      resultLines.push(wrapStandardSection(sectionName, templateSection.content));
+    } else if (existingSection) {
+      // Preserve project-specific content
+      resultLines.push(wrapStandardSection(sectionName, existingSection.content));
+    }
+  }
+
+  return resultLines.length > 0 ? resultLines.join('\n\n') : templateContent;
+}
+
+/** Upgrade CLAUDE.md with section-level merge.
+ * Preserves project-specific content while updating standard protocol sections.
+ *
+ * For files WITH section markers: merge at section level
+ * For files WITHOUT section markers: preserve project-specific sections
+ */
 export function upgradeClaudeMd(
-  _claudeMdPath: string,
+  claudeMdPath: string,
   name: string,
   description: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   _state?: any,
   paths?: Partial<ManagedProjectContextDisplayPaths>,
 ): string {
-  return generateClaudeMd(name, description, undefined, paths);
+  // Read existing content for merge
+  let existingContent: string | null = null;
+  try {
+    existingContent = readFileSync(claudeMdPath, 'utf-8');
+  } catch {
+    // File doesn't exist, generate fresh
+  }
+
+  // Generate new template
+  const templateContent = generateClaudeMd(name, description, undefined, paths);
+
+  // If existing content has section markers, do merge
+  if (existingContent && existingContent.includes(SECTION_MARKER_PREFIX)) {
+    return mergeSections(templateContent, existingContent);
+  }
+
+  // No section markers - extract and preserve project-specific content
+  if (existingContent) {
+    const preservedSections = extractProjectSpecificSections(existingContent);
+
+    if (preservedSections.length > 0) {
+      // Append preserved sections to template
+      const standardContent = templateContent.split('\n').slice(0, 20).join('\n'); // Header + standard sections
+      return `${templateContent}\n\n---\n\n## Project-Specific Content (Preserved)\n\n${preservedSections.join('\n\n')}`;
+    }
+  }
+
+  return templateContent;
+}
+
+/** Upgrade AGENTS.md with section-level merge.
+ * Preserves project-specific content while updating standard protocol sections.
+ *
+ * For files WITH section markers: merge at section level
+ * For files WITHOUT section markers: preserve project-specific sections
+ */
+export function upgradeAgentsMd(
+  agentsMdPath: string,
+  name: string,
+  description: string,
+  paths?: Partial<ManagedProjectContextDisplayPaths>,
+): string {
+  // Read existing content for merge
+  let existingContent: string | null = null;
+  try {
+    existingContent = readFileSync(agentsMdPath, 'utf-8');
+  } catch {
+    // File doesn't exist, generate fresh
+  }
+
+  // Generate new template
+  const templateContent = generateAgentsMd(name, description, paths);
+
+  // If existing content has section markers, do merge
+  if (existingContent && existingContent.includes(SECTION_MARKER_PREFIX)) {
+    return mergeSections(templateContent, existingContent);
+  }
+
+  // No section markers - extract and preserve project-specific content
+  if (existingContent) {
+    const preservedSections = extractProjectSpecificSections(existingContent);
+
+    if (preservedSections.length > 0) {
+      // Append preserved sections to template
+      return `${templateContent}\n\n---\n\n## Project-Specific Content (Preserved)\n\n${preservedSections.join('\n\n')}`;
+    }
+  }
+
+  return templateContent;
 }
 
 /** @deprecated State is now in .context/state.yaml, not in CLAUDE.md */

--- a/mcp-server/src/utils/standard-kit.ts
+++ b/mcp-server/src/utils/standard-kit.ts
@@ -4,7 +4,7 @@ import { join, dirname } from 'path';
 import yaml from 'yaml';
 import { getAgenticOSHome, loadRegistry } from './registry.js';
 import { getOfficialAgentAdapters, loadAgentAdapterMatrix } from './agent-adapter-matrix.js';
-import { CURRENT_TEMPLATE_VERSION, extractTemplateVersion, generateAgentsMd, generateClaudeMd, upgradeClaudeMd } from './distill.js';
+import { CURRENT_TEMPLATE_VERSION, extractTemplateVersion, generateAgentsMd, generateClaudeMd, upgradeClaudeMd, upgradeAgentsMd } from './distill.js';
 import { buildArchivedReferenceMessage, isArchivedReferenceProject } from './project-contract.js';
 import { validateContextPublicationPolicy } from './project-contract.js';
 import { resolveAgenticOSProductPath, resolveAgenticOSProductRoot, toCanonicalProductRelativePath } from './product-source-root.js';
@@ -369,7 +369,7 @@ export async function adoptStandardKit(args: { project_path?: string; project?: 
     }
 
     const upgraded = entry.path === 'AGENTS.md'
-      ? generateAgentsMd(project.projectName, project.projectDescription, project.agentContextPaths)
+      ? upgradeAgentsMd(destination, project.projectName, project.projectDescription, project.agentContextPaths)
       : upgradeClaudeMd(destination, project.projectName, project.projectDescription, undefined, project.agentContextPaths);
     await writeFile(destination, upgraded, 'utf-8');
     upgradedGeneratedFiles.push(entry.path);


### PR DESCRIPTION
## Summary

实现 Issue #374 修复：`standard_kit_adopt` 现在支持模块级合并，而非整体替换。

- **新增**：section markers 标记标准协议部分（adapter-role、canonical-policy、guardrail-protocol 等）
- **保留**：项目特定内容（Command Contract、Secret Contract、Navigation 等）
- **替换**：标准协议部分从模板更新

## Problem

存量项目升级 AGENTS.md/CLAUDE.md 时，`standard_kit_adopt` 整体替换文件，导致项目特定内容丢失（如 Agent-CLI-API 的 Command Contract、Secret Contract）。

## Solution

模块级合并策略：
1. 新生成的文件使用 `<!-- agenticos-section: section-name -->` 标记
2. 标准 section 从模板替换
3. 项目特定 section 从现有文件保留
4. 存量文件（无 markers）：通过标题识别项目特定 section 并保留

## Test Coverage

- 3 个新单元测试验证 section 标记生成和合并逻辑
- 所有 662 个现有测试通过

## Verification

```bash
npm test  # 662 tests passed
```