### PR TITLE
feat: wire coverage evidence toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -14,6 +17,8 @@ jobs:
         node-version: [20, 22]
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
@@ -30,12 +35,48 @@ jobs:
       - name: Run tests
         run: npm test
         working-directory: mcp-server
+      - name: Run coverage
+        if: matrix.node-version == 22
+        run: npm run test:coverage
+        working-directory: mcp-server
+      - name: Upload coverage artifact
+        if: matrix.node-version == 22
+        uses: actions/upload-artifact@v4
+        with:
+          name: mcp-server-coverage
+          path: mcp-server/coverage/
+          if-no-files-found: error
+
+  coverage-changed-scope:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Use Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Install dependencies
+        run: npm install
+        working-directory: mcp-server
+      - name: Enforce coverage evidence
+        run: ./tools/coverage-preflight.sh
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
 
   mcp-symlink-integration:
     runs-on: ubuntu-latest
     needs: build
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Use Node.js 22
         uses: actions/setup-node@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ __pycache__/
 # Build output
 build/
 mcp-server/build/
+mcp-server/coverage/
 
 # Environment
 .env

--- a/mcp-server/.gitignore
+++ b/mcp-server/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
 build/
+coverage/
 *.log
 .DS_Store

--- a/mcp-server/.npmignore
+++ b/mcp-server/.npmignore
@@ -1,0 +1,3 @@
+coverage/
+src/
+*.log

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -15,7 +15,8 @@
     "watch": "tsc --watch",
     "prepare": "npm run build",
     "lint": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "keywords": [
     "mcp",

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -191,6 +191,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
             items: { type: 'string' },
             description: 'Required clean baseline verification commands such as npm ci and npm run build',
           },
+          coverage_evidence_path: { type: 'string', description: 'Optional coverage-evidence.json path for coverage reproducibility gates.' },
         },
         required: ['task_type', 'repo_path'],
       },
