### PR TITLE
Route project switch intents through AgenticOS MCP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- agenticos-template: v14 -->
+<!-- agenticos-template: v15 -->
 # AGENTS.md — AgenticOS
 
 ## Adapter Role
@@ -33,6 +33,15 @@ If your runtime supports local stop hooks, configure `agenticos-record-reminder`
 If any of these cannot be answered clearly, **stop and ask**. Do not proceed with fuzzy assumptions.
 
 Once intent is resolved, collapse it into a clean execution objective. Do not carry the full intake rubric through every later step.
+
+## Project Switch Routing
+
+When the operator asks to switch, enter, or continue an AgenticOS project, including phrases such as "switch project", "enter project", "continue project", "切换项目", "进入项目", or "继续项目", route through AgenticOS MCP before filesystem discovery.
+
+1. If AgenticOS MCP tools are not visible yet, first use deferred tool discovery for AgenticOS MCP tools; in Codex-like clients, use `tool_search` before shell directory search.
+2. If `agenticos_switch` is available, call it before running shell commands to locate project directories.
+3. Use the returned project path / filesystem workdir as the explicit working directory for subsequent shell commands.
+4. Fall back to shell directory search only when AgenticOS MCP is unavailable or `agenticos_switch` cannot resolve the requested project.
 
 ## Guardrail Protocol (MANDATORY)
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,13 @@ first managed project:
 4. **Verify persistence** — on the second session, ask the tool to run
    `agenticos_status` and confirm it shows your previous context
 
+For natural-language switch requests such as "switch project", "enter project",
+"continue project", "切换项目", or "进入项目", agents should discover and call
+AgenticOS MCP `agenticos_switch` before shell directory search. In Codex-like
+clients where MCP tools may be deferred, use `tool_search` to discover
+AgenticOS MCP tools first. Fall back to shell directory search only when
+AgenticOS MCP is unavailable or cannot resolve the requested project.
+
 For a full walkthrough with `agenticos-bootstrap --first-run`, see
 [mcp-server/README.md](mcp-server/README.md).
 

