### PR TITLE
docs: fix Homebrew caveats and upgrade guidance (#360)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,18 @@ agenticos-bootstrap --workspace "$AGENTICOS_HOME" --first-run
 
 On macOS, `--first-run` also sets up `launchctl` persistence so GUI tools
 inherit `AGENTICOS_HOME` across sessions. Then restart your AI tool and
-confirm `agenticos_list` succeeds.
+run:
 
-Use `agenticos-bootstrap --verify` to audit the current state without
-mutating anything.
+```bash
+agenticos-config --validate
+agenticos-bootstrap --workspace "$AGENTICOS_HOME" --all --verify
+```
+
+Then confirm the server appears in the tool's MCP diagnostics and
+`agenticos_list` succeeds.
+
+Use `agenticos-bootstrap --workspace "$AGENTICOS_HOME" --all --verify` to
+audit the current state without mutating anything.
 
 ### Alternative: Per-agent manual setup
 

--- a/homebrew-tap/Formula/agenticos.rb
+++ b/homebrew-tap/Formula/agenticos.rb
@@ -46,10 +46,10 @@ class Agenticos < Formula
       2. Bootstrap one officially supported agent:
 
          Recommended helper
-           agenticos-bootstrap --workspace "#{var}/agenticos" --first-run
+           agenticos-bootstrap --workspace "$AGENTICOS_HOME" --first-run
 
          macOS GUI/session helper
-           agenticos-bootstrap --workspace "#{var}/agenticos" --persist-shell-env --persist-launchctl-env --apply
+           agenticos-bootstrap --workspace "$AGENTICOS_HOME" --persist-shell-env --persist-launchctl-env --apply
 
          Claude Code
            claude mcp add --transport stdio --scope user -e AGENTICOS_HOME="$AGENTICOS_HOME" agenticos -- agenticos-mcp
@@ -75,8 +75,12 @@ class Agenticos < Formula
 
       3. Restart the AI tool.
 
-      4. Verify activation by confirming the server is listed in the tool's MCP diagnostics
-         and by explicitly calling agenticos_list.
+      4. Verify the selected-client bootstrap state:
+           agenticos-config --validate
+           agenticos-bootstrap --workspace "$AGENTICOS_HOME" --all --verify
+
+         Then confirm the server is listed in the tool's MCP diagnostics and explicitly call
+         agenticos_list.
 
       5. If Claude Code or Codex still points at a source checkout path, remove the stale entry
          and re-add the canonical binary entrypoint:

--- a/homebrew-tap/Formula/agenticos.rb
+++ b/homebrew-tap/Formula/agenticos.rb
@@ -26,7 +26,8 @@ class Agenticos < Formula
     ohai ""
     ohai "Then run: agenticos-bootstrap --workspace \"#{var}/agenticos\" --first-run"
     ohai "On macOS, first-run mode also enables launchctl persistence for GUI/session inheritance."
-    ohai "To audit the current bootstrap state without changes, use: agenticos-bootstrap --verify"
+    ohai "To audit the current Homebrew/runtime bootstrap state without changes, use: agenticos-config --validate"
+    ohai "Then run: agenticos-bootstrap --workspace \"#{var}/agenticos\" --all --verify"
     ohai "Or bootstrap your agent manually (see caveats below) and restart the tool."
   end
 
@@ -75,7 +76,7 @@ class Agenticos < Formula
 
       3. Restart the AI tool.
 
-      4. Verify the selected-client bootstrap state:
+      4. Verify the Homebrew/runtime bootstrap state:
            agenticos-config --validate
            agenticos-bootstrap --workspace "$AGENTICOS_HOME" --all --verify
 

--- a/homebrew-tap/README.md
+++ b/homebrew-tap/README.md
@@ -22,7 +22,7 @@ Homebrew does **not**:
 - restart your AI tool
 - verify activation for you
 
-After installation, set `AGENTICOS_HOME` explicitly, bootstrap one officially supported agent, restart it, and verify the selected-client bootstrap state before relying on `agenticos_list`:
+After installation, set `AGENTICOS_HOME` explicitly, bootstrap one officially supported agent, restart it, and verify the Homebrew/runtime bootstrap state before relying on `agenticos_list`:
 
 ```bash
 # Example default workspace path for a Homebrew-only install
@@ -31,10 +31,6 @@ export AGENTICOS_HOME="$(brew --prefix)/var/agenticos"
 
 # Recommended: detect supported agents and register them automatically
 agenticos-bootstrap --workspace "$AGENTICOS_HOME" --first-run
-
-# Verify config and selected-client bootstrap state
-agenticos-config --validate
-agenticos-bootstrap --workspace "$AGENTICOS_HOME" --all --verify
 
 # Claude Code
 claude mcp add --transport stdio --scope user -e AGENTICOS_HOME="$AGENTICOS_HOME" agenticos -- agenticos-mcp
@@ -62,8 +58,15 @@ For Cursor, add this to `~/.cursor/mcp.json`:
 }
 ```
 
-Then restart the AI tool, confirm the server appears in the tool's MCP diagnostics, and verify `agenticos_list` works.
-If you prefer not to edit your shell profile, omit `--first-run` and use the explicit MCP commands below instead.
+Then restart the AI tool and verify the Homebrew/runtime bootstrap state:
+
+```bash
+agenticos-config --validate
+agenticos-bootstrap --workspace "$AGENTICOS_HOME" --all --verify
+```
+
+Then confirm the server appears in the tool's MCP diagnostics and verify `agenticos_list` works.
+If you prefer not to edit your shell profile, omit `--first-run` and use the explicit MCP commands above instead.
 On macOS, `--first-run` also enables `launchctl` persistence so GUI/session processes inherit `AGENTICOS_HOME`.
 Use `agenticos-bootstrap --workspace "$AGENTICOS_HOME" --all --verify` with the same flags to audit the current machine state without mutating it.
 

--- a/homebrew-tap/README.md
+++ b/homebrew-tap/README.md
@@ -22,7 +22,7 @@ Homebrew does **not**:
 - restart your AI tool
 - verify activation for you
 
-After installation, set `AGENTICOS_HOME` explicitly, bootstrap one officially supported agent, restart it, and verify `agenticos_list`:
+After installation, set `AGENTICOS_HOME` explicitly, bootstrap one officially supported agent, restart it, and verify the selected-client bootstrap state before relying on `agenticos_list`:
 
 ```bash
 # Example default workspace path for a Homebrew-only install
@@ -31,6 +31,10 @@ export AGENTICOS_HOME="$(brew --prefix)/var/agenticos"
 
 # Recommended: detect supported agents and register them automatically
 agenticos-bootstrap --workspace "$AGENTICOS_HOME" --first-run
+
+# Verify config and selected-client bootstrap state
+agenticos-config --validate
+agenticos-bootstrap --workspace "$AGENTICOS_HOME" --all --verify
 
 # Claude Code
 claude mcp add --transport stdio --scope user -e AGENTICOS_HOME="$AGENTICOS_HOME" agenticos -- agenticos-mcp
@@ -58,10 +62,10 @@ For Cursor, add this to `~/.cursor/mcp.json`:
 }
 ```
 
-Then restart the AI tool and confirm `agenticos_list` works.
+Then restart the AI tool, confirm the server appears in the tool's MCP diagnostics, and verify `agenticos_list` works.
 If you prefer not to edit your shell profile, omit `--first-run` and use the explicit MCP commands below instead.
 On macOS, `--first-run` also enables `launchctl` persistence so GUI/session processes inherit `AGENTICOS_HOME`.
-Use `agenticos-bootstrap --verify` with the same flags to audit the current machine state without mutating it.
+Use `agenticos-bootstrap --workspace "$AGENTICOS_HOME" --all --verify` with the same flags to audit the current machine state without mutating it.
 
 `AGENTICOS_HOME` may also be a long-term self-hosting workspace home. The
 Homebrew example path above is a default example, not the only valid workspace
@@ -90,7 +94,8 @@ codex mcp add --env AGENTICOS_HOME="$AGENTICOS_HOME" agenticos -- agenticos-mcp
 ## Upgrade
 
 ```bash
-brew upgrade agenticos
+brew update && brew upgrade agenticos
 ```
 
+`brew update` must run first so Homebrew refreshes tap metadata; `brew upgrade` only installs a version the local Homebrew cache already knows about.
 After upgrade, restart the AI tool so it launches the new `agenticos-mcp` process instead of any older long-lived session copy.

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -20,7 +20,7 @@ A project management system designed for AI collaboration. When you work on comp
 
 Install AgenticOS, set `AGENTICOS_HOME` explicitly, then either run `agenticos-bootstrap --workspace "$AGENTICOS_HOME" --first-run` or bootstrap one supported agent manually, restart that agent, and explicitly verify `agenticos_list` works before relying on project-intent routing.
 On macOS, `--first-run` also enables `launchctl` persistence for GUI/session inheritance.
-Use `agenticos-config --validate` and `agenticos-bootstrap --workspace "$AGENTICOS_HOME" --all --verify` to audit the selected agents and optional persistence layers without mutating them.
+Use `agenticos-config --validate` and `agenticos-bootstrap --workspace "$AGENTICOS_HOME" --all --verify` to audit the Homebrew/runtime bootstrap state and optional persistence layers without mutating them.
 `--apply` and `--first-run` also record bootstrap metadata in `$AGENTICOS_HOME/.agent-workspace/bootstrap-state.yaml`.
 
 After any local upgrade, reinstall, or source rebuild of `agenticos-mcp`, restart the current AI client before assuming its MCP tools reflect the new server behavior.
@@ -529,7 +529,11 @@ Get complete context for the current session project.
    ```bash
    echo $AGENTICOS_HOME
    ```
-2. Run `agenticos-bootstrap --verify` to audit the current bootstrap state
+2. Run:
+   ```bash
+   agenticos-config --validate
+   agenticos-bootstrap --workspace "$AGENTICOS_HOME" --all --verify
+   ```
 3. If the workspace was never initialized, run:
    ```bash
    agenticos-bootstrap --workspace "$AGENTICOS_HOME" --first-run

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -20,7 +20,7 @@ A project management system designed for AI collaboration. When you work on comp
 
 Install AgenticOS, set `AGENTICOS_HOME` explicitly, then either run `agenticos-bootstrap --workspace "$AGENTICOS_HOME" --first-run` or bootstrap one supported agent manually, restart that agent, and explicitly verify `agenticos_list` works before relying on project-intent routing.
 On macOS, `--first-run` also enables `launchctl` persistence for GUI/session inheritance.
-Use `agenticos-bootstrap --verify` to audit the selected agents and optional persistence layers without mutating them.
+Use `agenticos-config --validate` and `agenticos-bootstrap --workspace "$AGENTICOS_HOME" --all --verify` to audit the selected agents and optional persistence layers without mutating them.
 `--apply` and `--first-run` also record bootstrap metadata in `$AGENTICOS_HOME/.agent-workspace/bootstrap-state.yaml`.
 
 After any local upgrade, reinstall, or source rebuild of `agenticos-mcp`, restart the current AI client before assuming its MCP tools reflect the new server behavior.
@@ -634,11 +634,14 @@ If Homebrew reports that the installed version does not match the tap version,
 the Homebrew formula is stale. Repair with:
 
 ```bash
-brew upgrade agenticos     # fastest fix if a newer version exists in the tap
+brew update && brew upgrade agenticos
 ```
 
-If `brew upgrade` reports nothing to upgrade but the version still mismatches, the
-local Homebrew tap cache is stale. Force a refresh:
+`brew update` must run first so Homebrew refreshes tap metadata; `brew upgrade`
+only installs a version the local Homebrew cache already knows about.
+
+If `brew update && brew upgrade` still reports nothing to upgrade but the version
+still mismatches, the local Homebrew tap cache is stale. Force a refresh:
 
 ```bash
 brew untap agenticos/tap

--- a/mcp-server/src/utils/__tests__/homebrew-bootstrap-docs.test.ts
+++ b/mcp-server/src/utils/__tests__/homebrew-bootstrap-docs.test.ts
@@ -55,13 +55,23 @@ describe('homebrew bootstrap docs', () => {
       expect(normalized).toContain('restart');
       expect(doc).toContain('AGENTICOS_HOME');
       expect(doc).toContain('AGENTICOS_HOME="$AGENTICOS_HOME"');
+      expect(doc).toContain('agenticos-config --validate');
+      expect(doc).toContain('agenticos-bootstrap --workspace "$AGENTICOS_HOME" --all --verify');
       expect(normalized).not.toContain('seed workspace');
       expect(normalized).not.toContain('default: ~/agenticos');
       expect(normalized).not.toContain('product default: ~/agenticos');
+      expect(doc).not.toContain('/Users/jeking/');
+      expect(doc).not.toContain('/Users/huangsheng/');
       expect(doc).toContain('claude mcp get agenticos');
       expect(doc).toContain('claude mcp remove agenticos');
       expect(doc).toContain('codex mcp get agenticos');
       expect(doc).toContain('codex mcp remove agenticos');
+    }
+
+    for (const doc of [tapReadme, mcpReadme]) {
+      expect(doc).toContain('brew update && brew upgrade agenticos');
+      expect(doc).toContain('brew update');
+      expect(doc).toContain('brew upgrade');
     }
   });
 });