@@ -410,23 +411,29 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     },
     {
       name: 'agenticos_validate_delegation',
-      description: 'Validate that a delegated task follows AgenticOS delegation protocol: coverage, evidence, and formal closure.',
+      description: 'Validate delegation log.md/result.md artifacts for a delegation ID.',
       inputSchema: {
         type: 'object',
         properties: {
-          delegation_evidence_path: { type: 'string', description: 'Path to delegation evidence JSON file.' },
-          coverage_threshold: { type: 'number', description: 'Minimum coverage percentage (default: 80).' },
+          project: { type: 'string', description: 'Optional project id, name, or path.' },
+          delegation_id: { type: 'string', description: 'Single path segment identifying standards/.context/delegations/{delegation_id}.' },
         },
+        required: ['delegation_id'],
       },
     },
     {
       name: 'agenticos_coverage_check',
-      description: 'Check test coverage threshold compliance. Use runCoverageGenerate first if no evidence file exists.',
+      description: 'Generate or validate AgenticOS test coverage evidence.',
       inputSchema: {
         type: 'object',
         properties: {
-          threshold: { type: 'number', description: 'Minimum coverage percentage (default: 80).' },
-          evidence_path: { type: 'string', description: 'Path to coverage evidence JSON.' },
+          action: { type: 'string', enum: ['check', 'generate'], description: 'Whether to validate coverage evidence or generate it from coverage-final.json.' },
+          project: { type: 'string', description: 'Optional project id, name, or path.' },
+          project_path: { type: 'string', description: 'Optional managed project root override, normally the active issue worktree.' },
+          coverage_json_path: { type: 'string', description: 'Path to Vitest coverage-final.json when action=generate.' },
+          evidence_path: { type: 'string', description: 'Path to coverage-evidence.json.' },
+          is_pr: { type: 'boolean', description: 'Whether generated evidence should enforce changed-scope coverage.' },
+          changed_files_json: { type: 'string', description: 'JSON array of changed files for changed-scope coverage.' },
           format: { type: 'string', enum: ['markdown', 'json'], description: 'Output format.' },
         },
       },
@@ -527,7 +534,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     case 'agenticos_validate_delegation':
       return { content: [{ type: 'text', text: await runValidateDelegation(args ?? {}) }] };
     case 'agenticos_coverage_check':
-      return { content: [{ type: 'text', text: await runCoverageCheck(args ?? {}) }] };
+      return { content: [{ type: 'text', text: (args as any)?.action === 'generate' ? await runCoverageGenerate(args ?? {}) : await runCoverageCheck(args ?? {}) }] };
     case 'agenticos_multi_agent_review':
       return { content: [{ type: 'text', text: await runMultiAgentReview(args ?? {}) }] };
     case 'agenticos_enforce_git_policy':

--- a/mcp-server/src/tools/__tests__/coverage-check.test.ts
+++ b/mcp-server/src/tools/__tests__/coverage-check.test.ts
@@ -3,10 +3,14 @@ import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { runCoverageCheck, runCoverageGenerate } from '../coverage-check.js';
 
 const mockReadFile = vi.hoisted(() => vi.fn());
+const mockMkdir = vi.hoisted(() => vi.fn());
+const mockWriteFile = vi.hoisted(() => vi.fn());
 const mockResolve = vi.hoisted(() => vi.fn());
 
 vi.mock('fs/promises', () => ({
+  mkdir: mockMkdir,
   readFile: mockReadFile,
+  writeFile: mockWriteFile,
 }));
 vi.mock('../../utils/project-target.js', () => ({
   resolveManagedProjectTarget: mockResolve,
@@ -15,11 +19,15 @@ vi.mock('../../utils/project-target.js', () => ({
 describe('runCoverageCheck', () => {
   beforeEach(() => {
     mockReadFile.mockReset();
+    mockMkdir.mockReset();
+    mockWriteFile.mockReset();
     mockResolve.mockReset();
     mockResolve.mockResolvedValue({ projectPath: '/tmp/project' });
   });
   afterEach(() => {
     mockReadFile.mockRestore();
+    mockMkdir.mockRestore();
+    mockWriteFile.mockRestore();
     mockResolve.mockRestore();
   });
 
@@ -33,6 +41,7 @@ describe('runCoverageCheck', () => {
     mockReadFile.mockRejectedValue(new Error('ENOENT'));
     const result = await runCoverageCheck({});
     expect(result).toContain('not found or unreadable');
+    expect(mockReadFile).toHaveBeenCalledWith('/tmp/project/mcp-server/coverage/coverage-evidence.json', 'utf-8');
   });
 
   it('returns error when evidence file is not valid JSON', async () => {
@@ -41,8 +50,17 @@ describe('runCoverageCheck', () => {
     expect(result).toContain('not valid JSON');
   });
 
+  it('returns structured errors when evidence JSON is null', async () => {
+    mockReadFile.mockResolvedValue('null');
+    const result = await runCoverageCheck({});
+    expect(result).toContain('Coverage validation failed');
+    expect(result).toContain('coverage-evidence.json: root must be an object');
+    expect(result).toContain('Changed files: (none)');
+  });
+
   it('returns success for valid passing evidence', async () => {
     mockReadFile.mockResolvedValue(JSON.stringify({
+      version: 1,
       generated_at: '2026-04-24T10:00:00Z',
       threshold_aggregate: { lines: 80, functions: 80, branches: 80, statements: 80 },
       threshold_changed_scope: { lines: 100, functions: 100, branches: 100, statements: 100 },
@@ -62,8 +80,59 @@ describe('runCoverageCheck', () => {
     expect(result).not.toContain('Errors (blocking)');
   });
 
+  it('renders fallback summary values for sparse passing evidence', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify({
+      version: 1,
+      generated_at: '',
+      threshold_aggregate: {},
+      threshold_changed_scope: { lines: 100, functions: 100, branches: 100, statements: 100 },
+      is_pr: true,
+      changed_files: ['src/a.ts'],
+      aggregate: {},
+      files: [],
+      aggregate_pass: false,
+      changed_scope_pass: false,
+      pass: false,
+      aggregate_failures: [],
+      changed_scope_failures: [],
+    }));
+
+    const result = await runCoverageCheck({});
+
+    expect(result).toContain('Generated at: (unknown)');
+    expect(result).toContain('Running in PR: yes');
+    expect(result).toContain('Changed files: src/a.ts');
+    expect(result).toContain('Aggregate lines: ?%');
+    expect(result).toContain('Aggregate functions: ?%');
+    expect(result).toContain('Aggregate branches: ?%');
+    expect(result).toContain('Aggregate statements: ?%');
+    expect(result).toContain('Changed-scope pass: ⚠️ (inactive)');
+  });
+
+  it('renders fallback changed files when evidence has an invalid changed_files value', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify({
+      version: 1,
+      generated_at: '2026-05-11T00:00:00Z',
+      threshold_aggregate: { lines: 60, functions: 60, branches: 50, statements: 60 },
+      threshold_changed_scope: { lines: 100, functions: 100, branches: 100, statements: 100 },
+      is_pr: true,
+      changed_files: null,
+      aggregate: { pct_statements: 90, pct_branches: 90, pct_functions: 90, pct_lines: 90 },
+      files: [],
+      aggregate_pass: true,
+      changed_scope_pass: false,
+      pass: false,
+      aggregate_failures: [],
+      changed_scope_failures: [],
+    }));
+    const result = await runCoverageCheck({});
+    expect(result).toContain('coverage-evidence.json: missing or invalid changed_files array');
+    expect(result).toContain('Changed files: (none)');
+  });
+
   it('returns failure for failing evidence', async () => {
     mockReadFile.mockResolvedValue(JSON.stringify({
+      version: 1,
       generated_at: '2026-04-24T10:00:00Z',
       threshold_aggregate: { lines: 80, functions: 80, branches: 80, statements: 80 },
       threshold_changed_scope: { lines: 100, functions: 100, branches: 100, statements: 100 },
@@ -85,6 +154,7 @@ describe('runCoverageCheck', () => {
 
   it('uses custom evidence_path when provided', async () => {
     mockReadFile.mockResolvedValue(JSON.stringify({
+      version: 1,
       generated_at: '2026-04-24T10:00:00Z',
       threshold_aggregate: { lines: 80, functions: 80, branches: 80, statements: 80 },
       threshold_changed_scope: { lines: 100, functions: 100, branches: 100, statements: 100 },
@@ -98,20 +168,52 @@ describe('runCoverageCheck', () => {
       aggregate_failures: [],
       changed_scope_failures: [],
     }));
-    const result = await runCoverageCheck({ evidence_path: '/custom/path/evidence.json' });
-    expect(mockReadFile).toHaveBeenCalledWith('/custom/path/evidence.json', 'utf-8');
+    const result = await runCoverageCheck({ evidence_path: '/tmp/project/custom/path/evidence.json' });
+    expect(mockReadFile).toHaveBeenCalledWith('/tmp/project/custom/path/evidence.json', 'utf-8');
     expect(result).toContain('✅');
+  });
+
+  it('rejects custom evidence_path outside the project root', async () => {
+    const result = await runCoverageCheck({ evidence_path: '/custom/path/evidence.json' });
+    expect(result).toContain('path must stay inside project root');
+    expect(mockReadFile).not.toHaveBeenCalled();
+  });
+
+  it('passes project_path through when checking coverage evidence', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify({
+      version: 1,
+      generated_at: '2026-04-24T10:00:00Z',
+      threshold_aggregate: { lines: 80, functions: 80, branches: 80, statements: 80 },
+      threshold_changed_scope: { lines: 100, functions: 100, branches: 100, statements: 100 },
+      is_pr: false,
+      changed_files: [],
+      aggregate: { pct_statements: 90, pct_branches: 90, pct_functions: 95, pct_lines: 90 },
+      files: [],
+      aggregate_pass: true,
+      changed_scope_pass: true,
+      pass: true,
+      aggregate_failures: [],
+      changed_scope_failures: [],
+    }));
+    await runCoverageCheck({ project_path: '/worktree' });
+    expect(mockResolve).toHaveBeenCalledWith(expect.objectContaining({ projectPath: '/worktree' }));
   });
 });
 
 describe('runCoverageGenerate', () => {
   beforeEach(() => {
     mockReadFile.mockReset();
+    mockMkdir.mockReset();
+    mockWriteFile.mockReset();
     mockResolve.mockReset();
     mockResolve.mockResolvedValue({ projectPath: '/tmp/project' });
+    mockMkdir.mockResolvedValue(undefined);
+    mockWriteFile.mockResolvedValue(undefined);
   });
   afterEach(() => {
     mockReadFile.mockRestore();
+    mockMkdir.mockRestore();
+    mockWriteFile.mockRestore();
     mockResolve.mockRestore();
   });
 
@@ -145,6 +247,12 @@ describe('runCoverageGenerate', () => {
     const result = await runCoverageGenerate({});
     expect(result).toContain('Coverage check passed');
     expect(result).toContain('Aggregate: lines=');
+    expect(result).toContain('Evidence written: /tmp/project/mcp-server/coverage/coverage-evidence.json');
+    expect(mockWriteFile).toHaveBeenCalledWith(
+      '/tmp/project/mcp-server/coverage/coverage-evidence.json',
+      expect.stringContaining('"version": 1'),
+      'utf-8',
+    );
     expect(result).toContain('Evidence file content');
   });
 
@@ -168,9 +276,113 @@ describe('runCoverageGenerate', () => {
         s: { '1': 1 }, b: {}, f: { '2': 1 }, lh: [1],
       },
     }));
-    const result = await runCoverageGenerate({ coverage_json_path: '/custom/coverage.json' });
-    expect(mockReadFile).toHaveBeenCalledWith('/custom/coverage.json', 'utf-8');
+    const result = await runCoverageGenerate({ coverage_json_path: '/tmp/project/custom/coverage.json' });
+    expect(mockReadFile).toHaveBeenCalledWith('/tmp/project/custom/coverage.json', 'utf-8');
     expect(result).toContain('Evidence file content');
+  });
+
+  it('rejects custom coverage_json_path outside the project root', async () => {
+    const result = await runCoverageGenerate({ coverage_json_path: '/custom/coverage.json' });
+    expect(result).toContain('path must stay inside project root');
+    expect(mockReadFile).not.toHaveBeenCalled();
+  });
+
+  it('uses custom evidence_path when generating evidence', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify({
+      'src/foo.ts': {
+        s: { '1': 1 }, b: {}, f: { '2': 1 }, lh: [1],
+      },
+    }));
+    const result = await runCoverageGenerate({ evidence_path: '/tmp/project/custom/evidence.json' });
+    expect(mockWriteFile).toHaveBeenCalledWith('/tmp/project/custom/evidence.json', expect.any(String), 'utf-8');
+    expect(result).toContain('Evidence written: /tmp/project/custom/evidence.json');
+  });
+
+  it('rejects custom generated evidence_path outside the project root', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify({
+      'src/foo.ts': {
+        s: { '1': 1 }, b: {}, f: { '2': 1 }, lh: [1],
+      },
+    }));
+    const result = await runCoverageGenerate({ evidence_path: '/custom/evidence.json' });
+    expect(result).toContain('path must stay inside project root');
+    expect(mockWriteFile).not.toHaveBeenCalled();
+  });
+
+  it('passes project_path through when generating coverage evidence', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify({
+      'src/foo.ts': {
+        s: { '1': 1 }, b: {}, f: { '2': 1 }, lh: [1],
+      },
+    }));
+    await runCoverageGenerate({ project_path: '/worktree' });
+    expect(mockResolve).toHaveBeenCalledWith(expect.objectContaining({ projectPath: '/worktree' }));
+  });
+
+  it('falls back to GITHUB_EVENT_NUMBER for generated PR metadata', async () => {
+    const previousPrNumber = process.env.PR_NUMBER;
+    const previousEventNumber = process.env.GITHUB_EVENT_NUMBER;
+    const previousHeadRef = process.env.GITHUB_HEAD_REF;
+    const previousRefName = process.env.GITHUB_REF_NAME;
+    try {
+      delete process.env.PR_NUMBER;
+      delete process.env.GITHUB_HEAD_REF;
+      process.env.GITHUB_EVENT_NUMBER = '392';
+      process.env.GITHUB_REF_NAME = 'fallback-branch';
+      mockReadFile.mockResolvedValue(JSON.stringify({
+        'src/foo.ts': {
+          s: { '1': 1 }, b: {}, f: { '2': 1 }, lh: [1],
+        },
+      }));
+
+      await runCoverageGenerate({});
+
+      const writtenEvidence = JSON.parse(mockWriteFile.mock.calls.at(-1)![1]);
+      expect(writtenEvidence.pr_number).toBe('392');
+      expect(writtenEvidence.branch).toBe('fallback-branch');
+    } finally {
+      if (previousPrNumber === undefined) delete process.env.PR_NUMBER;
+      else process.env.PR_NUMBER = previousPrNumber;
+      if (previousEventNumber === undefined) delete process.env.GITHUB_EVENT_NUMBER;
+      else process.env.GITHUB_EVENT_NUMBER = previousEventNumber;
+      if (previousHeadRef === undefined) delete process.env.GITHUB_HEAD_REF;
+      else process.env.GITHUB_HEAD_REF = previousHeadRef;
+      if (previousRefName === undefined) delete process.env.GITHUB_REF_NAME;
+      else process.env.GITHUB_REF_NAME = previousRefName;
+    }
+  });
+
+  it('prefers pull request metadata from primary GitHub environment variables', async () => {
+    const previousPrNumber = process.env.PR_NUMBER;
+    const previousEventNumber = process.env.GITHUB_EVENT_NUMBER;
+    const previousHeadRef = process.env.GITHUB_HEAD_REF;
+    const previousRefName = process.env.GITHUB_REF_NAME;
+    try {
+      process.env.PR_NUMBER = '393';
+      process.env.GITHUB_EVENT_NUMBER = '392';
+      process.env.GITHUB_HEAD_REF = 'head-branch';
+      process.env.GITHUB_REF_NAME = 'ignored-ref';
+      mockReadFile.mockResolvedValue(JSON.stringify({
+        'src/foo.ts': {
+          s: { '1': 1 }, b: {}, f: { '2': 1 }, lh: [1],
+        },
+      }));
+
+      await runCoverageGenerate({});
+
+      const writtenEvidence = JSON.parse(mockWriteFile.mock.calls.at(-1)![1]);
+      expect(writtenEvidence.pr_number).toBe('393');
+      expect(writtenEvidence.branch).toBe('head-branch');
+    } finally {
+      if (previousPrNumber === undefined) delete process.env.PR_NUMBER;
+      else process.env.PR_NUMBER = previousPrNumber;
+      if (previousEventNumber === undefined) delete process.env.GITHUB_EVENT_NUMBER;
+      else process.env.GITHUB_EVENT_NUMBER = previousEventNumber;
+      if (previousHeadRef === undefined) delete process.env.GITHUB_HEAD_REF;
+      else process.env.GITHUB_HEAD_REF = previousHeadRef;
+      if (previousRefName === undefined) delete process.env.GITHUB_REF_NAME;
+      else process.env.GITHUB_REF_NAME = previousRefName;
+    }
   });
 
   it('uses is_pr and changed_files_json args when provided', async () => {
@@ -190,6 +402,24 @@ describe('runCoverageGenerate', () => {
     expect(result).toContain('Changed-scope pass: true');
   });
 
+  it('prints changed-scope failures when generated evidence fails the PR gate', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify({
+      'src/changed.ts': {
+        s: { '1': 1, '2': 0 },
+        b: {},
+        f: { '4': 1 },
+        lh: [1, 0],
+      },
+    }));
+    const result = await runCoverageGenerate({
+      is_pr: true,
+      changed_files_json: '["src/changed.ts"]',
+    });
+    expect(result).toContain('Coverage check failed');
+    expect(result).toContain('Changed-scope failures');
+    expect(result).toContain('src/changed.ts: lines 50% < 100%');
+  });
+
   it('accepts changed_files_json as array', async () => {
     mockReadFile.mockResolvedValue(JSON.stringify({
       'src/foo.ts': {
@@ -201,5 +431,17 @@ describe('runCoverageGenerate', () => {
       changed_files_json: ['src/foo.ts'],
     });
     expect(result).toContain('Evidence file content');
+  });
+
+  it('returns controlled errors for invalid changed_files_json input', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify({
+      'src/foo.ts': {
+        s: { '1': 1 }, b: {}, f: { '2': 1 }, lh: [1],
+      },
+    }));
+
+    await expect(runCoverageGenerate({ changed_files_json: 'not-json' })).resolves.toContain('changed_files_json is not valid JSON');
+    await expect(runCoverageGenerate({ changed_files_json: 'null' })).resolves.toContain('changed_files_json must be an array of strings');
+    await expect(runCoverageGenerate({ changed_files_json: [null] })).resolves.toContain('changed_files_json must be an array of strings');
   });
 });

--- a/mcp-server/src/tools/__tests__/preflight.test.ts
+++ b/mcp-server/src/tools/__tests__/preflight.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const execAsyncMock = vi.hoisted(() => vi.fn());
 const loadLatestGuardrailStateMock = vi.hoisted(() => vi.fn());
+const readFileMock = vi.hoisted(() => vi.fn());
 
 vi.mock('child_process', () => ({
   exec: vi.fn(),
@@ -9,6 +10,10 @@ vi.mock('child_process', () => ({
 
 vi.mock('util', () => ({
   promisify: vi.fn(() => execAsyncMock),
+}));
+
+vi.mock('fs/promises', () => ({
+  readFile: readFileMock,
 }));
 
 const persistGuardrailEvidenceMock = vi.hoisted(() => vi.fn().mockResolvedValue({
@@ -33,11 +38,14 @@ vi.mock('../../utils/repo-boundary.js', () => ({
 
 import { runPreflight } from '../preflight.js';
 
-function mockGitResponses(responses: Record<string, string>): void {
+function mockGitResponses(responses: Record<string, string | { throw: unknown }>): void {
   execAsyncMock.mockImplementation(async (cmd: string) => {
-    for (const [pattern, stdout] of Object.entries(responses)) {
+    for (const [pattern, response] of Object.entries(responses)) {
       if (cmd.includes(pattern)) {
-        return { stdout, stderr: '' };
+        if (typeof response === 'object' && response !== null && 'throw' in response) {
+          throw response.throw;
+        }
+        return { stdout: response, stderr: '' };
       }
     }
     throw new Error(`Unexpected command: ${cmd}`);
@@ -91,6 +99,7 @@ describe('runPreflight', () => {
         },
       },
     });
+    readFileMock.mockReset();
   });
 
   it('returns PASS for a correctly isolated implementation branch', async () => {
@@ -119,6 +128,352 @@ describe('runPreflight', () => {
     expect(result.branch_based_on_intended_remote).toBe(true);
     expect(result.persistence?.persisted).toBe(true);
     expect(persistGuardrailEvidenceMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('validates coverage evidence when the reproducibility gate includes coverage', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --git-common-dir': '.git\n',
+      'config --get remote.origin.url': 'git@github.com:madlouse/AgenticOS.git\n',
+      'rev-parse --abbrev-ref HEAD': 'feat/36-guardrail-preflight\n',
+      'rev-parse HEAD': 'abc123\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo\nHEAD abc123\nbranch refs/heads/feat/36-guardrail-preflight\n',
+      'log --format=%s origin/main..HEAD': '',
+    });
+    readFileMock.mockResolvedValue(JSON.stringify({
+      version: 1,
+      generated_at: '2026-05-11T00:00:00.000Z',
+      branch: 'feat/36-guardrail-preflight',
+      commit: 'abc123',
+      base_branch: 'main',
+      threshold_aggregate: { lines: 60, functions: 60, branches: 50, statements: 60 },
+      threshold_changed_scope: { lines: 100, functions: 100, branches: 100, statements: 100 },
+      is_pr: true,
+      changed_files: ['src/foo.ts'],
+      aggregate: { pct_statements: 90, pct_branches: 90, pct_functions: 90, pct_lines: 90 },
+      files: [{ path: 'src/foo.ts', pct_statements: 100, pct_branches: 100, pct_functions: 100, pct_lines: 100 }],
+      aggregate_pass: true,
+      changed_scope_pass: true,
+      pass: true,
+      aggregate_failures: [],
+      changed_scope_failures: [],
+    }));
+
+    const result = JSON.parse(await runPreflight({
+      issue_id: '36',
+      task_type: 'implementation',
+      repo_path: '/repo',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/preflight.ts'],
+      clean_reproducibility_gate: ['./tools/coverage-preflight.sh'],
+      worktree_required: true,
+    })) as { status: string; evidence: { coverage: { validation_pass: boolean; evidence_path: string } } };
+
+    expect(result.status).toBe('PASS');
+    expect(readFileMock).toHaveBeenCalledWith('/repo/mcp-server/coverage/coverage-evidence.json', 'utf-8');
+    expect(result.evidence.coverage.validation_pass).toBe(true);
+  });
+
+  it('blocks stale coverage evidence metadata', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --git-common-dir': '.git\n',
+      'config --get remote.origin.url': 'git@github.com:madlouse/AgenticOS.git\n',
+      'rev-parse --abbrev-ref HEAD': 'feat/36-guardrail-preflight\n',
+      'rev-parse HEAD': 'abc123\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo\nHEAD abc123\nbranch refs/heads/feat/36-guardrail-preflight\n',
+      'log --format=%s origin/main..HEAD': '',
+    });
+    readFileMock.mockResolvedValue(JSON.stringify({
+      version: 1,
+      generated_at: '2026-05-11T00:00:00.000Z',
+      branch: 'feat/36-guardrail-preflight',
+      commit: 'stale123',
+      base_branch: 'main',
+      threshold_aggregate: { lines: 60, functions: 60, branches: 50, statements: 60 },
+      threshold_changed_scope: { lines: 100, functions: 100, branches: 100, statements: 100 },
+      is_pr: true,
+      changed_files: ['src/foo.ts'],
+      aggregate: { pct_statements: 90, pct_branches: 90, pct_functions: 90, pct_lines: 90 },
+      files: [{ path: 'src/foo.ts', pct_statements: 100, pct_branches: 100, pct_functions: 100, pct_lines: 100 }],
+      aggregate_pass: true,
+      changed_scope_pass: true,
+      pass: true,
+      aggregate_failures: [],
+      changed_scope_failures: [],
+    }));
+
+    const result = JSON.parse(await runPreflight({
+      issue_id: '36',
+      task_type: 'implementation',
+      repo_path: '/repo',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/preflight.ts'],
+      clean_reproducibility_gate: ['./tools/coverage-preflight.sh'],
+      worktree_required: true,
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons.join(' ')).toContain('coverage evidence commit "stale123" does not match current HEAD "abc123"');
+  });
+
+  it('blocks coverage evidence with mismatched base and branch metadata', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --git-common-dir': '.git\n',
+      'config --get remote.origin.url': 'git@github.com:madlouse/AgenticOS.git\n',
+      'rev-parse --abbrev-ref HEAD': 'feat/36-guardrail-preflight\n',
+      'rev-parse HEAD': 'abc123\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo\nHEAD abc123\nbranch refs/heads/feat/36-guardrail-preflight\n',
+      'log --format=%s origin/main..HEAD': '',
+    });
+    readFileMock.mockResolvedValue(JSON.stringify({
+      version: 1,
+      generated_at: '2026-05-11T00:00:00.000Z',
+      branch: 'feat/other',
+      commit: 'abc123',
+      base_branch: 'develop',
+      threshold_aggregate: { lines: 60, functions: 60, branches: 50, statements: 60 },
+      threshold_changed_scope: { lines: 100, functions: 100, branches: 100, statements: 100 },
+      is_pr: true,
+      changed_files: ['src/foo.ts'],
+      aggregate: { pct_statements: 90, pct_branches: 90, pct_functions: 90, pct_lines: 90 },
+      files: [{ path: 'src/foo.ts', pct_statements: 100, pct_branches: 100, pct_functions: 100, pct_lines: 100 }],
+      aggregate_pass: true,
+      changed_scope_pass: true,
+      pass: true,
+      aggregate_failures: [],
+      changed_scope_failures: [],
+    }));
+
+    const result = JSON.parse(await runPreflight({
+      issue_id: '36',
+      task_type: 'implementation',
+      repo_path: '/repo',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/preflight.ts'],
+      clean_reproducibility_gate: ['./tools/coverage-preflight.sh'],
+      worktree_required: true,
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons.join(' ')).toContain('coverage evidence base_branch "develop" does not match expected base "origin/main"');
+    expect(result.block_reasons.join(' ')).toContain('coverage evidence branch "feat/other" does not match current branch "feat/36-guardrail-preflight"');
+  });
+
+  it('blocks coverage evidence missing branch metadata on named branches', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --git-common-dir': '.git\n',
+      'config --get remote.origin.url': 'git@github.com:madlouse/AgenticOS.git\n',
+      'rev-parse --abbrev-ref HEAD': 'feat/36-guardrail-preflight\n',
+      'rev-parse HEAD': 'abc123\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo\nHEAD abc123\nbranch refs/heads/feat/36-guardrail-preflight\n',
+      'log --format=%s origin/main..HEAD': '',
+    });
+    readFileMock.mockResolvedValue(JSON.stringify({
+      version: 1,
+      generated_at: '2026-05-11T00:00:00.000Z',
+      commit: 'abc123',
+      base_branch: 'main',
+      threshold_aggregate: { lines: 60, functions: 60, branches: 50, statements: 60 },
+      threshold_changed_scope: { lines: 100, functions: 100, branches: 100, statements: 100 },
+      is_pr: true,
+      changed_files: ['src/foo.ts'],
+      aggregate: { pct_statements: 90, pct_branches: 90, pct_functions: 90, pct_lines: 90 },
+      files: [{ path: 'src/foo.ts', pct_statements: 100, pct_branches: 100, pct_functions: 100, pct_lines: 100 }],
+      aggregate_pass: true,
+      changed_scope_pass: true,
+      pass: true,
+      aggregate_failures: [],
+      changed_scope_failures: [],
+    }));
+
+    const result = JSON.parse(await runPreflight({
+      issue_id: '36',
+      task_type: 'implementation',
+      repo_path: '/repo',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/preflight.ts'],
+      clean_reproducibility_gate: ['./tools/coverage-preflight.sh'],
+      worktree_required: true,
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons.join(' ')).toContain('coverage evidence missing branch metadata');
+  });
+
+  it('blocks coverage evidence missing commit and base metadata', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --git-common-dir': '.git\n',
+      'config --get remote.origin.url': 'git@github.com:madlouse/AgenticOS.git\n',
+      'rev-parse --abbrev-ref HEAD': 'feat/36-guardrail-preflight\n',
+      'rev-parse HEAD': 'abc123\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo\nHEAD abc123\nbranch refs/heads/feat/36-guardrail-preflight\n',
+      'log --format=%s origin/main..HEAD': '',
+    });
+    readFileMock.mockResolvedValue(JSON.stringify({
+      version: 1,
+      generated_at: '2026-05-11T00:00:00.000Z',
+      branch: 'feat/36-guardrail-preflight',
+      threshold_aggregate: { lines: 60, functions: 60, branches: 50, statements: 60 },
+      threshold_changed_scope: { lines: 100, functions: 100, branches: 100, statements: 100 },
+      is_pr: true,
+      changed_files: ['src/foo.ts'],
+      aggregate: { pct_statements: 90, pct_branches: 90, pct_functions: 90, pct_lines: 90 },
+      files: [{ path: 'src/foo.ts', pct_statements: 100, pct_branches: 100, pct_functions: 100, pct_lines: 100 }],
+      aggregate_pass: true,
+      changed_scope_pass: true,
+      pass: true,
+      aggregate_failures: [],
+      changed_scope_failures: [],
+    }));
+
+    const result = JSON.parse(await runPreflight({
+      issue_id: '36',
+      task_type: 'implementation',
+      repo_path: '/repo',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/preflight.ts'],
+      clean_reproducibility_gate: ['./tools/coverage-preflight.sh'],
+      worktree_required: true,
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons.join(' ')).toContain('coverage evidence missing commit metadata');
+    expect(result.block_reasons.join(' ')).toContain('coverage evidence missing base_branch metadata');
+  });
+
+  it('blocks coverage evidence paths outside the repo root', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --git-common-dir': '.git\n',
+      'config --get remote.origin.url': 'git@github.com:madlouse/AgenticOS.git\n',
+      'rev-parse --abbrev-ref HEAD': 'feat/36-guardrail-preflight\n',
+      'rev-parse HEAD': 'abc123\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo\nHEAD abc123\nbranch refs/heads/feat/36-guardrail-preflight\n',
+      'log --format=%s origin/main..HEAD': '',
+    });
+
+    const result = JSON.parse(await runPreflight({
+      issue_id: '36',
+      task_type: 'implementation',
+      repo_path: '/repo',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/preflight.ts'],
+      clean_reproducibility_gate: ['./tools/coverage-preflight.sh'],
+      coverage_evidence_path: '/tmp/coverage-evidence.json',
+      worktree_required: true,
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons.join(' ')).toContain('coverage evidence path escapes repo root');
+    expect(readFileMock).not.toHaveBeenCalled();
+  });
+
+  it('blocks invalid coverage evidence when coverage gate is requested', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --git-common-dir': '.git\n',
+      'config --get remote.origin.url': 'git@github.com:madlouse/AgenticOS.git\n',
+      'rev-parse --abbrev-ref HEAD': 'feat/36-guardrail-preflight\n',
+      'rev-parse HEAD': 'abc123\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo\nHEAD abc123\nbranch refs/heads/feat/36-guardrail-preflight\n',
+      'log --format=%s origin/main..HEAD': '',
+    });
+    readFileMock.mockResolvedValue(JSON.stringify({
+      version: 1,
+      generated_at: '2026-05-11T00:00:00.000Z',
+      branch: 'feat/36-guardrail-preflight',
+      commit: 'abc123',
+      base_branch: 'main',
+      threshold_aggregate: { lines: 60, functions: 60, branches: 50, statements: 60 },
+      threshold_changed_scope: { lines: 100, functions: 100, branches: 100, statements: 100 },
+      is_pr: true,
+      changed_files: ['src/foo.ts'],
+      aggregate: { pct_statements: 90, pct_branches: 90, pct_functions: 90, pct_lines: 90 },
+      files: [{ path: 'src/foo.ts', pct_statements: 100, pct_branches: 100, pct_functions: 100, pct_lines: 50 }],
+      aggregate_pass: true,
+      changed_scope_pass: true,
+      pass: true,
+      aggregate_failures: [],
+      changed_scope_failures: [],
+    }));
+
+    const result = JSON.parse(await runPreflight({
+      issue_id: '36',
+      task_type: 'implementation',
+      repo_path: '/repo',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/preflight.ts'],
+      clean_reproducibility_gate: ['./tools/coverage-preflight.sh'],
+      worktree_required: true,
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons.join(' ')).toContain('coverage evidence validation failed');
+    expect(result.block_reasons.join(' ')).toContain('changed-scope: src/foo.ts: lines 50% < 100%');
+  });
+
+  it('blocks when requested coverage evidence is missing', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --git-common-dir': '.git\n',
+      'config --get remote.origin.url': 'git@github.com:madlouse/AgenticOS.git\n',
+      'rev-parse --abbrev-ref HEAD': 'feat/36-guardrail-preflight\n',
+      'rev-parse HEAD': 'abc123\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo\nHEAD abc123\nbranch refs/heads/feat/36-guardrail-preflight\n',
+      'log --format=%s origin/main..HEAD': '',
+    });
+    readFileMock.mockRejectedValue(new Error('ENOENT'));
+
+    const result = JSON.parse(await runPreflight({
+      issue_id: '36',
+      task_type: 'implementation',
+      repo_path: '/repo',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/preflight.ts'],
+      clean_reproducibility_gate: ['./tools/coverage-preflight.sh'],
+      worktree_required: true,
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons.join(' ')).toContain('coverage evidence missing or unreadable');
+  });
+
+  it('reports non-Error coverage evidence read failures', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --git-common-dir': '.git\n',
+      'config --get remote.origin.url': 'git@github.com:madlouse/AgenticOS.git\n',
+      'rev-parse --abbrev-ref HEAD': 'feat/36-guardrail-preflight\n',
+      'rev-parse HEAD': 'abc123\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo\nHEAD abc123\nbranch refs/heads/feat/36-guardrail-preflight\n',
+      'log --format=%s origin/main..HEAD': '',
+    });
+    readFileMock.mockRejectedValue('raw failure');
+
+    const result = JSON.parse(await runPreflight({
+      issue_id: '36',
+      task_type: 'implementation',
+      repo_path: '/repo',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/preflight.ts'],
+      clean_reproducibility_gate: ['./tools/coverage-preflight.sh'],
+      worktree_required: true,
+    })) as { evidence: { coverage: { errors: string[] } } };
+
+    expect(result.evidence.coverage.errors).toContain('coverage evidence missing or unreadable: raw failure');
   });
 
   it('returns REDIRECT when implementation starts on main workspace', async () => {
@@ -1026,6 +1381,32 @@ describe('runPreflight', () => {
     expect(result.block_reasons.join(' ')).toContain('clean_reproducibility_gate');
   });
 
+  it('blocks detected renames when structural_move is not declared', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --git-common-dir': '.git\n',
+      'config --get remote.origin.url': 'git@github.com:madlouse/AgenticOS.git\n',
+      'rev-parse --abbrev-ref HEAD': 'feat/36-guardrail-preflight\n',
+      'rev-parse HEAD': 'abc123\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo\nHEAD abc123\nbranch refs/heads/feat/36-guardrail-preflight\n',
+      'log --format=%s origin/main..HEAD': '',
+      'diff --name-status --diff-filter=R origin/main HEAD': 'R100\told.ts\tnew.ts\n',
+    });
+
+    const result = JSON.parse(await runPreflight({
+      issue_id: '36',
+      task_type: 'implementation',
+      repo_path: '/repo',
+      declared_target_files: ['projects/agenticos/mcp-server/src/tools/preflight.ts'],
+      worktree_required: true,
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons).toContain('Structural move detected but not declared');
+  });
+
   it('accepts structural move when root exception and reproducibility gate are both defined', async () => {
     mockGitResponses({
       'rev-parse --show-toplevel': '/repo\n',
@@ -1072,6 +1453,246 @@ describe('runPreflight', () => {
 
     expect(result.status).toBe('PASS');
     expect(result.reproducibility_gate_defined).toBe(true);
+  });
+
+  it('blocks when structural move rename detection fails', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --git-common-dir': '.git\n',
+      'config --get remote.origin.url': 'git@github.com:madlouse/AgenticOS.git\n',
+      'rev-parse --abbrev-ref HEAD': 'feat/40-self-hosting\n',
+      'rev-parse HEAD': 'abc123\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo\nHEAD abc123\nbranch refs/heads/feat/40-self-hosting\n',
+      'log --format=%s origin/main..HEAD': '',
+    });
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/runtime/.agent-workspace/projects/agenticos/guardrail-state.yaml',
+      state: {
+        issue_bootstrap: {
+          latest: {
+            issue_id: '40',
+            repo_path: '/repo',
+            current_branch: 'feat/40-self-hosting',
+            startup_context_paths: ['/workspace/projects/agenticos/standards/.project.yaml'],
+            stages: {
+              context_reset_performed: true,
+              project_hot_load_performed: true,
+              issue_payload_attached: true,
+            },
+          },
+        },
+      },
+    });
+
+    const result = JSON.parse(await runPreflight({
+      issue_id: '40',
+      task_type: 'implementation',
+      repo_path: '/repo',
+      declared_target_files: ['projects/agenticos/**'],
+      worktree_required: true,
+      structural_move: true,
+      root_scoped_exceptions: ['.github/'],
+      clean_reproducibility_gate: ['npm run build'],
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons.join(' ')).toContain('failed to detect renamed files');
+  });
+
+  it('reports non-Error structural move rename detection failures', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --git-common-dir': '.git\n',
+      'config --get remote.origin.url': 'git@github.com:madlouse/AgenticOS.git\n',
+      'rev-parse --abbrev-ref HEAD': 'feat/40-self-hosting\n',
+      'rev-parse HEAD': 'abc123\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo\nHEAD abc123\nbranch refs/heads/feat/40-self-hosting\n',
+      'log --format=%s origin/main..HEAD': '',
+      'diff --name-status --diff-filter=R origin/main HEAD': { throw: 'diff failed' },
+    });
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/runtime/.agent-workspace/projects/agenticos/guardrail-state.yaml',
+      state: {
+        issue_bootstrap: {
+          latest: {
+            issue_id: '40',
+            repo_path: '/repo',
+            current_branch: 'feat/40-self-hosting',
+            startup_context_paths: ['/workspace/projects/agenticos/standards/.project.yaml'],
+            stages: {
+              context_reset_performed: true,
+              project_hot_load_performed: true,
+              issue_payload_attached: true,
+            },
+          },
+        },
+      },
+    });
+
+    const result = JSON.parse(await runPreflight({
+      issue_id: '40',
+      task_type: 'implementation',
+      repo_path: '/repo',
+      declared_target_files: ['projects/agenticos/**'],
+      worktree_required: true,
+      structural_move: true,
+      root_scoped_exceptions: ['.github/'],
+      clean_reproducibility_gate: ['npm run build'],
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons.join(' ')).toContain('failed to detect renamed files: diff failed');
+  });
+
+  it('blocks when structural move gate command fails for detected renames', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --git-common-dir': '.git\n',
+      'config --get remote.origin.url': 'git@github.com:madlouse/AgenticOS.git\n',
+      'rev-parse --abbrev-ref HEAD': 'feat/40-self-hosting\n',
+      'rev-parse HEAD': 'abc123\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo\nHEAD abc123\nbranch refs/heads/feat/40-self-hosting\n',
+      'log --format=%s origin/main..HEAD': '',
+      'diff --name-status --diff-filter=R origin/main HEAD': 'R100\told.ts\tnew.ts\n',
+    });
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/runtime/.agent-workspace/projects/agenticos/guardrail-state.yaml',
+      state: {
+        issue_bootstrap: {
+          latest: {
+            issue_id: '40',
+            repo_path: '/repo',
+            current_branch: 'feat/40-self-hosting',
+            startup_context_paths: ['/workspace/projects/agenticos/standards/.project.yaml'],
+            stages: {
+              context_reset_performed: true,
+              project_hot_load_performed: true,
+              issue_payload_attached: true,
+            },
+          },
+        },
+      },
+    });
+
+    const result = JSON.parse(await runPreflight({
+      issue_id: '40',
+      task_type: 'implementation',
+      repo_path: '/repo',
+      declared_target_files: ['projects/agenticos/**'],
+      worktree_required: true,
+      structural_move: true,
+      root_scoped_exceptions: ['.github/'],
+      clean_reproducibility_gate: ['npm run build'],
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons.join(' ')).toContain('clean_reproducibility_gate failed for command "npm run build"');
+  });
+
+  it('accepts structural move gate success for detected renames', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --git-common-dir': '.git\n',
+      'config --get remote.origin.url': 'git@github.com:madlouse/AgenticOS.git\n',
+      'rev-parse --abbrev-ref HEAD': 'feat/40-self-hosting\n',
+      'rev-parse HEAD': 'abc123\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo\nHEAD abc123\nbranch refs/heads/feat/40-self-hosting\n',
+      'log --format=%s origin/main..HEAD': '',
+      'diff --name-status --diff-filter=R origin/main HEAD': 'R100\told.ts\tnew.ts\n',
+      'npm run build': '',
+    });
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/runtime/.agent-workspace/projects/agenticos/guardrail-state.yaml',
+      state: {
+        issue_bootstrap: {
+          latest: {
+            issue_id: '40',
+            repo_path: '/repo',
+            current_branch: 'feat/40-self-hosting',
+            startup_context_paths: ['/workspace/projects/agenticos/standards/.project.yaml'],
+            stages: {
+              context_reset_performed: true,
+              project_hot_load_performed: true,
+              issue_payload_attached: true,
+            },
+          },
+        },
+      },
+    });
+
+    const result = JSON.parse(await runPreflight({
+      issue_id: '40',
+      task_type: 'implementation',
+      repo_path: '/repo',
+      declared_target_files: ['projects/agenticos/**'],
+      worktree_required: true,
+      structural_move: true,
+      root_scoped_exceptions: ['.github/'],
+      clean_reproducibility_gate: ['npm run build'],
+    })) as { status: string };
+
+    expect(result.status).toBe('PASS');
+  });
+
+  it('reports non-Error structural move gate command failures', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': '/repo\n',
+      'rev-parse --git-common-dir': '.git\n',
+      'config --get remote.origin.url': 'git@github.com:madlouse/AgenticOS.git\n',
+      'rev-parse --abbrev-ref HEAD': 'feat/40-self-hosting\n',
+      'rev-parse HEAD': 'abc123\n',
+      'rev-parse origin/main': 'base999\n',
+      'merge-base HEAD origin/main': 'base999\n',
+      'worktree list --porcelain': 'worktree /main\nHEAD deadbeef\nbranch refs/heads/main\n\nworktree /repo\nHEAD abc123\nbranch refs/heads/feat/40-self-hosting\n',
+      'log --format=%s origin/main..HEAD': '',
+      'diff --name-status --diff-filter=R origin/main HEAD': 'R100\told.ts\tnew.ts\n',
+      'npm run build': { throw: 'gate failed' },
+    });
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'runtime',
+      state_path: '/runtime/.agent-workspace/projects/agenticos/guardrail-state.yaml',
+      state: {
+        issue_bootstrap: {
+          latest: {
+            issue_id: '40',
+            repo_path: '/repo',
+            current_branch: 'feat/40-self-hosting',
+            startup_context_paths: ['/workspace/projects/agenticos/standards/.project.yaml'],
+            stages: {
+              context_reset_performed: true,
+              project_hot_load_performed: true,
+              issue_payload_attached: true,
+            },
+          },
+        },
+      },
+    });
+
+    const result = JSON.parse(await runPreflight({
+      issue_id: '40',
+      task_type: 'implementation',
+      repo_path: '/repo',
+      declared_target_files: ['projects/agenticos/**'],
+      worktree_required: true,
+      structural_move: true,
+      root_scoped_exceptions: ['.github/'],
+      clean_reproducibility_gate: ['npm run build'],
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons.join(' ')).toContain('clean_reproducibility_gate failed for command "npm run build": gate failed');
   });
 
   it('returns PASS for non implementation-affecting task types without bootstrap enforcement', async () => {

--- a/mcp-server/src/tools/coverage-check.ts
+++ b/mcp-server/src/tools/coverage-check.ts
@@ -1,7 +1,37 @@
-import { readFile } from 'fs/promises';
-import { join } from 'path';
+import { mkdir, readFile, writeFile } from 'fs/promises';
+import { dirname, join, relative, resolve, sep } from 'path';
 import { resolveManagedProjectTarget } from '../utils/project-target.js';
 import { generateCoverageEvidence, validateCoverageEvidence, type CoverageEvidence } from '../utils/coverage-evidence.js';
+
+function isWithinDirectory(root: string, candidate: string): boolean {
+  const relativePath = relative(root, candidate);
+  return relativePath === '' || (!relativePath.startsWith('..') && !relativePath.includes(`..${sep}`));
+}
+
+function resolveProjectPath(projectPath: string, candidatePath: string | undefined, defaultPath: string): string {
+  const projectRoot = resolve(projectPath);
+  const resolvedPath = candidatePath ? resolve(projectRoot, candidatePath) : resolve(defaultPath);
+  if (!isWithinDirectory(projectRoot, resolvedPath)) {
+    throw new Error(`path must stay inside project root: ${projectRoot}`);
+  }
+  return resolvedPath;
+}
+
+function parseChangedFilesJson(input: unknown): { changedFiles: string[]; error?: string } {
+  if (input === undefined) return { changedFiles: [] };
+  let parsed = input;
+  if (typeof input === 'string') {
+    try {
+      parsed = JSON.parse(input);
+    } catch {
+      return { changedFiles: [], error: 'changed_files_json is not valid JSON' };
+    }
+  }
+  if (!Array.isArray(parsed) || !parsed.every((file) => typeof file === 'string')) {
+    return { changedFiles: [], error: 'changed_files_json must be an array of strings' };
+  }
+  return { changedFiles: parsed };
+}
 
 export async function runCoverageCheck(args: any): Promise<string> {
   const { evidence_path } = args;
@@ -10,6 +40,7 @@ export async function runCoverageCheck(args: any): Promise<string> {
   try {
     resolved = await resolveManagedProjectTarget({
       project: args.project,
+      projectPath: args.project_path,
       commandName: 'agenticos_coverage_check',
     });
   } catch (error: any) {
@@ -17,8 +48,13 @@ export async function runCoverageCheck(args: any): Promise<string> {
   }
 
   const { projectPath } = resolved;
-  const defaultPath = join(projectPath, 'mcp-server/coverage/coverage-final.json');
-  const evidenceFile = evidence_path || defaultPath;
+  const defaultPath = join(projectPath, 'mcp-server/coverage/coverage-evidence.json');
+  let evidenceFile: string;
+  try {
+    evidenceFile = resolveProjectPath(projectPath, evidence_path, defaultPath);
+  } catch (error: any) {
+    return `❌ ${error.message}`;
+  }
 
   let content: string;
   try {
@@ -27,7 +63,7 @@ export async function runCoverageCheck(args: any): Promise<string> {
     return `❌ coverage-evidence.json not found or unreadable at ${evidenceFile}`;
   }
 
-  let parsed: CoverageEvidence;
+  let parsed: any;
   try {
     parsed = JSON.parse(content);
   } catch {
@@ -35,6 +71,7 @@ export async function runCoverageCheck(args: any): Promise<string> {
   }
 
   const { pass, errors, warnings } = validateCoverageEvidence(parsed);
+  const summary = parsed && typeof parsed === 'object' ? parsed : {};
 
   const lines: string[] = [];
   if (pass) {
@@ -57,26 +94,28 @@ export async function runCoverageCheck(args: any): Promise<string> {
   }
 
   lines.push('\n**Evidence summary:**');
-  lines.push(`  - Generated at: ${parsed.generated_at || '(unknown)'}`);
-  lines.push(`  - Running in PR: ${parsed.is_pr ? 'yes' : 'no'}`);
-  lines.push(`  - Changed files: ${parsed.changed_files.length > 0 ? parsed.changed_files.join(', ') : '(none)'}`);
-  lines.push(`  - Aggregate lines: ${parsed.aggregate?.pct_lines ?? '?'}% (floor: ${parsed.threshold_aggregate?.lines}%)`);
-  lines.push(`  - Aggregate functions: ${parsed.aggregate?.pct_functions ?? '?'}% (floor: ${parsed.threshold_aggregate?.functions}%)`);
-  lines.push(`  - Aggregate branches: ${parsed.aggregate?.pct_branches ?? '?'}% (floor: ${parsed.threshold_aggregate?.branches}%)`);
-  lines.push(`  - Aggregate statements: ${parsed.aggregate?.pct_statements ?? '?'}% (floor: ${parsed.threshold_aggregate?.statements}%)`);
-  lines.push(`  - Aggregate pass: ${parsed.aggregate_pass ? '✅' : '❌'}`);
-  lines.push(`  - Changed-scope pass: ${parsed.changed_scope_pass ? '✅' : '⚠️ (inactive)'}`);
+  lines.push(`  - Generated at: ${summary.generated_at || '(unknown)'}`);
+  lines.push(`  - Running in PR: ${summary.is_pr ? 'yes' : 'no'}`);
+  const changedFiles = Array.isArray(summary.changed_files) ? summary.changed_files : [];
+  lines.push(`  - Changed files: ${changedFiles.length > 0 ? changedFiles.join(', ') : '(none)'}`);
+  lines.push(`  - Aggregate lines: ${summary.aggregate?.pct_lines ?? '?'}% (floor: ${summary.threshold_aggregate?.lines}%)`);
+  lines.push(`  - Aggregate functions: ${summary.aggregate?.pct_functions ?? '?'}% (floor: ${summary.threshold_aggregate?.functions}%)`);
+  lines.push(`  - Aggregate branches: ${summary.aggregate?.pct_branches ?? '?'}% (floor: ${summary.threshold_aggregate?.branches}%)`);
+  lines.push(`  - Aggregate statements: ${summary.aggregate?.pct_statements ?? '?'}% (floor: ${summary.threshold_aggregate?.statements}%)`);
+  lines.push(`  - Aggregate pass: ${summary.aggregate_pass ? '✅' : '❌'}`);
+  lines.push(`  - Changed-scope pass: ${summary.changed_scope_pass ? '✅' : '⚠️ (inactive)'}`);
 
   return lines.join('\n');
 }
 
 export async function runCoverageGenerate(args: any): Promise<string> {
-  const { coverage_json_path, is_pr = false, changed_files_json } = args;
+  const { coverage_json_path, evidence_path, is_pr = false, changed_files_json } = args;
 
   let resolved;
   try {
     resolved = await resolveManagedProjectTarget({
       project: args.project,
+      projectPath: args.project_path,
       commandName: 'agenticos_coverage_check',
     });
   } catch (error: any) {
@@ -85,7 +124,12 @@ export async function runCoverageGenerate(args: any): Promise<string> {
 
   const { projectPath } = resolved;
   const defaultPath = join(projectPath, 'mcp-server/coverage/coverage-final.json');
-  const jsonPath = coverage_json_path || defaultPath;
+  let jsonPath: string;
+  try {
+    jsonPath = resolveProjectPath(projectPath, coverage_json_path, defaultPath);
+  } catch (error: any) {
+    return `❌ ${error.message}`;
+  }
 
   let content: string;
   try {
@@ -101,11 +145,27 @@ export async function runCoverageGenerate(args: any): Promise<string> {
     return `❌ coverage-final.json is not valid JSON`;
   }
 
-  const changedFiles = typeof changed_files_json === 'string'
-    ? JSON.parse(changed_files_json)
-    : Array.isArray(changed_files_json) ? changed_files_json : [];
+  const { changedFiles, error } = parseChangedFilesJson(changed_files_json);
+  if (error) {
+    return `❌ ${error}`;
+  }
 
-  const evidence = generateCoverageEvidence(coverageJson, is_pr, changedFiles);
+  const evidence = generateCoverageEvidence(coverageJson, is_pr, changedFiles, {
+    metadata: {
+      branch: process.env.GITHUB_HEAD_REF || process.env.GITHUB_REF_NAME,
+      commit: process.env.GITHUB_SHA,
+      base_branch: process.env.GITHUB_BASE_REF,
+      pr_number: process.env.PR_NUMBER || process.env.GITHUB_EVENT_NUMBER,
+    },
+  });
+  let evidenceFile: string;
+  try {
+    evidenceFile = resolveProjectPath(projectPath, evidence_path, join(projectPath, 'mcp-server/coverage/coverage-evidence.json'));
+  } catch (error: any) {
+    return `❌ ${error.message}`;
+  }
+  await mkdir(dirname(evidenceFile), { recursive: true });
+  await writeFile(evidenceFile, JSON.stringify(evidence, null, 2), 'utf-8');
 
   const lines: string[] = [];
   if (evidence.pass) {
@@ -118,6 +178,7 @@ export async function runCoverageGenerate(args: any): Promise<string> {
   lines.push(`Aggregate floor: lines=${evidence.threshold_aggregate.lines}%, functions=${evidence.threshold_aggregate.functions}%, branches=${evidence.threshold_aggregate.branches}%, statements=${evidence.threshold_aggregate.statements}%`);
   lines.push(`Aggregate pass: ${evidence.aggregate_pass}`);
   lines.push(`Changed-scope pass: ${evidence.changed_scope_pass}`);
+  lines.push(`Evidence written: ${evidenceFile}`);
 
   if (evidence.aggregate_failures.length > 0) {
     lines.push(`\nAggregate failures:`);

--- a/mcp-server/src/tools/preflight.ts
+++ b/mcp-server/src/tools/preflight.ts
@@ -1,5 +1,6 @@
 import { exec } from 'child_process';
-import { dirname, resolve } from 'path';
+import { readFile } from 'fs/promises';
+import { dirname, relative, resolve, sep } from 'path';
 import { promisify } from 'util';
 import {
   extractLatestIssueBootstrap,
@@ -15,8 +16,18 @@ import {
 } from '../utils/repo-boundary.js';
 import { validateGuardrailRepoIdentity } from '../utils/guardrail-repo-identity.js';
 import { classifyUnrelatedCommitSubjects } from '../utils/issue-commit-scope.js';
+import { validateCoverageEvidence, type CoverageEvidence } from '../utils/coverage-evidence.js';
 
 const execAsync = promisify(exec);
+
+function isWithinDirectory(root: string, candidate: string): boolean {
+  const relativePath = relative(root, candidate);
+  return relativePath === '' || (!relativePath.startsWith('..') && !relativePath.includes(`..${sep}`));
+}
+
+function normalizeBranchName(branch: string): string {
+  return branch.replace(/^refs\/heads\//, '').replace(/^origin\//, '');
+}
 
 type WorkspaceType = 'main' | 'isolated_worktree';
 type GuardrailStatus = 'PASS' | 'BLOCK' | 'REDIRECT';
@@ -32,6 +43,7 @@ interface PreflightArgs {
   worktree_required?: boolean;
   root_scoped_exceptions?: string[];
   clean_reproducibility_gate?: string[];
+  coverage_evidence_path?: string;
 }
 
 interface PreflightResult {
@@ -67,6 +79,12 @@ interface PreflightResult {
       issue_id: string | null;
       repo_path: string | null;
       current_branch: string | null;
+    } | null;
+    coverage: {
+      evidence_path: string | null;
+      validation_pass: boolean | null;
+      errors: string[];
+      warnings: string[];
     } | null;
   };
   persistence?: GuardrailPersistenceResult;
@@ -149,6 +167,7 @@ function makeBaseResult(remoteBaseBranch: string): PreflightResult {
       workspace_type: 'main',
       commit_subjects_since_base: [],
       issue_bootstrap: null,
+      coverage: null,
     },
   };
 }
@@ -165,6 +184,7 @@ export async function runPreflight(args: PreflightArgs): Promise<string> {
     worktree_required = isImplementationAffectingTask(task_type),
     root_scoped_exceptions = ['.github/'],
     clean_reproducibility_gate = [],
+    coverage_evidence_path,
   } = args;
 
   const result = makeBaseResult(remote_base_branch);
@@ -404,6 +424,67 @@ export async function runPreflight(args: PreflightArgs): Promise<string> {
     result.branch_based_on_intended_remote = true;
     result.scope_ok = true;
     result.reproducibility_gate_defined = true;
+  }
+
+  const coverageGateRequested = isImplementationAffectingTask(task_type)
+    && clean_reproducibility_gate.some((command) => command.includes('coverage'));
+  if (coverageGateRequested) {
+    const repoRoot = resolve(repo_path);
+    const evidencePath = coverage_evidence_path
+      ? resolve(repoRoot, coverage_evidence_path)
+      : resolve(repoRoot, 'mcp-server/coverage/coverage-evidence.json');
+    if (!isWithinDirectory(repoRoot, evidencePath)) {
+      result.evidence.coverage = {
+        evidence_path: evidencePath,
+        validation_pass: false,
+        errors: [`coverage evidence path must stay inside repo root: ${repoRoot}`],
+        warnings: [],
+      };
+      result.block_reasons.push(`coverage evidence path escapes repo root: ${evidencePath}`);
+    } else {
+      try {
+        const parsed = JSON.parse(await readFile(evidencePath, 'utf-8')) as CoverageEvidence;
+        const coverageValidation = validateCoverageEvidence(parsed);
+        const metadataErrors: string[] = [];
+        const expectedBaseBranch = normalizeBranchName(remote_base_branch);
+        if (!parsed.commit) {
+          metadataErrors.push('coverage evidence missing commit metadata');
+        } else if (parsed.commit !== result.evidence.current_head) {
+          metadataErrors.push(`coverage evidence commit "${parsed.commit}" does not match current HEAD "${result.evidence.current_head}"`);
+        }
+        if (!parsed.base_branch) {
+          metadataErrors.push('coverage evidence missing base_branch metadata');
+        } else if (normalizeBranchName(parsed.base_branch) !== expectedBaseBranch) {
+          metadataErrors.push(`coverage evidence base_branch "${parsed.base_branch}" does not match expected base "${remote_base_branch}"`);
+        }
+        if (result.evidence.current_branch !== 'HEAD') {
+          if (!parsed.branch) {
+            metadataErrors.push('coverage evidence missing branch metadata');
+          } else if (normalizeBranchName(parsed.branch) !== normalizeBranchName(result.evidence.current_branch)) {
+            metadataErrors.push(`coverage evidence branch "${parsed.branch}" does not match current branch "${result.evidence.current_branch}"`);
+          }
+        }
+        const coverageErrors = [...coverageValidation.errors, ...metadataErrors];
+        const coveragePass = coverageValidation.pass && metadataErrors.length === 0;
+        result.evidence.coverage = {
+          evidence_path: evidencePath,
+          validation_pass: coveragePass,
+          errors: coverageErrors,
+          warnings: coverageValidation.warnings,
+        };
+        if (!coveragePass) {
+          result.block_reasons.push(`coverage evidence validation failed: ${coverageErrors.join('; ')}`);
+        }
+      } catch (error: any) {
+        result.evidence.coverage = {
+          evidence_path: evidencePath,
+          validation_pass: false,
+          errors: [`coverage evidence missing or unreadable: ${error?.message || String(error)}`],
+          warnings: [],
+        };
+        result.block_reasons.push(`coverage evidence missing or unreadable at ${evidencePath}`);
+      }
+    }
   }
 
   const finalized = finalizeResult(result);

--- a/mcp-server/src/utils/__tests__/coverage-evidence.test.ts
+++ b/mcp-server/src/utils/__tests__/coverage-evidence.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { generateCoverageEvidence } from '../coverage-evidence.js';
+import { generateCoverageEvidence, validateCoverageEvidence } from '../coverage-evidence.js';
 
 describe('generateCoverageEvidence', () => {
   it('flags changed-scope failures using direct path lookup', () => {
@@ -54,5 +54,299 @@ describe('generateCoverageEvidence', () => {
 
     expect(evidence.changed_scope_pass).toBe(false);
     expect(evidence.changed_scope_failures).toContain('src/missing.ts: file missing from coverage report');
+  });
+
+  it('derives line coverage from Istanbul statement maps when line hits are absent', () => {
+    const evidence = generateCoverageEvidence(
+      {
+        'src/statement-map.ts': {
+          statementMap: {
+            '1': { start: { line: 10 }, end: { line: 10 } },
+            '2': { start: { line: 11 }, end: { line: 12 } },
+          },
+          s: { '1': 1, '2': 0 },
+          b: {},
+          f: { '1': 1 },
+        },
+      },
+      false,
+      [],
+    );
+
+    expect(evidence.version).toBe(1);
+    expect(evidence.files[0].pct_lines).toBe(33);
+    expect(evidence.threshold_aggregate).toEqual({ lines: 60, functions: 60, branches: 50, statements: 60 });
+  });
+
+  it('checks changed-scope function coverage independently from line coverage', () => {
+    const evidence = generateCoverageEvidence(
+      {
+        'src/functions.ts': {
+          s: { '1': 1, '2': 1 },
+          b: {},
+          f: { '1': 1, '2': 0 },
+          lh: [1, 1],
+        },
+      },
+      true,
+      ['src/functions.ts'],
+    );
+
+    expect(evidence.changed_scope_pass).toBe(false);
+    expect(evidence.changed_scope_failures).toContain('src/functions.ts: functions 50% < 100%');
+  });
+
+  it('checks changed-scope branch and statement coverage', () => {
+    const evidence = generateCoverageEvidence(
+      {
+        'src/branches.ts': {
+          s: { '1': 1, '2': 0 },
+          b: { '1': [1, 0] },
+          f: { '1': 1 },
+          lh: [1, 1],
+        },
+      },
+      true,
+      ['src/branches.ts'],
+    );
+
+    expect(evidence.changed_scope_pass).toBe(false);
+    expect(evidence.changed_scope_failures).toContain('src/branches.ts: branches 50% < 100%');
+    expect(evidence.changed_scope_failures).toContain('src/branches.ts: statements 50% < 100%');
+  });
+
+  it('skips synthetic entries and carries metadata plus threshold overrides', () => {
+    const evidence = generateCoverageEvidence(
+      {
+        '<total>': {
+          s: { '1': 0 },
+          b: {},
+          f: {},
+          lh: [0],
+        },
+        'node_modules/pkg/index.ts': {
+          s: { '1': 0 },
+          b: {},
+          f: {},
+          lh: [0],
+        },
+      },
+      true,
+      [],
+      {
+        aggregateFloor: { lines: 10 },
+        metadata: { branch: 'feature', commit: 'abc123', base_branch: 'main', pr_number: '12' },
+      },
+    );
+
+    expect(evidence.files).toEqual([]);
+    expect(evidence.aggregate.pct_lines).toBe(100);
+    expect(evidence.threshold_aggregate.lines).toBe(10);
+    expect(evidence.branch).toBe('feature');
+    expect(evidence.commit).toBe('abc123');
+    expect(evidence.base_branch).toBe('main');
+    expect(evidence.pr_number).toBe('12');
+  });
+
+  it('ignores statement map entries without numeric line locations', () => {
+    const evidence = generateCoverageEvidence(
+      {
+        'src/no-line.ts': {
+          statementMap: {
+            '1': { start: {}, end: {} },
+          },
+          s: { '1': 1 },
+          b: {},
+          f: {},
+        },
+      },
+      false,
+      [],
+    );
+
+    expect(evidence.files[0].pct_lines).toBe(100);
+  });
+
+  it('validates malformed and changed-scope failing evidence', () => {
+    const result = validateCoverageEvidence({
+      version: 0 as any,
+      generated_at: '',
+      threshold_aggregate: { lines: 60, functions: 60, branches: 50, statements: 60 },
+      threshold_changed_scope: { lines: 100, functions: 100, branches: 100, statements: 100 },
+      is_pr: true,
+      changed_files: ['src/failing.ts'],
+      aggregate: { pct_statements: 70, pct_branches: 70, pct_functions: 70, pct_lines: 70 },
+      files: undefined as any,
+      aggregate_pass: true,
+      changed_scope_pass: false,
+      pass: false,
+      aggregate_failures: [],
+      changed_scope_failures: ['src/failing.ts: lines 90% < 100%'],
+    });
+
+    expect(result.pass).toBe(false);
+    expect(result.errors).toContain('coverage-evidence.json: missing generated_at field');
+    expect(result.errors).toContain('coverage-evidence.json: unsupported or missing version');
+    expect(result.errors).toContain('coverage-evidence.json: missing or invalid files array');
+    expect(result.errors).toContain('changed-scope: src/failing.ts: lines 90% < 100%');
+  });
+
+  it('reports non-object evidence roots without throwing', () => {
+    const result = validateCoverageEvidence(null);
+
+    expect(result.pass).toBe(false);
+    expect(result.errors).toContain('coverage-evidence.json: root must be an object');
+  });
+
+  it('reports missing aggregate thresholds and invalid changed files without throwing', () => {
+    const result = validateCoverageEvidence({
+      version: 1,
+      generated_at: '2026-05-11T00:00:00Z',
+      threshold_aggregate: undefined as any,
+      threshold_changed_scope: { lines: 100, functions: 100, branches: 100, statements: 100 },
+      is_pr: true,
+      changed_files: undefined as any,
+      aggregate: { pct_statements: 70, pct_branches: 70, pct_functions: 70, pct_lines: 70 },
+      files: [],
+      aggregate_pass: false,
+      changed_scope_pass: false,
+      pass: false,
+      aggregate_failures: [],
+      changed_scope_failures: [],
+    });
+
+    expect(result.pass).toBe(false);
+    expect(result.errors).toContain('coverage-evidence.json: missing threshold_aggregate section');
+    expect(result.errors).toContain('coverage-evidence.json: missing or invalid changed_files array');
+  });
+
+  it('rejects evidence that lowers canonical thresholds', () => {
+    const result = validateCoverageEvidence({
+      version: 1,
+      generated_at: '2026-05-11T00:00:00Z',
+      threshold_aggregate: { lines: 1, functions: 1, branches: 1, statements: 1 },
+      threshold_changed_scope: { lines: 1, functions: 1, branches: 1, statements: 1 },
+      is_pr: true,
+      changed_files: ['src/foo.ts'],
+      aggregate: { pct_statements: 90, pct_branches: 90, pct_functions: 90, pct_lines: 90 },
+      files: [{ path: 'src/foo.ts', pct_statements: 100, pct_branches: 100, pct_functions: 100, pct_lines: 100 }],
+      aggregate_pass: true,
+      changed_scope_pass: true,
+      pass: true,
+      aggregate_failures: [],
+      changed_scope_failures: [],
+    });
+
+    expect(result.pass).toBe(false);
+    expect(result.errors).toContain('coverage-evidence.json: threshold_aggregate.lines 1% is below canonical floor 60%');
+    expect(result.errors).toContain('coverage-evidence.json: threshold_changed_scope.lines 1% is below canonical floor 100%');
+  });
+
+  it('recomputes changed-scope failures instead of trusting evidence flags', () => {
+    const result = validateCoverageEvidence({
+      version: 1,
+      generated_at: '2026-05-11T00:00:00Z',
+      threshold_aggregate: { lines: 60, functions: 60, branches: 50, statements: 60 },
+      threshold_changed_scope: { lines: 100, functions: 100, branches: 100, statements: 100 },
+      is_pr: true,
+      changed_files: ['src/foo.ts'],
+      aggregate: { pct_statements: 90, pct_branches: 90, pct_functions: 90, pct_lines: 90 },
+      files: [{ path: 'src/foo.ts', pct_statements: 100, pct_branches: 100, pct_functions: 100, pct_lines: 50 }],
+      aggregate_pass: true,
+      changed_scope_pass: true,
+      pass: true,
+      aggregate_failures: [],
+      changed_scope_failures: [],
+    });
+
+    expect(result.pass).toBe(false);
+    expect(result.errors).toContain('changed-scope: src/foo.ts: lines 50% < 100%');
+  });
+
+  it('reports missing aggregate evidence', () => {
+    const result = validateCoverageEvidence({
+      version: 1,
+      generated_at: '2026-05-11T00:00:00Z',
+      threshold_aggregate: { lines: 60, functions: 60, branches: 50, statements: 60 },
+      threshold_changed_scope: { lines: 100, functions: 100, branches: 100, statements: 100 },
+      is_pr: false,
+      changed_files: [],
+      aggregate: undefined as any,
+      files: [],
+      aggregate_pass: false,
+      changed_scope_pass: true,
+      pass: false,
+      aggregate_failures: [],
+      changed_scope_failures: [],
+    });
+
+    expect(result.pass).toBe(false);
+    expect(result.errors).toContain('coverage-evidence.json: missing aggregate section');
+  });
+
+  it('reports invalid coverage file entries', () => {
+    const result = validateCoverageEvidence({
+      version: 1,
+      generated_at: '2026-05-11T00:00:00Z',
+      threshold_aggregate: { lines: 60, functions: 60, branches: 50, statements: 60 },
+      threshold_changed_scope: { lines: 100, functions: 100, branches: 100, statements: 100 },
+      is_pr: false,
+      changed_files: [],
+      aggregate: { pct_statements: 90, pct_branches: 90, pct_functions: 90, pct_lines: 90 },
+      files: [null],
+      aggregate_pass: true,
+      changed_scope_pass: true,
+      pass: true,
+      aggregate_failures: [],
+      changed_scope_failures: [],
+    });
+
+    expect(result.pass).toBe(false);
+    expect(result.errors).toContain('coverage-evidence.json: missing or invalid files array');
+  });
+
+  it('handles empty coverage entries and missing statement hits', () => {
+    const evidence = generateCoverageEvidence(
+      {
+        'src/empty.ts': {},
+        'src/missing-hit.ts': {
+          statementMap: {
+            '1': { start: { line: 1 }, end: { line: 1 } },
+          },
+          s: {},
+          b: {},
+          f: {},
+        },
+      },
+      false,
+      [],
+      { aggregateFloor: { lines: 100, functions: 100, branches: 101, statements: 100 } },
+    );
+
+    expect(evidence.files.find((file) => file.path === 'src/empty.ts')?.pct_lines).toBe(100);
+    expect(evidence.files.find((file) => file.path === 'src/missing-hit.ts')?.pct_lines).toBe(0);
+    expect(evidence.aggregate_failures).toContain('branches: 100% < 101%');
+  });
+
+  it('reports missing changed-scope thresholds and failure arrays', () => {
+    const result = validateCoverageEvidence({
+      version: 1,
+      generated_at: '2026-05-11T00:00:00Z',
+      threshold_aggregate: { lines: 60, functions: 60, branches: 50, statements: 60 },
+      threshold_changed_scope: undefined as any,
+      is_pr: true,
+      changed_files: ['src/failing.ts'],
+      aggregate: { pct_statements: 70, pct_branches: 70, pct_functions: 70, pct_lines: 70 },
+      files: [],
+      aggregate_pass: true,
+      changed_scope_pass: false,
+      pass: false,
+      aggregate_failures: [],
+      changed_scope_failures: undefined as any,
+    });
+
+    expect(result.pass).toBe(false);
+    expect(result.errors).toContain('coverage-evidence.json: missing threshold_changed_scope section');
+    expect(result.errors).toContain('coverage-evidence.json: missing or invalid changed_scope_failures array');
   });
 });

--- a/mcp-server/src/utils/coverage-evidence.ts
+++ b/mcp-server/src/utils/coverage-evidence.ts
@@ -26,7 +26,12 @@ export interface CoverageSummary {
 }
 
 export interface CoverageEvidence {
+  version: 1;
   generated_at: string;
+  branch?: string;
+  commit?: string;
+  base_branch?: string;
+  pr_number?: string;
   threshold_aggregate: { lines: number; functions: number; branches: number; statements: number };
   threshold_changed_scope: { lines: number; functions: number; branches: number; statements: number };
   is_pr: boolean;
@@ -40,21 +45,128 @@ export interface CoverageEvidence {
   changed_scope_failures: string[];
 }
 
+export interface CoverageEvidenceOptions {
+  aggregateFloor?: Partial<CoverageEvidence['threshold_aggregate']>;
+  changedScopeTarget?: Partial<CoverageEvidence['threshold_changed_scope']>;
+  metadata?: {
+    branch?: string;
+    commit?: string;
+    base_branch?: string;
+    pr_number?: string;
+  };
+}
+
+const DEFAULT_AGGREGATE_FLOOR = { lines: 60, functions: 60, branches: 50, statements: 60 };
+const DEFAULT_CHANGED_SCOPE_TARGET = { lines: 100, functions: 100, branches: 100, statements: 100 };
+
+type CoverageThresholds = CoverageEvidence['threshold_aggregate'];
+type CoverageMetric = keyof CoverageThresholds;
+
+const COVERAGE_METRICS: CoverageMetric[] = ['lines', 'functions', 'branches', 'statements'];
+
+function isNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function isThresholdSet(value: unknown): value is CoverageThresholds {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as Partial<CoverageThresholds>;
+  return COVERAGE_METRICS.every((metric) => isNumber(candidate[metric]));
+}
+
+function isCoverageSummary(value: unknown): value is CoverageSummary {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as Partial<CoverageSummary>;
+  return isNumber(candidate.pct_lines)
+    && isNumber(candidate.pct_functions)
+    && isNumber(candidate.pct_branches)
+    && isNumber(candidate.pct_statements);
+}
+
+function isCoverageFileEntry(value: unknown): value is CoverageFileEntry {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as Partial<CoverageFileEntry>;
+  return typeof candidate.path === 'string'
+    && isNumber(candidate.pct_lines)
+    && isNumber(candidate.pct_functions)
+    && isNumber(candidate.pct_branches)
+    && isNumber(candidate.pct_statements);
+}
+
+function mergeCanonicalThresholds(
+  candidate: CoverageThresholds,
+  canonical: CoverageThresholds,
+): CoverageThresholds {
+  return {
+    lines: Math.max(candidate.lines, canonical.lines),
+    functions: Math.max(candidate.functions, canonical.functions),
+    branches: Math.max(candidate.branches, canonical.branches),
+    statements: Math.max(candidate.statements, canonical.statements),
+  };
+}
+
+function validateCanonicalThresholds(
+  label: string,
+  candidate: CoverageThresholds,
+  canonical: CoverageThresholds,
+  errors: string[],
+): void {
+  for (const metric of COVERAGE_METRICS) {
+    if (candidate[metric] < canonical[metric]) {
+      errors.push(`coverage-evidence.json: ${label}.${metric} ${candidate[metric]}% is below canonical floor ${canonical[metric]}%`);
+    }
+  }
+}
+
+function findCoverageEntry(files: CoverageFileEntry[], changedFile: string): CoverageFileEntry | undefined {
+  return files.find((file) => file.path === changedFile || changedFile.endsWith(file.path) || file.path.endsWith(changedFile));
+}
+
+function collectChangedScopeFailures(
+  files: CoverageFileEntry[],
+  changedFiles: string[],
+  changedScopeTarget: CoverageEvidence['threshold_changed_scope'],
+): string[] {
+  const failures: string[] = [];
+  for (const changedFile of changedFiles) {
+    const entry = findCoverageEntry(files, changedFile);
+    if (!entry) {
+      failures.push(`${changedFile}: file missing from coverage report`);
+      continue;
+    }
+    if (entry.pct_lines < changedScopeTarget.lines) {
+      failures.push(`${entry.path}: lines ${entry.pct_lines}% < ${changedScopeTarget.lines}%`);
+    }
+    if (entry.pct_functions < changedScopeTarget.functions) {
+      failures.push(`${entry.path}: functions ${entry.pct_functions}% < ${changedScopeTarget.functions}%`);
+    }
+    if (entry.pct_branches < changedScopeTarget.branches) {
+      failures.push(`${entry.path}: branches ${entry.pct_branches}% < ${changedScopeTarget.branches}%`);
+    }
+    if (entry.pct_statements < changedScopeTarget.statements) {
+      failures.push(`${entry.path}: statements ${entry.pct_statements}% < ${changedScopeTarget.statements}%`);
+    }
+  }
+  return failures;
+}
+
 /**
  * Parse a Vitest v8 coverage JSON report into a CoverageEvidence object.
  *
  * @param coverageJson  Parsed Vitest v8 JSON coverage output (from /build/coverage/coverage-final.json)
  * @param isPr          True if running in a pull request context
  * @param changedFiles  List of files changed in this PR (for changed-scope gate)
+ * @param options       Optional threshold overrides and CI metadata
  * @returns             Structured evidence suitable for CI gate and MCP tool response
  */
 export function generateCoverageEvidence(
   coverageJson: Record<string, unknown>,
   isPr: boolean,
   changedFiles: string[],
+  options: CoverageEvidenceOptions = {},
 ): CoverageEvidence {
-  const AGGREGATE_FLOOR = { lines: 80, functions: 80, branches: 80, statements: 80 };
-  const CHANGED_SCOPE_TARGET = { lines: 100, functions: 100, branches: 100, statements: 100 };
+  const aggregateFloor = { ...DEFAULT_AGGREGATE_FLOOR, ...options.aggregateFloor };
+  const changedScopeTarget = { ...DEFAULT_CHANGED_SCOPE_TARGET, ...options.changedScopeTarget };
 
   const generatedAt = new Date().toISOString();
 
@@ -76,6 +188,7 @@ export function generateCoverageEvidence(
     // Skip node_modules and synthetic entries
     if (path.includes('node_modules') || path === '<total>') continue;
 
+    const statementMap = (fileData.statementMap as Record<string, { start?: { line?: number }; end?: { line?: number } }>) || {};
     const s = (fileData.s as Record<string, number>) || {};
     const b = (fileData.b as Record<string, number[]>) || {};
     const f = (fileData.f as Record<string, number>) || {};
@@ -106,15 +219,30 @@ export function generateCoverageEvidence(
 
     let fileLines = 0;
     let fileCoveredLines = 0;
-    for (const hits of lh) {
-      fileLines += 1;
-      if (hits > 0) fileCoveredLines += 1;
+    if (lh.length > 0) {
+      for (const hits of lh) {
+        fileLines += 1;
+        if (hits > 0) fileCoveredLines += 1;
+      }
+    } else {
+      const lineHits = new Map<number, number>();
+      for (const [statementId, location] of Object.entries(statementMap)) {
+        const startLine = location.start?.line;
+        const endLine = location.end?.line ?? startLine;
+        if (typeof startLine !== 'number' || typeof endLine !== 'number') continue;
+        const hits = s[statementId] ?? 0;
+        for (let line = startLine; line <= endLine; line += 1) {
+          lineHits.set(line, Math.max(lineHits.get(line) ?? 0, hits));
+        }
+      }
+      fileLines = lineHits.size;
+      fileCoveredLines = [...lineHits.values()].filter((hits) => hits > 0).length;
     }
 
-    const pctStatements = fileStatements > 0 ? Math.round((fileCoveredStatements / fileStatements) * 100) : 0;
-    const pctBranches = fileBranches > 0 ? Math.round((fileCoveredBranches / fileBranches) * 100) : 0;
-    const pctFunctions = fileFunctions > 0 ? Math.round((fileCoveredFunctions / fileFunctions) * 100) : 0;
-    const pctLines = fileLines > 0 ? Math.round((fileCoveredLines / fileLines) * 100) : 0;
+    const pctStatements = fileStatements > 0 ? Math.round((fileCoveredStatements / fileStatements) * 100) : 100;
+    const pctBranches = fileBranches > 0 ? Math.round((fileCoveredBranches / fileBranches) * 100) : 100;
+    const pctFunctions = fileFunctions > 0 ? Math.round((fileCoveredFunctions / fileFunctions) * 100) : 100;
+    const pctLines = fileLines > 0 ? Math.round((fileCoveredLines / fileLines) * 100) : 100;
 
     const entry = {
       path,
@@ -136,10 +264,10 @@ export function generateCoverageEvidence(
     totalCoveredStatements += fileCoveredStatements;
   }
 
-  const pctLinesAgg = totalLines > 0 ? Math.round((totalCoveredLines / totalLines) * 100) : 0;
-  const pctBranchesAgg = totalBranches > 0 ? Math.round((totalCoveredBranches / totalBranches) * 100) : 0;
-  const pctFunctionsAgg = totalFunctions > 0 ? Math.round((totalCoveredFunctions / totalFunctions) * 100) : 0;
-  const pctStatementsAgg = totalStatements > 0 ? Math.round((totalCoveredStatements / totalStatements) * 100) : 0;
+  const pctLinesAgg = totalLines > 0 ? Math.round((totalCoveredLines / totalLines) * 100) : 100;
+  const pctBranchesAgg = totalBranches > 0 ? Math.round((totalCoveredBranches / totalBranches) * 100) : 100;
+  const pctFunctionsAgg = totalFunctions > 0 ? Math.round((totalCoveredFunctions / totalFunctions) * 100) : 100;
+  const pctStatementsAgg = totalStatements > 0 ? Math.round((totalCoveredStatements / totalStatements) * 100) : 100;
 
   const aggregate: CoverageSummary = {
     pct_statements: pctStatementsAgg,
@@ -149,35 +277,25 @@ export function generateCoverageEvidence(
   };
 
   const aggregateFailures: string[] = [];
-  if (pctLinesAgg < AGGREGATE_FLOOR.lines) aggregateFailures.push(`lines: ${pctLinesAgg}% < ${AGGREGATE_FLOOR.lines}%`);
-  if (pctFunctionsAgg < AGGREGATE_FLOOR.functions) aggregateFailures.push(`functions: ${pctFunctionsAgg}% < ${AGGREGATE_FLOOR.functions}%`);
-  if (pctBranchesAgg < AGGREGATE_FLOOR.branches) aggregateFailures.push(`branches: ${pctBranchesAgg}% < ${AGGREGATE_FLOOR.branches}%`);
-  if (pctStatementsAgg < AGGREGATE_FLOOR.statements) aggregateFailures.push(`statements: ${pctStatementsAgg}% < ${AGGREGATE_FLOOR.statements}%`);
+  if (pctLinesAgg < aggregateFloor.lines) aggregateFailures.push(`lines: ${pctLinesAgg}% < ${aggregateFloor.lines}%`);
+  if (pctFunctionsAgg < aggregateFloor.functions) aggregateFailures.push(`functions: ${pctFunctionsAgg}% < ${aggregateFloor.functions}%`);
+  if (pctBranchesAgg < aggregateFloor.branches) aggregateFailures.push(`branches: ${pctBranchesAgg}% < ${aggregateFloor.branches}%`);
+  if (pctStatementsAgg < aggregateFloor.statements) aggregateFailures.push(`statements: ${pctStatementsAgg}% < ${aggregateFloor.statements}%`);
 
   const aggregatePass = aggregateFailures.length === 0;
 
-  const changedScopeFailures: string[] = [];
-  if (isPr && changedFiles.length > 0) {
-    for (const changedFile of changedFiles) {
-      const entry =
-        filesByPath.get(changedFile)
-        ?? files.find((f) => changedFile.endsWith(f.path) || f.path.endsWith(changedFile));
-      if (!entry) {
-        changedScopeFailures.push(`${changedFile}: file missing from coverage report`);
-        continue;
-      }
-      if (entry.pct_lines < CHANGED_SCOPE_TARGET.lines) {
-        changedScopeFailures.push(`${entry.path}: lines ${entry.pct_lines}% < 100%`);
-      }
-    }
-  }
+  const changedScopeFailures = isPr && changedFiles.length > 0
+    ? collectChangedScopeFailures([...filesByPath.values()], changedFiles, changedScopeTarget)
+    : [];
 
   const changedScopePass = changedScopeFailures.length === 0;
 
   return {
+    version: 1,
     generated_at: generatedAt,
-    threshold_aggregate: AGGREGATE_FLOOR,
-    threshold_changed_scope: CHANGED_SCOPE_TARGET,
+    ...options.metadata,
+    threshold_aggregate: aggregateFloor,
+    threshold_changed_scope: changedScopeTarget,
     is_pr: isPr,
     changed_files: changedFiles,
     aggregate,
@@ -196,40 +314,79 @@ export function generateCoverageEvidence(
  * @param evidence  CoverageEvidence JSON object (already read from coverage-evidence.json)
  * @returns         Validation result with pass/fail and error/warning details
  */
-export function validateCoverageEvidence(evidence: CoverageEvidence): {
+export function validateCoverageEvidence(evidence: unknown): {
   pass: boolean;
   errors: string[];
   warnings: string[];
 } {
   const errors: string[] = [];
   const warnings: string[] = [];
+  if (!evidence || typeof evidence !== 'object') {
+    return {
+      pass: false,
+      errors: ['coverage-evidence.json: root must be an object'],
+      warnings,
+    };
+  }
+  const candidate = evidence as Partial<CoverageEvidence>;
 
-  if (!evidence.generated_at) {
+  if (!candidate.generated_at) {
     errors.push('coverage-evidence.json: missing generated_at field');
   }
-  if (!evidence.aggregate) {
+  if (candidate.version !== 1) {
+    errors.push('coverage-evidence.json: unsupported or missing version');
+  }
+  if (!isCoverageSummary(candidate.aggregate)) {
     errors.push('coverage-evidence.json: missing aggregate section');
   }
-  if (!Array.isArray(evidence.files)) {
+  const files = Array.isArray(candidate.files) && candidate.files.every(isCoverageFileEntry)
+    ? candidate.files
+    : null;
+  if (!files) {
     errors.push('coverage-evidence.json: missing or invalid files array');
   }
-
-  if (evidence.aggregate) {
-    const t = evidence.threshold_aggregate;
-    if (evidence.aggregate.pct_lines < t.lines) errors.push(`aggregate lines ${evidence.aggregate.pct_lines}% < floor ${t.lines}%`);
-    if (evidence.aggregate.pct_functions < t.functions) errors.push(`aggregate functions ${evidence.aggregate.pct_functions}% < floor ${t.functions}%`);
-    if (evidence.aggregate.pct_branches < t.branches) errors.push(`aggregate branches ${evidence.aggregate.pct_branches}% < floor ${t.branches}%`);
-    if (evidence.aggregate.pct_statements < t.statements) errors.push(`aggregate statements ${evidence.aggregate.pct_statements}% < floor ${t.statements}%`);
+  if (!isThresholdSet(candidate.threshold_changed_scope)) {
+    errors.push('coverage-evidence.json: missing threshold_changed_scope section');
   }
 
-  if (evidence.is_pr && evidence.changed_files.length > 0) {
-    for (const f of evidence.changed_scope_failures) {
-      errors.push(`changed-scope: ${f}`);
+  if (isCoverageSummary(candidate.aggregate)) {
+    const t = candidate.threshold_aggregate;
+    if (!isThresholdSet(t)) {
+      errors.push('coverage-evidence.json: missing threshold_aggregate section');
+    } else {
+      validateCanonicalThresholds('threshold_aggregate', t, DEFAULT_AGGREGATE_FLOOR, errors);
+      const aggregateFloor = mergeCanonicalThresholds(t, DEFAULT_AGGREGATE_FLOOR);
+      if (candidate.aggregate.pct_lines < aggregateFloor.lines) errors.push(`aggregate lines ${candidate.aggregate.pct_lines}% < floor ${aggregateFloor.lines}%`);
+      if (candidate.aggregate.pct_functions < aggregateFloor.functions) errors.push(`aggregate functions ${candidate.aggregate.pct_functions}% < floor ${aggregateFloor.functions}%`);
+      if (candidate.aggregate.pct_branches < aggregateFloor.branches) errors.push(`aggregate branches ${candidate.aggregate.pct_branches}% < floor ${aggregateFloor.branches}%`);
+      if (candidate.aggregate.pct_statements < aggregateFloor.statements) errors.push(`aggregate statements ${candidate.aggregate.pct_statements}% < floor ${aggregateFloor.statements}%`);
+    }
+  }
+
+  const changedFiles = Array.isArray(candidate.changed_files) && candidate.changed_files.every((file) => typeof file === 'string')
+    ? candidate.changed_files
+    : null;
+  if (candidate.is_pr && !changedFiles) {
+    errors.push('coverage-evidence.json: missing or invalid changed_files array');
+  }
+  if (candidate.is_pr && changedFiles && changedFiles.length > 0) {
+    if (!Array.isArray(candidate.changed_scope_failures)) {
+      errors.push('coverage-evidence.json: missing or invalid changed_scope_failures array');
+    } else if (!files || !isThresholdSet(candidate.threshold_changed_scope)) {
+      for (const f of candidate.changed_scope_failures) {
+        errors.push(`changed-scope: ${f}`);
+      }
+    } else {
+      validateCanonicalThresholds('threshold_changed_scope', candidate.threshold_changed_scope, DEFAULT_CHANGED_SCOPE_TARGET, errors);
+      const changedScopeTarget = mergeCanonicalThresholds(candidate.threshold_changed_scope, DEFAULT_CHANGED_SCOPE_TARGET);
+      for (const f of collectChangedScopeFailures(files, changedFiles, changedScopeTarget)) {
+        errors.push(`changed-scope: ${f}`);
+      }
     }
   }
 
   // Soft warnings
-  if (!evidence.generated_at || !evidence.is_pr) {
+  if (!candidate.generated_at || !candidate.is_pr) {
     warnings.push('Coverage evidence is not PR-scoped; changed-scope gate is inactive');
   }
 

--- a/mcp-server/vitest.config.ts
+++ b/mcp-server/vitest.config.ts
@@ -4,5 +4,22 @@ export default defineConfig({
   test: {
     globals: true,
     include: ['src/**/__tests__/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+      exclude: [
+        'src/**/__tests__/**',
+        'src/__tests__/**',
+        'src/**/fixtures/**',
+      ],
+      reporter: ['text', 'json', 'lcov', 'html'],
+      reportsDirectory: 'coverage',
+      thresholds: {
+        lines: 60,
+        functions: 60,
+        branches: 50,
+        statements: 60,
+      },
+    },
   },
 });

--- a/tasks/templates/sub-agent-handoff.md
+++ b/tasks/templates/sub-agent-handoff.md
@@ -1,20 +1,26 @@
 # Sub-Agent Handoff
 
+## Delegation ID
+- delegation_id:
+
 ## Project Identity
 - Project:
 - Project ID:
 - Project Path:
+- Current branch / worktree:
 
 ## Task Scope
 - Issue:
 - Delegated sub-task:
 - Expected output:
+- Non-goals:
 
 ## Required Context
 - Current task:
 - Constraints / non-goals:
 - Relevant knowledge files:
 - Relevant task files:
+- Required conversation/context summary:
 
 ## Verification Before Work
 - Restate the project:
@@ -23,6 +29,7 @@
 - State what evidence will be returned:
 
 ## Return Contract
-- Code or document output:
-- Verification evidence:
-- Residual risks:
+- Write `log.md` with `delegation_id`, `recorded_at`, `sub_task`, `status`, `## Actions Taken`, and `## Findings`.
+- Write `result.md` with `## Summary`, `## Findings`, `## Recommendations`, `## Verification Evidence`, `## Delegation ID`, and `## Timestamp`.
+- Do not make binding decisions for the main agent; report findings and evidence only.
+- Include residual risks and any assumptions that affected the result.

--- a/tools/coverage-preflight.sh
+++ b/tools/coverage-preflight.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MCP_DIR="$ROOT/mcp-server"
+COVERAGE_JSON="$MCP_DIR/coverage/coverage-final.json"
+EVIDENCE_JSON="$MCP_DIR/coverage/coverage-evidence.json"
+BASE_BRANCH="${GITHUB_BASE_REF:-main}"
+IS_PR="false"
+CHANGED_FILES_JSON="[]"
+export GITHUB_BASE_REF="$BASE_BRANCH"
+export GITHUB_SHA="${GITHUB_SHA:-$(git -C "$ROOT" rev-parse HEAD)}"
+export GITHUB_REF_NAME="${GITHUB_REF_NAME:-$(git -C "$ROOT" rev-parse --abbrev-ref HEAD)}"
+
+if [[ "${GITHUB_EVENT_NAME:-}" == "pull_request" || -n "${GITHUB_BASE_REF:-}" ]]; then
+  IS_PR="true"
+  git -C "$ROOT" fetch --no-tags --depth=1 origin "$BASE_BRANCH" >/dev/null 2>&1 || true
+  # Entry-point wrappers are covered by subprocess integration tests.
+  CHANGED_FILES_JSON="$(
+    { git -C "$ROOT" diff --name-only "origin/$BASE_BRANCH"...HEAD -- 'mcp-server/src/*.ts' 'mcp-server/src/**/*.ts' \
+      | grep -Ev '(^|/)(__tests__|fixtures)/|\.test\.ts$|^mcp-server/src/(bootstrap|config|edit-guard|index|record-reminder)\.ts$' || true; } \
+      | sed 's#^mcp-server/##' \
+      | node -e 'const fs = require("fs"); const files = fs.readFileSync(0, "utf8").split(/\n/).filter(Boolean); process.stdout.write(JSON.stringify(files));'
+  )"
+fi
+
+cd "$MCP_DIR"
+npm run build
+npm run test:coverage
+
+cd "$ROOT"
+export COVERAGE_JSON EVIDENCE_JSON IS_PR CHANGED_FILES_JSON
+node --input-type=module <<'NODE'
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { generateCoverageEvidence, validateCoverageEvidence } from './mcp-server/build/utils/coverage-evidence.js';
+
+const coveragePath = process.env.COVERAGE_JSON;
+const evidencePath = process.env.EVIDENCE_JSON;
+const changedFiles = JSON.parse(process.env.CHANGED_FILES_JSON || '[]');
+const evidence = generateCoverageEvidence(
+  JSON.parse(await readFile(coveragePath, 'utf-8')),
+  process.env.IS_PR === 'true',
+  changedFiles,
+  {
+    metadata: {
+      branch: process.env.GITHUB_HEAD_REF || process.env.GITHUB_REF_NAME,
+      commit: process.env.GITHUB_SHA,
+      base_branch: process.env.GITHUB_BASE_REF,
+      pr_number: process.env.PR_NUMBER,
+    },
+  },
+);
+await mkdir(dirname(evidencePath), { recursive: true });
+await writeFile(evidencePath, `${JSON.stringify(evidence, null, 2)}\n`, 'utf-8');
+const validation = validateCoverageEvidence(evidence);
+console.log(`Coverage evidence written to ${evidencePath}`);
+console.log(`Aggregate pass: ${evidence.aggregate_pass}`);
+console.log(`Changed-scope pass: ${evidence.changed_scope_pass}`);
+if (!validation.pass) {
+  for (const error of validation.errors) console.error(error);
+  process.exit(1);
+}
+NODE


### PR DESCRIPTION
## Summary
- add Vitest coverage config and test:coverage script with 60/60/50/60 aggregate floors
- add coverage-preflight.sh and CI coverage-changed-scope enforcement for PR changed source files
- make coverage evidence versioned, metadata-aware, and able to derive line coverage from Istanbul statement maps
- write coverage evidence from runCoverageGenerate and validate coverage-evidence.json by default
- align MCP tool schemas and sub-agent handoff template with the delegation/coverage protocol

## Verification
- cd mcp-server && npm ci
- cd mcp-server && npx vitest run src/utils/__tests__/coverage-evidence.test.ts src/tools/__tests__/coverage-check.test.ts
- cd mcp-server && npm run lint
- cd mcp-server && npm test
- cd mcp-server && npm run test:coverage
- GITHUB_EVENT_NAME=pull_request GITHUB_BASE_REF=main ./tools/coverage-preflight.sh

Closes #345