### PR TITLE
fix: use sed instead of npm version to avoid Version not changed error (#404)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,13 +39,20 @@ jobs:
           TAG="${{ github.ref_name }}"
           VERSION="${TAG#v}"
           echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "TAG=$TAG" >> $GITHUB_ENV
 
       - name: Update package.json version
         working-directory: mcp-server
         run: |
-          echo "Updating package.json from $(cat package.json | grep '"version"' | cut -d'"' -f4) to $VERSION"
-          npm version $VERSION --no-git-tag-version
-          cat package.json | grep '"version"'
+          CURRENT=$(grep '"version"' package.json | cut -d'"' -f4)
+          echo "Current version: $CURRENT, Target: $VERSION"
+          if [ "$CURRENT" != "$VERSION" ]; then
+            sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" package.json
+            echo "Updated package.json to $VERSION"
+          else
+            echo "Version already $VERSION, no update needed"
+          fi
+          grep '"version"' package.json
 
       - name: Install and build
         working-directory: mcp-server


### PR DESCRIPTION
## Summary

- **Bug**: `npm version $VERSION --no-git-tag-version` fails when version is already correct, causing release workflow to fail
- **Fix**: Replace `npm version` with `sed` for version update - works regardless of whether version needs to change

## Changes

| File | Change |
|------|--------|
| `.github/workflows/release.yml` | Replace `npm version` with `sed` + version check |

## Test plan

- [ ] Verify PR CI passes
- [ ] Re-trigger the v0.4.19 release workflow

## Related Issues

- Closes #404

🤖 Generated with [Claude Code](https://claude.com/claude-code)