### PR TITLE
fix: infer local policy for legacy local-only projects (#380)

### DIFF
--- a/mcp-server/src/tools/__tests__/init.test.ts
+++ b/mcp-server/src/tools/__tests__/init.test.ts
@@ -61,6 +61,10 @@ describe('initProject', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     process.env.AGENTICOS_HOME = '/home/testuser/AgenticOS';
+    yamlMock.parse.mockImplementation((content: string) => {
+      try { return JSON.parse(content); } catch { return undefined; }
+    });
+    yamlMock.stringify.mockImplementation((obj: unknown) => JSON.stringify(obj));
     // Default: simulate registry file does not exist (causes loadRegistry to return default)
     fsMock.existsSync.mockReturnValue(false);
     fsPromisesMock.readFile.mockRejectedValue(new Error('ENOENT'));
@@ -393,7 +397,48 @@ describe('initProject', () => {
 
     const result = await initProject({ name: 'Test Project', topology: 'local_directory_only' });
 
-    expect(result).toContain('is not registered');
+    expect(result).toContain('has not completed source-control topology initialization');
+    expect(result).toContain('normalize_existing=true');
+  });
+
+  it('preserves normalize_existing guidance for a registered local_directory_only project missing publication policy', async () => {
+    fsMock.existsSync.mockReturnValue(true);
+    fsPromisesMock.access.mockResolvedValue(undefined);
+    fsPromisesMock.readFile.mockImplementation(async (path: any) => {
+      const normalizedPath = String(path);
+      if (normalizedPath.endsWith('registry.yaml')) {
+        return JSON.stringify({
+          version: '1.0.0',
+          last_updated: '2025-01-01T00:00:00.000Z',
+          active_project: 'test-project',
+          projects: [
+            {
+              id: 'test-project',
+              name: 'Test Project',
+              path: '/home/testuser/AgenticOS/projects/test-project',
+              status: 'active',
+              created: '2025-01-01',
+              last_accessed: '2025-01-01T00:00:00.000Z',
+            },
+          ],
+        });
+      }
+
+      if (normalizedPath.endsWith('.project.yaml')) {
+        return JSON.stringify({
+          meta: { id: 'test-project', name: 'Test Project' },
+          source_control: {
+            topology: 'local_directory_only',
+          },
+        });
+      }
+
+      throw new Error(`Unexpected readFile path: ${normalizedPath}`);
+    });
+
+    const result = await initProject({ name: 'Test Project', topology: 'local_directory_only' });
+
+    expect(result).toContain('context_publication_policy');
     expect(result).toContain('normalize_existing=true');
   });
 });

--- a/mcp-server/src/tools/__tests__/record.test.ts
+++ b/mcp-server/src/tools/__tests__/record.test.ts
@@ -222,6 +222,27 @@ describe('recordSession', () => {
     expect(fsPromisesMock.writeFile.mock.calls.some((call) => String(call[0]).endsWith('state.yaml'))).toBe(false);
   });
 