--- a/mcp-server/src/utils/__tests__/homebrew-bootstrap-docs.test.ts
+++ b/mcp-server/src/utils/__tests__/homebrew-bootstrap-docs.test.ts
@@ -57,11 +57,12 @@ describe('homebrew bootstrap docs', () => {
       expect(doc).toContain('AGENTICOS_HOME="$AGENTICOS_HOME"');
       expect(doc).toContain('agenticos-config --validate');
       expect(doc).toContain('agenticos-bootstrap --workspace "$AGENTICOS_HOME" --all --verify');
+      expect(doc).not.toContain('agenticos-bootstrap --verify');
       expect(normalized).not.toContain('seed workspace');
       expect(normalized).not.toContain('default: ~/agenticos');
       expect(normalized).not.toContain('product default: ~/agenticos');
-      expect(doc).not.toContain('/Users/jeking/');
-      expect(doc).not.toContain('/Users/huangsheng/');
+      expect(doc).not.toMatch(/\/Users\/[^/\s]+/);
+      expect(doc).not.toMatch(/\/home\/[^/\s]+/);
       expect(doc).toContain('claude mcp get agenticos');
       expect(doc).toContain('claude mcp remove agenticos');
       expect(doc).toContain('codex mcp get agenticos');
@@ -72,6 +73,12 @@ describe('homebrew bootstrap docs', () => {
       expect(doc).toContain('brew update && brew upgrade agenticos');
       expect(doc).toContain('brew update');
       expect(doc).toContain('brew upgrade');
+    }
+
+    for (const doc of [rootReadme, tapReadme, formula, mcpReadme]) {
+      if (doc.includes('brew upgrade agenticos')) {
+        expect(doc).toContain('brew update && brew upgrade agenticos');
+      }
     }
   });
 });


