### PR TITLE
fix: migrate legacy review logs

### DIFF
--- a/.meta/templates/global-review-log.md
+++ b/.meta/templates/global-review-log.md
@@ -1,52 +1,8 @@
 # <!-- agenticos-template: v1 -->
 # Global Review Log
 
-## Purpose
+<!-- agenticos:global-review-log:v2 -->
 
-Use this file as the stable cumulative log for multi-step work that should later be reviewed as one sequence.
-
-Typical triggers:
-
-- mechanism passes
-- cleanup waves
-- migrations
-- broad review-driven change sets
-
-## Review Standard
-
-For each landed step, capture:
-
-- intent
-- changed surfaces
-- verification
-- residual risk
-
-Later, use this one file as the basis for whole-pass review.
-
----
-
-## Step N
-
-**Title**:
-
-**Status**:
-
-**Intent**:
-
-- 
-
-**Mechanism**:
-
-- 
-
-**Primary implementation surfaces**:
-
-- 
-
-**Verification**:
-
-- 
-
-**Residual risk / follow-up**:
-
-- 
+<table>
+<thead><tr><th>PR</th><th>Agents</th><th>Recommendation</th><th>Findings</th><th>Date</th></tr></thead>
+<tbody>

--- a/mcp-server/src/tools/__tests__/multi-agent-review.test.ts
+++ b/mcp-server/src/tools/__tests__/multi-agent-review.test.ts
@@ -399,14 +399,10 @@ describe('multi-agent-review', () => {
       expect(migratedContent).toContain('javascript:alert?1?');
     });
 
