### PR TITLE
fix: add Homebrew bump to release.yml + update formula to v0.4.18 (#400)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,13 +7,19 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: release-${{ github.ref_name }}
   cancel-in-progress: false
 
+env:
+  FORMULA_NAME: agenticos
+  FORMULA_PATH: Formula/agenticos.rb
+  HOMEBREW_TAP: madlouse/homebrew-agenticos
+
 jobs:
-  release:
+  build-and-release:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -36,29 +42,62 @@ jobs:
         run: npm pack
 
       - name: Move tarball to root
-        run: mv mcp-server/agenticos-mcp-*.tgz ./agenticos-mcp.tgz
+        run: mv mcp-server/agenticos-mcp-*.tgz ./agenticos-mcp-${{ github.ref_name }}.tgz
 
       - name: Verify tarball exists
         run: |
-          if [ ! -f ./agenticos-mcp.tgz ]; then
-            echo "ERROR: agenticos-mcp.tgz not found"
+          if [ ! -f ./agenticos-mcp-${{ github.ref_name }}.tgz ]; then
+            echo "ERROR: tarball not found"
             exit 1
           fi
-          echo "Tarball found: $(du -sh agenticos-mcp.tgz)"
+          echo "Tarball: $(du -sh agenticos-mcp-${{ github.ref_name }}.tgz)"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: agenticos-mcp.tgz
+          files: agenticos-mcp-${{ github.ref_name }}.tgz
           generate_release_notes: true
 
-      - name: Update Homebrew formula
-        timeout-minutes: 10
+  bump-homebrew:
+    needs: build-and-release
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Download release artifact
+        run: |
+          curl -sL -o agenticos-mcp-${{ github.ref_name }}.tgz \
+            "https://github.com/madlouse/AgenticOS/releases/download/${{ github.ref_name }}/agenticos-mcp-${{ github.ref_name }}.tgz"
+
+      - name: Update Homebrew formula in tap repo
         uses: mislav/bump-homebrew-formula-action@v4
         with:
-          formula-name: agenticos
-          formula-path: Formula/agenticos.rb
-          homebrew-tap: madlouse/agenticos
+          formula-name: ${{ env.FORMULA_NAME }}
+          formula-path: ${{ env.FORMULA_PATH }}
+          homebrew-tap: ${{ env.HOMEBREW_TAP }}
           tag-name: ${{ github.ref_name }}
         env:
           COMMITTER_TOKEN: ${{ secrets.HOMEBREW_TAP_PAT }}
+
+      - name: Sync formula to source repo
+        run: |
+          # After mislav bumps the tap repo, sync the version back to source
+          # This ensures both copies stay in sync
+          TAG="${{ github.ref_name }}"
+          VERSION="${TAG#v}"
+          SHA=$(shasum -a 256 agenticos-mcp-${TAG}.tgz | cut -d' ' -f1)
+          sed -i.bak \
+            -e "s|releases/download/v[0-9.]*/agenticos-mcp-[^/]*\.tgz|releases/download/v${VERSION}/agenticos-mcp-${VERSION}.tgz|" \
+            -e "s|version \"[0-9.]*\"|version \"${VERSION}\"|" \
+            -e "s| sha256 \"[a-f0-9]*\"| sha256 \"${SHA}\"|" \
+            homebrew-tap/Formula/agenticos.rb
+          rm homebrew-tap/Formula/agenticos.rb.bak
+          git add homebrew-tap/Formula/agenticos.rb
+          git commit -m "chore: sync formula to v${VERSION} [skip ci]"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Notify on Homebrew update failure
+        if: failure()
+        run: |
+          echo "Homebrew formula update failed for ${{ github.ref_name }}"
+          echo "Manual intervention required in ${{ env.HOMEBREW_TAP }} repository"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,25 +34,29 @@ jobs:
         run: npm pack
 
       - name: Move tarball to root
-        run: mv mcp-server/agenticos-mcp-*.tgz ./agenticos-mcp.tgz
-
-      - name: Compute SHA256 for formula
-        id: sha
-        run: |
-          echo "sha256=$(shasum -a 256 agenticos-mcp.tgz | cut -d' ' -f1)" >> $GITHUB_OUTPUT
-          echo "size=$(du -sh agenticos-mcp.tgz | cut -f1)" >> $GITHUB_OUTPUT
+        run: mv mcp-server/agenticos-mcp-*.tgz ./
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: agenticos-mcp.tgz
+          files: agenticos-mcp-*.tgz
           generate_release_notes: true
 
-      - name: Verify release asset is reachable
+      - name: Wait for release asset propagation
         run: |
-          URL="https://github.com/madlouse/AgenticOS/releases/download/${{ github.ref_name }}/agenticos-mcp.tgz"
-          echo "Checking release asset URL: $URL"
-          curl -sI "$URL" | head -1
+          # Wait for GitHub CDN to propagate the release asset (5-30s typically)
+          echo "Waiting for release asset to become globally reachable..."
+          for i in 1 2 3 4 5; do
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://github.com/madlouse/AgenticOS/releases/download/${{ github.ref_name }}/agenticos-mcp.tgz")
+            echo "Attempt $i: HTTP status $STATUS"
+            if [ "$STATUS" = "200" ]; then
+              echo "Release asset is reachable"
+              exit 0
+            fi
+            echo "Retrying in 5 seconds..."
+            sleep 5
+          done
+          echo "Warning: release asset may not be fully propagated yet"
 
       - name: Update Homebrew formula
         uses: mislav/bump-homebrew-formula-action@v4
@@ -63,8 +67,3 @@ jobs:
           tag-name: ${{ github.ref_name }}
         env:
           COMMITTER_TOKEN: ${{ secrets.HOMEBREW_TAP_PAT }}
-
-      - name: Verify Homebrew formula bump
-        run: |
-          echo "Release ${{ github.ref_name }} completed"
-          echo "Homebrew formula update triggered for madlouse/agenticos tap"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,6 @@
 name: Release
 
+# AgenticOS own release: triggered on tag push
 on:
   push:
     tags:
@@ -36,3 +37,28 @@ jobs:
         with:
           files: agenticos-mcp.tgz
           generate_release_notes: true
+
+      - name: Update Homebrew formula
+        uses: mislav/bump-homebrew-formula-action@v4
+        with:
+          formula-name: agenticos
+          formula-path: Formula/agenticos.rb
+          homebrew-tap: madlouse/agenticos
+          tag-name: ${{ github.ref_name }}
+        env:
+          COMMITTER_TOKEN: ${{ secrets.HOMEBREW_TAP_PAT }}
+
+      - name: Upload formula update as release asset
+        run: |
+          # The mislav action creates a PR; we need the formula from that PR
+          # For now, just verify the bump happened
+          echo "Homebrew formula updated via mislav/bump-homebrew-formula-action"
+
+  verify:
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify release artifacts
+        run: |
+          echo "Verifying release ${{ github.ref_name }} completed successfully"
+          echo "Homebrew formula should now point to ${{ github.ref_name }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 concurrency:
   group: release-${{ github.ref_name }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   release:
@@ -22,6 +22,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: 'npm'
+          cache-dependency-path: mcp-server/package-lock.json
 
       - name: Install and build
         working-directory: mcp-server
@@ -33,13 +35,25 @@ jobs:
         working-directory: mcp-server
         run: npm pack
 
+      - name: Move tarball to root
+        run: mv mcp-server/agenticos-mcp-*.tgz ./agenticos-mcp.tgz
+
+      - name: Verify tarball exists
+        run: |
+          if [ ! -f ./agenticos-mcp.tgz ]; then
+            echo "ERROR: agenticos-mcp.tgz not found"
+            exit 1
+          fi
+          echo "Tarball found: $(du -sh agenticos-mcp.tgz)"
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: agenticos-mcp-*.tgz
+          files: agenticos-mcp.tgz
           generate_release_notes: true
 
       - name: Update Homebrew formula
+        timeout-minutes: 10
         uses: mislav/bump-homebrew-formula-action@v4
         with:
           formula-name: agenticos

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,31 +33,11 @@ jobs:
         working-directory: mcp-server
         run: npm pack
 
-      - name: Move tarball to root
-        run: mv mcp-server/agenticos-mcp-*.tgz ./agenticos-mcp.tgz
-
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: agenticos-mcp.tgz
+          files: agenticos-mcp-*.tgz
           generate_release_notes: true
-
-      - name: Wait for release asset propagation
-        run: |
-          echo "Waiting for release asset to become globally reachable..."
-          for i in 1 2 3 4 5; do
-            STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-              --max-time 10 --connect-timeout 5 \
-              "https://github.com/madlouse/AgenticOS/releases/download/${{ github.ref_name }}/agenticos-mcp.tgz")
-            echo "Attempt $i: HTTP status $STATUS"
-            if [ "$STATUS" = "200" ]; then
-              echo "Release asset is reachable"
-              exit 0
-            fi
-            echo "Retrying in $((i * 2)) seconds..."
-            sleep $((i * 2))
-          done
-          echo "Warning: release asset may not be fully propagated yet"
 
       - name: Update Homebrew formula
         uses: mislav/bump-homebrew-formula-action@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -34,27 +34,28 @@ jobs:
         run: npm pack
 
       - name: Move tarball to root
-        run: mv mcp-server/agenticos-mcp-*.tgz ./
+        run: mv mcp-server/agenticos-mcp-*.tgz ./agenticos-mcp.tgz
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: agenticos-mcp-*.tgz
+          files: agenticos-mcp.tgz
           generate_release_notes: true
 
       - name: Wait for release asset propagation
         run: |
-          # Wait for GitHub CDN to propagate the release asset (5-30s typically)
           echo "Waiting for release asset to become globally reachable..."
           for i in 1 2 3 4 5; do
-            STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://github.com/madlouse/AgenticOS/releases/download/${{ github.ref_name }}/agenticos-mcp.tgz")
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+              --max-time 10 --connect-timeout 5 \
+              "https://github.com/madlouse/AgenticOS/releases/download/${{ github.ref_name }}/agenticos-mcp.tgz")
             echo "Attempt $i: HTTP status $STATUS"
             if [ "$STATUS" = "200" ]; then
               echo "Release asset is reachable"
               exit 0
             fi
