### PR TITLE
fix: bound multi-agent review resources

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
+        "p-limit": "^6.2.0",
         "yaml": "^2.3.4"
       },
       "bin": {
@@ -2490,6 +2491,21 @@
         "wrappy": "1"
       }
     },
+    "node_modules/p-limit": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
+      "integrity": "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -3557,6 +3573,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zod": {

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -27,6 +27,7 @@
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
+    "p-limit": "^6.2.0",
     "yaml": "^2.3.4"
   },
   "devDependencies": {

--- a/mcp-server/src/tools/__tests__/multi-agent-review.test.ts
+++ b/mcp-server/src/tools/__tests__/multi-agent-review.test.ts
@@ -261,13 +261,18 @@ describe('multi-agent-review', () => {
       const mod = await loadModule();
       await mod.persistReviewLog(REVIEW_RESULT, '/repo');
       expect(appendFileMock).toHaveBeenCalledWith(
-        '/repo/tasks/global-review-log.details.md',
-        expect.stringContaining('## PR #42'),
+        '/repo/tasks/global-review-log.md',
+        expect.stringContaining('<tr>'),
         'utf-8',
       );
       expect(appendFileMock).toHaveBeenCalledWith(
-        '/repo/tasks/global-review-log.details.md',
-        expect.stringContaining('### OK Code Reviewer'),
+        '/repo/tasks/global-review-log.md',
+        expect.stringContaining('<details><summary>Details</summary>'),
+        'utf-8',
+      );
+      expect(appendFileMock).toHaveBeenCalledWith(
+        '/repo/tasks/global-review-log.md',
+        expect.stringContaining('OK Code Reviewer'),
         'utf-8',
       );
     });
@@ -284,33 +289,20 @@ describe('multi-agent-review', () => {
         expect.stringContaining('# Global Review Log'),
         expect.objectContaining({ flag: 'wx' }),
       );
-      expect(writeFileMock).toHaveBeenNthCalledWith(
-        2,
-        '/repo/tasks/global-review-log.details.md',
-        expect.stringContaining('# Global Review Log Details'),
-        expect.objectContaining({ flag: 'wx' }),
-      );
-      expect(appendFileMock).toHaveBeenCalledTimes(2);
+      expect(appendFileMock).toHaveBeenCalledTimes(1);
       expect(appendFileMock).toHaveBeenCalledWith(
         '/repo/tasks/global-review-log.md',
-        expect.stringContaining('| [#42]('),
-        'utf-8',
-      );
-      expect(appendFileMock).toHaveBeenCalledWith(
-        '/repo/tasks/global-review-log.details.md',
-        expect.stringContaining('## PR #42'),
+        expect.stringContaining('<a href="https://github.com/madlouse/AgenticOS/pull/42">#42</a>'),
         'utf-8',
       );
     });
 
     it('treats EEXIST during header creation as a harmless concurrent writer race', async () => {
-      writeFileMock
-        .mockRejectedValueOnce(Object.assign(new Error('exists'), { code: 'EEXIST' }))
-        .mockRejectedValueOnce(Object.assign(new Error('exists'), { code: 'EEXIST' }));
+      writeFileMock.mockRejectedValueOnce(Object.assign(new Error('exists'), { code: 'EEXIST' }));
 
       const mod = await loadModule();
       await expect(mod.persistReviewLog(REVIEW_RESULT, '/repo')).resolves.toBe('/repo/tasks/global-review-log.md');
-      expect(appendFileMock).toHaveBeenCalledTimes(2);
+      expect(appendFileMock).toHaveBeenCalledTimes(1);
     });
 
     it('runs the main review path with bounded orchestration and per-agent timeouts', async () => {

--- a/mcp-server/src/tools/__tests__/multi-agent-review.test.ts
+++ b/mcp-server/src/tools/__tests__/multi-agent-review.test.ts
@@ -8,6 +8,7 @@ Object.defineProperty(execMock, promisify.custom, {
 });
 
 const appendFileMock = vi.fn();
+const lstatMock = vi.fn();
 const mkdirMock = vi.fn();
 const unlinkMock = vi.fn();
 const writeFileMock = vi.fn();
@@ -23,6 +24,7 @@ vi.mock('crypto', () => ({
 
 vi.mock('fs/promises', async () => ({
   appendFile: appendFileMock,
+  lstat: lstatMock,
   mkdir: mkdirMock,
   unlink: unlinkMock,
   writeFile: writeFileMock,
@@ -71,6 +73,9 @@ describe('multi-agent-review', () => {
 
     appendFileMock.mockReset();
     appendFileMock.mockResolvedValue(undefined);
+
+    lstatMock.mockReset();
+    lstatMock.mockRejectedValue(Object.assign(new Error('missing'), { code: 'ENOENT' }));
 
     mkdirMock.mockReset();
     mkdirMock.mockResolvedValue(undefined);
@@ -283,6 +288,8 @@ describe('multi-agent-review', () => {
 
       expect(logPath).toBe('/repo/tasks/global-review-log.md');
       expect(mkdirMock).toHaveBeenCalledWith('/repo/tasks', { recursive: true });
+      expect(lstatMock).toHaveBeenCalledWith('/repo/tasks');
+      expect(lstatMock).toHaveBeenCalledWith('/repo/tasks/global-review-log.md');
       expect(writeFileMock).toHaveBeenNthCalledWith(
         1,
         '/repo/tasks/global-review-log.md',
@@ -303,6 +310,16 @@ describe('multi-agent-review', () => {
       const mod = await loadModule();
       await expect(mod.persistReviewLog(REVIEW_RESULT, '/repo')).resolves.toBe('/repo/tasks/global-review-log.md');
       expect(appendFileMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('refuses to write through symlinked log surfaces', async () => {
+      lstatMock
+        .mockResolvedValueOnce({ isSymbolicLink: () => false })
+        .mockResolvedValueOnce({ isSymbolicLink: () => true });
+
+      const mod = await loadModule();
+      await expect(mod.persistReviewLog(REVIEW_RESULT, '/repo')).rejects.toThrow('Refusing to write review log through symlinked path');
+      expect(appendFileMock).not.toHaveBeenCalled();
     });
 
     it('runs the main review path with bounded orchestration and per-agent timeouts', async () => {

--- a/mcp-server/src/tools/__tests__/multi-agent-review.test.ts
+++ b/mcp-server/src/tools/__tests__/multi-agent-review.test.ts
@@ -261,12 +261,12 @@ describe('multi-agent-review', () => {
       const mod = await loadModule();
       await mod.persistReviewLog(REVIEW_RESULT, '/repo');
       expect(appendFileMock).toHaveBeenCalledWith(
-        '/repo/tasks/global-review-log.md',
+        '/repo/tasks/global-review-log.details.md',
         expect.stringContaining('## PR #42'),
         'utf-8',
       );
       expect(appendFileMock).toHaveBeenCalledWith(
-        '/repo/tasks/global-review-log.md',
+        '/repo/tasks/global-review-log.details.md',
         expect.stringContaining('### OK Code Reviewer'),
         'utf-8',
       );
@@ -284,20 +284,33 @@ describe('multi-agent-review', () => {
         expect.stringContaining('# Global Review Log'),
         expect.objectContaining({ flag: 'wx' }),
       );
-      expect(appendFileMock).toHaveBeenCalledTimes(1);
+      expect(writeFileMock).toHaveBeenNthCalledWith(
+        2,
+        '/repo/tasks/global-review-log.details.md',
+        expect.stringContaining('# Global Review Log Details'),
+        expect.objectContaining({ flag: 'wx' }),
+      );
+      expect(appendFileMock).toHaveBeenCalledTimes(2);
       expect(appendFileMock).toHaveBeenCalledWith(
         '/repo/tasks/global-review-log.md',
+        expect.stringContaining('| [#42]('),
+        'utf-8',
+      );
+      expect(appendFileMock).toHaveBeenCalledWith(
+        '/repo/tasks/global-review-log.details.md',
         expect.stringContaining('## PR #42'),
         'utf-8',
       );
     });
 
     it('treats EEXIST during header creation as a harmless concurrent writer race', async () => {
-      writeFileMock.mockRejectedValueOnce(Object.assign(new Error('exists'), { code: 'EEXIST' }));
+      writeFileMock
+        .mockRejectedValueOnce(Object.assign(new Error('exists'), { code: 'EEXIST' }))
+        .mockRejectedValueOnce(Object.assign(new Error('exists'), { code: 'EEXIST' }));
 
       const mod = await loadModule();
       await expect(mod.persistReviewLog(REVIEW_RESULT, '/repo')).resolves.toBe('/repo/tasks/global-review-log.md');
-      expect(appendFileMock).toHaveBeenCalledTimes(1);
+      expect(appendFileMock).toHaveBeenCalledTimes(2);
     });
 
     it('runs the main review path with bounded orchestration and per-agent timeouts', async () => {

--- a/mcp-server/src/tools/__tests__/multi-agent-review.test.ts
+++ b/mcp-server/src/tools/__tests__/multi-agent-review.test.ts
@@ -7,7 +7,6 @@ Object.defineProperty(execMock, promisify.custom, {
   value: execAsyncMock,
 });
 
-const accessMock = vi.fn();
 const appendFileMock = vi.fn();
 const mkdirMock = vi.fn();
 const unlinkMock = vi.fn();
@@ -23,7 +22,6 @@ vi.mock('crypto', () => ({
 }));
 
 vi.mock('fs/promises', async () => ({
-  access: accessMock,
   appendFile: appendFileMock,
   mkdir: mkdirMock,
   unlink: unlinkMock,
@@ -70,9 +68,6 @@ describe('multi-agent-review', () => {
 
     execAsyncMock.mockReset();
     execAsyncMock.mockResolvedValue({ stdout: '', stderr: '' });
-
-    accessMock.mockReset();
-    accessMock.mockResolvedValue(undefined);
 
     appendFileMock.mockReset();
     appendFileMock.mockResolvedValue(undefined);
@@ -208,20 +203,8 @@ describe('multi-agent-review', () => {
   });
 
   describe('agent execution settings', () => {
-    it('uses longer timeout for architecture reviewer', async () => {
-      const mod = await loadModule();
-      expect(mod.getClaudeAgentTimeoutMs('architecture-reviewer')).toBe(300000);
-      expect(mod.getClaudeAgentTimeoutMs('qa-expert')).toBe(180000);
-    });
-
-    it('builds temp file paths with uuid suffixes', async () => {
-      const mod = await loadModule();
-      const path = mod.buildPromptTempFilePath('/tmp/test', 123, 456, 'uuid-123');
-      expect(path).toBe('/tmp/test/claude-agent-prompt-123-456-uuid-123.txt');
-    });
-
-    it('runs claude with expanded buffer and cleans up prompt files', async () => {
-      process.env.TMPDIR = '/tmp/test-agent-review';
+    it('runs claude with expanded buffer, shell-safe prompt files, and cleanup', async () => {
+      process.env.TMPDIR = `/tmp/test-agent-review-$(echo nope)-o'hare`;
       execAsyncMock.mockResolvedValue({
         stdout: '**Findings:**\n- Missing limit\n\n**Recommendations:**\n- Add tests\n\n**Summary:**\nNeeds follow-up.',
         stderr: '',
@@ -235,11 +218,14 @@ describe('multi-agent-review', () => {
       expect(result.summary).toBe('Needs follow-up.');
 
       const tmpFile = writeFileMock.mock.calls[0][0] as string;
-      expect(tmpFile).toContain('/tmp/test-agent-review/claude-agent-prompt-');
+      expect(tmpFile).toContain('/tmp/test-agent-review-$(echo nope)-o\'hare/claude-agent-prompt-');
       expect(tmpFile).toContain('uuid-123.txt');
 
+      const execCommand = execAsyncMock.mock.calls[0][0] as string;
+      expect(execCommand).toContain(`--system-prompt-file '/tmp/test-agent-review-$(echo nope)-o'\\''hare`);
+      expect(execCommand).not.toContain(`--system-prompt-file "${tmpFile}"`);
       expect(execAsyncMock).toHaveBeenCalledWith(
-        expect.stringContaining(`--system-prompt-file "${tmpFile}"`),
+        expect.any(String),
         expect.objectContaining({
           timeout: 300000,
           maxBuffer: 10 * 1024 * 1024,
@@ -273,44 +259,103 @@ describe('multi-agent-review', () => {
 
     it('formats log entries as append-only sections', async () => {
       const mod = await loadModule();
-      const entry = mod.formatReviewLogEntry(REVIEW_RESULT, '2026-05-11T10:00:00.000Z');
-      expect(entry).toContain('## PR #42');
-      expect(entry).toContain('Recommendation: **REQUEST_CHANGES**');
-      expect(entry).toContain('### OK Code Reviewer');
+      await mod.persistReviewLog(REVIEW_RESULT, '/repo');
+      expect(appendFileMock).toHaveBeenCalledWith(
+        '/repo/tasks/global-review-log.md',
+        expect.stringContaining('## PR #42'),
+        'utf-8',
+      );
+      expect(appendFileMock).toHaveBeenCalledWith(
+        '/repo/tasks/global-review-log.md',
+        expect.stringContaining('### OK Code Reviewer'),
+        'utf-8',
+      );
     });
 
-    it('creates log header once and appends new entries', async () => {
-      accessMock.mockRejectedValueOnce(new Error('missing'));
-
+    it('creates log header atomically before appending new entries', async () => {
       const mod = await loadModule();
       const logPath = await mod.persistReviewLog(REVIEW_RESULT, '/repo');
 
       expect(logPath).toBe('/repo/tasks/global-review-log.md');
       expect(mkdirMock).toHaveBeenCalledWith('/repo/tasks', { recursive: true });
-      expect(appendFileMock).toHaveBeenNthCalledWith(
+      expect(writeFileMock).toHaveBeenNthCalledWith(
         1,
         '/repo/tasks/global-review-log.md',
         expect.stringContaining('# Global Review Log'),
-        'utf-8',
+        expect.objectContaining({ flag: 'wx' }),
       );
-      expect(appendFileMock).toHaveBeenNthCalledWith(
-        2,
-        '/repo/tasks/global-review-log.md',
-        expect.stringContaining('## PR #42'),
-        'utf-8',
-      );
-    });
-
-    it('appends without rewriting when the log already exists', async () => {
-      const mod = await loadModule();
-      await mod.persistReviewLog(REVIEW_RESULT, '/repo');
-
       expect(appendFileMock).toHaveBeenCalledTimes(1);
       expect(appendFileMock).toHaveBeenCalledWith(
         '/repo/tasks/global-review-log.md',
         expect.stringContaining('## PR #42'),
         'utf-8',
       );
+    });
+
+    it('treats EEXIST during header creation as a harmless concurrent writer race', async () => {
+      writeFileMock.mockRejectedValueOnce(Object.assign(new Error('exists'), { code: 'EEXIST' }));
+
+      const mod = await loadModule();
+      await expect(mod.persistReviewLog(REVIEW_RESULT, '/repo')).resolves.toBe('/repo/tasks/global-review-log.md');
+      expect(appendFileMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('runs the main review path with bounded orchestration and per-agent timeouts', async () => {
+      let activeReviews = 0;
+      let maxActiveReviews = 0;
+
+      execAsyncMock.mockImplementation(async (command: string, options?: { timeout?: number; maxBuffer?: number }) => {
+        if (command.startsWith('gh pr view')) {
+          return {
+            stdout: JSON.stringify({
+              title: PR_DETAILS.title,
+              body: PR_DETAILS.body,
+              state: PR_DETAILS.state,
+              author: { login: PR_DETAILS.author },
+              files: PR_DETAILS.changedFiles.map((path) => ({ path })),
+              additions: PR_DETAILS.additions,
+              deletions: PR_DETAILS.deletions,
+            }),
+            stderr: '',
+          };
+        }
+
+        if (command.startsWith('gh pr diff')) {
+          return { stdout: 'diff --git a/src/index.ts b/src/index.ts', stderr: '' };
+        }
+
+        if (command.startsWith('command claude')) {
+          activeReviews += 1;
+          maxActiveReviews = Math.max(maxActiveReviews, activeReviews);
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          activeReviews -= 1;
+
+          return {
+            stdout: '**Findings:**\n- Looks fine\n\n**Recommendations:**\n- Ship it\n\n**Summary:**\nNo blocking issues.',
+            stderr: '',
+          };
+        }
+
+        throw new Error(`unexpected command: ${command}`);
+      });
+
+      const mod = await loadModule();
+      const output = await mod.runMultiAgentReview({
+        pr_number: 42,
+        repo_path: '/repo',
+        agents: ['code-reviewer', 'security-auditor', 'qa-expert', 'architecture-reviewer'],
+      });
+
+      expect(output).toContain('## Multi-Agent Review — PR #42');
+      expect(output).toContain('**Agents:** 4/4 completed');
+      expect(maxActiveReviews).toBe(2);
+
+      const claudeCallOptions = execAsyncMock.mock.calls
+        .filter(([command]) => (command as string).startsWith('command claude'))
+        .map(([, options]) => options as { timeout: number; maxBuffer: number });
+
+      expect(claudeCallOptions).toContainEqual(expect.objectContaining({ timeout: 300000, maxBuffer: 10 * 1024 * 1024 }));
+      expect(claudeCallOptions).toContainEqual(expect.objectContaining({ timeout: 180000, maxBuffer: 10 * 1024 * 1024 }));
     });
   });
 

--- a/mcp-server/src/tools/__tests__/multi-agent-review.test.ts
+++ b/mcp-server/src/tools/__tests__/multi-agent-review.test.ts
@@ -1,6 +1,38 @@
-import { describe, it, expect } from 'vitest';
+import { promisify } from 'util';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mod = await import('../multi-agent-review.js');
+const execAsyncMock = vi.fn();
+const execMock = vi.fn();
+Object.defineProperty(execMock, promisify.custom, {
+  value: execAsyncMock,
+});
+
+const accessMock = vi.fn();
+const appendFileMock = vi.fn();
+const mkdirMock = vi.fn();
+const unlinkMock = vi.fn();
+const writeFileMock = vi.fn();
+const randomUUIDMock = vi.fn();
+
+vi.mock('child_process', () => ({
+  exec: execMock,
+}));
+
+vi.mock('crypto', () => ({
+  randomUUID: randomUUIDMock,
+}));
+
+vi.mock('fs/promises', async () => ({
+  access: accessMock,
+  appendFile: appendFileMock,
+  mkdir: mkdirMock,
+  unlink: unlinkMock,
+  writeFile: writeFileMock,
+}));
+
+async function loadModule() {
+  return import('../multi-agent-review.js');
+}
 
 const PR_DETAILS = {
   title: 'feat: add delegation toolchain',
@@ -12,9 +44,55 @@ const PR_DETAILS = {
   deletions: 30,
 };
 
+const REVIEW_RESULT = {
+  pr_number: 42,
+  total_agents: 2,
+  successful_agents: 2,
+  failed_agents: 0,
+  reviews: [
+    {
+      agent: 'code-reviewer',
+      agent_name: 'Code Reviewer',
+      status: 'ok' as const,
+      findings: ['Needs more tests'],
+      recommendations: ['Add unit tests'],
+      summary: 'Solid overall.',
+      duration_ms: 100,
+    },
+  ],
+  aggregated_summary: '1 agent reviewed the PR.',
+  overall_recommendation: 'REQUEST_CHANGES' as const,
+};
+
 describe('multi-agent-review', () => {
+  beforeEach(() => {
+    vi.resetModules();
+
+    execAsyncMock.mockReset();
+    execAsyncMock.mockResolvedValue({ stdout: '', stderr: '' });
+
+    accessMock.mockReset();
+    accessMock.mockResolvedValue(undefined);
+
+    appendFileMock.mockReset();
+    appendFileMock.mockResolvedValue(undefined);
+
+    mkdirMock.mockReset();
+    mkdirMock.mockResolvedValue(undefined);
+
+    unlinkMock.mockReset();
+    unlinkMock.mockResolvedValue(undefined);
+
+    writeFileMock.mockReset();
+    writeFileMock.mockResolvedValue(undefined);
+
+    randomUUIDMock.mockReset();
+    randomUUIDMock.mockReturnValue('uuid-123');
+  });
+
   describe('mapToClaudeAgentType', () => {
-    it('maps known agent types', () => {
+    it('maps known agent types', async () => {
+      const mod = await loadModule();
       expect(mod.mapToClaudeAgentType('code-reviewer')).toBe('code-reviewer');
       expect(mod.mapToClaudeAgentType('security-auditor')).toBe('security-auditor');
       expect(mod.mapToClaudeAgentType('qa-expert')).toBe('qa-expert');
@@ -22,27 +100,31 @@ describe('multi-agent-review', () => {
       expect(mod.mapToClaudeAgentType('performance-engineer')).toBe('performance-engineer');
     });
 
-    it('defaults unknown agents to code-reviewer', () => {
+    it('defaults unknown agents to code-reviewer', async () => {
+      const mod = await loadModule();
       expect(mod.mapToClaudeAgentType('unknown-agent')).toBe('code-reviewer');
       expect(mod.mapToClaudeAgentType('')).toBe('code-reviewer');
     });
   });
 
   describe('aggregateResults', () => {
-    it('returns REQUEST_CHANGES for empty reviews', () => {
+    it('returns REQUEST_CHANGES for empty reviews', async () => {
+      const mod = await loadModule();
       const result = mod.aggregateResults([]);
       expect(result.recommendation).toBe('REQUEST_CHANGES');
       expect(result.summary).toContain('No reviews were completed');
     });
 
-    it('returns APPROVE when no blockers', () => {
+    it('returns APPROVE when no blockers', async () => {
+      const mod = await loadModule();
       const reviews = [
         { findings: ['Style issue'], recommendations: ['Fix formatting'], status: 'ok', duration_ms: 100 },
       ] as any;
       expect(mod.aggregateResults(reviews).recommendation).toBe('APPROVE');
     });
 
-    it('returns BLOCK when blockers >= 40%', () => {
+    it('returns BLOCK when blockers >= 40%', async () => {
+      const mod = await loadModule();
       const reviews = [
         { findings: ['SECURITY: RCE'], recommendations: [], status: 'ok', duration_ms: 100 },
         { findings: ['Blocker'], recommendations: [], status: 'ok', duration_ms: 100 },
@@ -51,7 +133,8 @@ describe('multi-agent-review', () => {
       expect(mod.aggregateResults(reviews).recommendation).toBe('BLOCK');
     });
 
-    it('returns REQUEST_CHANGES for 1 blocker out of 4', () => {
+    it('returns REQUEST_CHANGES for 1 blocker out of 4', async () => {
+      const mod = await loadModule();
       const reviews = [
         { findings: ['SECURITY: critical'], status: 'ok', recommendations: [], duration_ms: 100 },
         { findings: ['Style'], status: 'ok', recommendations: [], duration_ms: 100 },
@@ -61,14 +144,16 @@ describe('multi-agent-review', () => {
       expect(mod.aggregateResults(reviews).recommendation).toBe('REQUEST_CHANGES');
     });
 
-    it('returns REQUEST_CHANGES when any agent errors', () => {
+    it('returns REQUEST_CHANGES when any agent errors', async () => {
+      const mod = await loadModule();
       const reviews = [
         { findings: [], status: 'error', recommendations: [], duration_ms: 0 },
       ] as any;
       expect(mod.aggregateResults(reviews).recommendation).toBe('REQUEST_CHANGES');
     });
 
-    it('counts findings and recommendations in summary', () => {
+    it('counts findings and recommendations in summary', async () => {
+      const mod = await loadModule();
       const reviews = [
         { findings: ['A', 'B'], recommendations: ['X', 'Y', 'Z'], status: 'ok', duration_ms: 100 },
       ] as any;
@@ -76,31 +161,11 @@ describe('multi-agent-review', () => {
       expect(result.summary).toContain('2 finding(s)');
       expect(result.summary).toContain('3 recommendation(s)');
     });
-
-    it('flags blocking issues in summary', () => {
-      const reviews = [
-        { findings: ['SECURITY: XSS'], status: 'ok', recommendations: [], duration_ms: 100 },
-      ] as any;
-      expect(mod.aggregateResults(reviews).summary).toContain('1 agent(s) flagged blocking issues');
-    });
-
-    it('flags errors in summary', () => {
-      const reviews = [
-        { findings: [], status: 'error', recommendations: [], duration_ms: 0 },
-      ] as any;
-      expect(mod.aggregateResults(reviews).summary).toContain('1 agent(s) encountered errors');
-    });
-
-    it('reports overall recommendation in summary', () => {
-      const reviews = [
-        { findings: ['Style'], recommendations: [], status: 'ok', duration_ms: 100 },
-      ] as any;
-      expect(mod.aggregateResults(reviews).summary).toContain('Overall recommendation: APPROVE');
-    });
   });
 
   describe('buildReviewPrompt', () => {
-    it('includes PR number and title', () => {
+    it('includes PR number and title', async () => {
+      const mod = await loadModule();
       const prompt = mod.buildReviewPrompt(PR_DETAILS, '', {
         name: 'Code Reviewer',
         focus: 'quality',
@@ -110,7 +175,8 @@ describe('multi-agent-review', () => {
       expect(prompt).toContain('feat: add delegation toolchain');
     });
 
-    it('includes author and stats', () => {
+    it('includes author and stats', async () => {
+      const mod = await loadModule();
       const prompt = mod.buildReviewPrompt(PR_DETAILS, '', {
         name: 'QA', focus: 'coverage', description: 'QA review',
       }, 1);
@@ -119,22 +185,19 @@ describe('multi-agent-review', () => {
       expect(prompt).toContain('-30');
     });
 
-    it('includes changed files', () => {
-      const prompt = mod.buildReviewPrompt(PR_DETAILS, '', {
+    it('limits file list to 30', async () => {
+      const mod = await loadModule();
+      const manyFiles = Array.from({ length: 50 }, (_, i) => `src/file${i}.ts`);
+      const details = { ...PR_DETAILS, changedFiles: manyFiles };
+      const prompt = mod.buildReviewPrompt(details, '', {
         name: 'QA', focus: 'coverage', description: 'QA review',
       }, 1);
-      expect(prompt).toContain('src/index.ts');
-      expect(prompt).toContain('src/tools/index.ts');
+      const fileLines = prompt.split('\n').filter((line) => line.startsWith('src/file'));
+      expect(fileLines.length).toBe(30);
     });
 
-    it('includes diff content', () => {
-      const prompt = mod.buildReviewPrompt(PR_DETAILS, '--- diff ---', {
-        name: 'QA', focus: 'coverage', description: 'QA review',
-      }, 1);
-      expect(prompt).toContain('--- diff ---');
-    });
-
-    it('truncates long diffs with marker', () => {
+    it('truncates long diffs with marker', async () => {
+      const mod = await loadModule();
       const longDiff = 'a'.repeat(20000);
       const prompt = mod.buildReviewPrompt(PR_DETAILS, longDiff, {
         name: 'QA', focus: 'coverage', description: 'QA review',
@@ -142,41 +205,118 @@ describe('multi-agent-review', () => {
       expect(prompt).toContain('... (truncated)');
       expect(prompt.length).toBeLessThan(12000);
     });
+  });
 
-    it('limits file list to 30', () => {
-      const manyFiles = Array.from({ length: 50 }, (_, i) => `src/file${i}.ts`);
-      const details = { ...PR_DETAILS, changedFiles: manyFiles };
-      const prompt = mod.buildReviewPrompt(details, '', {
-        name: 'QA', focus: 'coverage', description: 'QA review',
-      }, 1);
-      const lines = prompt.split('\n');
-      const fileLines = lines.filter(l => l.startsWith('src/file'));
-      expect(fileLines.length).toBe(30);
+  describe('agent execution settings', () => {
+    it('uses longer timeout for architecture reviewer', async () => {
+      const mod = await loadModule();
+      expect(mod.getClaudeAgentTimeoutMs('architecture-reviewer')).toBe(300000);
+      expect(mod.getClaudeAgentTimeoutMs('qa-expert')).toBe(180000);
     });
 
-    it('includes agent role and focus areas', () => {
-      const prompt = mod.buildReviewPrompt(PR_DETAILS, '', {
-        name: 'Security Auditor',
-        focus: 'vulnerabilities',
-        description: 'Audits security',
-      }, 1);
-      expect(prompt).toContain('Security Auditor review');
-      expect(prompt).toContain('Audits security');
-      expect(prompt).toContain('vulnerabilities');
+    it('builds temp file paths with uuid suffixes', async () => {
+      const mod = await loadModule();
+      const path = mod.buildPromptTempFilePath('/tmp/test', 123, 456, 'uuid-123');
+      expect(path).toBe('/tmp/test/claude-agent-prompt-123-456-uuid-123.txt');
     });
 
-    it('requests Findings/Recommendations/Summary format', () => {
-      const prompt = mod.buildReviewPrompt(PR_DETAILS, '', {
-        name: 'QA', focus: 'coverage', description: 'QA review',
-      }, 1);
-      expect(prompt).toContain('**Findings:**');
-      expect(prompt).toContain('**Recommendations:**');
-      expect(prompt).toContain('**Summary:**');
+    it('runs claude with expanded buffer and cleans up prompt files', async () => {
+      process.env.TMPDIR = '/tmp/test-agent-review';
+      execAsyncMock.mockResolvedValue({
+        stdout: '**Findings:**\n- Missing limit\n\n**Recommendations:**\n- Add tests\n\n**Summary:**\nNeeds follow-up.',
+        stderr: '',
+      });
+
+      const mod = await loadModule();
+      const result = await mod.runClaudeAgent('architecture-reviewer', 'review this diff');
+
+      expect(result.findings).toEqual(['Missing limit']);
+      expect(result.recommendations).toEqual(['Add tests']);
+      expect(result.summary).toBe('Needs follow-up.');
+
+      const tmpFile = writeFileMock.mock.calls[0][0] as string;
+      expect(tmpFile).toContain('/tmp/test-agent-review/claude-agent-prompt-');
+      expect(tmpFile).toContain('uuid-123.txt');
+
+      expect(execAsyncMock).toHaveBeenCalledWith(
+        expect.stringContaining(`--system-prompt-file "${tmpFile}"`),
+        expect.objectContaining({
+          timeout: 300000,
+          maxBuffer: 10 * 1024 * 1024,
+        }),
+      );
+      expect(unlinkMock).toHaveBeenCalledWith(tmpFile);
+    });
+  });
+
+  describe('concurrency and persistence', () => {
+    it('limits concurrent agent execution to 2', async () => {
+      const mod = await loadModule();
+      let active = 0;
+      let maxActive = 0;
+
+      const settled = await mod.runAgentReviews(
+        ['a', 'b', 'c', 'd'],
+        async (agentType: string) => {
+          active += 1;
+          maxActive = Math.max(maxActive, active);
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          active -= 1;
+          return agentType;
+        },
+        2,
+      );
+
+      expect(maxActive).toBe(2);
+      expect(settled.every((result) => result.status === 'fulfilled')).toBe(true);
+    });
+
+    it('formats log entries as append-only sections', async () => {
+      const mod = await loadModule();
+      const entry = mod.formatReviewLogEntry(REVIEW_RESULT, '2026-05-11T10:00:00.000Z');
+      expect(entry).toContain('## PR #42');
+      expect(entry).toContain('Recommendation: **REQUEST_CHANGES**');
+      expect(entry).toContain('### OK Code Reviewer');
+    });
+
+    it('creates log header once and appends new entries', async () => {
+      accessMock.mockRejectedValueOnce(new Error('missing'));
+
+      const mod = await loadModule();
+      const logPath = await mod.persistReviewLog(REVIEW_RESULT, '/repo');
+
+      expect(logPath).toBe('/repo/tasks/global-review-log.md');
+      expect(mkdirMock).toHaveBeenCalledWith('/repo/tasks', { recursive: true });
+      expect(appendFileMock).toHaveBeenNthCalledWith(
+        1,
+        '/repo/tasks/global-review-log.md',
+        expect.stringContaining('# Global Review Log'),
+        'utf-8',
+      );
+      expect(appendFileMock).toHaveBeenNthCalledWith(
+        2,
+        '/repo/tasks/global-review-log.md',
+        expect.stringContaining('## PR #42'),
+        'utf-8',
+      );
+    });
+
+    it('appends without rewriting when the log already exists', async () => {
+      const mod = await loadModule();
+      await mod.persistReviewLog(REVIEW_RESULT, '/repo');
+
+      expect(appendFileMock).toHaveBeenCalledTimes(1);
+      expect(appendFileMock).toHaveBeenCalledWith(
+        '/repo/tasks/global-review-log.md',
+        expect.stringContaining('## PR #42'),
+        'utf-8',
+      );
     });
   });
 
   describe('AGENT_ROLES', () => {
-    it('defines all 5 agent types', () => {
+    it('defines all 5 agent types', async () => {
+      const mod = await loadModule();
       const roles = mod.AGENT_ROLES as Record<string, any>;
       expect(Object.keys(roles)).toHaveLength(5);
       expect(roles['code-reviewer']).toBeDefined();
@@ -184,16 +324,6 @@ describe('multi-agent-review', () => {
       expect(roles['qa-expert']).toBeDefined();
       expect(roles['architecture-reviewer']).toBeDefined();
       expect(roles['performance-engineer']).toBeDefined();
-    });
-
-    it('each role has name, focus, description, agent_type', () => {
-      const roles = mod.AGENT_ROLES as Record<string, any>;
-      for (const [key, role] of Object.entries(roles)) {
-        expect(role.name).toBeTruthy();
-        expect(role.focus).toBeTruthy();
-        expect(role.description).toBeTruthy();
-        expect(role.agent_type).toBe(key);
-      }
     });
   });
 });

--- a/mcp-server/src/tools/multi-agent-review.ts
+++ b/mcp-server/src/tools/multi-agent-review.ts
@@ -18,15 +18,50 @@ function sanitize(value: string): string {
     .substring(0, 500);
 }
 
-function buildReviewSummaryRow(
+function escapeHtml(value: string): string {
+  return sanitize(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function buildReviewLogRow(
   result: MultiAgentReviewResult,
   now: string,
 ): string {
   const agentNames = result.reviews.map((r) => sanitize(r.agent_name)).join(', ');
   const findingCount = result.reviews.reduce((sum, r) => sum + r.findings.length, 0);
   const date = now.split('T')[0];
+  const detailSections = result.reviews.map((review) => {
+    const findings = review.findings.length > 0
+      ? `<ul>${review.findings.map((finding) => `<li>${escapeHtml(finding)}</li>`).join('')}</ul>`
+      : '<p><em>none</em></p>';
+    const recommendations = review.recommendations.length > 0
+      ? `<ul>${review.recommendations.map((recommendation) => `<li>${escapeHtml(recommendation)}</li>`).join('')}</ul>`
+      : '<p><em>none</em></p>';
+    const status = review.status === 'ok' ? 'OK' : 'ERROR';
 
-  return `| [#${result.pr_number}](https://github.com/madlouse/AgenticOS/pull/${result.pr_number}) | ${agentNames} | **${result.overall_recommendation}** | ${findingCount} | ${date} |\n`;
+    return [
+      `<section><strong>${status} ${escapeHtml(review.agent_name)}</strong></section>`,
+      `<p>${escapeHtml(review.summary)}</p>`,
+      `<p><strong>Findings (${review.findings.length}):</strong></p>`,
+      findings,
+      `<p><strong>Recommendations (${review.recommendations.length}):</strong></p>`,
+      recommendations,
+    ].join('');
+  }).join('<hr />');
+
+  return [
+    '<tr>',
+    `<td><a href="https://github.com/madlouse/AgenticOS/pull/${result.pr_number}">#${result.pr_number}</a><details><summary>Details</summary>${detailSections}</details></td>`,
+    `<td>${escapeHtml(agentNames)}</td>`,
+    `<td><strong>${escapeHtml(result.overall_recommendation)}</strong></td>`,
+    `<td>${findingCount}</td>`,
+    `<td>${date}</td>`,
+    '</tr>\n',
+  ].join('');
 }
 
 function shellQuote(value: string): string {
@@ -297,56 +332,15 @@ export function aggregateResults(reviews: AgentReviewResult[]): {
   return { summary, recommendation };
 }
 
-function formatReviewLogEntry(
-  result: MultiAgentReviewResult,
-  now: string,
-): string {
-  const agentNames = result.reviews.map((r) => sanitize(r.agent_name)).join(', ');
-  const findingCount = result.reviews.reduce((sum, r) => sum + r.findings.length, 0);
-  const date = now.split('T')[0];
-
-  return [
-    '',
-    '---',
-    `## PR #${result.pr_number} — ${now}`,
-    '',
-    `- Agents: ${agentNames}`,
-    `- Recommendation: **${result.overall_recommendation}**`,
-    `- Findings: ${findingCount}`,
-    `- Date: ${date}`,
-    `- Duration: ${result.reviews.reduce((s, r) => s + r.duration_ms, 0)}ms`,
-    '',
-    ...result.reviews.map((r) => {
-      const status = r.status === 'ok' ? 'OK' : 'ERROR';
-      return [
-        `### ${status} ${sanitize(r.agent_name)}`,
-        '',
-        `**Summary:** ${sanitize(r.summary)}`,
-        '',
-        `**Findings (${r.findings.length}):**`,
-        ...(r.findings.length > 0 ? r.findings.map((f) => `- ${sanitize(f)}`) : ['_none_']),
-        '',
-        `**Recommendations (${r.recommendations.length}):**`,
-        ...(r.recommendations.length > 0 ? r.recommendations.map((r2) => `- ${sanitize(r2)}`) : ['_none_']),
-        '',
-      ].join('\n');
-    }),
-  ].join('\n');
-}
-
 export async function persistReviewLog(
   result: MultiAgentReviewResult,
   repoPath: string,
 ): Promise<string> {
   const safeBase = resolve(repoPath);
   const reviewLogPath = resolve(safeBase, 'tasks/global-review-log.md');
-  const reviewDetailsPath = resolve(safeBase, 'tasks/global-review-log.details.md');
   // Guard: resolved path must stay within the repo directory
   if (!reviewLogPath.startsWith(safeBase + '/')) {
     throw new Error('Review log path escaped repository directory');
-  }
-  if (!reviewDetailsPath.startsWith(safeBase + '/')) {
-    throw new Error('Review detail log path escaped repository directory');
   }
   const now = new Date().toISOString();
   await mkdir(resolve(safeBase, 'tasks'), { recursive: true });
@@ -357,8 +351,9 @@ export async function persistReviewLog(
       [
         '# Global Review Log',
         '',
-        '| PR | Agents | Recommendation | Findings | Date |',
-        '|---|---|---|---|---|',
+        '<table>',
+        '<thead><tr><th>PR</th><th>Agents</th><th>Recommendation</th><th>Findings</th><th>Date</th></tr></thead>',
+        '<tbody>',
         '',
       ].join('\n'),
       { encoding: 'utf-8', flag: 'wx' },
@@ -370,26 +365,7 @@ export async function persistReviewLog(
     }
   }
 
-  try {
-    await writeFile(
-      reviewDetailsPath,
-      [
-        '# Global Review Log Details',
-        '',
-        'Detailed review entries are appended chronologically.',
-        '',
-      ].join('\n'),
-      { encoding: 'utf-8', flag: 'wx' },
-    );
-  } catch (err) {
-    const code = typeof err === 'object' && err && 'code' in err ? err.code : undefined;
-    if (code !== 'EEXIST') {
-      throw err;
-    }
-  }
-
-  await appendFile(reviewLogPath, buildReviewSummaryRow(result, now), 'utf-8');
-  await appendFile(reviewDetailsPath, formatReviewLogEntry(result, now), 'utf-8');
+  await appendFile(reviewLogPath, buildReviewLogRow(result, now), 'utf-8');
   return reviewLogPath;
 }
 

--- a/mcp-server/src/tools/multi-agent-review.ts
+++ b/mcp-server/src/tools/multi-agent-review.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'crypto';
 import { exec } from 'child_process';
-import { appendFile, mkdir, unlink, writeFile } from 'fs/promises';
+import { appendFile, lstat, mkdir, unlink, writeFile } from 'fs/promises';
 import { resolve } from 'path';
 import { promisify } from 'util';
 import pLimit from 'p-limit';
@@ -66,6 +66,21 @@ function buildReviewLogRow(
 
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+async function assertNotSymlink(path: string): Promise<void> {
+  try {
+    const stat = await lstat(path);
+    if (stat.isSymbolicLink()) {
+      throw new Error(`Refusing to write review log through symlinked path: ${path}`);
+    }
+  } catch (err) {
+    const code = typeof err === 'object' && err && 'code' in err ? err.code : undefined;
+    if (code === 'ENOENT') {
+      return;
+    }
+    throw err;
+  }
 }
 
 // Agent role definitions for multi-agent review
@@ -343,7 +358,10 @@ export async function persistReviewLog(
     throw new Error('Review log path escaped repository directory');
   }
   const now = new Date().toISOString();
-  await mkdir(resolve(safeBase, 'tasks'), { recursive: true });
+  const tasksDir = resolve(safeBase, 'tasks');
+  await mkdir(tasksDir, { recursive: true });
+  await assertNotSymlink(tasksDir);
+  await assertNotSymlink(reviewLogPath);
 
   try {
     await writeFile(

--- a/mcp-server/src/tools/multi-agent-review.ts
+++ b/mcp-server/src/tools/multi-agent-review.ts
@@ -1,9 +1,15 @@
+import { randomUUID } from 'crypto';
 import { exec } from 'child_process';
-import { readFile, writeFile } from 'fs/promises';
+import { access, appendFile, mkdir, unlink, writeFile } from 'fs/promises';
 import { resolve } from 'path';
 import { promisify } from 'util';
+import pLimit from 'p-limit';
 
 const execAsync = promisify(exec);
+export const AGENT_REVIEW_CONCURRENCY = 2;
+export const CLAUDE_MAX_BUFFER_BYTES = 10 * 1024 * 1024;
+const DEFAULT_AGENT_TIMEOUT_MS = 180000;
+const ARCHITECTURE_AGENT_TIMEOUT_MS = 300000;
 
 function sanitize(value: string): string {
   return value.replace(/[`*_~[\]()#>]/g, '?').substring(0, 500);
@@ -75,6 +81,16 @@ interface MultiAgentReviewResult {
 export function mapToClaudeAgentType(agent: string): string {
   const known = ['code-reviewer', 'security-auditor', 'qa-expert', 'architecture-reviewer', 'performance-engineer'];
   return known.includes(agent) ? agent : 'code-reviewer';
+}
+
+export function getClaudeAgentTimeoutMs(agentType: string): number {
+  return agentType === 'architecture-reviewer'
+    ? ARCHITECTURE_AGENT_TIMEOUT_MS
+    : DEFAULT_AGENT_TIMEOUT_MS;
+}
+
+export function buildPromptTempFilePath(tmpDir: string, pid: number, timestamp: number, uuid: string): string {
+  return `${tmpDir}/claude-agent-prompt-${pid}-${timestamp}-${uuid}.txt`;
 }
 
 async function runGh(repoPath: string, args: string): Promise<string> {
@@ -161,12 +177,12 @@ Format your response exactly as:
 (2-3 sentence assessment)`;
 }
 
-async function runClaudeAgent(
+export async function runClaudeAgent(
   agentType: string,
   prompt: string,
 ): Promise<{ findings: string[]; recommendations: string[]; summary: string }> {
   const tmpDir = process.env.TEMP_DIR || process.env.TMPDIR || '/tmp';
-  const tmpFile = `${tmpDir}/claude-agent-prompt-${process.pid}-${Date.now()}.txt`;
+  const tmpFile = buildPromptTempFilePath(tmpDir, process.pid, Date.now(), randomUUID());
 
   try {
     const agentFlag = mapToClaudeAgentType(agentType);
@@ -178,7 +194,7 @@ async function runClaudeAgent(
     // Redirect stdin from /dev/null to prevent 'no stdin data received' warning
     const { stdout } = await execAsync(
       `command claude --print --agent ${agentFlag} --system-prompt-file "${tmpFile}" . --dangerously-skip-permissions < /dev/null`,
-      { timeout: 120000, maxBuffer: 1024 * 1024 * 2 },
+      { timeout: getClaudeAgentTimeoutMs(agentType), maxBuffer: CLAUDE_MAX_BUFFER_BYTES },
     );
 
     const result = stdout.trim();
@@ -221,7 +237,6 @@ async function runClaudeAgent(
     };
   } finally {
     // Always clean up temp file
-    const { unlink } = await import('fs/promises');
     await unlink(tmpFile).catch(() => {/* ignore */});
   }
 }
@@ -264,51 +279,27 @@ export function aggregateResults(reviews: AgentReviewResult[]): {
   return { summary, recommendation };
 }
 
-async function persistReviewLog(
+export function formatReviewLogEntry(
   result: MultiAgentReviewResult,
-  repoPath: string,
-): Promise<string> {
-  const safeBase = resolve(repoPath);
-  const reviewLogPath = resolve(safeBase, 'tasks/global-review-log.md');
-  // Guard: resolved path must stay within the repo directory
-  if (!reviewLogPath.startsWith(safeBase + '/')) {
-    throw new Error('Review log path escaped repository directory');
-  }
-  const now = new Date().toISOString();
-
-  let existing: string[] = [];
-  try {
-    const content = await readFile(reviewLogPath, 'utf-8');
-    existing = content.split('\n');
-  } catch {
-    existing = [
-      '# Global Review Log',
-      '',
-      '| PR | Agents | Recommendation | Findings | Date |',
-      '|---|---|---|---|---|',
-    ];
-  }
-
+  now: string,
+): string {
   const agentNames = result.reviews.map((r) => sanitize(r.agent_name)).join(', ');
   const findingCount = result.reviews.reduce((sum, r) => sum + r.findings.length, 0);
   const date = now.split('T')[0];
 
-  const tableRow = `| [#${result.pr_number}](https://github.com/madlouse/AgenticOS/pull/${result.pr_number}) | ${agentNames} | **${result.overall_recommendation}** | ${findingCount} | ${date} |`;
-
-  const lastSepIdx = existing.lastIndexOf('|---|');
-  if (lastSepIdx !== -1) {
-    existing.splice(lastSepIdx + 1, 0, tableRow);
-  }
-
-  const newSection = [
+  return [
     '',
     '---',
     `## PR #${result.pr_number} — ${now}`,
     '',
-    `**Agents:** ${agentNames} | **Overall:** ${result.overall_recommendation} | **Duration:** ${result.reviews.reduce((s, r) => s + r.duration_ms, 0)}ms`,
+    `- Agents: ${agentNames}`,
+    `- Recommendation: **${result.overall_recommendation}**`,
+    `- Findings: ${findingCount}`,
+    `- Date: ${date}`,
+    `- Duration: ${result.reviews.reduce((s, r) => s + r.duration_ms, 0)}ms`,
     '',
     ...result.reviews.map((r) => {
-      const status = r.status === 'ok' ? '✅' : '❌';
+      const status = r.status === 'ok' ? 'OK' : 'ERROR';
       return [
         `### ${status} ${sanitize(r.agent_name)}`,
         '',
@@ -323,14 +314,47 @@ async function persistReviewLog(
       ].join('\n');
     }),
   ].join('\n');
+}
 
-  const insertIdx = existing.indexOf('| PR | Agents | Recommendation | Findings | Date |');
-  if (insertIdx !== -1) {
-    existing.splice(insertIdx + 5, 0, newSection.trim());
+export async function persistReviewLog(
+  result: MultiAgentReviewResult,
+  repoPath: string,
+): Promise<string> {
+  const safeBase = resolve(repoPath);
+  const reviewLogPath = resolve(safeBase, 'tasks/global-review-log.md');
+  // Guard: resolved path must stay within the repo directory
+  if (!reviewLogPath.startsWith(safeBase + '/')) {
+    throw new Error('Review log path escaped repository directory');
+  }
+  const now = new Date().toISOString();
+  await mkdir(resolve(safeBase, 'tasks'), { recursive: true });
+
+  try {
+    await access(reviewLogPath);
+  } catch {
+    await appendFile(
+      reviewLogPath,
+      [
+        '# Global Review Log',
+        '',
+        'Review entries are appended chronologically to avoid O(N) rewrites as the log grows.',
+        '',
+      ].join('\n'),
+      'utf-8',
+    );
   }
 
-  await writeFile(reviewLogPath, existing.join('\n'), 'utf-8');
+  await appendFile(reviewLogPath, formatReviewLogEntry(result, now), 'utf-8');
   return reviewLogPath;
+}
+
+export async function runAgentReviews<T>(
+  agentTypes: string[],
+  runner: (agentType: string) => Promise<T>,
+  concurrency = AGENT_REVIEW_CONCURRENCY,
+): Promise<PromiseSettledResult<T>[]> {
+  const limit = pLimit(concurrency);
+  return Promise.allSettled(agentTypes.map((agentType) => limit(() => runner(agentType))));
 }
 
 export async function runMultiAgentReview(args: MultiAgentReviewArgs): Promise<string> {
@@ -357,7 +381,7 @@ export async function runMultiAgentReview(args: MultiAgentReviewArgs): Promise<s
     const prDetails = await getPrDetails(repo_path, pr_number);
     const diff = await getFileDiff(repo_path, pr_number);
 
-    const reviewPromises = validAgents.map(async (agentType) => {
+    const settled = await runAgentReviews(validAgents, async (agentType) => {
       const agentRole = AGENT_ROLES[agentType];
       const agentStart = Date.now();
       const prompt = buildReviewPrompt(prDetails, diff, agentRole, pr_number);
@@ -374,8 +398,6 @@ export async function runMultiAgentReview(args: MultiAgentReviewArgs): Promise<s
         duration_ms: Date.now() - agentStart,
       } satisfies AgentReviewResult;
     });
-
-    const settled = await Promise.allSettled(reviewPromises);
 
     const reviews: AgentReviewResult[] = [];
     for (const outcome of settled) {

--- a/mcp-server/src/tools/multi-agent-review.ts
+++ b/mcp-server/src/tools/multi-agent-review.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'crypto';
 import { exec } from 'child_process';
-import { access, appendFile, mkdir, unlink, writeFile } from 'fs/promises';
+import { appendFile, mkdir, unlink, writeFile } from 'fs/promises';
 import { resolve } from 'path';
 import { promisify } from 'util';
 import pLimit from 'p-limit';
@@ -12,7 +12,14 @@ const DEFAULT_AGENT_TIMEOUT_MS = 180000;
 const ARCHITECTURE_AGENT_TIMEOUT_MS = 300000;
 
 function sanitize(value: string): string {
-  return value.replace(/[`*_~[\]()#>]/g, '?').substring(0, 500);
+  return value
+    .replace(/[\r\n]+/g, ' ')
+    .replace(/[`*_~[\]()#>]/g, '?')
+    .substring(0, 500);
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
 // Agent role definitions for multi-agent review
@@ -83,13 +90,13 @@ export function mapToClaudeAgentType(agent: string): string {
   return known.includes(agent) ? agent : 'code-reviewer';
 }
 
-export function getClaudeAgentTimeoutMs(agentType: string): number {
+function getClaudeAgentTimeoutMs(agentType: string): number {
   return agentType === 'architecture-reviewer'
     ? ARCHITECTURE_AGENT_TIMEOUT_MS
     : DEFAULT_AGENT_TIMEOUT_MS;
 }
 
-export function buildPromptTempFilePath(tmpDir: string, pid: number, timestamp: number, uuid: string): string {
+function buildPromptTempFilePath(tmpDir: string, pid: number, timestamp: number, uuid: string): string {
   return `${tmpDir}/claude-agent-prompt-${pid}-${timestamp}-${uuid}.txt`;
 }
 
@@ -193,7 +200,7 @@ export async function runClaudeAgent(
     // execFile doesn't invoke a shell, so 'command' builtin isn't available — use execAsync instead
     // Redirect stdin from /dev/null to prevent 'no stdin data received' warning
     const { stdout } = await execAsync(
-      `command claude --print --agent ${agentFlag} --system-prompt-file "${tmpFile}" . --dangerously-skip-permissions < /dev/null`,
+      `command claude --print --agent ${agentFlag} --system-prompt-file ${shellQuote(tmpFile)} . --dangerously-skip-permissions < /dev/null`,
       { timeout: getClaudeAgentTimeoutMs(agentType), maxBuffer: CLAUDE_MAX_BUFFER_BYTES },
     );
 
@@ -279,7 +286,7 @@ export function aggregateResults(reviews: AgentReviewResult[]): {
   return { summary, recommendation };
 }
 
-export function formatReviewLogEntry(
+function formatReviewLogEntry(
   result: MultiAgentReviewResult,
   now: string,
 ): string {
@@ -330,9 +337,7 @@ export async function persistReviewLog(
   await mkdir(resolve(safeBase, 'tasks'), { recursive: true });
 
   try {
-    await access(reviewLogPath);
-  } catch {
-    await appendFile(
+    await writeFile(
       reviewLogPath,
       [
         '# Global Review Log',
@@ -340,8 +345,13 @@ export async function persistReviewLog(
         'Review entries are appended chronologically to avoid O(N) rewrites as the log grows.',
         '',
       ].join('\n'),
-      'utf-8',
+      { encoding: 'utf-8', flag: 'wx' },
     );
+  } catch (err) {
+    const code = typeof err === 'object' && err && 'code' in err ? err.code : undefined;
+    if (code !== 'EEXIST') {
+      throw err;
+    }
   }
 
   await appendFile(reviewLogPath, formatReviewLogEntry(result, now), 'utf-8');

--- a/mcp-server/src/tools/multi-agent-review.ts
+++ b/mcp-server/src/tools/multi-agent-review.ts
@@ -18,6 +18,17 @@ function sanitize(value: string): string {
     .substring(0, 500);
 }
 
+function buildReviewSummaryRow(
+  result: MultiAgentReviewResult,
+  now: string,
+): string {
+  const agentNames = result.reviews.map((r) => sanitize(r.agent_name)).join(', ');
+  const findingCount = result.reviews.reduce((sum, r) => sum + r.findings.length, 0);
+  const date = now.split('T')[0];
+
+  return `| [#${result.pr_number}](https://github.com/madlouse/AgenticOS/pull/${result.pr_number}) | ${agentNames} | **${result.overall_recommendation}** | ${findingCount} | ${date} |\n`;
+}
+
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
@@ -329,9 +340,13 @@ export async function persistReviewLog(
 ): Promise<string> {
   const safeBase = resolve(repoPath);
   const reviewLogPath = resolve(safeBase, 'tasks/global-review-log.md');
+  const reviewDetailsPath = resolve(safeBase, 'tasks/global-review-log.details.md');
   // Guard: resolved path must stay within the repo directory
   if (!reviewLogPath.startsWith(safeBase + '/')) {
     throw new Error('Review log path escaped repository directory');
+  }
+  if (!reviewDetailsPath.startsWith(safeBase + '/')) {
+    throw new Error('Review detail log path escaped repository directory');
   }
   const now = new Date().toISOString();
   await mkdir(resolve(safeBase, 'tasks'), { recursive: true });
@@ -342,7 +357,8 @@ export async function persistReviewLog(
       [
         '# Global Review Log',
         '',
-        'Review entries are appended chronologically to avoid O(N) rewrites as the log grows.',
+        '| PR | Agents | Recommendation | Findings | Date |',
+        '|---|---|---|---|---|',
         '',
       ].join('\n'),
       { encoding: 'utf-8', flag: 'wx' },
@@ -354,7 +370,26 @@ export async function persistReviewLog(
     }
   }
 
-  await appendFile(reviewLogPath, formatReviewLogEntry(result, now), 'utf-8');
+  try {
+    await writeFile(
+      reviewDetailsPath,
+      [
+        '# Global Review Log Details',
+        '',
+        'Detailed review entries are appended chronologically.',
+        '',
+      ].join('\n'),
+      { encoding: 'utf-8', flag: 'wx' },
+    );
+  } catch (err) {
+    const code = typeof err === 'object' && err && 'code' in err ? err.code : undefined;
+    if (code !== 'EEXIST') {
+      throw err;
+    }
+  }
+
+  await appendFile(reviewLogPath, buildReviewSummaryRow(result, now), 'utf-8');
+  await appendFile(reviewDetailsPath, formatReviewLogEntry(result, now), 'utf-8');
   return reviewLogPath;
 }
 


### PR DESCRIPTION
## Summary
- bound multi-agent review execution with `p-limit` at concurrency 2
- raise Claude review limits with 10MB buffers, UUID temp prompt files, and longer reviewer timeouts
- switch review log persistence to append-only writes and add focused regression tests

## Testing
- `cd mcp-server && npm ci`
- `cd mcp-server && npm run lint`
- `cd mcp-server && npm test`

Closes #351.