### PR DESCRIPTION
## Summary
- fix Homebrew caveats so they use neutral workspace guidance and explicit selected-client verification steps
- add AgenticOS configuration audit
Action: validate
Scope: all
Status: PASS
Checked at: 2026-05-11T07:54:24.329Z
Canonical workspace: /Users/jeking/dev/AgenticOS

All detected configuration sources agree on /Users/jeking/dev/AgenticOS.

Sources:
- process.env AGENTICOS_HOME
  status: configured
  value: /Users/jeking/dev/AgenticOS
  location: current process environment
  fix: export AGENTICOS_HOME=... before starting the client
  detail: Active runtime environment value.
- shell profile export
  status: configured
  value: /Users/jeking/dev/AgenticOS
  location: /Users/jeking/.zshrc
  fix: /Users/jeking/.zshrc
  detail: Detected export AGENTICOS_HOME entry in the shell profile.
- launchctl session env
  status: configured
  value: /Users/jeking/dev/AgenticOS
  location: launchctl getenv AGENTICOS_HOME
  fix: launchctl setenv AGENTICOS_HOME ...
  detail: launchctl reports an inherited GUI/session workspace.
- Claude Code settings env
  status: unset
  value: UNSET
  location: /Users/jeking/.claude/settings.json
  fix: /Users/jeking/.claude/settings.json
  detail: Config file exists but does not contain AGENTICOS_HOME for AgenticOS.