-            echo "Retrying in 5 seconds..."
-            sleep 5
+            echo "Retrying in $((i * 2)) seconds..."
+            sleep $((i * 2))
           done
           echo "Warning: release asset may not be fully propagated yet"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,5 @@
 name: Release
 
-# AgenticOS own release: triggered on tag push
 on:
   push:
     tags:
@@ -9,9 +8,14 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: release-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 
@@ -32,11 +36,23 @@ jobs:
       - name: Move tarball to root
         run: mv mcp-server/agenticos-mcp-*.tgz ./agenticos-mcp.tgz
 
+      - name: Compute SHA256 for formula
+        id: sha
+        run: |
+          echo "sha256=$(shasum -a 256 agenticos-mcp.tgz | cut -d' ' -f1)" >> $GITHUB_OUTPUT
+          echo "size=$(du -sh agenticos-mcp.tgz | cut -f1)" >> $GITHUB_OUTPUT
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           files: agenticos-mcp.tgz
           generate_release_notes: true
+
+      - name: Verify release asset is reachable
+        run: |
+          URL="https://github.com/madlouse/AgenticOS/releases/download/${{ github.ref_name }}/agenticos-mcp.tgz"
+          echo "Checking release asset URL: $URL"
+          curl -sI "$URL" | head -1
 
       - name: Update Homebrew formula
         uses: mislav/bump-homebrew-formula-action@v4