-    it('removes stale migration locks before retrying migration', async () => {
+    it('times out instead of deleting a contended migration lock', async () => {
       writeFileMock
         .mockRejectedValueOnce(Object.assign(new Error('exists'), { code: 'EEXIST' }))
-        .mockRejectedValueOnce(Object.assign(new Error('locked'), { code: 'EEXIST' }));
-      lstatMock
-        .mockResolvedValueOnce({ isSymbolicLink: () => false })
-        .mockResolvedValueOnce({ isSymbolicLink: () => false })
-        .mockResolvedValueOnce({ isSymbolicLink: () => false, mtimeMs: Date.now() - 20 * 60 * 1000 });
+        .mockRejectedValue(Object.assign(new Error('locked'), { code: 'EEXIST' }));
       openFileMock.mockImplementation(async () => ({
         read: async (buffer: Buffer) => {
           const content = '# Global Review Log\n\n| PR | Agents | Recommendation | Findings | Date |\n';
@@ -418,13 +414,10 @@ describe('multi-agent-review', () => {
       readFileMock.mockResolvedValueOnce('# Global Review Log\n');
 
       const mod = await loadModule();
-      await mod.persistReviewLog(REVIEW_RESULT, '/repo');
+      await expect(mod.persistReviewLog(REVIEW_RESULT, '/repo')).rejects.toThrow('Timed out waiting for review log migration lock');
 
-      expect(unlinkMock).toHaveBeenCalledWith('/repo/tasks/global-review-log.md.migration.lock');
-      expect(renameMock).toHaveBeenCalledWith(
-        expect.stringContaining('/repo/tasks/global-review-log.md.migration.'),
-        '/repo/tasks/global-review-log.md',
-      );
+      expect(unlinkMock).not.toHaveBeenCalledWith('/repo/tasks/global-review-log.md.migration.lock');
+      expect(renameMock).not.toHaveBeenCalled();
     });
 
     it('does not treat arbitrary embedded tables as canonical review logs', async () => {

--- a/mcp-server/src/tools/__tests__/multi-agent-review.test.ts
+++ b/mcp-server/src/tools/__tests__/multi-agent-review.test.ts
@@ -428,6 +428,38 @@ describe('multi-agent-review', () => {
       expect(renameMock).not.toHaveBeenCalled();
     });
 
+    it('appends after a concurrent migration finishes while waiting on the lock', async () => {
+      vi.useFakeTimers();
+      writeFileMock
+        .mockRejectedValueOnce(Object.assign(new Error('exists'), { code: 'EEXIST' }))
+        .mockRejectedValueOnce(Object.assign(new Error('locked'), { code: 'EEXIST' }));
+      let prefixReadCount = 0;
+      openFileMock.mockImplementation(async () => ({
+        read: async (buffer: Buffer) => {
+          prefixReadCount += 1;
+          const content = prefixReadCount === 1
+            ? '# Global Review Log\n\n| PR | Agents | Recommendation | Findings | Date |\n'
+            : '# Global Review Log\n\n<!-- agenticos:global-review-log:v2 -->\n\n<table>\n<tbody>\n';
+          buffer.write(content);
+          return { bytesRead: Buffer.byteLength(content) };
+        },
+        close: async () => undefined,
+      }));
+
+      const mod = await loadModule();
+      const persistPromise = mod.persistReviewLog(REVIEW_RESULT, '/repo');
+      try {
+        await vi.advanceTimersByTimeAsync(100);
+        await expect(persistPromise).resolves.toBe('/repo/tasks/global-review-log.md');
+      } finally {
+        vi.useRealTimers();
+      }
+
+      expect(readFileMock).not.toHaveBeenCalled();
+      expect(renameMock).not.toHaveBeenCalled();
+      expect(appendFileMock).toHaveBeenCalledTimes(1);
+    });
+
     it('does not treat arbitrary embedded tables as canonical review logs', async () => {
       writeFileMock.mockRejectedValueOnce(Object.assign(new Error('exists'), { code: 'EEXIST' }));
       openFileMock.mockImplementation(async () => ({

--- a/mcp-server/src/tools/__tests__/multi-agent-review.test.ts
+++ b/mcp-server/src/tools/__tests__/multi-agent-review.test.ts
@@ -10,7 +10,9 @@ Object.defineProperty(execMock, promisify.custom, {
 const appendFileMock = vi.fn();
 const lstatMock = vi.fn();
 const mkdirMock = vi.fn();
+const openFileMock = vi.fn();
 const readFileMock = vi.fn();
+const renameMock = vi.fn();
 const unlinkMock = vi.fn();
 const writeFileMock = vi.fn();
 const randomUUIDMock = vi.fn();
@@ -27,7 +29,9 @@ vi.mock('fs/promises', async () => ({
   appendFile: appendFileMock,
   lstat: lstatMock,
   mkdir: mkdirMock,
+  open: openFileMock,
   readFile: readFileMock,
+  rename: renameMock,
   unlink: unlinkMock,
   writeFile: writeFileMock,
 }));
@@ -82,8 +86,21 @@ describe('multi-agent-review', () => {
     mkdirMock.mockReset();
     mkdirMock.mockResolvedValue(undefined);
 
+    openFileMock.mockReset();
+    openFileMock.mockImplementation(async () => ({
+      read: async (buffer: Buffer) => {
+        const content = '# Global Review Log\n\n<!-- agenticos:global-review-log:v2 -->\n\n<table>\n<tbody>\n';
+        buffer.write(content);
+        return { bytesRead: Buffer.byteLength(content) };
+      },
+      close: async () => undefined,
+    }));
+
     readFileMock.mockReset();
     readFileMock.mockResolvedValue('# Global Review Log\n\n<table>\n<tbody>\n');
+
+    renameMock.mockReset();
+    renameMock.mockResolvedValue(undefined);
 
     unlinkMock.mockReset();
     unlinkMock.mockResolvedValue(undefined);
@@ -314,12 +331,21 @@ describe('multi-agent-review', () => {
 
       const mod = await loadModule();
       await expect(mod.persistReviewLog(REVIEW_RESULT, '/repo')).resolves.toBe('/repo/tasks/global-review-log.md');
-      expect(readFileMock).toHaveBeenCalledWith('/repo/tasks/global-review-log.md', 'utf-8');
+      expect(readFileMock).not.toHaveBeenCalled();
       expect(appendFileMock).toHaveBeenCalledTimes(1);
+      expect(writeFileMock).toHaveBeenCalledTimes(1);
     });
 
     it('migrates legacy markdown review logs before appending new rows', async () => {
       writeFileMock.mockRejectedValueOnce(Object.assign(new Error('exists'), { code: 'EEXIST' }));
+      openFileMock.mockImplementation(async () => ({
+        read: async (buffer: Buffer) => {
+          const content = '# Global Review Log\n\n| PR | Agents | Recommendation | Findings | Date |\n';
+          buffer.write(content);
+          return { bytesRead: Buffer.byteLength(content) };
+        },
+        close: async () => undefined,
+      }));
       readFileMock.mockResolvedValueOnce([
         '# Global Review Log',
         '',
@@ -333,13 +359,45 @@ describe('multi-agent-review', () => {
 
       expect(writeFileMock).toHaveBeenNthCalledWith(
         2,
-        '/repo/tasks/global-review-log.md',
+        '/repo/tasks/global-review-log.md.migration.lock',
+        expect.any(String),
+        expect.objectContaining({ flag: 'wx' }),
+      );
+      expect(writeFileMock).toHaveBeenNthCalledWith(
+        3,
+        expect.stringContaining('/repo/tasks/global-review-log.md.migration.'),
         expect.stringContaining('Legacy markdown review log content preserved during one-time migration.'),
         'utf-8',
       );
-      expect(writeFileMock.mock.calls[1][1]).toContain('<tbody>');
-      expect(writeFileMock.mock.calls[1][1]).toContain('| [#1](https://github.com/madlouse/AgenticOS/pull/1) | Old Agent |');
+      expect(writeFileMock.mock.calls[2][1]).toContain('<!-- agenticos:global-review-log:v2 -->');
+      expect(writeFileMock.mock.calls[2][1]).toContain('<a href="https://github.com/madlouse/AgenticOS/pull/1">#1</a>');
+      expect(writeFileMock.mock.calls[2][1]).toContain('| [#1](https://github.com/madlouse/AgenticOS/pull/1) | Old Agent |');
+      expect(renameMock).toHaveBeenCalledWith(
+        expect.stringContaining('/repo/tasks/global-review-log.md.migration.'),
+        '/repo/tasks/global-review-log.md',
+      );
       expect(appendFileMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not treat arbitrary embedded tables as canonical review logs', async () => {
+      writeFileMock.mockRejectedValueOnce(Object.assign(new Error('exists'), { code: 'EEXIST' }));
+      openFileMock.mockImplementation(async () => ({
+        read: async (buffer: Buffer) => {
+          const content = '# Notes\n\n<table><tbody><tr><td>not the review schema</td></tr></tbody></table>\n';
+          buffer.write(content);
+          return { bytesRead: Buffer.byteLength(content) };
+        },
+        close: async () => undefined,
+      }));
+      readFileMock.mockResolvedValueOnce('# Notes\n\n<table><tbody><tr><td>not the review schema</td></tr></tbody></table>\n');
+
+      const mod = await loadModule();
+      await mod.persistReviewLog(REVIEW_RESULT, '/repo');
+
+      expect(renameMock).toHaveBeenCalledWith(
+        expect.stringContaining('/repo/tasks/global-review-log.md.migration.'),
+        '/repo/tasks/global-review-log.md',
+      );
     });
 
     it('refuses to write through symlinked log surfaces', async () => {

--- a/mcp-server/src/tools/__tests__/multi-agent-review.test.ts
+++ b/mcp-server/src/tools/__tests__/multi-agent-review.test.ts
@@ -10,6 +10,7 @@ Object.defineProperty(execMock, promisify.custom, {
 const appendFileMock = vi.fn();
 const lstatMock = vi.fn();
 const mkdirMock = vi.fn();
+const readFileMock = vi.fn();
 const unlinkMock = vi.fn();
 const writeFileMock = vi.fn();
 const randomUUIDMock = vi.fn();
@@ -26,6 +27,7 @@ vi.mock('fs/promises', async () => ({
   appendFile: appendFileMock,
   lstat: lstatMock,
   mkdir: mkdirMock,
+  readFile: readFileMock,
   unlink: unlinkMock,
   writeFile: writeFileMock,
 }));
@@ -79,6 +81,9 @@ describe('multi-agent-review', () => {
 
     mkdirMock.mockReset();
     mkdirMock.mockResolvedValue(undefined);
+
+    readFileMock.mockReset();
+    readFileMock.mockResolvedValue('# Global Review Log\n\n<table>\n<tbody>\n');
 
     unlinkMock.mockReset();
     unlinkMock.mockResolvedValue(undefined);
@@ -309,6 +314,31 @@ describe('multi-agent-review', () => {
 
       const mod = await loadModule();
       await expect(mod.persistReviewLog(REVIEW_RESULT, '/repo')).resolves.toBe('/repo/tasks/global-review-log.md');
+      expect(readFileMock).toHaveBeenCalledWith('/repo/tasks/global-review-log.md', 'utf-8');
+      expect(appendFileMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('migrates legacy markdown review logs before appending new rows', async () => {
+      writeFileMock.mockRejectedValueOnce(Object.assign(new Error('exists'), { code: 'EEXIST' }));
+      readFileMock.mockResolvedValueOnce([
+        '# Global Review Log',
+        '',
+        '| PR | Agents | Recommendation | Findings | Date |',
+        '|---|---|---|---|---|',
+        '| [#1](https://github.com/madlouse/AgenticOS/pull/1) | Old Agent | **APPROVE** | 0 | 2026-05-10 |',
+      ].join('\n'));
+
+      const mod = await loadModule();
+      await mod.persistReviewLog(REVIEW_RESULT, '/repo');
+
+      expect(writeFileMock).toHaveBeenNthCalledWith(
+        2,
+        '/repo/tasks/global-review-log.md',
+        expect.stringContaining('Legacy markdown review log content preserved during one-time migration.'),
+        'utf-8',
+      );
+      expect(writeFileMock.mock.calls[1][1]).toContain('<tbody>');
+      expect(writeFileMock.mock.calls[1][1]).toContain('| [#1](https://github.com/madlouse/AgenticOS/pull/1) | Old Agent |');
       expect(appendFileMock).toHaveBeenCalledTimes(1);
     });
 
@@ -373,8 +403,8 @@ describe('multi-agent-review', () => {
       expect(maxActiveReviews).toBe(2);
 
       const claudeCallOptions = execAsyncMock.mock.calls
-        .filter(([command]) => (command as string).startsWith('command claude'))
-        .map(([, options]) => options as { timeout: number; maxBuffer: number });
+        .filter((call: unknown[]) => (call[0] as string).startsWith('command claude'))
+        .map((call: unknown[]) => call[1] as { timeout: number; maxBuffer: number });
 
       expect(claudeCallOptions).toContainEqual(expect.objectContaining({ timeout: 300000, maxBuffer: 10 * 1024 * 1024 }));
       expect(claudeCallOptions).toContainEqual(expect.objectContaining({ timeout: 180000, maxBuffer: 10 * 1024 * 1024 }));

--- a/mcp-server/src/tools/__tests__/multi-agent-review.test.ts
+++ b/mcp-server/src/tools/__tests__/multi-agent-review.test.ts
@@ -400,6 +400,7 @@ describe('multi-agent-review', () => {
     });
 
     it('times out instead of deleting a contended migration lock', async () => {
+      vi.useFakeTimers();
       writeFileMock
         .mockRejectedValueOnce(Object.assign(new Error('exists'), { code: 'EEXIST' }))
         .mockRejectedValue(Object.assign(new Error('locked'), { code: 'EEXIST' }));
@@ -414,7 +415,14 @@ describe('multi-agent-review', () => {
       readFileMock.mockResolvedValueOnce('# Global Review Log\n');
 
       const mod = await loadModule();
-      await expect(mod.persistReviewLog(REVIEW_RESULT, '/repo')).rejects.toThrow('Timed out waiting for review log migration lock');
+      const persistPromise = mod.persistReviewLog(REVIEW_RESULT, '/repo');
+      const expectation = expect(persistPromise).rejects.toThrow('Timed out waiting for review log migration lock');
+      try {
+        await vi.advanceTimersByTimeAsync(60000);
+        await expectation;
+      } finally {
+        vi.useRealTimers();
+      }
 
       expect(unlinkMock).not.toHaveBeenCalledWith('/repo/tasks/global-review-log.md.migration.lock');
       expect(renameMock).not.toHaveBeenCalled();

--- a/mcp-server/src/tools/__tests__/multi-agent-review.test.ts
+++ b/mcp-server/src/tools/__tests__/multi-agent-review.test.ts
@@ -379,6 +379,54 @@ describe('multi-agent-review', () => {
       expect(appendFileMock).toHaveBeenCalledTimes(1);
     });
 
+    it('preserves unsafe legacy markdown PR URLs as escaped text', async () => {
+      writeFileMock.mockRejectedValueOnce(Object.assign(new Error('exists'), { code: 'EEXIST' }));
+      openFileMock.mockImplementation(async () => ({
+        read: async (buffer: Buffer) => {
+          const content = '# Global Review Log\n\n| PR | Agents | Recommendation | Findings | Date |\n';
+          buffer.write(content);
+          return { bytesRead: Buffer.byteLength(content) };
+        },
+        close: async () => undefined,
+      }));
+      readFileMock.mockResolvedValueOnce('| [#1](javascript:alert(1)) | Old Agent | **APPROVE** | 0 | 2026-05-10 |');
+
+      const mod = await loadModule();
+      await mod.persistReviewLog(REVIEW_RESULT, '/repo');
+
+      const migratedContent = writeFileMock.mock.calls[2][1] as string;
+      expect(migratedContent).not.toContain('href="javascript:alert(1)"');
+      expect(migratedContent).toContain('javascript:alert?1?');
+    });
+
+    it('removes stale migration locks before retrying migration', async () => {
+      writeFileMock
+        .mockRejectedValueOnce(Object.assign(new Error('exists'), { code: 'EEXIST' }))
+        .mockRejectedValueOnce(Object.assign(new Error('locked'), { code: 'EEXIST' }));
+      lstatMock
+        .mockResolvedValueOnce({ isSymbolicLink: () => false })
+        .mockResolvedValueOnce({ isSymbolicLink: () => false })
+        .mockResolvedValueOnce({ isSymbolicLink: () => false, mtimeMs: Date.now() - 20 * 60 * 1000 });
+      openFileMock.mockImplementation(async () => ({
+        read: async (buffer: Buffer) => {
+          const content = '# Global Review Log\n\n| PR | Agents | Recommendation | Findings | Date |\n';
+          buffer.write(content);
+          return { bytesRead: Buffer.byteLength(content) };
+        },
+        close: async () => undefined,
+      }));
+      readFileMock.mockResolvedValueOnce('# Global Review Log\n');
+
+      const mod = await loadModule();
+      await mod.persistReviewLog(REVIEW_RESULT, '/repo');
+
+      expect(unlinkMock).toHaveBeenCalledWith('/repo/tasks/global-review-log.md.migration.lock');
+      expect(renameMock).toHaveBeenCalledWith(
+        expect.stringContaining('/repo/tasks/global-review-log.md.migration.'),
+        '/repo/tasks/global-review-log.md',
+      );
+    });
+
     it('does not treat arbitrary embedded tables as canonical review logs', async () => {
       writeFileMock.mockRejectedValueOnce(Object.assign(new Error('exists'), { code: 'EEXIST' }));
       openFileMock.mockImplementation(async () => ({

--- a/mcp-server/src/tools/__tests__/standard-kit.test.ts
+++ b/mcp-server/src/tools/__tests__/standard-kit.test.ts
@@ -52,6 +52,7 @@ async function setupKitHome(): Promise<{ home: string; projectRoot: string }> {
           { path: '.context/state.yaml', canonical_source: 'projects/agenticos/.meta/templates/state.yaml' },
           { path: 'tasks/templates/agent-preflight-checklist.yaml', canonical_source: 'projects/agenticos/.meta/templates/agent-preflight-checklist.yaml' },
           { path: 'tasks/templates/issue-design-brief.md', canonical_source: 'projects/agenticos/.meta/templates/issue-design-brief.md' },
+          { path: 'tasks/templates/global-review-log.md', canonical_source: 'projects/agenticos/.meta/templates/global-review-log.md' },
           { path: 'tasks/templates/non-code-evaluation-rubric.yaml', canonical_source: 'projects/agenticos/.meta/templates/non-code-evaluation-rubric.yaml' },
           { path: 'tasks/templates/sub-agent-handoff.md', canonical_source: 'projects/agenticos/.meta/templates/sub-agent-handoff.md' },
           { path: 'tasks/templates/submission-evidence.md', canonical_source: 'projects/agenticos/.meta/templates/submission-evidence.md' },
@@ -67,6 +68,7 @@ async function setupKitHome(): Promise<{ home: string; projectRoot: string }> {
         '.context/state.yaml',
         'tasks/templates/agent-preflight-checklist.yaml',
         'tasks/templates/issue-design-brief.md',
+        'tasks/templates/global-review-log.md',
         'tasks/templates/non-code-evaluation-rubric.yaml',
         'tasks/templates/sub-agent-handoff.md',
         'tasks/templates/submission-evidence.md',
@@ -95,6 +97,7 @@ async function setupKitHome(): Promise<{ home: string; projectRoot: string }> {
   await writeFile(join(templateRoot, 'state.yaml'), '# Contract:\n# - Mutable operational working state only\n# - Keep current task, working memory, and latest guardrail evidence here\n# - Do not append raw conversation transcripts here\n# - Durable synthesis belongs in knowledge/\nsession:\n  id: "session-001"\n  started: "YYYY-MM-DDTHH:MM:SSZ"\n  agent: "claude-sonnet-4.6"\ncurrent_task:\n  id: null\n  title: null\n  status: "pending"\n  next_step: null\nworking_memory:\n  facts: []\n  decisions: []\n  pending: []\nmemory_contract:\n  version: 1\n  quick_start_role: "project_orientation"\n  state_role: "operational_working_state"\n  conversations_role: "append_only_session_history"\n  knowledge_role: "durable_synthesis"\n  tasks_role: "execution_artifacts"\nloaded_context:\n  - ".project.yaml"\n', 'utf-8');
   await writeFile(join(templateRoot, 'agent-preflight-checklist.yaml'), 'version: 0.2\n', 'utf-8');
   await writeFile(join(templateRoot, 'issue-design-brief.md'), '# Issue Design Brief\n\n## Objective Synthesis\n- User-stated request:\n- Inferred end goal:\n- Operator signals / partial methods:\n- Constraints:\n- Contradictions or weak assumptions to resolve:\n- Non-goals:\n', 'utf-8');
+  await writeFile(join(templateRoot, 'global-review-log.md'), '# <!-- agenticos-template: v1 -->\n# Global Review Log\n\n<!-- agenticos:global-review-log:v2 -->\n\n<table>\n<thead><tr><th>PR</th><th>Agents</th><th>Recommendation</th><th>Findings</th><th>Date</th></tr></thead>\n<tbody>\n', 'utf-8');
   await writeFile(join(templateRoot, 'non-code-evaluation-rubric.yaml'), 'version: 0.1\nname: non-code-evaluation-rubric\n', 'utf-8');
   await writeFile(join(templateRoot, 'sub-agent-handoff.md'), '# Sub-Agent Handoff\n', 'utf-8');
   await writeFile(join(templateRoot, 'submission-evidence.md'), '# Submission Evidence\n', 'utf-8');

--- a/mcp-server/src/tools/multi-agent-review.ts
+++ b/mcp-server/src/tools/multi-agent-review.ts
@@ -12,6 +12,7 @@ const DEFAULT_AGENT_TIMEOUT_MS = 180000;
 const ARCHITECTURE_AGENT_TIMEOUT_MS = 300000;
 const REVIEW_LOG_MARKER = '<!-- agenticos:global-review-log:v2 -->';
 const REVIEW_LOG_TABLE_HEADER = '<thead><tr><th>PR</th><th>Agents</th><th>Recommendation</th><th>Findings</th><th>Date</th></tr></thead>';
+const MIGRATION_LOCK_STALE_MS = 10 * 60 * 1000;
 
 function sanitize(value: string): string {
   return value
@@ -109,6 +110,10 @@ function stripMarkdown(value: string): string {
   return value.replace(/\*\*/g, '').trim();
 }
 
+function isSafeReviewUrl(url: string, prNumber: string): boolean {
+  return url === `https://github.com/madlouse/AgenticOS/pull/${prNumber}`;
+}
+
 function buildLegacySummaryRow(line: string, now: string): string | null {
   const cells = line.split('|').slice(1, -1).map((cell) => cell.trim());
   if (cells.length < 5 || cells[0] === 'PR' || /^-+$/.test(cells[0])) {
@@ -116,7 +121,7 @@ function buildLegacySummaryRow(line: string, now: string): string | null {
   }
 
   const prMatch = cells[0].match(/\[#(\d+)\]\(([^)]+)\)/);
-  const prCell = prMatch
+  const prCell = prMatch && isSafeReviewUrl(prMatch[2], prMatch[1])
     ? `<a href="${escapeHtmlBlock(prMatch[2])}">#${prMatch[1]}</a>`
     : escapeHtml(stripMarkdown(cells[0]));
   const date = stripMarkdown(cells[4]) || now.split('T')[0];
@@ -180,6 +185,26 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
 }
 
+async function removeStaleMigrationLock(lockPath: string): Promise<boolean> {
+  try {
+    const stat = await lstat(lockPath);
+    if (stat.isSymbolicLink()) {
+      throw new Error(`Refusing to remove symlinked review log migration lock: ${lockPath}`);
+    }
+    if (Date.now() - stat.mtimeMs <= MIGRATION_LOCK_STALE_MS) {
+      return false;
+    }
+    await unlink(lockPath);
+    return true;
+  } catch (err) {
+    const code = typeof err === 'object' && err && 'code' in err ? err.code : undefined;
+    if (code === 'ENOENT') {
+      return true;
+    }
+    throw err;
+  }
+}
+
 async function ensureCanonicalReviewLog(reviewLogPath: string, now: string): Promise<void> {
   try {
     await writeFile(reviewLogPath, buildReviewLogHeader(), { encoding: 'utf-8', flag: 'wx' });
@@ -224,6 +249,9 @@ async function ensureCanonicalReviewLog(reviewLogPath: string, now: string): Pro
       const code = typeof err === 'object' && err && 'code' in err ? err.code : undefined;
       if (code !== 'EEXIST') {
         throw err;
+      }
+      if (await removeStaleMigrationLock(lockPath)) {
+        continue;
       }
       await sleep(100);
       if (isCanonicalReviewLog(await readReviewLogPrefix(reviewLogPath))) {

--- a/mcp-server/src/tools/multi-agent-review.ts
+++ b/mcp-server/src/tools/multi-agent-review.ts
@@ -12,7 +12,7 @@ const DEFAULT_AGENT_TIMEOUT_MS = 180000;
 const ARCHITECTURE_AGENT_TIMEOUT_MS = 300000;
 const REVIEW_LOG_MARKER = '<!-- agenticos:global-review-log:v2 -->';
 const REVIEW_LOG_TABLE_HEADER = '<thead><tr><th>PR</th><th>Agents</th><th>Recommendation</th><th>Findings</th><th>Date</th></tr></thead>';
-const MIGRATION_LOCK_ATTEMPTS = 10;
+const MIGRATION_LOCK_ATTEMPTS = 600;
 const MIGRATION_LOCK_RETRY_MS = 100;
 
 function sanitize(value: string): string {

--- a/mcp-server/src/tools/multi-agent-review.ts
+++ b/mcp-server/src/tools/multi-agent-review.ts
@@ -12,7 +12,8 @@ const DEFAULT_AGENT_TIMEOUT_MS = 180000;
 const ARCHITECTURE_AGENT_TIMEOUT_MS = 300000;
 const REVIEW_LOG_MARKER = '<!-- agenticos:global-review-log:v2 -->';
 const REVIEW_LOG_TABLE_HEADER = '<thead><tr><th>PR</th><th>Agents</th><th>Recommendation</th><th>Findings</th><th>Date</th></tr></thead>';
-const MIGRATION_LOCK_STALE_MS = 10 * 60 * 1000;
+const MIGRATION_LOCK_ATTEMPTS = 10;
+const MIGRATION_LOCK_RETRY_MS = 100;
 
 function sanitize(value: string): string {
   return value
@@ -185,26 +186,6 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
 }
 
-async function removeStaleMigrationLock(lockPath: string): Promise<boolean> {
-  try {
-    const stat = await lstat(lockPath);
-    if (stat.isSymbolicLink()) {
-      throw new Error(`Refusing to remove symlinked review log migration lock: ${lockPath}`);
-    }
-    if (Date.now() - stat.mtimeMs <= MIGRATION_LOCK_STALE_MS) {
-      return false;
-    }
-    await unlink(lockPath);
-    return true;
-  } catch (err) {
-    const code = typeof err === 'object' && err && 'code' in err ? err.code : undefined;
-    if (code === 'ENOENT') {
-      return true;
-    }
-    throw err;
-  }
-}
-
 async function ensureCanonicalReviewLog(reviewLogPath: string, now: string): Promise<void> {
   try {
     await writeFile(reviewLogPath, buildReviewLogHeader(), { encoding: 'utf-8', flag: 'wx' });
@@ -221,7 +202,7 @@ async function ensureCanonicalReviewLog(reviewLogPath: string, now: string): Pro
   }
 
   const lockPath = `${reviewLogPath}.migration.lock`;
-  for (let attempt = 0; attempt < 50; attempt += 1) {
+  for (let attempt = 0; attempt < MIGRATION_LOCK_ATTEMPTS; attempt += 1) {
     try {
       await writeFile(lockPath, `${process.pid}\n`, { encoding: 'utf-8', flag: 'wx' });
       try {
@@ -250,10 +231,7 @@ async function ensureCanonicalReviewLog(reviewLogPath: string, now: string): Pro
       if (code !== 'EEXIST') {
         throw err;
       }
-      if (await removeStaleMigrationLock(lockPath)) {
-        continue;
-      }
-      await sleep(100);
+      await sleep(MIGRATION_LOCK_RETRY_MS);
       if (isCanonicalReviewLog(await readReviewLogPrefix(reviewLogPath))) {
         return;
       }

--- a/mcp-server/src/tools/multi-agent-review.ts
+++ b/mcp-server/src/tools/multi-agent-review.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'crypto';
 import { exec } from 'child_process';
-import { appendFile, lstat, mkdir, readFile, unlink, writeFile } from 'fs/promises';
+import { appendFile, lstat, mkdir, open as openFile, readFile, rename, unlink, writeFile } from 'fs/promises';
 import { resolve } from 'path';
 import { promisify } from 'util';
 import pLimit from 'p-limit';
@@ -10,6 +10,8 @@ export const AGENT_REVIEW_CONCURRENCY = 2;
 export const CLAUDE_MAX_BUFFER_BYTES = 10 * 1024 * 1024;
 const DEFAULT_AGENT_TIMEOUT_MS = 180000;
 const ARCHITECTURE_AGENT_TIMEOUT_MS = 300000;
+const REVIEW_LOG_MARKER = '<!-- agenticos:global-review-log:v2 -->';
+const REVIEW_LOG_TABLE_HEADER = '<thead><tr><th>PR</th><th>Agents</th><th>Recommendation</th><th>Findings</th><th>Date</th></tr></thead>';
 
 function sanitize(value: string): string {
   return value
@@ -40,8 +42,10 @@ function buildReviewLogHeader(): string {
   return [
     '# Global Review Log',
     '',
+    REVIEW_LOG_MARKER,
+    '',
     '<table>',
-    '<thead><tr><th>PR</th><th>Agents</th><th>Recommendation</th><th>Findings</th><th>Date</th></tr></thead>',
+    REVIEW_LOG_TABLE_HEADER,
     '<tbody>',
     '',
   ].join('\n');
@@ -101,8 +105,45 @@ function buildLegacyMigrationRow(legacyContent: string, now: string): string {
   ].join('');
 }
 
+function stripMarkdown(value: string): string {
+  return value.replace(/\*\*/g, '').trim();
+}
+
+function buildLegacySummaryRow(line: string, now: string): string | null {
+  const cells = line.split('|').slice(1, -1).map((cell) => cell.trim());
+  if (cells.length < 5 || cells[0] === 'PR' || /^-+$/.test(cells[0])) {
+    return null;
+  }
+
+  const prMatch = cells[0].match(/\[#(\d+)\]\(([^)]+)\)/);
+  const prCell = prMatch
+    ? `<a href="${escapeHtmlBlock(prMatch[2])}">#${prMatch[1]}</a>`
+    : escapeHtml(stripMarkdown(cells[0]));
+  const date = stripMarkdown(cells[4]) || now.split('T')[0];
+
+  return [
+    '<tr>',
+    `<td>${prCell}<details><summary>Details</summary><p>Migrated from legacy markdown summary row.</p><pre>${escapeHtmlBlock(line)}</pre></details></td>`,
+    `<td>${escapeHtml(stripMarkdown(cells[1]))}</td>`,
+    `<td><strong>${escapeHtml(stripMarkdown(cells[2]))}</strong></td>`,
+    `<td>${escapeHtml(stripMarkdown(cells[3]))}</td>`,
+    `<td>${escapeHtml(date)}</td>`,
+    '</tr>\n',
+  ].join('');
+}
+
+function buildLegacyMigrationRows(legacyContent: string, now: string): string {
+  const migratedRows = legacyContent
+    .split('\n')
+    .map((line) => buildLegacySummaryRow(line, now))
+    .filter((row): row is string => row !== null);
+
+  return migratedRows.join('') + buildLegacyMigrationRow(legacyContent, now);
+}
+
 function isCanonicalReviewLog(content: string): boolean {
-  return content.includes('<table>') && content.includes('<tbody>');
+  return content.includes(REVIEW_LOG_MARKER) ||
+    (content.includes(REVIEW_LOG_TABLE_HEADER) && content.includes('<tbody>'));
 }
 
 function shellQuote(value: string): string {
@@ -124,6 +165,21 @@ async function assertNotSymlink(path: string): Promise<void> {
   }
 }
 
+async function readReviewLogPrefix(path: string): Promise<string> {
+  const handle = await openFile(path, 'r');
+  try {
+    const buffer = Buffer.alloc(4096);
+    const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+    return buffer.subarray(0, bytesRead).toString('utf-8');
+  } finally {
+    await handle.close();
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
+}
+
 async function ensureCanonicalReviewLog(reviewLogPath: string, now: string): Promise<void> {
   try {
     await writeFile(reviewLogPath, buildReviewLogHeader(), { encoding: 'utf-8', flag: 'wx' });
@@ -135,16 +191,48 @@ async function ensureCanonicalReviewLog(reviewLogPath: string, now: string): Pro
     }
   }
 
-  const existing = await readFile(reviewLogPath, 'utf-8');
-  if (isCanonicalReviewLog(existing)) {
+  if (isCanonicalReviewLog(await readReviewLogPrefix(reviewLogPath))) {
     return;
   }
 
-  await writeFile(
-    reviewLogPath,
-    buildReviewLogHeader() + buildLegacyMigrationRow(existing, now),
-    'utf-8',
-  );
+  const lockPath = `${reviewLogPath}.migration.lock`;
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    try {
+      await writeFile(lockPath, `${process.pid}\n`, { encoding: 'utf-8', flag: 'wx' });
+      try {
+        if (isCanonicalReviewLog(await readReviewLogPrefix(reviewLogPath))) {
+          return;
+        }
+        const existing = await readFile(reviewLogPath, 'utf-8');
+        const tempPath = `${reviewLogPath}.migration.${process.pid}.${randomUUID()}.tmp`;
+        try {
+          await writeFile(
+            tempPath,
+            buildReviewLogHeader() + buildLegacyMigrationRows(existing, now),
+            'utf-8',
+          );
+          await rename(tempPath, reviewLogPath);
+        } catch (err) {
+          await unlink(tempPath).catch(() => {/* ignore */});
+          throw err;
+        }
+        return;
+      } finally {
+        await unlink(lockPath).catch(() => {/* ignore */});
+      }
+    } catch (err) {
+      const code = typeof err === 'object' && err && 'code' in err ? err.code : undefined;
+      if (code !== 'EEXIST') {
+        throw err;
+      }
+      await sleep(100);
+      if (isCanonicalReviewLog(await readReviewLogPrefix(reviewLogPath))) {
+        return;
+      }
+    }
+  }
+
+  throw new Error(`Timed out waiting for review log migration lock: ${lockPath}`);
 }
 
 // Agent role definitions for multi-agent review

--- a/mcp-server/src/tools/multi-agent-review.ts
+++ b/mcp-server/src/tools/multi-agent-review.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'crypto';
 import { exec } from 'child_process';
-import { appendFile, lstat, mkdir, unlink, writeFile } from 'fs/promises';
+import { appendFile, lstat, mkdir, readFile, unlink, writeFile } from 'fs/promises';
 import { resolve } from 'path';
 import { promisify } from 'util';
 import pLimit from 'p-limit';
@@ -25,6 +25,26 @@ function escapeHtml(value: string): string {
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#39;');
+}
+
+function escapeHtmlBlock(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function buildReviewLogHeader(): string {
+  return [
+    '# Global Review Log',
+    '',
+    '<table>',
+    '<thead><tr><th>PR</th><th>Agents</th><th>Recommendation</th><th>Findings</th><th>Date</th></tr></thead>',
+    '<tbody>',
+    '',
+  ].join('\n');
 }
 
 function buildReviewLogRow(
@@ -64,6 +84,27 @@ function buildReviewLogRow(
   ].join('');
 }
 
+function buildLegacyMigrationRow(legacyContent: string, now: string): string {
+  const date = now.split('T')[0];
+
+  return [
+    '<tr>',
+    '<td>legacy<details><summary>Details</summary>',
+    '<p>Legacy markdown review log content preserved during one-time migration.</p>',
+    `<pre>${escapeHtmlBlock(legacyContent)}</pre>`,
+    '</details></td>',
+    '<td>Legacy log</td>',
+    '<td><strong>MIGRATED</strong></td>',
+    '<td>0</td>',
+    `<td>${date}</td>`,
+    '</tr>\n',
+  ].join('');
+}
+
+function isCanonicalReviewLog(content: string): boolean {
+  return content.includes('<table>') && content.includes('<tbody>');
+}
+
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
@@ -81,6 +122,29 @@ async function assertNotSymlink(path: string): Promise<void> {
     }
     throw err;
   }
+}
+
+async function ensureCanonicalReviewLog(reviewLogPath: string, now: string): Promise<void> {
+  try {
+    await writeFile(reviewLogPath, buildReviewLogHeader(), { encoding: 'utf-8', flag: 'wx' });
+    return;
+  } catch (err) {
+    const code = typeof err === 'object' && err && 'code' in err ? err.code : undefined;
+    if (code !== 'EEXIST') {
+      throw err;
+    }
+  }
+
+  const existing = await readFile(reviewLogPath, 'utf-8');
+  if (isCanonicalReviewLog(existing)) {
+    return;
+  }
+
+  await writeFile(
+    reviewLogPath,
+    buildReviewLogHeader() + buildLegacyMigrationRow(existing, now),
+    'utf-8',
+  );
 }
 
 // Agent role definitions for multi-agent review
@@ -363,25 +427,7 @@ export async function persistReviewLog(
   await assertNotSymlink(tasksDir);
   await assertNotSymlink(reviewLogPath);
 
-  try {
-    await writeFile(
-      reviewLogPath,
-      [
-        '# Global Review Log',
-        '',
-        '<table>',
-        '<thead><tr><th>PR</th><th>Agents</th><th>Recommendation</th><th>Findings</th><th>Date</th></tr></thead>',
-        '<tbody>',
-        '',
-      ].join('\n'),
-      { encoding: 'utf-8', flag: 'wx' },
-    );
-  } catch (err) {
-    const code = typeof err === 'object' && err && 'code' in err ? err.code : undefined;
-    if (code !== 'EEXIST') {
-      throw err;
-    }
-  }
+  await ensureCanonicalReviewLog(reviewLogPath, now);
 
   await appendFile(reviewLogPath, buildReviewLogRow(result, now), 'utf-8');
   return reviewLogPath;

--- a/tasks/templates/global-review-log.md
+++ b/tasks/templates/global-review-log.md
@@ -1,51 +1,5 @@
 # Global Review Log
 
-## Purpose
-
-Use this file as the stable cumulative log for multi-step work that should later be reviewed as one sequence.
-
-Typical triggers:
-
-- mechanism passes
-- cleanup waves
-- migrations
-- broad review-driven change sets
-
-## Review Standard
-
-For each landed step, capture:
-
-- intent
-- changed surfaces
-- verification
-- residual risk
-
-Later, use this one file as the basis for whole-pass review.
-
----
-
-## Step N
-
-**Title**:
-
-**Status**:
-
-**Intent**:
-
-- 
-
-**Mechanism**:
-
-- 
-
-**Primary implementation surfaces**:
-
-- 
-
-**Verification**:
-
-- 
-
-**Residual risk / follow-up**:
-
-- 
+<table>
+<thead><tr><th>PR</th><th>Agents</th><th>Recommendation</th><th>Findings</th><th>Date</th></tr></thead>
+<tbody>

--- a/tasks/templates/global-review-log.md
+++ b/tasks/templates/global-review-log.md
@@ -1,4 +1,7 @@
+# <!-- agenticos-template: v1 -->
 # Global Review Log
+
+<!-- agenticos:global-review-log:v2 -->
 
 <table>
 <thead><tr><th>PR</th><th>Agents</th><th>Recommendation</th><th>Findings</th><th>Date</th></tr></thead>


### PR DESCRIPTION
## Summary
- detect existing non-canonical `tasks/global-review-log.md` files before appending new multi-agent review rows
- migrate legacy markdown logs once into the canonical append-only HTML table format while preserving old content in a migration detail row
- update the shipped global-review-log template to match the runtime format
- add regression coverage for canonical existing logs, legacy migration, and append behavior

## Testing
- `cd mcp-server && npm ci`
- `cd mcp-server && npm run lint`
- `cd mcp-server && npm test`

Closes #389.