- Claude legacy MCP env
  status: configured
  value: /Users/jeking/dev/AgenticOS
  location: /Users/jeking/.claude.json
  fix: /Users/jeking/.claude.json
  detail: Detected AGENTICOS_HOME in the config file.
- Codex MCP config
  status: configured
  value: /Users/jeking/dev/AgenticOS
  location: /Users/jeking/.codex/config.toml
  fix: /Users/jeking/.codex/config.toml
  detail: Detected AGENTICOS_HOME in Codex config.
- Cursor MCP config
  status: configured
  value: /Users/jeking/dev/AgenticOS
  location: /Users/jeking/.cursor/mcp.json
  fix: /Users/jeking/.cursor/mcp.json
  detail: Detected AGENTICOS_HOME in the config file.
- Homebrew runtime-home hint (/opt/homebrew/var/agenticos)
  status: present
  value: /opt/homebrew/var/agenticos
  location: /opt/homebrew/var/agenticos
  fix: /opt/homebrew/var/agenticos
  detail: Default Homebrew runtime-home path exists on this machine.
- Homebrew runtime-home hint (/usr/local/var/agenticos)
  status: missing
  value: UNSET
  location: /usr/local/var/agenticos
  fix: /usr/local/var/agenticos
  detail: Default Homebrew runtime-home path does not exist on this machine. and AgenticOS bootstrap verification

Workspace: /Users/jeking/dev/AgenticOS

OK claude-code: registration verified via `claude mcp get agenticos` (workspace env matches)
OK codex: registration verified via `~/.codex/config.toml` (CLI output redacted)
OK cursor: verified /Users/jeking/.cursor/mcp.json
FAIL gemini-cli: Loaded cached credentials.
Configured MCP servers:

✗ pencil: /Users/jeking/.cursor/extensions/highagency.pencildev-0.6.32-universal/out/mcp-server-darwin-arm64 --app cursor (stdio) - Disconnected
   Recovery: agenticos-bootstrap --agents gemini-cli across the Homebrew-facing docs
- update Homebrew upgrade guidance to use  and explain why Already up-to-date. must run first
- strengthen the Homebrew docs regression test to catch stale personal paths and missing verification/upgrade guidance

## Validation
- npm ci
- npm test
- npm run lint
- agenticos_pr_scope_check PASS

## Issues
- closes #360
- closes #354