@@ -48,17 +64,7 @@ jobs:
         env:
           COMMITTER_TOKEN: ${{ secrets.HOMEBREW_TAP_PAT }}
 
-      - name: Upload formula update as release asset
+      - name: Verify Homebrew formula bump
         run: |
-          # The mislav action creates a PR; we need the formula from that PR
-          # For now, just verify the bump happened
-          echo "Homebrew formula updated via mislav/bump-homebrew-formula-action"
-
-  verify:
-    needs: release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Verify release artifacts
-        run: |
-          echo "Verifying release ${{ github.ref_name }} completed successfully"
-          echo "Homebrew formula should now point to ${{ github.ref_name }}"
+          echo "Release ${{ github.ref_name }} completed"
+          echo "Homebrew formula update triggered for madlouse/agenticos tap"

--- a/homebrew-tap/Formula/agenticos.rb
+++ b/homebrew-tap/Formula/agenticos.rb
@@ -5,7 +5,7 @@ class Agenticos < Formula
   homepage "https://github.com/madlouse/AgenticOS"
   url "https://github.com/madlouse/AgenticOS/releases/download/v0.4.18/agenticos-mcp-0.4.18.tgz"
   version "0.4.18"
-  sha256 "TODO" # Will be updated by mislav/bump-homebrew-formula-action on next release
+  sha256 "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5"
   license "MIT"
 
   depends_on "node"

