### PR TITLE
fix: fail closed on missing delegation files

### DIFF
--- a/mcp-server/src/tools/__tests__/validate-delegation.test.ts
+++ b/mcp-server/src/tools/__tests__/validate-delegation.test.ts
@@ -1,5 +1,6 @@
 /// <reference types="vitest/globals" />
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import type { ExecFileOptions } from 'child_process';
 import { runValidateDelegation as runValidateDelegationActual } from '../validate-delegation.js';
 import {
   fixturePassing,
@@ -10,8 +11,7 @@ import {
 const mockValidate = vi.hoisted(() => vi.fn());
 const mockResolve = vi.hoisted(() => vi.fn());
 const mockRealpath = vi.hoisted(() => vi.fn());
-const mockLstat = vi.hoisted(() => vi.fn());
-const mockOpen = vi.hoisted(() => vi.fn());
+const mockExecFile = vi.hoisted(() => vi.fn());
 
 vi.mock('../../utils/delegation-validation.js', () => ({
   validateDelegationContent: mockValidate,
@@ -19,34 +19,46 @@ vi.mock('../../utils/delegation-validation.js', () => ({
 vi.mock('../../utils/project-target.js', () => ({
   resolveManagedProjectTarget: mockResolve,
 }));
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return {
+    ...actual,
+    execFile: mockExecFile,
+  };
+});
 vi.mock('fs/promises', () => ({
-  lstat: mockLstat,
-  open: mockOpen,
   realpath: mockRealpath,
 }));
+
+function installExecFileSuccess(stdout = 'file content') {
+  mockExecFile.mockImplementation(
+    (
+      _file: string,
+      _args: string[],
+      _options: ExecFileOptions,
+      callback: (error: Error | null, stdout: string, stderr: string) => void,
+    ) => {
+      callback(null, stdout, '');
+      return {} as any;
+    },
+  );
+}
 
 describe('runValidateDelegation', () => {
   beforeEach(() => {
     mockValidate.mockReset();
     mockResolve.mockReset();
     mockRealpath.mockReset();
-    mockLstat.mockReset();
-    mockOpen.mockReset();
+    mockExecFile.mockReset();
     mockResolve.mockResolvedValue({ projectPath: '/tmp/project' });
     mockRealpath.mockImplementation(async (path: string) => path);
-    mockLstat.mockResolvedValue({ dev: 1, ino: 2, isSymbolicLink: () => false });
-    mockOpen.mockResolvedValue({
-      readFile: vi.fn().mockResolvedValue('file content'),
-      stat: vi.fn().mockResolvedValue({ dev: 1, ino: 2 }),
-      close: vi.fn().mockResolvedValue(undefined),
-    });
+    installExecFileSuccess();
   });
   afterEach(() => {
     mockValidate.mockRestore();
     mockResolve.mockRestore();
     mockRealpath.mockRestore();
-    mockLstat.mockRestore();
-    mockOpen.mockRestore();
+    mockExecFile.mockRestore();
   });
 
   it('returns error when delegation_id is missing', async () => {
@@ -59,6 +71,7 @@ describe('runValidateDelegation', () => {
     expect(result).toContain('must be a single relative path segment');
     expect(mockResolve).not.toHaveBeenCalled();
     expect(mockRealpath).not.toHaveBeenCalled();
+    expect(mockExecFile).not.toHaveBeenCalled();
     expect(mockValidate).not.toHaveBeenCalled();
   });
 
@@ -108,8 +121,7 @@ describe('runValidateDelegation', () => {
 
     await runValidateDelegationActual({ delegation_id: 'test-005' });
 
-    expect(mockOpen).toHaveBeenNthCalledWith(1, '/tmp/project/.real/delegations/test-005/log.md', expect.any(Number));
-    expect(mockOpen).toHaveBeenNthCalledWith(2, '/tmp/project/.real/delegations/test-005/result.md', expect.any(Number));
+    expect(mockExecFile).toHaveBeenCalledTimes(2);
     expect(mockValidate).toHaveBeenCalledWith('file content', 'file content', 'test-005');
   });
 
@@ -123,7 +135,7 @@ describe('runValidateDelegation', () => {
 
     expect(result).toContain('delegation file not found or unreadable at /tmp/project/standards/.context/delegations/test-006/log.md');
     expect(mockValidate).not.toHaveBeenCalled();
-    expect(mockOpen).not.toHaveBeenCalled();
+    expect(mockExecFile).not.toHaveBeenCalled();
   });
 
   it('returns a direct file error when result.md canonicalization cannot resolve the file', async () => {
@@ -137,30 +149,44 @@ describe('runValidateDelegation', () => {
 
     expect(result).toContain('delegation file not found or unreadable at /tmp/project/standards/.context/delegations/test-006/result.md');
     expect(mockValidate).not.toHaveBeenCalled();
-    expect(mockOpen).not.toHaveBeenCalled();
+    expect(mockExecFile).not.toHaveBeenCalled();
   });
 
-  it('fails closed when a canonicalized file changes before it is read', async () => {
-    mockOpen.mockResolvedValueOnce({
-      readFile: vi.fn().mockResolvedValue('file content'),
-      stat: vi.fn().mockResolvedValue({ dev: 9, ino: 9 }),
-      close: vi.fn().mockResolvedValue(undefined),
-    });
+  it('fails closed when the secure reader rejects a changed file path', async () => {
+    mockExecFile.mockImplementationOnce(
+      (
+        _file: string,
+        _args: string[],
+        _options: ExecFileOptions,
+        callback: (error: Error | null, stdout: string, stderr: string) => void,
+      ) => {
+        callback(new Error('secure read failed'), '', '');
+        return {} as any;
+      },
+    );
 
     const result = await runValidateDelegationActual({ delegation_id: 'test-009' });
 
-    expect(result).toContain('delegation file changed during validation');
+    expect(result).toContain('delegation file not found or unreadable at /tmp/project/standards/.context/delegations/test-009/log.md');
     expect(mockValidate).not.toHaveBeenCalled();
   });
 
-  it('fails closed when a parent path component becomes a symlink before read', async () => {
-    mockLstat
-      .mockResolvedValueOnce({ dev: 1, ino: 2, isSymbolicLink: () => true });
+  it('fails closed when the secure reader rejects a changed parent path', async () => {
+    mockExecFile.mockImplementationOnce(
+      (
+        _file: string,
+        _args: string[],
+        _options: ExecFileOptions,
+        callback: (error: Error | null, stdout: string, stderr: string) => void,
+      ) => {
+        callback(new Error('secure read failed'), '', '');
+        return {} as any;
+      },
+    );
 
     const result = await runValidateDelegationActual({ delegation_id: 'test-010' });
 
-    expect(result).toContain('delegation file changed during validation');
-    expect(mockOpen).not.toHaveBeenCalled();
+    expect(result).toContain('delegation file not found or unreadable at /tmp/project/standards/.context/delegations/test-010/log.md');
     expect(mockValidate).not.toHaveBeenCalled();
   });
 

--- a/mcp-server/src/tools/__tests__/validate-delegation.test.ts
+++ b/mcp-server/src/tools/__tests__/validate-delegation.test.ts
@@ -10,14 +10,16 @@ import {
 const mockValidate = vi.hoisted(() => vi.fn());
 const mockResolve = vi.hoisted(() => vi.fn());
 const mockRealpath = vi.hoisted(() => vi.fn());
+const mockOpen = vi.hoisted(() => vi.fn());
 
 vi.mock('../../utils/delegation-validation.js', () => ({
-  validateDelegationOutput: mockValidate,
+  validateDelegationContent: mockValidate,
 }));
 vi.mock('../../utils/project-target.js', () => ({
   resolveManagedProjectTarget: mockResolve,
 }));
 vi.mock('fs/promises', () => ({
+  open: mockOpen,
   realpath: mockRealpath,
 }));
 
@@ -26,13 +28,19 @@ describe('runValidateDelegation', () => {
     mockValidate.mockReset();
     mockResolve.mockReset();
     mockRealpath.mockReset();
+    mockOpen.mockReset();
     mockResolve.mockResolvedValue({ projectPath: '/tmp/project' });
     mockRealpath.mockImplementation(async (path: string) => path);
+    mockOpen.mockResolvedValue({
+      readFile: vi.fn().mockResolvedValue('file content'),
+      close: vi.fn().mockResolvedValue(undefined),
+    });
   });
   afterEach(() => {
     mockValidate.mockRestore();
     mockResolve.mockRestore();
     mockRealpath.mockRestore();
+    mockOpen.mockRestore();
   });
 
   it('returns error when delegation_id is missing', async () => {
@@ -75,7 +83,7 @@ describe('runValidateDelegation', () => {
   });
 
   it('formats a passing validation result', async () => {
-    mockValidate.mockResolvedValue(fixturePassing());
+    mockValidate.mockReturnValue(fixturePassing());
 
     const result = await runValidateDelegationActual({ delegation_id: 'test-001' });
     expect(result).toContain('✅');
@@ -90,15 +98,13 @@ describe('runValidateDelegation', () => {
       .mockResolvedValueOnce('/tmp/project/.real/delegations')
       .mockResolvedValueOnce('/tmp/project/.real/delegations/test-005/log.md')
       .mockResolvedValueOnce('/tmp/project/.real/delegations/test-005/result.md');
-    mockValidate.mockResolvedValue(fixturePassing());
+    mockValidate.mockReturnValue(fixturePassing());
 
     await runValidateDelegationActual({ delegation_id: 'test-005' });
 
-    expect(mockValidate).toHaveBeenCalledWith(
-      '/tmp/project/.real/delegations/test-005/log.md',
-      '/tmp/project/.real/delegations/test-005/result.md',
-      'test-005',
-    );
+    expect(mockOpen).toHaveBeenNthCalledWith(1, '/tmp/project/.real/delegations/test-005/log.md', expect.any(Number));
+    expect(mockOpen).toHaveBeenNthCalledWith(2, '/tmp/project/.real/delegations/test-005/result.md', expect.any(Number));
+    expect(mockValidate).toHaveBeenCalledWith('file content', 'file content', 'test-005');
   });
 
   it('returns a direct file error when canonicalization cannot resolve the files', async () => {
@@ -111,6 +117,21 @@ describe('runValidateDelegation', () => {
 
     expect(result).toContain('delegation file not found or unreadable at /tmp/project/standards/.context/delegations/test-006/log.md');
     expect(mockValidate).not.toHaveBeenCalled();
+    expect(mockOpen).not.toHaveBeenCalled();
+  });
+
+  it('returns a direct file error when result.md canonicalization cannot resolve the file', async () => {
+    mockRealpath
+      .mockResolvedValueOnce('/tmp/project')
+      .mockResolvedValueOnce('/tmp/project/standards/.context/delegations')
+      .mockResolvedValueOnce('/tmp/project/standards/.context/delegations/test-006/log.md')
+      .mockRejectedValueOnce(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+
+    const result = await runValidateDelegationActual({ delegation_id: 'test-006' });
+
+    expect(result).toContain('delegation file not found or unreadable at /tmp/project/standards/.context/delegations/test-006/result.md');
+    expect(mockValidate).not.toHaveBeenCalled();
+    expect(mockOpen).not.toHaveBeenCalled();
   });
 
   it('fails closed when canonicalization errors are not missing-file cases', async () => {
@@ -135,7 +156,7 @@ describe('runValidateDelegation', () => {
   });
 
   it('formats a failing validation result with errors and warnings', async () => {
-    mockValidate.mockResolvedValue(
+    mockValidate.mockReturnValue(
       fixtureFailing(
         ['log.md missing delegation_id field'],
         ['Findings section is empty'],
@@ -149,7 +170,7 @@ describe('runValidateDelegation', () => {
   });
 
   it('includes escalation details when present', async () => {
-    mockValidate.mockResolvedValue(
+    mockValidate.mockReturnValue(
       fixtureEscalation('Too many failures', 'Restart delegation', 5),
     );
 

--- a/mcp-server/src/tools/__tests__/validate-delegation.test.ts
+++ b/mcp-server/src/tools/__tests__/validate-delegation.test.ts
@@ -101,20 +101,16 @@ describe('runValidateDelegation', () => {
     );
   });
 
-  it('falls back to the original paths when realpath cannot resolve the files', async () => {
+  it('returns a direct file error when canonicalization cannot resolve the files', async () => {
     mockRealpath
       .mockResolvedValueOnce('/tmp/project')
       .mockResolvedValueOnce('/tmp/project/standards/.context/delegations')
       .mockRejectedValueOnce(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
-    mockValidate.mockResolvedValue(fixturePassing());
 
-    await runValidateDelegationActual({ delegation_id: 'test-006' });
+    const result = await runValidateDelegationActual({ delegation_id: 'test-006' });
 
-    expect(mockValidate).toHaveBeenCalledWith(
-      '/tmp/project/standards/.context/delegations/test-006/log.md',
-      '/tmp/project/standards/.context/delegations/test-006/result.md',
-      'test-006',
-    );
+    expect(result).toContain('delegation file not found or unreadable at /tmp/project/standards/.context/delegations/test-006/log.md');
+    expect(mockValidate).not.toHaveBeenCalled();
   });
 
   it('fails closed when canonicalization errors are not missing-file cases', async () => {

--- a/mcp-server/src/tools/__tests__/validate-delegation.test.ts
+++ b/mcp-server/src/tools/__tests__/validate-delegation.test.ts
@@ -1,6 +1,5 @@
 /// <reference types="vitest/globals" />
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
-import type { ExecFileOptions } from 'child_process';
 import { runValidateDelegation as runValidateDelegationActual } from '../validate-delegation.js';
 import {
   fixturePassing,
@@ -11,7 +10,9 @@ import {
 const mockValidate = vi.hoisted(() => vi.fn());
 const mockResolve = vi.hoisted(() => vi.fn());
 const mockRealpath = vi.hoisted(() => vi.fn());
-const mockExecFile = vi.hoisted(() => vi.fn());
+const mockLstat = vi.hoisted(() => vi.fn());
+const mockOpen = vi.hoisted(() => vi.fn());
+const mockSpawnSync = vi.hoisted(() => vi.fn());
 
 vi.mock('../../utils/delegation-validation.js', () => ({
   validateDelegationContent: mockValidate,
@@ -23,42 +24,40 @@ vi.mock('child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof import('child_process')>();
   return {
     ...actual,
-    execFile: mockExecFile,
+    spawnSync: mockSpawnSync,
   };
 });
 vi.mock('fs/promises', () => ({
+  lstat: mockLstat,
+  open: mockOpen,
   realpath: mockRealpath,
 }));
-
-function installExecFileSuccess(stdout = 'file content') {
-  mockExecFile.mockImplementation(
-    (
-      _file: string,
-      _args: string[],
-      _options: ExecFileOptions,
-      callback: (error: Error | null, stdout: string, stderr: string) => void,
-    ) => {
-      callback(null, stdout, '');
-      return {} as any;
-    },
-  );
-}
 
 describe('runValidateDelegation', () => {
   beforeEach(() => {
     mockValidate.mockReset();
     mockResolve.mockReset();
     mockRealpath.mockReset();
-    mockExecFile.mockReset();
+    mockLstat.mockReset();
+    mockOpen.mockReset();
+    mockSpawnSync.mockReset();
     mockResolve.mockResolvedValue({ projectPath: '/tmp/project' });
     mockRealpath.mockImplementation(async (path: string) => path);
-    installExecFileSuccess();
+    mockLstat.mockResolvedValue({ dev: 1, ino: 2 });
+    mockOpen.mockResolvedValue({
+      fd: 11,
+      stat: vi.fn().mockResolvedValue({ dev: 1, ino: 2 }),
+      close: vi.fn().mockResolvedValue(undefined),
+    });
+    mockSpawnSync.mockReturnValue({ status: 0, stdout: 'file content', stderr: '', error: undefined });
   });
   afterEach(() => {
     mockValidate.mockRestore();
     mockResolve.mockRestore();
     mockRealpath.mockRestore();
-    mockExecFile.mockRestore();
+    mockLstat.mockRestore();
+    mockOpen.mockRestore();
+    mockSpawnSync.mockRestore();
   });
 
   it('returns error when delegation_id is missing', async () => {
@@ -71,7 +70,7 @@ describe('runValidateDelegation', () => {
     expect(result).toContain('must be a single relative path segment');
     expect(mockResolve).not.toHaveBeenCalled();
     expect(mockRealpath).not.toHaveBeenCalled();
-    expect(mockExecFile).not.toHaveBeenCalled();
+    expect(mockSpawnSync).not.toHaveBeenCalled();
     expect(mockValidate).not.toHaveBeenCalled();
   });
 
@@ -121,7 +120,7 @@ describe('runValidateDelegation', () => {
 
     await runValidateDelegationActual({ delegation_id: 'test-005' });
 
-    expect(mockExecFile).toHaveBeenCalledTimes(2);
+    expect(mockSpawnSync).toHaveBeenCalledTimes(2);
     expect(mockValidate).toHaveBeenCalledWith('file content', 'file content', 'test-005');
   });
 
@@ -135,7 +134,7 @@ describe('runValidateDelegation', () => {
 
     expect(result).toContain('delegation file not found or unreadable at /tmp/project/standards/.context/delegations/test-006/log.md');
     expect(mockValidate).not.toHaveBeenCalled();
-    expect(mockExecFile).not.toHaveBeenCalled();
+    expect(mockSpawnSync).not.toHaveBeenCalled();
   });
 
   it('returns a direct file error when result.md canonicalization cannot resolve the file', async () => {
@@ -149,21 +148,11 @@ describe('runValidateDelegation', () => {
 
     expect(result).toContain('delegation file not found or unreadable at /tmp/project/standards/.context/delegations/test-006/result.md');
     expect(mockValidate).not.toHaveBeenCalled();
-    expect(mockExecFile).not.toHaveBeenCalled();
+    expect(mockSpawnSync).not.toHaveBeenCalled();
   });
 
   it('fails closed when the secure reader rejects a changed file path', async () => {
-    mockExecFile.mockImplementationOnce(
-      (
-        _file: string,
-        _args: string[],
-        _options: ExecFileOptions,
-        callback: (error: Error | null, stdout: string, stderr: string) => void,
-      ) => {
-        callback(new Error('secure read failed'), '', '');
-        return {} as any;
-      },
-    );
+    mockSpawnSync.mockReturnValueOnce({ status: 1, stdout: '', stderr: 'secure read failed', error: undefined });
 
     const result = await runValidateDelegationActual({ delegation_id: 'test-009' });
 
@@ -172,21 +161,25 @@ describe('runValidateDelegation', () => {
   });
 
   it('fails closed when the secure reader rejects a changed parent path', async () => {
-    mockExecFile.mockImplementationOnce(
-      (
-        _file: string,
-        _args: string[],
-        _options: ExecFileOptions,
-        callback: (error: Error | null, stdout: string, stderr: string) => void,
-      ) => {
-        callback(new Error('secure read failed'), '', '');
-        return {} as any;
-      },
-    );
+    mockSpawnSync.mockReturnValueOnce({ status: 1, stdout: '', stderr: 'secure read failed', error: undefined });
 
     const result = await runValidateDelegationActual({ delegation_id: 'test-010' });
 
     expect(result).toContain('delegation file not found or unreadable at /tmp/project/standards/.context/delegations/test-010/log.md');
+    expect(mockValidate).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when the pinned project root changes before secure read', async () => {
+    mockOpen.mockResolvedValueOnce({
+      fd: 11,
+      stat: vi.fn().mockResolvedValue({ dev: 9, ino: 9 }),
+      close: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const result = await runValidateDelegationActual({ delegation_id: 'test-011' });
+
+    expect(result).toContain('delegation file changed during validation');
+    expect(mockSpawnSync).not.toHaveBeenCalled();
     expect(mockValidate).not.toHaveBeenCalled();
   });
 

--- a/mcp-server/src/tools/__tests__/validate-delegation.test.ts
+++ b/mcp-server/src/tools/__tests__/validate-delegation.test.ts
@@ -34,7 +34,7 @@ describe('runValidateDelegation', () => {
     mockOpen.mockReset();
     mockResolve.mockResolvedValue({ projectPath: '/tmp/project' });
     mockRealpath.mockImplementation(async (path: string) => path);
-    mockLstat.mockResolvedValue({ dev: 1, ino: 2 });
+    mockLstat.mockResolvedValue({ dev: 1, ino: 2, isSymbolicLink: () => false });
     mockOpen.mockResolvedValue({
       readFile: vi.fn().mockResolvedValue('file content'),
       stat: vi.fn().mockResolvedValue({ dev: 1, ino: 2 }),
@@ -150,6 +150,17 @@ describe('runValidateDelegation', () => {
     const result = await runValidateDelegationActual({ delegation_id: 'test-009' });
 
     expect(result).toContain('delegation file changed during validation');
+    expect(mockValidate).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when a parent path component becomes a symlink before read', async () => {
+    mockLstat
+      .mockResolvedValueOnce({ dev: 1, ino: 2, isSymbolicLink: () => true });
+
+    const result = await runValidateDelegationActual({ delegation_id: 'test-010' });
+
+    expect(result).toContain('delegation file changed during validation');
+    expect(mockOpen).not.toHaveBeenCalled();
     expect(mockValidate).not.toHaveBeenCalled();
   });
 

--- a/mcp-server/src/tools/__tests__/validate-delegation.test.ts
+++ b/mcp-server/src/tools/__tests__/validate-delegation.test.ts
@@ -10,6 +10,7 @@ import {
 const mockValidate = vi.hoisted(() => vi.fn());
 const mockResolve = vi.hoisted(() => vi.fn());
 const mockRealpath = vi.hoisted(() => vi.fn());
+const mockLstat = vi.hoisted(() => vi.fn());
 const mockOpen = vi.hoisted(() => vi.fn());
 
 vi.mock('../../utils/delegation-validation.js', () => ({
@@ -19,6 +20,7 @@ vi.mock('../../utils/project-target.js', () => ({
   resolveManagedProjectTarget: mockResolve,
 }));
 vi.mock('fs/promises', () => ({
+  lstat: mockLstat,
   open: mockOpen,
   realpath: mockRealpath,
 }));
@@ -28,11 +30,14 @@ describe('runValidateDelegation', () => {
     mockValidate.mockReset();
     mockResolve.mockReset();
     mockRealpath.mockReset();
+    mockLstat.mockReset();
     mockOpen.mockReset();
     mockResolve.mockResolvedValue({ projectPath: '/tmp/project' });
     mockRealpath.mockImplementation(async (path: string) => path);
+    mockLstat.mockResolvedValue({ dev: 1, ino: 2 });
     mockOpen.mockResolvedValue({
       readFile: vi.fn().mockResolvedValue('file content'),
+      stat: vi.fn().mockResolvedValue({ dev: 1, ino: 2 }),
       close: vi.fn().mockResolvedValue(undefined),
     });
   });
@@ -40,6 +45,7 @@ describe('runValidateDelegation', () => {
     mockValidate.mockRestore();
     mockResolve.mockRestore();
     mockRealpath.mockRestore();
+    mockLstat.mockRestore();
     mockOpen.mockRestore();
   });
 
@@ -132,6 +138,19 @@ describe('runValidateDelegation', () => {
     expect(result).toContain('delegation file not found or unreadable at /tmp/project/standards/.context/delegations/test-006/result.md');
     expect(mockValidate).not.toHaveBeenCalled();
     expect(mockOpen).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when a canonicalized file changes before it is read', async () => {
+    mockOpen.mockResolvedValueOnce({
+      readFile: vi.fn().mockResolvedValue('file content'),
+      stat: vi.fn().mockResolvedValue({ dev: 9, ino: 9 }),
+      close: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const result = await runValidateDelegationActual({ delegation_id: 'test-009' });
+
+    expect(result).toContain('delegation file changed during validation');
+    expect(mockValidate).not.toHaveBeenCalled();
   });
 
   it('fails closed when canonicalization errors are not missing-file cases', async () => {

--- a/mcp-server/src/tools/validate-delegation.ts
+++ b/mcp-server/src/tools/validate-delegation.ts
@@ -4,6 +4,37 @@ import { validateDelegationOutput } from '../utils/delegation-validation.js';
 import { resolveManagedProjectTarget } from '../utils/project-target.js';
 import { isPathWithinRoot } from '../utils/worktree-topology.js';
 
+async function canonicalizeDelegationFile(filePath: string, resolvedDelegationsRoot: string): Promise<{
+  path: string | null;
+  error: string | null;
+}> {
+  try {
+    const resolvedPath = await realpath(filePath);
+    if (!isPathWithinRoot(resolvedPath, resolvedDelegationsRoot)) {
+      return {
+        path: null,
+        error: '❌ delegation_id resolves outside the delegations directory',
+      };
+    }
+    return {
+      path: resolvedPath,
+      error: null,
+    };
+  } catch (error: any) {
+    const errorCode = typeof error?.code === 'string' ? error.code : '';
+    if (errorCode === 'ENOENT' || errorCode === 'ENOTDIR') {
+      return {
+        path: null,
+        error: `❌ delegation file not found or unreadable at ${filePath}`,
+      };
+    }
+    return {
+      path: null,
+      error: '❌ failed to canonicalize delegation files',
+    };
+  }
+}
+
 export async function runValidateDelegation(args: any): Promise<string> {
   const delegationId = typeof args.delegation_id === 'string' ? args.delegation_id.trim() : '';
 
@@ -30,40 +61,32 @@ export async function runValidateDelegation(args: any): Promise<string> {
   const delegationBase = resolve(delegationsRoot, delegationId);
   const logPath = `${delegationBase}/log.md`;
   const resultPath = `${delegationBase}/result.md`;
-  let validatedLogPath = logPath;
-  let validatedResultPath = resultPath;
 
+  let resolvedDelegationsRoot: string;
   try {
-    const [resolvedProjectPath, resolvedDelegationsRoot] = await Promise.all([
+    const [resolvedProjectPath, canonicalDelegationsRoot] = await Promise.all([
       realpath(projectPath),
       realpath(delegationsRoot),
     ]);
-    if (!isPathWithinRoot(resolvedDelegationsRoot, resolvedProjectPath)) {
+    if (!isPathWithinRoot(canonicalDelegationsRoot, resolvedProjectPath)) {
       return '❌ delegation_id resolves outside the delegations directory';
     }
-
-    try {
-      const [resolvedLogPath, resolvedResultPath] = await Promise.all([
-        realpath(logPath),
-        realpath(resultPath),
-      ]);
-      if (!isPathWithinRoot(resolvedLogPath, resolvedDelegationsRoot) || !isPathWithinRoot(resolvedResultPath, resolvedDelegationsRoot)) {
-        return '❌ delegation_id resolves outside the delegations directory';
-      }
-      validatedLogPath = resolvedLogPath;
-      validatedResultPath = resolvedResultPath;
-    } catch (error: any) {
-      const errorCode = typeof error?.code === 'string' ? error.code : '';
-      if (errorCode !== 'ENOENT' && errorCode !== 'ENOTDIR') {
-        return '❌ failed to canonicalize delegation files';
-      }
-      // Let the validator report missing or unreadable log/result files.
-    }
+    resolvedDelegationsRoot = canonicalDelegationsRoot;
   } catch {
     return '❌ failed to resolve delegation root';
   }
 
-  const result = await validateDelegationOutput(validatedLogPath, validatedResultPath, delegationId);
+  const validatedLogPath = await canonicalizeDelegationFile(logPath, resolvedDelegationsRoot);
+  if (validatedLogPath.error) {
+    return validatedLogPath.error;
+  }
+
+  const validatedResultPath = await canonicalizeDelegationFile(resultPath, resolvedDelegationsRoot);
+  if (validatedResultPath.error) {
+    return validatedResultPath.error;
+  }
+
+  const result = await validateDelegationOutput(validatedLogPath.path!, validatedResultPath.path!, delegationId);
 
   const lines: string[] = [];
   if (result.pass) {

--- a/mcp-server/src/tools/validate-delegation.ts
+++ b/mcp-server/src/tools/validate-delegation.ts
@@ -1,9 +1,40 @@
-import { constants } from 'fs';
-import { lstat, open, realpath } from 'fs/promises';
-import { basename, join, relative, resolve } from 'path';
+import { execFile } from 'child_process';
+import { realpath } from 'fs/promises';
+import { basename, relative, resolve } from 'path';
 import { validateDelegationContent } from '../utils/delegation-validation.js';
 import { resolveManagedProjectTarget } from '../utils/project-target.js';
 import { isPathWithinRoot } from '../utils/worktree-topology.js';
+
+const SECURE_READ_SCRIPT = String.raw`
+import os
+import sys
+
+root = sys.argv[1]
+relative_path = sys.argv[2]
+parts = [part for part in relative_path.split('/') if part not in ('', '.')]
+if not parts or any(part == '..' for part in parts):
+    raise SystemExit(2)
+
+dir_fds = []
+file_fd = None
+try:
+    current_fd = os.open(root, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    dir_fds.append(current_fd)
+
+    for part in parts[:-1]:
+        current_fd = os.open(part, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW, dir_fd=current_fd)
+        dir_fds.append(current_fd)
+
+    file_fd = os.open(parts[-1], os.O_RDONLY | os.O_NOFOLLOW, dir_fd=current_fd)
+    with os.fdopen(file_fd, 'r', encoding='utf-8') as handle:
+        sys.stdout.write(handle.read())
+    file_fd = None
+finally:
+    if file_fd is not None:
+        os.close(file_fd)
+    for fd in reversed(dir_fds):
+        os.close(fd)
+`;
 
 async function canonicalizeDelegationFile(filePath: string, resolvedDelegationsRoot: string): Promise<{
   path: string | null;
@@ -44,42 +75,38 @@ async function readDelegationFileContent(
   content: string | null;
   error: string | null;
 }> {
-  let handle;
-  try {
-    const relativePath = relative(resolvedDelegationsRoot, canonicalPath);
-    const segments = relativePath.split('/').filter((segment) => segment.length > 0);
-    let currentPath = resolvedDelegationsRoot;
-    for (const segment of segments) {
-      currentPath = join(currentPath, segment);
-      const currentStat = await lstat(currentPath);
-      if (currentStat.isSymbolicLink()) {
-        return {
-          content: null,
-          error: '❌ delegation file changed during validation',
-        };
-      }
-    }
-
-    const expectedStat = await lstat(canonicalPath);
-    handle = await open(canonicalPath, constants.O_RDONLY | constants.O_NOFOLLOW);
-    const openedStat = await handle.stat();
-    if (openedStat.dev !== expectedStat.dev || openedStat.ino !== expectedStat.ino) {
-      return {
-        content: null,
-        error: '❌ delegation file changed during validation',
-      };
-    }
+  const relativePath = relative(resolvedDelegationsRoot, canonicalPath).replace(/\\/g, '/');
+  if (!relativePath || relativePath === '..' || relativePath.startsWith('../')) {
     return {
-      content: await handle.readFile('utf-8'),
-      error: null,
+      content: null,
+      error: '❌ delegation file changed during validation',
     };
+  }
+
+  try {
+    const content = await new Promise<string>((resolvePromise, rejectPromise) => {
+      execFile(
+        'python3',
+        ['-c', SECURE_READ_SCRIPT, resolvedDelegationsRoot, relativePath],
+        {
+          encoding: 'utf-8',
+          maxBuffer: 1024 * 1024,
+        },
+        (error, stdout) => {
+          if (error) {
+            rejectPromise(error);
+            return;
+          }
+          resolvePromise(stdout);
+        },
+      );
+    });
+    return { content, error: null };
   } catch {
     return {
       content: null,
       error: `❌ delegation file not found or unreadable at ${displayPath}`,
     };
-  } finally {
-    await handle?.close().catch(() => undefined);
   }
 }
 

--- a/mcp-server/src/tools/validate-delegation.ts
+++ b/mcp-server/src/tools/validate-delegation.ts
@@ -1,5 +1,5 @@
 import { constants } from 'fs';
-import { open, realpath } from 'fs/promises';
+import { lstat, open, realpath } from 'fs/promises';
 import { basename, resolve } from 'path';
 import { validateDelegationContent } from '../utils/delegation-validation.js';
 import { resolveManagedProjectTarget } from '../utils/project-target.js';
@@ -42,7 +42,15 @@ async function readDelegationFileContent(canonicalPath: string, displayPath: str
 }> {
   let handle;
   try {
+    const expectedStat = await lstat(canonicalPath);
     handle = await open(canonicalPath, constants.O_RDONLY | constants.O_NOFOLLOW);
+    const openedStat = await handle.stat();
+    if (openedStat.dev !== expectedStat.dev || openedStat.ino !== expectedStat.ino) {
+      return {
+        content: null,
+        error: '❌ delegation file changed during validation',
+      };
+    }
     return {
       content: await handle.readFile('utf-8'),
       error: null,

--- a/mcp-server/src/tools/validate-delegation.ts
+++ b/mcp-server/src/tools/validate-delegation.ts
@@ -1,6 +1,6 @@
 import { constants } from 'fs';
 import { lstat, open, realpath } from 'fs/promises';
-import { basename, resolve } from 'path';
+import { basename, join, relative, resolve } from 'path';
 import { validateDelegationContent } from '../utils/delegation-validation.js';
 import { resolveManagedProjectTarget } from '../utils/project-target.js';
 import { isPathWithinRoot } from '../utils/worktree-topology.js';
@@ -36,12 +36,30 @@ async function canonicalizeDelegationFile(filePath: string, resolvedDelegationsR
   }
 }
 
-async function readDelegationFileContent(canonicalPath: string, displayPath: string): Promise<{
+async function readDelegationFileContent(
+  resolvedDelegationsRoot: string,
+  canonicalPath: string,
+  displayPath: string,
+): Promise<{
   content: string | null;
   error: string | null;
 }> {
   let handle;
   try {
+    const relativePath = relative(resolvedDelegationsRoot, canonicalPath);
+    const segments = relativePath.split('/').filter((segment) => segment.length > 0);
+    let currentPath = resolvedDelegationsRoot;
+    for (const segment of segments) {
+      currentPath = join(currentPath, segment);
+      const currentStat = await lstat(currentPath);
+      if (currentStat.isSymbolicLink()) {
+        return {
+          content: null,
+          error: '❌ delegation file changed during validation',
+        };
+      }
+    }
+
     const expectedStat = await lstat(canonicalPath);
     handle = await open(canonicalPath, constants.O_RDONLY | constants.O_NOFOLLOW);
     const openedStat = await handle.stat();
@@ -116,12 +134,12 @@ export async function runValidateDelegation(args: any): Promise<string> {
     return validatedResultPath.error;
   }
 
-  const logContent = await readDelegationFileContent(validatedLogPath.path!, logPath);
+  const logContent = await readDelegationFileContent(resolvedDelegationsRoot, validatedLogPath.path!, logPath);
   if (logContent.error) {
     return logContent.error;
   }
 
-  const resultContent = await readDelegationFileContent(validatedResultPath.path!, resultPath);
+  const resultContent = await readDelegationFileContent(resolvedDelegationsRoot, validatedResultPath.path!, resultPath);
   if (resultContent.error) {
     return resultContent.error;
   }

--- a/mcp-server/src/tools/validate-delegation.ts
+++ b/mcp-server/src/tools/validate-delegation.ts
@@ -51,6 +51,7 @@ finally:
 
 async function canonicalizeDelegationFile(filePath: string, resolvedDelegationsRoot: string): Promise<{
   path: string | null;
+  stat: { dev: number; ino: number } | null;
   error: string | null;
 }> {
   try {
@@ -58,11 +59,14 @@ async function canonicalizeDelegationFile(filePath: string, resolvedDelegationsR
     if (!isPathWithinRoot(resolvedPath, resolvedDelegationsRoot)) {
       return {
         path: null,
+        stat: null,
         error: '❌ delegation_id resolves outside the delegations directory',
       };
     }
+    const expectedStat = await lstat(resolvedPath);
     return {
       path: resolvedPath,
+      stat: { dev: expectedStat.dev, ino: expectedStat.ino },
       error: null,
     };
   } catch (error: any) {
@@ -70,11 +74,13 @@ async function canonicalizeDelegationFile(filePath: string, resolvedDelegationsR
     if (errorCode === 'ENOENT' || errorCode === 'ENOTDIR') {
       return {
         path: null,
+        stat: null,
         error: `❌ delegation file not found or unreadable at ${filePath}`,
       };
     }
     return {
       path: null,
+      stat: null,
       error: '❌ failed to canonicalize delegation files',
     };
   }
@@ -82,8 +88,11 @@ async function canonicalizeDelegationFile(filePath: string, resolvedDelegationsR
 
 async function readDelegationFileContent(
   resolvedProjectPath: string,
+  expectedProjectStat: { dev: number; ino: number },
   resolvedDelegationsRoot: string,
+  expectedDelegationsStat: { dev: number; ino: number },
   canonicalPath: string,
+  expectedFileStat: { dev: number; ino: number },
   displayPath: string,
 ): Promise<{
   content: string | null;
@@ -109,9 +118,6 @@ async function readDelegationFileContent(
   try {
     const delegationsRelativePath = relative(resolvedProjectPath, resolvedDelegationsRoot).replace(/\\/g, '/');
     const delegationsDepth = delegationsRelativePath.split('/').filter((segment) => segment.length > 0).length;
-    const expectedDelegationsStat = await lstat(resolvedDelegationsRoot);
-    const expectedFileStat = await lstat(canonicalPath);
-    const expectedProjectStat = await lstat(resolvedProjectPath);
     projectRootHandle = await open(resolvedProjectPath, constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW);
     const openedProjectStat = await projectRootHandle.stat();
     if (openedProjectStat.dev !== expectedProjectStat.dev || openedProjectStat.ino !== expectedProjectStat.ino) {
@@ -182,7 +188,9 @@ export async function runValidateDelegation(args: any): Promise<string> {
   const resultPath = `${delegationBase}/result.md`;
 
   let resolvedProjectPath: string;
+  let expectedProjectStat: { dev: number; ino: number };
   let resolvedDelegationsRoot: string;
+  let expectedDelegationsStat: { dev: number; ino: number };
   try {
     const [canonicalProjectPath, canonicalDelegationsRoot] = await Promise.all([
       realpath(projectPath),
@@ -193,6 +201,12 @@ export async function runValidateDelegation(args: any): Promise<string> {
     }
     resolvedProjectPath = canonicalProjectPath;
     resolvedDelegationsRoot = canonicalDelegationsRoot;
+    const [projectStat, delegationsStat] = await Promise.all([
+      lstat(canonicalProjectPath),
+      lstat(canonicalDelegationsRoot),
+    ]);
+    expectedProjectStat = { dev: projectStat.dev, ino: projectStat.ino };
+    expectedDelegationsStat = { dev: delegationsStat.dev, ino: delegationsStat.ino };
   } catch {
     return '❌ failed to resolve delegation root';
   }
@@ -209,8 +223,11 @@ export async function runValidateDelegation(args: any): Promise<string> {
 
   const logContent = await readDelegationFileContent(
     resolvedProjectPath,
+    expectedProjectStat,
     resolvedDelegationsRoot,
+    expectedDelegationsStat,
     validatedLogPath.path!,
+    validatedLogPath.stat!,
     logPath,
   );
   if (logContent.error) {
@@ -219,8 +236,11 @@ export async function runValidateDelegation(args: any): Promise<string> {
 
   const resultContent = await readDelegationFileContent(
     resolvedProjectPath,
+    expectedProjectStat,
     resolvedDelegationsRoot,
+    expectedDelegationsStat,
     validatedResultPath.path!,
+    validatedResultPath.stat!,
     resultPath,
   );
   if (resultContent.error) {

--- a/mcp-server/src/tools/validate-delegation.ts
+++ b/mcp-server/src/tools/validate-delegation.ts
@@ -1,5 +1,6 @@
-import { execFile } from 'child_process';
-import { realpath } from 'fs/promises';
+import { spawnSync } from 'child_process';
+import { constants } from 'fs';
+import { lstat, open, realpath } from 'fs/promises';
 import { basename, relative, resolve } from 'path';
 import { validateDelegationContent } from '../utils/delegation-validation.js';
 import { resolveManagedProjectTarget } from '../utils/project-target.js';
@@ -9,8 +10,8 @@ const SECURE_READ_SCRIPT = String.raw`
 import os
 import sys
 
-root = sys.argv[1]
-relative_path = sys.argv[2]
+project_fd = 3
+relative_path = sys.argv[1]
 parts = [part for part in relative_path.split('/') if part not in ('', '.')]
 if not parts or any(part == '..' for part in parts):
     raise SystemExit(2)
@@ -18,7 +19,7 @@ if not parts or any(part == '..' for part in parts):
 dir_fds = []
 file_fd = None
 try:
-    current_fd = os.open(root, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    current_fd = os.dup(project_fd)
     dir_fds.append(current_fd)
 
     for part in parts[:-1]:
@@ -68,6 +69,7 @@ async function canonicalizeDelegationFile(filePath: string, resolvedDelegationsR
 }
 
 async function readDelegationFileContent(
+  resolvedProjectPath: string,
   resolvedDelegationsRoot: string,
   canonicalPath: string,
   displayPath: string,
@@ -75,38 +77,55 @@ async function readDelegationFileContent(
   content: string | null;
   error: string | null;
 }> {
-  const relativePath = relative(resolvedDelegationsRoot, canonicalPath).replace(/\\/g, '/');
-  if (!relativePath || relativePath === '..' || relativePath.startsWith('../')) {
+  const relativePath = relative(resolvedProjectPath, canonicalPath).replace(/\\/g, '/');
+  const relativeFromDelegationsRoot = relative(resolvedDelegationsRoot, canonicalPath).replace(/\\/g, '/');
+  if (
+    !relativePath
+    || relativePath === '..'
+    || relativePath.startsWith('../')
+    || !relativeFromDelegationsRoot
+    || relativeFromDelegationsRoot === '..'
+    || relativeFromDelegationsRoot.startsWith('../')
+  ) {
     return {
       content: null,
       error: '❌ delegation file changed during validation',
     };
   }
 
+  let projectRootHandle;
   try {
-    const content = await new Promise<string>((resolvePromise, rejectPromise) => {
-      execFile(
-        'python3',
-        ['-c', SECURE_READ_SCRIPT, resolvedDelegationsRoot, relativePath],
-        {
-          encoding: 'utf-8',
-          maxBuffer: 1024 * 1024,
-        },
-        (error, stdout) => {
-          if (error) {
-            rejectPromise(error);
-            return;
-          }
-          resolvePromise(stdout);
-        },
-      );
-    });
+    const expectedProjectStat = await lstat(resolvedProjectPath);
+    projectRootHandle = await open(resolvedProjectPath, constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW);
+    const openedProjectStat = await projectRootHandle.stat();
+    if (openedProjectStat.dev !== expectedProjectStat.dev || openedProjectStat.ino !== expectedProjectStat.ino) {
+      return {
+        content: null,
+        error: '❌ delegation file changed during validation',
+      };
+    }
+
+    const command = spawnSync(
+      'python3',
+      ['-c', SECURE_READ_SCRIPT, relativePath],
+      {
+        encoding: 'utf-8',
+        maxBuffer: 1024 * 1024,
+        stdio: ['ignore', 'pipe', 'pipe', projectRootHandle.fd],
+      },
+    );
+    if (command.status !== 0 || command.error) {
+      throw command.error || new Error(command.stderr || 'secure read failed');
+    }
+    const content = command.stdout;
     return { content, error: null };
   } catch {
     return {
       content: null,
       error: `❌ delegation file not found or unreadable at ${displayPath}`,
     };
+  } finally {
+    await projectRootHandle?.close().catch(() => undefined);
   }
 }
 
@@ -137,15 +156,17 @@ export async function runValidateDelegation(args: any): Promise<string> {
   const logPath = `${delegationBase}/log.md`;
   const resultPath = `${delegationBase}/result.md`;
 
+  let resolvedProjectPath: string;
   let resolvedDelegationsRoot: string;
   try {
-    const [resolvedProjectPath, canonicalDelegationsRoot] = await Promise.all([
+    const [canonicalProjectPath, canonicalDelegationsRoot] = await Promise.all([
       realpath(projectPath),
       realpath(delegationsRoot),
     ]);
-    if (!isPathWithinRoot(canonicalDelegationsRoot, resolvedProjectPath)) {
+    if (!isPathWithinRoot(canonicalDelegationsRoot, canonicalProjectPath)) {
       return '❌ delegation_id resolves outside the delegations directory';
     }
+    resolvedProjectPath = canonicalProjectPath;
     resolvedDelegationsRoot = canonicalDelegationsRoot;
   } catch {
     return '❌ failed to resolve delegation root';
@@ -161,12 +182,22 @@ export async function runValidateDelegation(args: any): Promise<string> {
     return validatedResultPath.error;
   }
 
-  const logContent = await readDelegationFileContent(resolvedDelegationsRoot, validatedLogPath.path!, logPath);
+  const logContent = await readDelegationFileContent(
+    resolvedProjectPath,
+    resolvedDelegationsRoot,
+    validatedLogPath.path!,
+    logPath,
+  );
   if (logContent.error) {
     return logContent.error;
   }
 
-  const resultContent = await readDelegationFileContent(resolvedDelegationsRoot, validatedResultPath.path!, resultPath);
+  const resultContent = await readDelegationFileContent(
+    resolvedProjectPath,
+    resolvedDelegationsRoot,
+    validatedResultPath.path!,
+    resultPath,
+  );
   if (resultContent.error) {
     return resultContent.error;
   }

--- a/mcp-server/src/tools/validate-delegation.ts
+++ b/mcp-server/src/tools/validate-delegation.ts
@@ -12,6 +12,11 @@ import sys
 
 project_fd = 3
 relative_path = sys.argv[1]
+delegations_depth = int(sys.argv[2])
+expected_root_dev = int(sys.argv[3])
+expected_root_ino = int(sys.argv[4])
+expected_file_dev = int(sys.argv[5])
+expected_file_ino = int(sys.argv[6])
 parts = [part for part in relative_path.split('/') if part not in ('', '.')]
 if not parts or any(part == '..' for part in parts):
     raise SystemExit(2)
@@ -22,11 +27,18 @@ try:
     current_fd = os.dup(project_fd)
     dir_fds.append(current_fd)
 
-    for part in parts[:-1]:
+    for index, part in enumerate(parts[:-1], start=1):
         current_fd = os.open(part, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW, dir_fd=current_fd)
         dir_fds.append(current_fd)
+        if index == delegations_depth:
+            current_stat = os.fstat(current_fd)
+            if current_stat.st_dev != expected_root_dev or current_stat.st_ino != expected_root_ino:
+                raise SystemExit(3)
 
     file_fd = os.open(parts[-1], os.O_RDONLY | os.O_NOFOLLOW, dir_fd=current_fd)
+    file_stat = os.fstat(file_fd)
+    if file_stat.st_dev != expected_file_dev or file_stat.st_ino != expected_file_ino:
+        raise SystemExit(4)
     with os.fdopen(file_fd, 'r', encoding='utf-8') as handle:
         sys.stdout.write(handle.read())
     file_fd = None
@@ -95,6 +107,10 @@ async function readDelegationFileContent(
 
   let projectRootHandle;
   try {
+    const delegationsRelativePath = relative(resolvedProjectPath, resolvedDelegationsRoot).replace(/\\/g, '/');
+    const delegationsDepth = delegationsRelativePath.split('/').filter((segment) => segment.length > 0).length;
+    const expectedDelegationsStat = await lstat(resolvedDelegationsRoot);
+    const expectedFileStat = await lstat(canonicalPath);
     const expectedProjectStat = await lstat(resolvedProjectPath);
     projectRootHandle = await open(resolvedProjectPath, constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW);
     const openedProjectStat = await projectRootHandle.stat();
@@ -107,7 +123,16 @@ async function readDelegationFileContent(
 
     const command = spawnSync(
       'python3',
-      ['-c', SECURE_READ_SCRIPT, relativePath],
+      [
+        '-c',
+        SECURE_READ_SCRIPT,
+        relativePath,
+        String(delegationsDepth),
+        String(expectedDelegationsStat.dev),
+        String(expectedDelegationsStat.ino),
+        String(expectedFileStat.dev),
+        String(expectedFileStat.ino),
+      ],
       {
         encoding: 'utf-8',
         maxBuffer: 1024 * 1024,

--- a/mcp-server/src/tools/validate-delegation.ts
+++ b/mcp-server/src/tools/validate-delegation.ts
@@ -1,6 +1,7 @@
-import { realpath } from 'fs/promises';
+import { constants } from 'fs';
+import { open, realpath } from 'fs/promises';
 import { basename, resolve } from 'path';
-import { validateDelegationOutput } from '../utils/delegation-validation.js';
+import { validateDelegationContent } from '../utils/delegation-validation.js';
 import { resolveManagedProjectTarget } from '../utils/project-target.js';
 import { isPathWithinRoot } from '../utils/worktree-topology.js';
 
@@ -32,6 +33,27 @@ async function canonicalizeDelegationFile(filePath: string, resolvedDelegationsR
       path: null,
       error: '❌ failed to canonicalize delegation files',
     };
+  }
+}
+
+async function readDelegationFileContent(canonicalPath: string, displayPath: string): Promise<{
+  content: string | null;
+  error: string | null;
+}> {
+  let handle;
+  try {
+    handle = await open(canonicalPath, constants.O_RDONLY | constants.O_NOFOLLOW);
+    return {
+      content: await handle.readFile('utf-8'),
+      error: null,
+    };
+  } catch {
+    return {
+      content: null,
+      error: `❌ delegation file not found or unreadable at ${displayPath}`,
+    };
+  } finally {
+    await handle?.close().catch(() => undefined);
   }
 }
 
@@ -86,7 +108,17 @@ export async function runValidateDelegation(args: any): Promise<string> {
     return validatedResultPath.error;
   }
 
-  const result = await validateDelegationOutput(validatedLogPath.path!, validatedResultPath.path!, delegationId);
+  const logContent = await readDelegationFileContent(validatedLogPath.path!, logPath);
+  if (logContent.error) {
+    return logContent.error;
+  }
+
+  const resultContent = await readDelegationFileContent(validatedResultPath.path!, resultPath);
+  if (resultContent.error) {
+    return resultContent.error;
+  }
+
+  const result = validateDelegationContent(logContent.content!, resultContent.content!, delegationId);
 
   const lines: string[] = [];
   if (result.pass) {

--- a/mcp-server/src/utils/delegation-validation.ts
+++ b/mcp-server/src/utils/delegation-validation.ts
@@ -80,6 +80,72 @@ export function sectionNonEmpty(content: string, heading: string): boolean {
   return extractHeadingContent(content, heading) !== null;
 }
 
+export function validateDelegationContent(
+  logContent: string,
+  resultContent: string,
+  delegationId: string,
+): ValidationResult {
+  const warnings: string[] = [];
+
+  const logId = extractField(logContent, 'delegation_id');
+  const logRecordedAt = extractField(logContent, 'recorded_at');
+  const logSubTask = extractField(logContent, 'sub_task');
+  const logStatus = extractField(logContent, 'status');
+
+  const logIdPresent = logId !== null;
+  const logIdMatches = logIdPresent ? logId === delegationId : null;
+  const logRecordedAtPresent = logRecordedAt !== null;
+  const logRecordedAtValid = logRecordedAt !== null ? ISO8601_RE.test(logRecordedAt) : false;
+  const logSubTaskPresent = logSubTask !== null;
+  const logStatusPresent = logStatus !== null;
+  const logStatusValid = logStatus !== null ? VALID_STATUSES.includes(logStatus) : false;
+  const logActionsNonempty = sectionNonEmpty(logContent, '## Actions Taken');
+  const logFindingsNonempty = sectionNonEmpty(logContent, '## Findings');
+
+  if (!logActionsNonempty) warnings.push('log.md: ## Actions Taken section is empty');
+
+  const resultId = extractAfterHeading(resultContent, '## Delegation ID');
+  const resultTimestamp = extractAfterHeading(resultContent, '## Timestamp');
+  const resultSummary = extractHeadingContent(resultContent, '## Summary');
+  const resultFindingsNonempty = sectionNonEmpty(resultContent, '## Findings') || sectionNonEmpty(resultContent, '## findings');
+  const resultRecsNonempty = sectionNonEmpty(resultContent, '## Recommendations') || sectionNonEmpty(resultContent, '## recommendations');
+
+  const resultIdPresent = resultId !== null;
+  const resultIdMatches = resultIdPresent ? resultId === delegationId : null;
+  const resultTimestampPresent = resultTimestamp !== null;
+  const resultSummaryNonempty = resultSummary !== null && resultSummary.replace(/\s/g, '').length >= 10;
+
+  const logErrors = [
+    !logIdPresent ? 'log.md: delegation_id field is missing' : null,
+    logIdMatches === false ? `log.md: delegation_id mismatch (expected ${delegationId}, got ${logId})` : null,
+    !logRecordedAtPresent ? 'log.md: recorded_at field is missing' : null,
+    !logRecordedAtValid ? `log.md: recorded_at is not ISO 8601 (got ${logRecordedAt})` : null,
+    !logSubTaskPresent ? 'log.md: sub_task field is missing' : null,
+    !logStatusPresent ? 'log.md: status field is missing' : null,
+    !logStatusValid ? `log.md: status must be one of ${VALID_STATUSES.join('|')} (got ${logStatus})` : null,
+    !logFindingsNonempty ? 'log.md: ## Findings section is empty' : null,
+  ].filter(Boolean) as string[];
+
+  const resultErrors = [
+    !resultIdPresent ? 'result.md: Delegation ID field is missing' : null,
+    resultIdMatches === false ? `result.md: Delegation ID mismatch (expected ${delegationId}, got ${resultId})` : null,
+    !resultTimestampPresent ? 'result.md: Timestamp field is missing' : null,
+    !resultSummaryNonempty ? 'result.md: Summary field is empty or too short' : null,
+    !resultFindingsNonempty ? 'result.md: ## Findings section is empty' : null,
+    !resultRecsNonempty ? 'result.md: ## Recommendations section is empty' : null,
+  ].filter(Boolean) as string[];
+
+  return mkResult(
+    logErrors.length === 0 && resultErrors.length === 0,
+    logErrors.length === 0,
+    resultErrors.length === 0,
+    [...logErrors, ...resultErrors],
+    warnings,
+    mkLogChecks(logIdPresent, logIdMatches, logRecordedAtPresent, logRecordedAtValid, logSubTaskPresent, logStatusPresent, logStatusValid, logActionsNonempty, logFindingsNonempty),
+    mkResultChecks(resultIdPresent, resultIdMatches, resultTimestampPresent, resultSummaryNonempty, resultFindingsNonempty, resultRecsNonempty),
+  );
+}
+
 /**
  * Validates that a sub-agent delegation produced complete, well-formed output.
  *


### PR DESCRIPTION
Closes #385

## Summary
- remove the ENOENT/ENOTDIR fallback that reopened unresolved delegation paths
- canonicalize log/result paths individually and return direct tool-level errors for missing files
- keep validation on canonicalized paths only once containment checks pass
- update validate-delegation tests to cover the missing-file fail-closed behavior

## Verification
- npm ci
- npm run lint
- npm test -- src/tools/__tests__/validate-delegation.test.ts src/utils/__tests__/delegation-validation.test.ts
- npm test
- agenticos_pr_scope_check PASS