+  it('records successfully for legacy local_directory_only projects with missing publication policy', async () => {
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry());
+    mockProjectFiles({
+      projectYaml: {
+        meta: {
+          id: 'test-project',
+          name: 'Test Project',
+        },
+        source_control: {
+          topology: 'local_directory_only',
+        },
+      },
+    });
+
+    const result = await recordSession({ summary: 'legacy local-only record' });
+
+    expect(result).toContain('✅ Session recorded for "Test Project"');
+    expect(result).toContain('Raw conversation: .context/conversations/');
+    expect(result).toContain('State: .context/state.yaml (updated)');
+  });
+
   it('creates conversation file with correct date-based filename', async () => {
     registryMock.loadRegistry.mockResolvedValue(buildRegistry());
 

--- a/mcp-server/src/tools/__tests__/record.test.ts
+++ b/mcp-server/src/tools/__tests__/record.test.ts
@@ -241,6 +241,11 @@ describe('recordSession', () => {
     expect(result).toContain('✅ Session recorded for "Test Project"');
     expect(result).toContain('Raw conversation: .context/conversations/');
     expect(result).toContain('State: .context/state.yaml (updated)');
+    expect(fsPromisesMock.writeFile.mock.calls.some((call) => String(call[0]).endsWith('state.yaml'))).toBe(true);
+    expect(registryMock.patchProjectMetadata).toHaveBeenCalledWith(
+      'test-project',
+      expect.objectContaining({ last_recorded: expect.any(String) }),
+    );
   });
 
   it('creates conversation file with correct date-based filename', async () => {

--- a/mcp-server/src/tools/__tests__/save.test.ts
+++ b/mcp-server/src/tools/__tests__/save.test.ts
@@ -218,6 +218,33 @@ describe('saveState', () => {
     expect(writtenState.session.last_backup).toBeDefined();
   });
 
+  it('degrades to local-only save behavior for legacy local_directory_only projects with missing publication policy', async () => {
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry());
+    mockProjectFiles({
+      projectYaml: {
+        meta: {
+          id: 'test-project',
+          name: 'Test Project',
+        },
+        source_control: {
+          topology: 'local_directory_only',
+        },
+      },
+      state: { session: {} },
+    });
+
+    childProcessMock.exec.mockImplementation(
+      (_cmd: string, cb: (err: Error, stdout?: string, stderr?: string) => void) => {
+        cb(new Error('not a git repo'), '', '');
+      }
+    );
+
+    const result = await saveState({ message: 'legacy local-only save' });
+
+    expect(result).toContain('State saved but no git repo found');
+    expect(result).toContain('no git repo');
+  });
+
   it('runs git add, commit, push when git repo exists', async () => {
     registryMock.loadRegistry.mockResolvedValue(buildRegistry());
     mockProjectFiles({ state: { session: {} } });

--- a/mcp-server/src/tools/__tests__/save.test.ts
+++ b/mcp-server/src/tools/__tests__/save.test.ts
@@ -243,6 +243,10 @@ describe('saveState', () => {
 
     expect(result).toContain('State saved but no git repo found');
     expect(result).toContain('no git repo');
+    const stateYamlCall = fsPromisesMock.writeFile.mock.calls.find((c) => c[0].endsWith('state.yaml'));
+    expect(stateYamlCall).toBeDefined();
+    const writtenState = JSON.parse(stateYamlCall![1] as string);
+    expect(writtenState.session.last_backup).toBeDefined();
   });
 
   it('runs git add, commit, push when git repo exists', async () => {

--- a/mcp-server/src/tools/init.ts
+++ b/mcp-server/src/tools/init.ts
@@ -3,7 +3,7 @@ import { join } from 'path';
 import yaml from 'yaml';
 import { loadRegistry, patchRegistry, getAgenticOSHome } from '../utils/registry.js';
 import { generateClaudeMd, generateAgentsMd } from '../utils/distill.js';
-import { buildProjectTopologyInitializationMessage, validateContextPublicationPolicy, type ContextPublicationPolicy, type ProjectTopology } from '../utils/project-contract.js';
+import { buildProjectTopologyInitializationMessage, hasDeclaredContextPublicationPolicy, validateContextPublicationPolicy, type ContextPublicationPolicy, type ProjectTopology } from '../utils/project-contract.js';
 import { resolveManagedProjectContextDisplayPaths, resolveManagedProjectContextPaths } from '../utils/agent-context-paths.js';
 import { ensureCaseKnowledgeDirectories } from '../utils/case-knowledge.js';
 
@@ -174,6 +174,9 @@ export async function initProject(args: any): Promise<string> {
     const existingProjectYaml = await loadExistingProjectYaml(projectPath);
     if (!existingProjectYaml?.source_control?.topology) {
       return buildProjectTopologyInitializationMessage(name);
+    }
+    if (existingProjectYaml.source_control.topology === 'local_directory_only' && !hasDeclaredContextPublicationPolicy(existingProjectYaml)) {
+      return `Project "${name}" is missing source_control.context_publication_policy. Use "local_private", "private_continuity", or "public_distilled". Re-run agenticos_init with normalize_existing=true and the intended topology/publication contract.`;
     }
     const publicationValidation = validateContextPublicationPolicy(name, existingProjectYaml);
     if (!publicationValidation.ok) {

--- a/mcp-server/src/utils/__tests__/project-contract.test.ts
+++ b/mcp-server/src/utils/__tests__/project-contract.test.ts
@@ -19,6 +19,20 @@ describe('validateContextPublicationPolicy', () => {
     })).toEqual({ ok: true, policy: 'local_private' });
   });
 
+  it('rejects explicit blank publication policy for local_directory_only projects', () => {
+    const result = validateContextPublicationPolicy('Blank Policy', {
+      source_control: {
+        topology: 'local_directory_only',
+        context_publication_policy: '   ',
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain('context_publication_policy');
+    }
+  });
+
   it('accepts private_continuity for github_versioned projects', () => {
     expect(validateContextPublicationPolicy('Private Repo', {
       source_control: {

--- a/mcp-server/src/utils/__tests__/project-contract.test.ts
+++ b/mcp-server/src/utils/__tests__/project-contract.test.ts
@@ -11,6 +11,14 @@ describe('validateContextPublicationPolicy', () => {
     })).toEqual({ ok: true, policy: 'local_private' });
   });
 
+  it('infers local_private for legacy local_directory_only projects when policy is missing', () => {
+    expect(validateContextPublicationPolicy('Legacy Local Project', {
+      source_control: {
+        topology: 'local_directory_only',
+      },
+    })).toEqual({ ok: true, policy: 'local_private' });
+  });
+
   it('accepts private_continuity for github_versioned projects', () => {
     expect(validateContextPublicationPolicy('Private Repo', {
       source_control: {

--- a/mcp-server/src/utils/project-contract.ts
+++ b/mcp-server/src/utils/project-contract.ts
@@ -20,6 +20,10 @@ export function isValidContextPublicationPolicy(value: unknown): value is Contex
   return value === 'local_private' || value === 'private_continuity' || value === 'public_distilled';
 }
 
+function isMissingContextPublicationPolicy(value: unknown): boolean {
+  return value === undefined || value === null || (typeof value === 'string' && value.trim().length === 0);
+}
+
 export function validateContextPublicationPolicy(projectName: string, projectYaml: any): { ok: true; policy: ContextPublicationPolicy } | { ok: false; message: string } {
   const contract = getSourceControlContract(projectYaml);
   const topology = contract?.topology;
@@ -33,6 +37,10 @@ export function validateContextPublicationPolicy(projectName: string, projectYam
   }
 
   if (!isValidContextPublicationPolicy(policy)) {
+    if (topology === 'local_directory_only' && isMissingContextPublicationPolicy(policy)) {
+      return { ok: true, policy: 'local_private' };
+    }
+
     return {
       ok: false,
       message: `Project "${projectName}" is missing source_control.context_publication_policy. Use "local_private", "private_continuity", or "public_distilled".`,

--- a/mcp-server/src/utils/project-contract.ts
+++ b/mcp-server/src/utils/project-contract.ts
@@ -20,8 +20,9 @@ export function isValidContextPublicationPolicy(value: unknown): value is Contex
   return value === 'local_private' || value === 'private_continuity' || value === 'public_distilled';
 }
 
-function isMissingContextPublicationPolicy(value: unknown): boolean {
-  return value === undefined || value === null || (typeof value === 'string' && value.trim().length === 0);
+export function hasDeclaredContextPublicationPolicy(projectYaml: any): boolean {
+  const contract = getSourceControlContract(projectYaml);
+  return Boolean(contract && Object.prototype.hasOwnProperty.call(contract, 'context_publication_policy'));
 }
 
 export function validateContextPublicationPolicy(projectName: string, projectYaml: any): { ok: true; policy: ContextPublicationPolicy } | { ok: false; message: string } {
@@ -37,7 +38,7 @@ export function validateContextPublicationPolicy(projectName: string, projectYam
   }
 
   if (!isValidContextPublicationPolicy(policy)) {
-    if (topology === 'local_directory_only' && isMissingContextPublicationPolicy(policy)) {
+    if (topology === 'local_directory_only' && !hasDeclaredContextPublicationPolicy(projectYaml)) {
       return { ok: true, policy: 'local_private' };
     }
 


### PR DESCRIPTION
## Summary
- infer `local_private` for legacy `local_directory_only` projects when `source_control.context_publication_policy` is missing
- allow `agenticos_record` and `agenticos_save` to keep working for this legacy project shape without mutating project files
- add regression coverage for the validator and record/save flows

## Validation
- npm test
- npm run lint
- agenticos_pr_scope_check PASS

## Issue
- closes #380