--- a/homebrew-tap/Formula/agenticos.rb
+++ b/homebrew-tap/Formula/agenticos.rb
@@ -3,9 +3,9 @@ require "language/node"
 class Agenticos < Formula
   desc "AI-native project management MCP server for coding agents"
   homepage "https://github.com/madlouse/AgenticOS"
-  url "https://github.com/madlouse/AgenticOS/releases/download/v0.4.8/agenticos-mcp-0.4.8.tgz"
-  version "0.4.8"
-  sha256 "b9e2e9a46f7d544ae5371c814d551cd15e864ebbb4a551e6e496d4164f16aa00"
+  url "https://github.com/madlouse/AgenticOS/releases/download/v0.4.18/agenticos-mcp-0.4.18.tgz"
+  version "0.4.18"
+  sha256 "TODO" # Will be updated by mislav/bump-homebrew-formula-action on next release
   license "MIT"
 
   depends_on "node"

--- a/standards/.context/release-process.md
+++ b/standards/.context/release-process.md
@@ -9,6 +9,12 @@ Semantic versioning: `MAJOR.MINOR.PATCH`
 - **MINOR**: new features, new tools, new MCP capabilities
 - **MAJOR**: breaking API changes
 
+## Release Automation
+
+Releases are automated via `.github/workflows/release.yml`:
+- Triggered by pushing a tag matching `v*` (e.g., `git tag v0.4.19 && git push origin v0.4.19`)
+- Runs: build → npm pack → create GitHub Release → update Homebrew formula
+
 ## Pre-release Checklist
 
 Before creating a GitHub release:
@@ -16,19 +22,28 @@ Before creating a GitHub release:
 - [ ] All PRs in the release group are merged to `main`
 - [ ] `main` passes CI (build + all tests)
 - [ ] Version bumped in `mcp-server/package.json`
-- [ ] Build clean: `npm run build` passes
 - [ ] Tests pass: `AGENTICOS_HOME=<path> npx vitest run` — all green
-- [ ] Package tgz built: `npm pack`
-- [ ] SHA256 computed: `shasum -a 256 *.tgz`
-- [ ] Homebrew formula updated with new URL + version + SHA
-- [ ] GitHub Release created with descriptive release notes
-- [ ] tgz uploaded to GitHub Release assets
-- [ ] Homebrew formula committed and pushed to `homebrew-tap` repo
-- [ ] Local Homebrew upgraded: `brew reinstall madlouse/agenticos/agenticos && brew link --overwrite madlouse/agenticos/agenticos`
-- [ ] Version verified: `agenticos-mcp --version` matches new version
-- [ ] MCP health checked: `claude mcp list` shows agenticos ✓
+- [ ] Commit version bump: `git add mcp-server/package.json && git commit -m "chore: release v<VERSION>"`
+- [ ] Push and tag: `git tag v<VERSION> && git push origin v<VERSION>`
 
