### PR TITLE
fix: warn when switch does not change cwd (#379)

### DIFF
--- a/mcp-server/src/tools/__tests__/switch.test.ts
+++ b/mcp-server/src/tools/__tests__/switch.test.ts
@@ -169,6 +169,9 @@ describe('switchProject — agenticos_switch tests', () => {
       expect(result).toContain('✅ Switched to project "Test Project"');
       expect(result).toContain('Path: /test/path');
       expect(result).toContain('Status: active');
+      expect(result).toContain('🧰 Filesystem workdir: /test/path');
+      expect(result).toContain('agenticos_switch did not change your shell cwd');
+      expect(result).toContain('Avoid relative-path edits until your shell cwd is aligned to this project.');
     });
 
     it('finds project by name', async () => {

--- a/mcp-server/src/tools/__tests__/switch.test.ts
+++ b/mcp-server/src/tools/__tests__/switch.test.ts
@@ -172,6 +172,8 @@ describe('switchProject — agenticos_switch tests', () => {
       expect(result).toContain('🧰 Filesystem workdir: /test/path');
       expect(result).toContain('agenticos_switch did not change your shell cwd');
       expect(result).toContain('Avoid relative-path edits until your shell cwd is aligned to this project.');
+      expect(result.indexOf('Status: active')).toBeLessThan(result.indexOf('🧰 Filesystem workdir: /test/path'));
+      expect(result.indexOf('🧰 Filesystem workdir: /test/path')).toBeLessThan(result.indexOf('Context loaded from:'));
     });
 
     it('finds project by name', async () => {

--- a/mcp-server/src/tools/project.ts
+++ b/mcp-server/src/tools/project.ts
@@ -325,6 +325,15 @@ function buildSwitchContextSummaryLines(input: SwitchContextSummaryInput): strin
   return lines;
 }
 
+function buildFilesystemAlignmentLines(projectPath: string): string[] {
+  return [
+    `🧰 Filesystem workdir: ${projectPath}`,
+    '⚠️ Project binding changed, but agenticos_switch did not change your shell cwd.',
+    '   Use this project path as workdir for every filesystem operation.',
+    '   Avoid relative-path edits until your shell cwd is aligned to this project.',
+  ];
+}
+
 export async function switchProject(args: any): Promise<string> {
   const { project } = args;
   const registry = await loadRegistry();
@@ -504,8 +513,9 @@ export async function switchProject(args: any): Promise<string> {
     lastRecorded: found.last_recorded,
     committedSnapshotAssessment,
   });
+  const filesystemAlignmentSummary = buildFilesystemAlignmentLines(found.path);
 
-  return `✅ Switched to project "${found.name}"\n\nPath: ${found.path}\nStatus: ${found.status}\n\n${contextSummary.join('\n')}${committedSnapshotSummary.length > 0 ? `\n${committedSnapshotSummary.join('\n')}` : ''}\n${transcriptRoutingSummary.length > 0 ? `\n${transcriptRoutingSummary.join('\n')}\n` : '\n'}Context loaded from:\n- ${found.path}/.project.yaml\n- ${contextPaths.quickStartPath}\n- ${contextPaths.statePath}\n\n${guardrailSummary.join('\n')}\n${issueBootstrapSummary.join('\n')}${bootstrap}`;
+  return `✅ Switched to project "${found.name}"\n\nPath: ${found.path}\nStatus: ${found.status}\n${filesystemAlignmentSummary.join('\n')}\n\n${contextSummary.join('\n')}${committedSnapshotSummary.length > 0 ? `\n${committedSnapshotSummary.join('\n')}` : ''}\n${transcriptRoutingSummary.length > 0 ? `\n${transcriptRoutingSummary.join('\n')}\n` : '\n'}Context loaded from:\n- ${found.path}/.project.yaml\n- ${contextPaths.quickStartPath}\n- ${contextPaths.statePath}\n\n${guardrailSummary.join('\n')}\n${issueBootstrapSummary.join('\n')}${bootstrap}`;
 }
 
 export async function listProjects(): Promise<string> {


### PR DESCRIPTION
## Summary
- make `agenticos_switch` emit an explicit filesystem alignment contract after project switch
- surface the switched project path as the required workdir for filesystem operations
- warn that shell cwd is unchanged and that relative-path edits are unsafe until cwd is aligned
- add switch test coverage for the new warning contract

## Testing
- `npm test`
- `npm run lint`
- `agenticos_pr_scope_check` against the issue worktree path

## Notes
- This fixes the unsafe invariant reported in #379 without pretending that the MCP server can mutate the caller shell cwd directly.
- The contract is now explicit in switch output so downstream adapters and operators have a machine-visible workdir target.