--- a/mcp-server/src/utils/__tests__/distill.test.ts
+++ b/mcp-server/src/utils/__tests__/distill.test.ts
@@ -5,6 +5,8 @@ import {
   CLAUDE_ADAPTER_LINES,
   CLAUDE_RUNTIME_GUIDANCE_TITLE,
   CURRENT_TEMPLATE_VERSION,
+  PROJECT_SWITCH_ROUTING_CONTENT,
+  PROJECT_SWITCH_ROUTING_TITLE,
   SHARED_POLICY_BULLETS,
   SHARED_POLICY_TITLE,
   TASK_INTAKE_RULE_TITLE,
@@ -12,6 +14,8 @@ import {
   generateClaudeMd,
   upgradeClaudeMd,
   upgradeAgentsMd,
+  updateClaudeMdState,
+  extractTemplateVersion,
   mergeSections,
   STANDARD_SECTION_NAMES,
 } from '../distill.js';
@@ -24,8 +28,8 @@ describe('distill templates', () => {
   it('generates AGENTS.md with the current template version and minimal required sections', () => {
     const content = generateAgentsMd('Demo Project', 'Test project');
 
-    expect(CURRENT_TEMPLATE_VERSION).toBe(14);
-    expect(content).toContain('<!-- agenticos-template: v14 -->');
+    expect(CURRENT_TEMPLATE_VERSION).toBe(15);
+    expect(content).toContain('<!-- agenticos-template: v15 -->');
     expect(content).toContain('## Adapter Role');
     expect(content).toContain(AGENTS_ADAPTER_LINES[0]);
     expect(content).toContain(AGENTS_ADAPTER_LINES[1]);
@@ -42,6 +46,13 @@ describe('distill templates', () => {
     expect(content).toContain('**Intent**');
     expect(content).toContain('**Data Source**');
     expect(content).toContain('**Scope**');
+    expect(content).toContain(`## ${PROJECT_SWITCH_ROUTING_TITLE}`);
+    expect(content).toContain(PROJECT_SWITCH_ROUTING_CONTENT);
+    expect(content).toContain('tool_search');
+    expect(content).toContain('切换项目');
+    expect(content).toContain('进入项目');
+    expect(content).toContain('continue project');
+    expect(content).toContain('Fall back to shell directory search only when AgenticOS MCP is unavailable');
     expect(content).toContain('## Guardrail Protocol (MANDATORY)');
     expect(content).toContain('agenticos_preflight');
     expect(content).toContain('agenticos_status');
@@ -65,8 +76,8 @@ describe('distill templates', () => {
   it('generates CLAUDE.md with minimal required sections', () => {
     const content = generateClaudeMd('Demo Project', 'Test project');
 
-    expect(CURRENT_TEMPLATE_VERSION).toBe(14);
-    expect(content).toContain('<!-- agenticos-template: v14 -->');
+    expect(CURRENT_TEMPLATE_VERSION).toBe(15);
+    expect(content).toContain('<!-- agenticos-template: v15 -->');
     expect(content).toContain('## Adapter Role');
     expect(content).toContain(CLAUDE_ADAPTER_LINES[0]);
     expect(content).toContain(CLAUDE_ADAPTER_LINES[1]);
@@ -83,6 +94,10 @@ describe('distill templates', () => {
     expect(content).toContain('**Intent**');
     expect(content).toContain('**Data Source**');
     expect(content).toContain('**Scope**');
+    expect(content).toContain(`## ${PROJECT_SWITCH_ROUTING_TITLE}`);
+    expect(content).toContain('tool_search');
+    expect(content).toContain('switch project');
+    expect(content).toContain('继续项目');
     expect(content).toContain('## Guardrail Protocol (MANDATORY)');
     expect(content).toContain('## MANDATORY: Recording Protocol');
     expect(content).toContain('## Session Start Protocol');
@@ -127,7 +142,7 @@ describe('section markers', () => {
     expect(content).toContain('<!-- agenticos-section: recording-protocol -->');
 
     // All standard sections should be marked
-    expect(STANDARD_SECTION_NAMES.length).toBe(8);
+    expect(STANDARD_SECTION_NAMES.length).toBe(9);
   });
 
   it('mergeSections preserves project-specific content from existing file', () => {
@@ -206,8 +221,8 @@ Old guardrail text
       expect(result).toContain('用户入口保持小写');
       expect(result).toContain('1Password 是唯一事实源');
 
-      // Should have v14 marker
-      expect(result).toContain('v14');
+      // Should have v15 marker
+      expect(result).toContain('v15');
     } finally {
       await unlink(tempPath);
     }
@@ -225,6 +240,10 @@ describe('merge sections edge cases', () => {
     const template = generateClaudeMd('Test', '');
     const result = mergeSections(template, '');
     expect(result).toBe(template);
+  });
+
+  it('mergeSections without section markers falls back to the template content', () => {
+    expect(mergeSections('plain template', 'plain existing')).toBe('plain template');
   });
 
   it('mergeSections with existing section markers preserves project-specific sections', () => {
@@ -314,6 +333,37 @@ Old recording
     expect(result).toContain('Custom Project Section');
     expect(result).toContain('Project-specific bullet');
   });
+
+  it('mergeSections preserves matching non-standard template sections from existing', () => {
+    const template = `<!-- agenticos-section: project-specific -->
+## Project Specific
+
+Template content
+<!-- /agenticos-section -->`;
+    const existing = `<!-- agenticos-section: project-specific -->
+## Project Specific
+
+Existing content
+<!-- /agenticos-section -->`;
+
+    const result = mergeSections(template, existing);
+
+    expect(result).toContain('Existing content');
+    expect(result).not.toContain('Template content');
+  });
+
+  it('mergeSections parses marker sections without markdown titles', () => {
+    const template = `<!-- agenticos-section: custom -->
+No title template
+<!-- /agenticos-section -->`;
+    const existing = `<!-- agenticos-section: custom -->
+No title existing
+<!-- /agenticos-section -->`;
+
+    const result = mergeSections(template, existing);
+
+    expect(result).toContain('No title existing');
+  });
 });
 
 describe('upgrade functions edge cases', () => {
@@ -322,7 +372,7 @@ describe('upgrade functions edge cases', () => {
     const result = upgradeClaudeMd(nonExistentPath, 'Test', 'Test desc');
 
     // Should generate template without errors
-    expect(result).toContain('<!-- agenticos-template: v14 -->');
+    expect(result).toContain('<!-- agenticos-template: v15 -->');
     expect(result).toContain('## Adapter Role');
   });
 
@@ -354,7 +404,7 @@ More custom content
       const result = upgradeClaudeMd(tempPath, 'Legacy Project', '');
 
       // Should have new template content
-      expect(result).toContain('v14');
+      expect(result).toContain('v15');
       expect(result).toContain('This project has one canonical AgenticOS execution policy');
 
       // Should preserve custom sections
@@ -391,7 +441,7 @@ CLI adapter role
       const result = upgradeAgentsMd(tempPath, 'CLI Project', '');
 
       // Should have new template content
-      expect(result).toContain('v14');
+      expect(result).toContain('v15');
       expect(result).toContain('This project has one canonical AgenticOS execution policy');
 
       // Should preserve project-specific sections
@@ -399,6 +449,96 @@ CLI adapter role
       expect(result).toContain('Command 1');
       expect(result).toContain('Secret Contract');
       expect(result).toContain('Secret 1');
+    } finally {
+      await unlink(tempPath);
+    }
+  });
+
+  it('upgradeClaudeMd preserves unknown sections before legacy recording protocol headers', async () => {
+    const existingContent = `<!-- agenticos-template: v13 -->
+# CLAUDE.md — Legacy Project
+
+## Custom Operations
+
+- Keep this custom operation
+
+## Recording Protocol
+
+Legacy recording instructions
+`;
+
+    const tempPath = join(tmpdir(), 'test-legacy-recording-claude.md');
+    await writeFile(tempPath, existingContent, 'utf-8');
+
+    try {
+      const result = upgradeClaudeMd(tempPath, 'Legacy Project', '');
+
+      expect(result).toContain('Custom Operations');
+      expect(result).toContain('Keep this custom operation');
+      expect(result).not.toContain('Legacy recording instructions');
+    } finally {
+      await unlink(tempPath);
+    }
+  });
+
+  it('upgradeClaudeMd splits adjacent unknown legacy sections conservatively', async () => {
+    const existingContent = `<!-- agenticos-template: v13 -->
+# CLAUDE.md — Legacy Project
+
+## First Unknown
+## Second Unknown
+
+Second body
+`;
+
+    const tempPath = join(tmpdir(), 'test-adjacent-unknown-claude.md');
+    await writeFile(tempPath, existingContent, 'utf-8');
+
+    try {
+      const result = upgradeClaudeMd(tempPath, 'Legacy Project', '');
+
+      expect(result).toContain('First Unknown');
+      expect(result).toContain('Second Unknown');
+      expect(result).toContain('Second body');
+    } finally {
+      await unlink(tempPath);
+    }
+  });
+
+  it('upgradeAgentsMd with non-existent file generates fresh template', () => {
+    const nonExistentPath = join(tmpdir(), 'non-existent-agents-' + Date.now() + '.md');
+    const result = upgradeAgentsMd(nonExistentPath, 'Test', 'Test desc');
+
+    expect(result).toContain('<!-- agenticos-template: v15 -->');
+    expect(result).toContain('## Project Switch Routing');
+  });
+
+  it('upgradeAgentsMd with section markers uses mergeSections', async () => {
+    const existingContent = `<!-- agenticos-template: v13 -->
+# AGENTS.md — Marked Project
+
+<!-- agenticos-section: canonical-policy -->
+## Canonical Policy
+Old canonical
+<!-- /agenticos-section -->
+
+<!-- agenticos-section: custom-agent-content -->
+## Custom Agent Content
+
+- Agent bullet
+<!-- /agenticos-section -->
+`;
+
+    const tempPath = join(tmpdir(), 'test-marked-agents.md');
+    await writeFile(tempPath, existingContent, 'utf-8');
+
+    try {
+      const result = upgradeAgentsMd(tempPath, 'Marked Project', '');
+
+      expect(result).toContain('This project has one canonical AgenticOS execution policy');
+      expect(result).not.toContain('Old canonical');
+      expect(result).toContain('Custom Agent Content');
+      expect(result).toContain('Agent bullet');
     } finally {
       await unlink(tempPath);
     }
@@ -444,6 +584,11 @@ Old canonical
 });
 
 describe('section markers format consistency', () => {
+  it('extractTemplateVersion returns parsed version or zero when absent', () => {
+    expect(extractTemplateVersion('<!-- agenticos-template: v15 -->')).toBe(15);
+    expect(extractTemplateVersion('# No marker')).toBe(0);
+  });
+
   it('generateClaudeMd produces consistent marker format', () => {
     const content = generateClaudeMd('Test', '');
 
@@ -479,5 +624,13 @@ describe('section markers format consistency', () => {
     expect(STANDARD_SECTION_NAMES).toContain('runtime-notes');
     expect(STANDARD_SECTION_NAMES).toContain('stop-hook');
     expect(STANDARD_SECTION_NAMES).toContain('task-intake-rule');
+    expect(STANDARD_SECTION_NAMES).toContain('project-switch-routing');
+  });
+
+  it('updateClaudeMdState is a no-op because state lives in state.yaml', async () => {
+    await expect(updateClaudeMdState('/tmp/CLAUDE.md', {})).resolves.toEqual({
+      updated: false,
+      created: false,
+    });
   });
 });

--- a/mcp-server/src/utils/distill.ts
+++ b/mcp-server/src/utils/distill.ts
@@ -7,7 +7,7 @@ import { STOP_HOOK_MIGRATION_BULLETS } from './stop-hook-guidance.js';
  * Current template version. Increment when templates change.
  * Used for auto-upgrade on project switch.
  */
-export const CURRENT_TEMPLATE_VERSION = 14;
+export const CURRENT_TEMPLATE_VERSION = 15;
 
 /** Version marker format in generated files */
 const VERSION_MARKER = `<!-- agenticos-template: v${CURRENT_TEMPLATE_VERSION} -->`;
@@ -77,6 +77,14 @@ If any of these cannot be answered clearly, **stop and ask**. Do not proceed wit
 
 Once intent is resolved, collapse it into a clean execution objective. Do not carry the full intake rubric through every later step.` as const;
 
+export const PROJECT_SWITCH_ROUTING_TITLE = 'Project Switch Routing';
+export const PROJECT_SWITCH_ROUTING_CONTENT = `When the operator asks to switch, enter, or continue an AgenticOS project, including phrases such as "switch project", "enter project", "continue project", "切换项目", "进入项目", or "继续项目", route through AgenticOS MCP before filesystem discovery.
+
+1. If AgenticOS MCP tools are not visible yet, first use deferred tool discovery for AgenticOS MCP tools; in Codex-like clients, use \`tool_search\` before shell directory search.
+2. If \`agenticos_switch\` is available, call it before running shell commands to locate project directories.
+3. Use the returned project path / filesystem workdir as the explicit working directory for subsequent shell commands.
+4. Fall back to shell directory search only when AgenticOS MCP is unavailable or \`agenticos_switch\` cannot resolve the requested project.` as const;
+
 export const DESIGN_PHILOSOPHY_TITLE = 'Design Philosophy';
 
 /**
@@ -97,13 +105,6 @@ export const CONTINUITY_CONTRACT_BULLETS = [
 export function extractTemplateVersion(content: string): number {
   const match = content.match(/<!--\s*agenticos-template:\s*v(\d+)\s*-->/);
   return match ? parseInt(match[1], 10) : 0;
-}
-
-/** Update version marker in existing content to current version */
-function ensureVersionMarker(content: string): string {
-  if (content.includes(`agenticos-template: v${CURRENT_TEMPLATE_VERSION}`)) return content;
-  const cleaned = content.replace(/<!--\s*agenticos-template:\s*v\d+\s*-->\n?/, '');
-  return `${VERSION_MARKER}\n${cleaned}`;
 }
 
 function renderSharedPolicySection(): string {
@@ -168,6 +169,10 @@ export function generateAgentsMd(
     {
       name: 'task-intake-rule',
       content: `## ${TASK_INTAKE_RULE_TITLE}\n\n${TASK_INTAKE_RULE_CONTENT}`
+    },
+    {
+      name: 'project-switch-routing',
+      content: `## ${PROJECT_SWITCH_ROUTING_TITLE}\n\n${PROJECT_SWITCH_ROUTING_CONTENT}`
     },
     {
       name: 'guardrail-protocol',
@@ -235,6 +240,7 @@ export const STANDARD_SECTION_NAMES = [
   'runtime-notes',
   'stop-hook',
   'task-intake-rule',
+  'project-switch-routing',
   'guardrail-protocol',
   'recording-protocol',
   'session-start-protocol',
@@ -254,6 +260,7 @@ const SECTION_TITLES: Record<string, string> = {
   'runtime-notes': 'Claude Runtime Notes',
   'stop-hook': 'Stop-Hook (Optional)',
   'task-intake-rule': 'Task Intake Rule',
+  'project-switch-routing': 'Project Switch Routing',
   'guardrail-protocol': 'Guardrail Protocol (MANDATORY)',
   'recording-protocol': 'MANDATORY: Recording Protocol',
   'session-start-protocol': 'Session Start Protocol',
@@ -319,6 +326,10 @@ export function generateClaudeMd(
     {
       name: 'task-intake-rule',
       content: `## ${TASK_INTAKE_RULE_TITLE}\n\n${TASK_INTAKE_RULE_CONTENT}`
+    },
+    {
+      name: 'project-switch-routing',
+      content: `## ${PROJECT_SWITCH_ROUTING_TITLE}\n\n${PROJECT_SWITCH_ROUTING_CONTENT}`
     },
     {
       name: 'guardrail-protocol',
@@ -425,6 +436,7 @@ function extractProjectSpecificSections(existingContent: string): string[] {
           'runtime-notes': ['Claude Runtime Notes', 'Codex / Generic Runtime Notes'],
           'stop-hook': ['Stop-Hook (Optional)'],
           'task-intake-rule': ['Task Intake Rule'],
+          'project-switch-routing': ['Project Switch Routing'],
           'guardrail-protocol': ['Guardrail Protocol (MANDATORY)'],
           'recording-protocol': ['MANDATORY: Recording Protocol', 'Recording Protocol (MANDATORY)'],
           'session-start-protocol': ['Session Start Protocol'],


### PR DESCRIPTION
## Root cause

The generated AGENTS/CLAUDE guidance only told adapters to call `agenticos_switch` after detecting they were not on a project. It did not explicitly cover natural-language switch/enter/continue project intents, including Chinese phrases, and it did not explain that Codex-like clients may need deferred tool discovery with `tool_search` before any filesystem search. That left agents free to start with shell directory discovery instead of routing the user intent through AgenticOS MCP first.

## Changes

- Bump the generated adapter template to v15.
- Add a Project Switch Routing section to the generated template and root AGENTS.md.
- Document MCP-first natural-language project switching in README.
- Add focused distill tests for the new template content and related edge coverage.

## Verification

- `npm test -- --run src/utils/__tests__/distill.test.ts`
- `npm run lint`
- `npm run test:coverage`
- `./tools/coverage-preflight.sh`
- `agenticos_pr_scope_check`

Fixes #407