-## Release Commands
+## CI/CD Release Flow (Automated)
+
+```
+git tag v<VERSION> && git push origin v<VERSION>
+    ↓
+.github/workflows/release.yml triggers
+    ↓
+1. Build (npm install + npm run build)
+2. Create tarball (npm pack)
+3. Create GitHub Release (softprops/action-gh-release)
+4. Update Homebrew formula (mislav/bump-homebrew-formula-action)
+    ↓
+GitHub Release created + Homebrew PR auto-opened
+```
+
+## Manual Release Commands (Fallback)
+
+If CI is unavailable, run manually:
 
 ```bash
 # 1. Bump version in mcp-server/package.json
@@ -50,7 +65,7 @@ gh release create v<VERSION> \
 gh release upload v<VERSION> agenticos-mcp-*.tgz
 
 # 6. Update homebrew-tap/Formula/agenticos.rb (both repos)
-# URL: https://github.com/madlouse/AgenticOS/releases/download/v<VERSION>/agenticos-mcp-<VERSION>.tggz
+# URL: https://github.com/madlouse/AgenticOS/releases/download/v<VERSION>/agenticos-mcp-<VERSION>.tgz
 # Version + SHA256 updated
 
 # 7. Commit and push formula to both:
@@ -75,7 +90,55 @@ claude mcp list
 
 Both must be updated on every release. The local tap is what `brew install` reads.
 
+## Required Secrets
+
+For automated Homebrew bumps, the repository needs:
+
+| Secret | Purpose |
+|--------|---------|
+| `HOMEBREW_TAP_PAT` | PAT with `repo` scope for `mislav/bump-homebrew-formula-action` to create PRs |
+
 ## Post-release
 
 - [ ] MCP registration verified in Claude Code and other agents
 - [ ] Release notes posted to relevant channels if needed
+
+## Workflow Template for Other Projects
+
+The `.github/workflows/release.yml` in AgenticOS is designed as a template for other projects.
+To reuse in other projects:
+
+```yaml
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Install and build
+        run: npm install && npm run build
+      - name: Create npm tarball
+        run: npm pack
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: "*.tgz"
+      - name: Update Homebrew formula
+        uses: mislav/bump-homebrew-formula-action@v4
+        with:
+          formula-name: YOUR_FORMULA
+          formula-path: Formula/yourformula.rb
+          homebrew-tap: user/homebrew-yourtap
+          tag-name: ${{ github.ref_name }}
+        env:
+          COMMITTER_TOKEN: ${{ secrets.YOUR_PAT_SECRET }}
+```
+
+For reusable workflow_call version, see `homebrew-bump.yml`.


### PR DESCRIPTION
## Summary

- **Bug**: `release.yml` never called `homebrew-bump.yml`, causing Homebrew formula to fall behind 10 versions (v0.4.8 → v0.4.18)
- **Fix**: Add `mislav/bump-homebrew-formula-action` step directly in `release.yml` after GitHub Release creation
- **Update**: Bump `homebrew-tap/Formula/agenticos.rb` from v0.4.8 to v0.4.18
- **Docs**: Update `release-process.md` to document automated CI/CD flow + workflow template for other projects

## Changes

| File | Change |
|------|--------|
| `.github/workflows/release.yml` | Added Homebrew formula bump step after release creation |
| `homebrew-tap/Formula/agenticos.rb` | Version v0.4.8 → v0.4.18 |
| `standards/.context/release-process.md` | Document automated flow, secrets, workflow template |

## Test plan

- [ ] Verify PR CI passes
- [ ] After merge, create a test tag to verify `release.yml` triggers correctly
- [ ] Verify Homebrew formula PR is auto-created by mislav action

## Related Issues

- Closes #400

🤖 Generated with [Claude Code](https://claude.com/claude-code)