### PR TITLE
fix: auto-configure Claude PWD alignment hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,14 @@ After Homebrew installation, the fastest path to a working setup is:
 
 ```bash
 export AGENTICOS_HOME=/absolute/path/to/your/workspace   # any valid workspace home
-agenticos-bootstrap --workspace "$AGENTICOS_HOME" --first-run
+agenticos-bootstrap --workspace "$AGENTICOS_HOME" --first-run --auto-configure-hooks
 ```
 
 On macOS, `--first-run` also sets up `launchctl` persistence so GUI tools
-inherit `AGENTICOS_HOME` across sessions. Then restart your AI tool and
-run:
+inherit `AGENTICOS_HOME` across sessions. `--auto-configure-hooks` adds the
+Claude Code PostToolUse hook that lets `agenticos_switch` emit a path and have
+Claude Code align the client shell PWD automatically when supported.
+Then restart your AI tool and run:
 
 ```bash
 agenticos-config --validate

--- a/homebrew-tap/Formula/agenticos.rb
+++ b/homebrew-tap/Formula/agenticos.rb
@@ -46,10 +46,13 @@ class Agenticos < Formula
       2. Bootstrap one officially supported agent:
 
          Recommended helper
-           agenticos-bootstrap --workspace "$AGENTICOS_HOME" --first-run
+           agenticos-bootstrap --workspace "$AGENTICOS_HOME" --first-run --auto-configure-hooks
 
          macOS GUI/session helper
            agenticos-bootstrap --workspace "$AGENTICOS_HOME" --persist-shell-env --persist-launchctl-env --apply
+
+         Claude Code PWD alignment hook
+           agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent claude-code --auto-configure-hooks --apply
 
          Claude Code
            claude mcp add --transport stdio --scope user -e AGENTICOS_HOME="$AGENTICOS_HOME" agenticos -- agenticos-mcp

--- a/homebrew-tap/README.md
+++ b/homebrew-tap/README.md
@@ -68,6 +68,7 @@ agenticos-bootstrap --workspace "$AGENTICOS_HOME" --all --verify
 Then confirm the server appears in the tool's MCP diagnostics and verify `agenticos_list` works.
 If you prefer not to edit your shell profile, omit `--first-run` and use the explicit MCP commands above instead.
 On macOS, `--first-run` also enables `launchctl` persistence so GUI/session processes inherit `AGENTICOS_HOME`.
+For Claude Code PWD alignment after `agenticos_switch`, run `agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent claude-code --auto-configure-hooks --apply` or include `--auto-configure-hooks` with `--first-run`.
 Use `agenticos-bootstrap --workspace "$AGENTICOS_HOME" --all --verify` with the same flags to audit the current machine state without mutating it.
 
 `AGENTICOS_HOME` may also be a long-term self-hosting workspace home. The

--- a/mcp-server/src/utils/__tests__/bootstrap-cli.test.ts
+++ b/mcp-server/src/utils/__tests__/bootstrap-cli.test.ts
@@ -3,7 +3,13 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import yaml from 'yaml';
-import { buildHelpLines, parseCliArgs, resolveSelectedAgents, runBootstrapCli } from '../bootstrap-cli.js';
+import {
+  buildDryRunLines,
+  buildHelpLines,
+  parseCliArgs,
+  resolveSelectedAgents,
+  runBootstrapCli,
+} from '../bootstrap-cli.js';
 
 function createDeps() {
   const files = new Map<string, string>();
@@ -102,6 +108,24 @@ describe('bootstrap cli', () => {
         apply: false,
         verify: false,
         firstRun: false,
+        all: true,
+        agents: [],
+        help: false,
+        persistShellEnv: false,
+        persistLaunchctlEnv: false,
+        autoConfigureHooks: false,
+      },
+      [
+        { id: 'codex', label: 'Codex', installed: true, detection_hint: 'test' },
+        { id: 'claude-code', label: 'Claude Code', installed: false, detection_hint: 'test' },
+      ],
+    )).toEqual(['codex', 'claude-code']);
+
+    expect(resolveSelectedAgents(
+      {
+        apply: false,
+        verify: false,
+        firstRun: false,
         all: false,
         agents: [],
         help: false,
@@ -114,6 +138,83 @@ describe('bootstrap cli', () => {
         { id: 'claude-code', label: 'Claude Code', installed: false, detection_hint: 'test' },
       ],
     )).toEqual(['codex']);
+  });
+
+  it('renders dry-run state for missing agents', () => {
+    const lines = buildDryRunLines(
+      '/tmp/workspace',
+      'explicit --workspace',
+      [
+        { id: 'codex', label: 'Codex', installed: true, detection_hint: 'test' },
+        { id: 'claude-code', label: 'Claude Code', installed: false, detection_hint: 'test' },
+      ],
+      ['claude-code'],
+      {
+        apply: false,
+        verify: false,
+        firstRun: false,
+        all: false,
+        agents: ['claude-code'],
+        help: false,
+        persistShellEnv: true,
+        persistLaunchctlEnv: true,
+        autoConfigureHooks: true,
+      },
+      undefined,
+      '/Users/tester',
+    );
+
+    expect(lines.join('\n')).toContain('- claude-code: no (test)');
+    expect(lines.join('\n')).toContain('launchctl setenv AGENTICOS_HOME');
+  });
+
+  it('reports non-Error thrown failures', () => {
+    const detectHarness = createDeps();
+    detectHarness.deps.commandExists = () => {
+      throw 'detect exploded';
+    };
+
+    expect(runBootstrapCli(['--workspace', '/tmp/workspace'], detectHarness.deps)).toBe(1);
+    expect(detectHarness.stderr).toContain('detect exploded');
+
+    const cursorHarness = createDeps();
+    cursorHarness.deps.writeFile = () => {
+      throw 'cursor config locked';
+    };
+    expect(runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'cursor', '--apply'],
+      cursorHarness.deps,
+    )).toBe(1);
+    expect(cursorHarness.stdout.some((line) => line.includes('FAIL cursor: cursor config locked'))).toBe(true);
+
+    const profileHarness = createDeps();
+    profileHarness.deps.writeFile = (path: string, content: string) => {
+      if (path === 'profile') throw 'profile locked';
+      profileHarness.files.set(path, content);
+    };
+    expect(runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'codex', '--persist-shell-env', '--shell-profile', 'profile', '--apply'],
+      profileHarness.deps,
+    )).toBe(1);
+    expect(profileHarness.stdout.some((line) => line.includes('FAIL shell-profile: profile locked'))).toBe(true);
+
+    const hookHarness = createDeps();
+    hookHarness.deps.writeFile = () => {
+      throw 'hook settings locked';
+    };
+    expect(runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'claude-code', '--auto-configure-hooks', '--apply'],
+      hookHarness.deps,
+    )).toBe(1);
+    expect(hookHarness.stdout.some((line) => line.includes('FAIL claude-pwd-hook'))).toBe(true);
+
+    const stateHarness = createDeps();
+    stateHarness.deps.writeFile = (path: string, content: string) => {
+      if (path.endsWith('bootstrap-state.yaml')) throw 'state locked';
+      stateHarness.files.set(path, content);
+    };
+    expect(runBootstrapCli(['--workspace', '/tmp/workspace', '--agent', 'codex', '--apply'], stateHarness.deps)).toBe(1);
+    expect(stateHarness.stdout.some((line) => line.includes('FAIL bootstrap-state: state locked'))).toBe(true);
   });
 
   it('applies codex bootstrap and persists shell env', () => {
@@ -434,6 +535,21 @@ describe('bootstrap cli', () => {
       verifyHarness.deps,
     )).toBe(1);
     expect(verifyHarness.stdout.some((line) => line.includes('FAIL launchctl: /tmp/other'))).toBe(true);
+
+    const emptyVerifyHarness = createDeps();
+    emptyVerifyHarness.deps.runCommand = (command: string, args: string[], failOnError: boolean) => {
+      emptyVerifyHarness.commands.push({ command, args, failOnError });
+      if ([command, ...args].join(' ') === 'launchctl getenv AGENTICOS_HOME') {
+        return { ok: false, detail: '' };
+      }
+      return { ok: true, detail: 'ok' };
+    };
+
+    expect(runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'codex', '--persist-launchctl-env', '--apply'],
+      emptyVerifyHarness.deps,
+    )).toBe(1);
+    expect(emptyVerifyHarness.stdout.some((line) => line.includes('launchctl getenv did not report'))).toBe(true);
   });
 
   it('fails launchctl persistence on non-macos platforms', () => {
@@ -500,6 +616,19 @@ describe('bootstrap cli', () => {
     expect(harness.stdout.some((line) => line.includes('OK shell-profile'))).toBe(true);
     expect(harness.stdout.some((line) => line.includes('OK launchctl'))).toBe(true);
     expect(harness.files.has('/tmp/workspace/.agent-workspace/bootstrap-state.yaml')).toBe(false);
+  });
+
+  it('verifies shell profile through the default shell path', () => {
+    const harness = createDeps();
+    harness.files.set('/Users/tester/.profile', 'export AGENTICOS_HOME="/tmp/workspace"\n');
+
+    const exitCode = runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'codex', '--persist-shell-env', '--verify'],
+      harness.deps,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(harness.stdout.some((line) => line.includes('OK shell-profile: verified /Users/tester/.profile'))).toBe(true);
   });
 
   it('verifies codex redacted output through config file fallback', () => {

--- a/mcp-server/src/utils/__tests__/bootstrap-cli.test.ts
+++ b/mcp-server/src/utils/__tests__/bootstrap-cli.test.ts
@@ -126,6 +126,74 @@ describe('bootstrap cli', () => {
     expect(harness.stdout.some((line) => line.includes('shell-profile'))).toBe(true);
   });
 
+  it('prints Claude PWD hook dry-run guidance without mutating settings', () => {
+    const harness = createDeps();
+
+    const exitCode = runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'claude-code', '--auto-configure-hooks'],
+      harness.deps,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(harness.files.has('/Users/tester/.claude/settings.json')).toBe(false);
+    expect(harness.stdout.some((line) => line.includes('claude-pwd-hook'))).toBe(true);
+    expect(harness.stdout.some((line) => line.includes('add agenticos_switch PostToolUse hook'))).toBe(true);
+  });
+
+  it('adds Claude PWD alignment hook during apply when requested', () => {
+    const harness = createDeps();
+
+    const exitCode = runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'claude-code', '--auto-configure-hooks', '--apply'],
+      harness.deps,
+    );
+
+    expect(exitCode).toBe(0);
+    const settings = JSON.parse(harness.files.get('/Users/tester/.claude/settings.json') || '{}');
+    expect(settings.hooks.PostToolUse).toHaveLength(1);
+    expect(settings.hooks.PostToolUse[0].matcher).toBe('mcp__agenticos__agenticos_switch');
+    expect(settings.hooks.PostToolUse[0].hooks[0].command).toContain('tool_response.path');
+    expect(harness.stdout.some((line) => line.includes('OK claude-pwd-hook'))).toBe(true);
+  });
+
+  it('does not duplicate an existing Claude PWD alignment hook', () => {
+    const harness = createDeps();
+    harness.files.set('/Users/tester/.claude/settings.json', JSON.stringify({
+      hooks: {
+        PostToolUse: [
+          {
+            matcher: 'mcp__agenticos__agenticos_switch',
+            hooks: [{ type: 'command', command: 'cd "$(jq -r .tool_response.path)"', shell: 'bash' }],
+          },
+        ],
+      },
+    }));
+
+    const exitCode = runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'claude-code', '--auto-configure-hooks', '--apply'],
+      harness.deps,
+    );
+
+    expect(exitCode).toBe(0);
+    const settings = JSON.parse(harness.files.get('/Users/tester/.claude/settings.json') || '{}');
+    expect(settings.hooks.PostToolUse).toHaveLength(1);
+    expect(harness.stdout.some((line) => line.includes('Detected PostToolUse hook'))).toBe(true);
+  });
+
+  it('fails apply when Claude settings cannot be merged', () => {
+    const harness = createDeps();
+    harness.files.set('/Users/tester/.claude/settings.json', '[]');
+
+    const exitCode = runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'claude-code', '--auto-configure-hooks', '--apply'],
+      harness.deps,
+    );
+
+    expect(exitCode).toBe(1);
+    expect(harness.stdout.some((line) => line.includes('FAIL claude-pwd-hook'))).toBe(true);
+    expect(harness.stdout.some((line) => line.includes('Claude Code settings must be a JSON object'))).toBe(true);
+  });
+
   it('fails closed when no explicit or preconfirmed workspace exists', () => {
     const harness = createDeps();
     harness.deps.env.AGENTICOS_SOURCE_ROOT = '/Users/tester/dev/AgenticOS';

--- a/mcp-server/src/utils/__tests__/bootstrap-cli.test.ts
+++ b/mcp-server/src/utils/__tests__/bootstrap-cli.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import yaml from 'yaml';
-import { runBootstrapCli } from '../bootstrap-cli.js';
+import { buildHelpLines, parseCliArgs, resolveSelectedAgents, runBootstrapCli } from '../bootstrap-cli.js';
 
 function createDeps() {
   const files = new Map<string, string>();
@@ -58,6 +61,61 @@ function createDeps() {
 }
 
 describe('bootstrap cli', () => {
+  it('prints help and parses option edge cases', () => {
+    const harness = createDeps();
+
+    expect(runBootstrapCli(['--help'], harness.deps)).toBe(0);
+    expect(harness.stdout.join('\n')).toContain('agenticos-bootstrap');
+    expect(buildHelpLines().join('\n')).toContain('--auto-configure-hooks');
+    expect(parseCliArgs(['--all', '--auto-configure-hooks']).all).toBe(true);
+    expect(() => parseCliArgs(['--workspace'])).toThrow('--workspace requires a path.');
+    expect(() => parseCliArgs(['--agent'])).toThrow('--agent requires a value.');
+    expect(() => parseCliArgs(['--shell-profile'])).toThrow('--shell-profile requires a path.');
+    expect(() => parseCliArgs(['--bogus'])).toThrow('Unknown argument: --bogus');
+  });
+
+  it('rejects apply and verify together', () => {
+    const harness = createDeps();
+
+    const exitCode = runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'codex', '--apply', '--verify'],
+      harness.deps,
+    );
+
+    expect(exitCode).toBe(1);
+    expect(harness.stderr.some((line) => line.includes('--apply and --verify cannot be used together.'))).toBe(true);
+  });
+
+  it('rejects empty agent selections', () => {
+    const harness = createDeps();
+    harness.deps.commandExists = () => false;
+
+    const exitCode = runBootstrapCli(['--workspace', '/tmp/workspace', '--agent', ','], harness.deps);
+
+    expect(exitCode).toBe(1);
+    expect(harness.stderr.some((line) => line.includes('No agents selected'))).toBe(true);
+  });
+
+  it('resolves installed agents when no explicit selection is provided', () => {
+    expect(resolveSelectedAgents(
+      {
+        apply: false,
+        verify: false,
+        firstRun: false,
+        all: false,
+        agents: [],
+        help: false,
+        persistShellEnv: false,
+        persistLaunchctlEnv: false,
+        autoConfigureHooks: false,
+      },
+      [
+        { id: 'codex', label: 'Codex', installed: true, detection_hint: 'test' },
+        { id: 'claude-code', label: 'Claude Code', installed: false, detection_hint: 'test' },
+      ],
+    )).toEqual(['codex']);
+  });
+
   it('applies codex bootstrap and persists shell env', () => {
     const harness = createDeps();
 
@@ -112,6 +170,21 @@ describe('bootstrap cli', () => {
     expect(content).toContain('/tmp/workspace');
   });
 
+  it('reports cursor config write errors during apply', () => {
+    const harness = createDeps();
+    harness.deps.writeFile = () => {
+      throw new Error('cursor config locked');
+    };
+
+    const exitCode = runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'cursor', '--apply'],
+      harness.deps,
+    );
+
+    expect(exitCode).toBe(1);
+    expect(harness.stdout.some((line) => line.includes('FAIL cursor: cursor config locked'))).toBe(true);
+  });
+
   it('prints dry-run plan without mutating files', () => {
     const harness = createDeps();
 
@@ -124,6 +197,31 @@ describe('bootstrap cli', () => {
     expect(harness.commands).toHaveLength(0);
     expect(harness.files.size).toBe(0);
     expect(harness.stdout.some((line) => line.includes('shell-profile'))).toBe(true);
+  });
+
+  it('prints launchctl dry-run action when requested', () => {
+    const harness = createDeps();
+
+    const exitCode = runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'codex', '--persist-launchctl-env'],
+      harness.deps,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(harness.stdout.some((line) => line.includes('launchctl: run'))).toBe(true);
+  });
+
+  it('prints cursor dry-run config and Claude hook guidance without auto flag', () => {
+    const harness = createDeps();
+
+    const exitCode = runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'cursor', '--agent', 'claude-code'],
+      harness.deps,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(harness.stdout.join('\n')).toContain('~/.cursor/mcp.json');
+    expect(harness.stdout.join('\n')).toContain('rerun with --auto-configure-hooks --apply');
   });
 
   it('prints Claude PWD hook dry-run guidance without mutating settings', () => {
@@ -154,6 +252,20 @@ describe('bootstrap cli', () => {
     expect(settings.hooks.PostToolUse[0].matcher).toBe('mcp__agenticos__agenticos_switch');
     expect(settings.hooks.PostToolUse[0].hooks[0].command).toContain('tool_response.path');
     expect(harness.stdout.some((line) => line.includes('OK claude-pwd-hook'))).toBe(true);
+  });
+
+  it('warns but does not fail when Claude hook is missing and auto configure is not requested', () => {
+    const harness = createDeps();
+
+    const exitCode = runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'claude-code', '--apply'],
+      harness.deps,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(harness.stdout.some((line) => line.includes('WARN claude-pwd-hook'))).toBe(true);
+    const bootstrapState = yaml.parse(harness.files.get('/tmp/workspace/.agent-workspace/bootstrap-state.yaml') || '');
+    expect(bootstrapState.claude_pwd_hook.fatal).toBe(false);
   });
 
   it('does not duplicate an existing Claude PWD alignment hook', () => {
@@ -192,6 +304,57 @@ describe('bootstrap cli', () => {
     expect(exitCode).toBe(1);
     expect(harness.stdout.some((line) => line.includes('FAIL claude-pwd-hook'))).toBe(true);
     expect(harness.stdout.some((line) => line.includes('Claude Code settings must be a JSON object'))).toBe(true);
+  });
+
+  it('fails when agent registration apply command fails', () => {
+    const harness = createDeps();
+    harness.deps.runCommand = (command: string, args: string[], failOnError: boolean) => {
+      harness.commands.push({ command, args, failOnError });
+      if ([command, ...args].join(' ') === 'codex mcp add --env AGENTICOS_HOME=/tmp/workspace agenticos -- agenticos-mcp') {
+        return { ok: false, detail: 'add failed' };
+      }
+      return { ok: true, detail: 'ok' };
+    };
+
+    const exitCode = runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'codex', '--apply'],
+      harness.deps,
+    );
+
+    expect(exitCode).toBe(1);
+    expect(harness.stdout.some((line) => line.includes('FAIL codex: add failed'))).toBe(true);
+  });
+
+  it('reports shell profile persistence write errors', () => {
+    const harness = createDeps();
+    harness.deps.writeFile = (path: string, content: string) => {
+      if (path.endsWith('.zshrc')) throw new Error('profile locked');
+      harness.files.set(path, content);
+    };
+
+    const exitCode = runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'codex', '--persist-shell-env', '--shell-profile', '/Users/tester/.zshrc', '--apply'],
+      harness.deps,
+    );
+
+    expect(exitCode).toBe(1);
+    expect(harness.stdout.some((line) => line.includes('FAIL shell-profile: profile locked'))).toBe(true);
+  });
+
+  it('reports bootstrap state write errors', () => {
+    const harness = createDeps();
+    harness.deps.writeFile = (path: string, content: string) => {
+      if (path.endsWith('bootstrap-state.yaml')) throw new Error('state locked');
+      harness.files.set(path, content);
+    };
+
+    const exitCode = runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'codex', '--apply'],
+      harness.deps,
+    );
+
+    expect(exitCode).toBe(1);
+    expect(harness.stdout.some((line) => line.includes('FAIL bootstrap-state: state locked'))).toBe(true);
   });
 
   it('fails closed when no explicit or preconfirmed workspace exists', () => {
@@ -241,6 +404,38 @@ describe('bootstrap cli', () => {
     expect(harness.stdout.some((line) => line.includes('OK launchctl'))).toBe(true);
   });
 
+  it('fails launchctl apply when setenv fails or verification mismatches', () => {
+    const setHarness = createDeps();
+    setHarness.deps.runCommand = (command: string, args: string[], failOnError: boolean) => {
+      setHarness.commands.push({ command, args, failOnError });
+      if ([command, ...args].join(' ') === 'launchctl setenv AGENTICOS_HOME /tmp/workspace') {
+        return { ok: false, detail: 'setenv failed' };
+      }
+      return { ok: true, detail: 'ok' };
+    };
+
+    expect(runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'codex', '--persist-launchctl-env', '--apply'],
+      setHarness.deps,
+    )).toBe(1);
+    expect(setHarness.stdout.some((line) => line.includes('FAIL launchctl: setenv failed'))).toBe(true);
+
+    const verifyHarness = createDeps();
+    verifyHarness.deps.runCommand = (command: string, args: string[], failOnError: boolean) => {
+      verifyHarness.commands.push({ command, args, failOnError });
+      if ([command, ...args].join(' ') === 'launchctl getenv AGENTICOS_HOME') {
+        return { ok: true, detail: '/tmp/other' };
+      }
+      return { ok: true, detail: 'ok' };
+    };
+
+    expect(runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'codex', '--persist-launchctl-env', '--apply'],
+      verifyHarness.deps,
+    )).toBe(1);
+    expect(verifyHarness.stdout.some((line) => line.includes('FAIL launchctl: /tmp/other'))).toBe(true);
+  });
+
   it('fails launchctl persistence on non-macos platforms', () => {
     const harness = createDeps();
     harness.deps.platform = 'linux';
@@ -252,6 +447,32 @@ describe('bootstrap cli', () => {
 
     expect(exitCode).toBe(1);
     expect(harness.stdout.some((line) => line.includes('FAIL launchctl'))).toBe(true);
+  });
+
+  it('fails launchctl verification on non-macOS or empty output', () => {
+    const linuxHarness = createDeps();
+    linuxHarness.deps.platform = 'linux';
+
+    expect(runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'codex', '--persist-launchctl-env', '--verify'],
+      linuxHarness.deps,
+    )).toBe(1);
+    expect(linuxHarness.stdout.some((line) => line.includes('supported only on macOS'))).toBe(true);
+
+    const emptyHarness = createDeps();
+    emptyHarness.deps.runCommand = (command: string, args: string[], failOnError: boolean) => {
+      emptyHarness.commands.push({ command, args, failOnError });
+      if ([command, ...args].join(' ') === 'launchctl getenv AGENTICOS_HOME') {
+        return { ok: false, detail: '' };
+      }
+      return { ok: true, detail: 'ok' };
+    };
+
+    expect(runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'codex', '--persist-launchctl-env', '--verify'],
+      emptyHarness.deps,
+    )).toBe(1);
+    expect(emptyHarness.stdout.some((line) => line.includes('launchctl getenv did not report'))).toBe(true);
   });
 
   it('verifies codex, shell profile, and launchctl state without mutating', () => {
@@ -279,6 +500,42 @@ describe('bootstrap cli', () => {
     expect(harness.stdout.some((line) => line.includes('OK shell-profile'))).toBe(true);
     expect(harness.stdout.some((line) => line.includes('OK launchctl'))).toBe(true);
     expect(harness.files.has('/tmp/workspace/.agent-workspace/bootstrap-state.yaml')).toBe(false);
+  });
+
+  it('verifies codex redacted output through config file fallback', () => {
+    const harness = createDeps();
+    const home = mkdtempSync(join(tmpdir(), 'agenticos-bootstrap-test-'));
+    try {
+      harness.deps.homeDir = home;
+      mkdirSync(join(home, '.codex'), { recursive: true });
+      writeFileSync(join(home, '.codex', 'config.toml'), 'agenticos = true\nAGENTICOS_HOME = "/tmp/workspace"\n');
+      harness.deps.runCommand = (command: string, args: string[], failOnError: boolean) => {
+        harness.commands.push({ command, args, failOnError });
+        if ([command, ...args].join(' ') === 'codex mcp get agenticos') {
+          return { ok: true, detail: 'AGENTICOS_HOME=*****' };
+        }
+        return { ok: true, detail: 'ok' };
+      };
+
+      expect(runBootstrapCli(['--workspace', '/tmp/workspace', '--agent', 'codex', '--verify'], harness.deps)).toBe(0);
+      expect(harness.stdout.some((line) => line.includes('CLI output redacted'))).toBe(true);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('fails codex redacted verification when config fallback mismatches', () => {
+    const harness = createDeps();
+    harness.deps.runCommand = (command: string, args: string[], failOnError: boolean) => {
+      harness.commands.push({ command, args, failOnError });
+      if ([command, ...args].join(' ') === 'codex mcp get agenticos') {
+        return { ok: true, detail: 'AGENTICOS_HOME=*****' };
+      }
+      return { ok: true, detail: 'ok' };
+    };
+
+    expect(runBootstrapCli(['--workspace', '/tmp/workspace', '--agent', 'codex', '--verify'], harness.deps)).toBe(1);
+    expect(harness.stdout.some((line) => line.includes('workspace path mismatch'))).toBe(true);
   });
 
   it('fails verification when codex points at a different workspace', () => {
@@ -322,6 +579,38 @@ describe('bootstrap cli', () => {
     expect(harness.stdout.some((line) => line.includes('Recovery: claude mcp add'))).toBe(true);
   });
 
+  it('verifies gemini and cursor agents', () => {
+    const geminiHarness = createDeps();
+
+    expect(runBootstrapCli(['--workspace', '/tmp/workspace', '--agent', 'gemini-cli', '--verify'], geminiHarness.deps)).toBe(0);
+    expect(geminiHarness.stdout.some((line) => line.includes('OK gemini-cli'))).toBe(true);
+
+    const failedGeminiHarness = createDeps();
+    failedGeminiHarness.deps.runCommand = (command: string, args: string[], failOnError: boolean) => {
+      failedGeminiHarness.commands.push({ command, args, failOnError });
+      if ([command, ...args].join(' ') === 'gemini mcp list') {
+        return { ok: true, detail: 'no servers' };
+      }
+      return { ok: true, detail: 'ok' };
+    };
+    expect(runBootstrapCli(['--workspace', '/tmp/workspace', '--agent', 'gemini-cli', '--verify'], failedGeminiHarness.deps)).toBe(1);
+    expect(failedGeminiHarness.stdout.some((line) => line.includes('FAIL gemini-cli'))).toBe(true);
+
+    const missingCursorHarness = createDeps();
+    expect(runBootstrapCli(['--workspace', '/tmp/workspace', '--agent', 'cursor', '--verify'], missingCursorHarness.deps)).toBe(1);
+    expect(missingCursorHarness.stdout.some((line) => line.includes('missing /Users/tester/.cursor/mcp.json'))).toBe(true);
+
+    const cursorHarness = createDeps();
+    cursorHarness.files.set('/Users/tester/.cursor/mcp.json', JSON.stringify({ mcpServers: { agenticos: { env: { AGENTICOS_HOME: '/tmp/workspace' } } } }));
+    expect(runBootstrapCli(['--workspace', '/tmp/workspace', '--agent', 'cursor', '--verify'], cursorHarness.deps)).toBe(0);
+    expect(cursorHarness.stdout.some((line) => line.includes('OK cursor'))).toBe(true);
+
+    const mismatchCursorHarness = createDeps();
+    mismatchCursorHarness.files.set('/Users/tester/.cursor/mcp.json', JSON.stringify({ mcpServers: { agenticos: { env: { AGENTICOS_HOME: '/tmp/other' } } } }));
+    expect(runBootstrapCli(['--workspace', '/tmp/workspace', '--agent', 'cursor', '--verify'], mismatchCursorHarness.deps)).toBe(1);
+    expect(mismatchCursorHarness.stdout.some((line) => line.includes('expected agenticos MCP entry'))).toBe(true);
+  });
+
   it('fails verification when the expected shell profile export is missing', () => {
     const harness = createDeps();
 
@@ -343,6 +632,28 @@ describe('bootstrap cli', () => {
     expect(harness.stdout.some((line) => line.includes('FAIL shell-profile'))).toBe(true);
   });
 
+  it('fails verification when shell profile points at a different workspace', () => {
+    const harness = createDeps();
+    harness.files.set('/Users/tester/.zshrc', 'export AGENTICOS_HOME="/tmp/other"\n');
+
+    const exitCode = runBootstrapCli(
+      [
+        '--workspace',
+        '/tmp/workspace',
+        '--agent',
+        'codex',
+        '--persist-shell-env',
+        '--shell-profile',
+        '/Users/tester/.zshrc',
+        '--verify',
+      ],
+      harness.deps,
+    );
+
+    expect(exitCode).toBe(1);
+    expect(harness.stdout.some((line) => line.includes('expected export AGENTICOS_HOME="/tmp/workspace"'))).toBe(true);
+  });
+
   it('enables apply, shell persistence, and launchctl persistence in first-run mode on macOS', () => {
     const harness = createDeps();
 
@@ -358,6 +669,22 @@ describe('bootstrap cli', () => {
     expect(harness.files.get('/Users/tester/.profile')).toContain('export AGENTICOS_HOME="/tmp/workspace"');
     expect(harness.stdout.some((line) => line.includes('OK shell-profile'))).toBe(true);
     expect(harness.stdout.some((line) => line.includes('OK launchctl'))).toBe(true);
+  });
+
+  it('enables shell persistence only in first-run mode on non-macOS', () => {
+    const harness = createDeps();
+    harness.deps.platform = 'linux';
+
+    const exitCode = runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'codex', '--first-run'],
+      harness.deps,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(harness.commands.map((entry) => [entry.command, ...entry.args].join(' '))).not.toContain(
+      'launchctl setenv AGENTICOS_HOME /tmp/workspace',
+    );
+    expect(harness.stdout.some((line) => line.includes('OK shell-profile'))).toBe(true);
   });
 
   it('rejects combining first-run with verify', () => {

--- a/mcp-server/src/utils/__tests__/claude-pwd-hook.test.ts
+++ b/mcp-server/src/utils/__tests__/claude-pwd-hook.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import {
+  hasClaudePwdAlignmentHook,
+  inspectClaudePwdAlignmentHook,
+  mergeClaudePwdAlignmentHook,
+} from '../claude-pwd-hook.js';
+
+describe('claude-pwd-hook', () => {
+  it('rejects non-object and malformed hook structures', () => {
+    expect(hasClaudePwdAlignmentHook(null)).toBe(false);
+    expect(hasClaudePwdAlignmentHook([])).toBe(false);
+    expect(hasClaudePwdAlignmentHook({ hooks: [] })).toBe(false);
+    expect(hasClaudePwdAlignmentHook({ hooks: { PostToolUse: {} } })).toBe(false);
+    expect(hasClaudePwdAlignmentHook({ hooks: { PostToolUse: [null] } })).toBe(false);
+    expect(hasClaudePwdAlignmentHook({ hooks: { PostToolUse: [{ matcher: 1 }] } })).toBe(false);
+    expect(hasClaudePwdAlignmentHook({ hooks: { PostToolUse: [{ matcher: 'other', hooks: [] }] } })).toBe(false);
+    expect(hasClaudePwdAlignmentHook({ hooks: { PostToolUse: [{ matcher: 'agenticos_switch', hooks: {} }] } })).toBe(false);
+    expect(hasClaudePwdAlignmentHook({ hooks: { PostToolUse: [{ matcher: 'agenticos_switch', hooks: [null] }] } })).toBe(false);
+    expect(hasClaudePwdAlignmentHook({ hooks: { PostToolUse: [{ matcher: 'agenticos_switch', hooks: [{ type: 'command', command: 1 }] }] } })).toBe(false);
+  });
+
+  it('inspects missing, configured, unset, and invalid settings content', () => {
+    expect(inspectClaudePwdAlignmentHook(null).status).toBe('missing');
+    expect(inspectClaudePwdAlignmentHook('{bad json').status).toBe('unavailable');
+    expect(inspectClaudePwdAlignmentHook('{}').status).toBe('unset');
+    expect(inspectClaudePwdAlignmentHook(JSON.stringify({
+      hooks: {
+        PostToolUse: [
+          {
+            matcher: 'mcp__agenticos__agenticos_switch',
+            hooks: [{ type: 'command', command: 'cd "$(jq -r .tool_response.path)"' }],
+          },
+        ],
+      },
+    })).status).toBe('configured');
+  });
+
+  it('merges into empty and existing settings', () => {
+    const empty = mergeClaudePwdAlignmentHook(null);
+    expect(empty.changed).toBe(true);
+    expect(JSON.parse(empty.content).hooks.PostToolUse).toHaveLength(1);
+
+    const existing = mergeClaudePwdAlignmentHook(JSON.stringify({
+      env: { AGENTICOS_HOME: '/workspace' },
+      hooks: {
+        PostToolUse: [
+          { matcher: 'other', hooks: [{ type: 'command', command: 'true' }] },
+        ],
+      },
+    }));
+    const parsed = JSON.parse(existing.content);
+    expect(parsed.env.AGENTICOS_HOME).toBe('/workspace');
+    expect(parsed.hooks.PostToolUse).toHaveLength(2);
+  });
+
+  it('preserves existing configured content and rejects invalid shapes', () => {
+    const configured = JSON.stringify({
+      hooks: {
+        PostToolUse: [
+          {
+            matcher: 'mcp__agenticos__agenticos_switch',
+            hooks: [{ type: 'command', command: 'cd "$(jq -r .tool_response.path)"' }],
+          },
+        ],
+      },
+    });
+    const result = mergeClaudePwdAlignmentHook(configured);
+    expect(result.changed).toBe(false);
+    expect(result.content).toBe(`${configured}\n`);
+
+    const newlineResult = mergeClaudePwdAlignmentHook(`${configured}\n`);
+    expect(newlineResult.changed).toBe(false);
+    expect(newlineResult.content).toBe(`${configured}\n`);
+
+    expect(() => mergeClaudePwdAlignmentHook('[]')).toThrow('Claude Code settings must be a JSON object.');
+    expect(() => mergeClaudePwdAlignmentHook(JSON.stringify({ hooks: [] }))).toThrow('hooks must be a JSON object.');
+    expect(() => mergeClaudePwdAlignmentHook(JSON.stringify({ hooks: { PostToolUse: {} } }))).toThrow('hooks.PostToolUse must be an array.');
+  });
+});

--- a/mcp-server/src/utils/__tests__/config-audit.test.ts
+++ b/mcp-server/src/utils/__tests__/config-audit.test.ts
@@ -128,6 +128,28 @@ describe('config audit', () => {
 
     expect(result.sources.find((source) => source.id === 'codex_config')?.status).toBe('unset');
     expect(result.sources.find((source) => source.id === 'claude_settings')?.status).toBe('unset');
+    expect(result.sources.find((source) => source.id === 'claude_pwd_alignment_hook')?.status).toBe('unset');
+  });
+
+  it('detects Claude Code PWD alignment hook without making it canonical workspace input', () => {
+    const harness = createDeps();
+    harness.files.set('/Users/tester/.claude/settings.json', JSON.stringify({
+      hooks: {
+        PostToolUse: [
+          {
+            matcher: 'mcp__agenticos__agenticos_switch',
+            hooks: [{ type: 'command', command: 'cd "$(echo $ARGUMENTS | jq -r .tool_response.path)"' }],
+          },
+        ],
+      },
+    }));
+
+    const result = runConfigAudit({ action: 'show', scope: 'mcp' }, harness.deps);
+    const hookSource = result.sources.find((source) => source.id === 'claude_pwd_alignment_hook');
+
+    expect(result.canonical_workspace).toBeNull();
+    expect(hookSource?.status).toBe('configured');
+    expect(hookSource?.value).toBe('mcp__agenticos__agenticos_switch');
   });
 
   it('accepts generic Codex AGENTICOS_HOME entries outside a focused agent block', () => {

--- a/mcp-server/src/utils/bootstrap-cli.ts
+++ b/mcp-server/src/utils/bootstrap-cli.ts
@@ -548,9 +548,7 @@ function configureClaudePwdAlignmentHook(
     return {
       ok: true,
       fatal: false,
-      detail: merged.changed
-        ? `updated ${settingsPath}`
-        : `already configured in ${settingsPath}`,
+      detail: `updated ${settingsPath}`,
     };
   } catch (error) {
     return {

--- a/mcp-server/src/utils/bootstrap-cli.ts
+++ b/mcp-server/src/utils/bootstrap-cli.ts
@@ -364,7 +364,7 @@ function getRecoveryCommand(agentId: SupportedAgentId): string {
     'cursor': 'agenticos-bootstrap --agents cursor',
     'gemini-cli': 'agenticos-bootstrap --agents gemini-cli',
   };
-  return commands[agentId] || '';
+  return commands[agentId];
 }
 
 function runVerification(

--- a/mcp-server/src/utils/bootstrap-cli.ts
+++ b/mcp-server/src/utils/bootstrap-cli.ts
@@ -1,6 +1,11 @@
 import yaml from 'yaml';
 import { readFileSync } from 'fs';
 import { detectDefaultShellProfile, detectDefaultWorkspace, detectSupportedAgents, detectWorkspaceCandidates, formatCommand, mergeCursorMcpConfig, parseAgentSelection, renderBootstrapCommand, renderCursorConfigSnippet, renderRepairRemoveCommand, upsertAgenticOSEnvExport, type DetectedAgent, type SupportedAgentId } from './bootstrap-helper.js';
+import {
+  CLAUDE_SETTINGS_PATH,
+  inspectClaudePwdAlignmentHook,
+  mergeClaudePwdAlignmentHook,
+} from './claude-pwd-hook.js';
 
 export interface CliOptions {
   apply: boolean;
@@ -13,6 +18,7 @@ export interface CliOptions {
   persistShellEnv: boolean;
   persistLaunchctlEnv: boolean;
   shellProfile?: string;
+  autoConfigureHooks: boolean;
 }
 
 export interface ApplyResult {
@@ -23,6 +29,12 @@ export interface ApplyResult {
 
 export interface CommandResult {
   ok: boolean;
+  detail: string;
+}
+
+export interface HookConfigResult {
+  ok: boolean;
+  fatal: boolean;
   detail: string;
 }
 
@@ -50,6 +62,7 @@ export function parseCliArgs(argv: string[]): CliOptions {
     help: false,
     persistShellEnv: false,
     persistLaunchctlEnv: false,
+    autoConfigureHooks: false,
   };
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -76,6 +89,9 @@ export function parseCliArgs(argv: string[]): CliOptions {
         break;
       case '--persist-launchctl-env':
         options.persistLaunchctlEnv = true;
+        break;
+      case '--auto-configure-hooks':
+        options.autoConfigureHooks = true;
         break;
       case '--workspace': {
         const value = argv[index + 1];
@@ -174,6 +190,9 @@ export function runBootstrapCli(argv: string[], deps: BootstrapCliDeps): number 
     const launchctlResult = options.persistLaunchctlEnv
       ? persistLaunchctlEnv(workspaceSelection.workspace, deps)
       : null;
+    const hookConfigResult = selectedAgents.includes('claude-code')
+      ? configureClaudePwdAlignmentHook(options, deps)
+      : null;
     const bootstrapStateResult = persistBootstrapState(
       workspaceSelection.workspace,
       selectedAgents,
@@ -181,6 +200,7 @@ export function runBootstrapCli(argv: string[], deps: BootstrapCliDeps): number 
       results,
       shellProfileResult,
       launchctlResult,
+      hookConfigResult,
       deps,
     );
 
@@ -197,6 +217,10 @@ export function runBootstrapCli(argv: string[], deps: BootstrapCliDeps): number 
       const marker = launchctlResult.ok ? 'OK' : 'FAIL';
       deps.stdout(`${marker} launchctl: ${launchctlResult.detail}`);
     }
+    if (hookConfigResult) {
+      const marker = hookConfigResult.ok ? 'OK' : hookConfigResult.fatal ? 'FAIL' : 'WARN';
+      deps.stdout(`${marker} claude-pwd-hook: ${hookConfigResult.detail}`);
+    }
     {
       const marker = bootstrapStateResult.ok ? 'OK' : 'FAIL';
       deps.stdout(`${marker} bootstrap-state: ${bootstrapStateResult.detail}`);
@@ -205,6 +229,7 @@ export function runBootstrapCli(argv: string[], deps: BootstrapCliDeps): number 
     return results.some((result) => !result.ok)
       || (shellProfileResult && !shellProfileResult.ok)
       || (launchctlResult && !launchctlResult.ok)
+      || (hookConfigResult && hookConfigResult.fatal)
       || !bootstrapStateResult.ok
       ? 1
       : 0;
@@ -219,7 +244,7 @@ export function buildHelpLines(): string[] {
     'agenticos-bootstrap — bootstrap AgenticOS MCP registrations',
     '',
     'Usage:',
-    '  agenticos-bootstrap [--workspace <path>] [--agent <id>] [--all] [--first-run] [--persist-shell-env] [--persist-launchctl-env] [--shell-profile <path>] [--verify] [--apply]',
+    '  agenticos-bootstrap [--workspace <path>] [--agent <id>] [--all] [--first-run] [--persist-shell-env] [--persist-launchctl-env] [--auto-configure-hooks] [--shell-profile <path>] [--verify] [--apply]',
     '',
     'Behavior:',
     '  Without `--apply`, prints a dry-run bootstrap plan.',
@@ -228,6 +253,7 @@ export function buildHelpLines(): string[] {
     '  `--first-run` is a convenience mode: it implies `--apply`, enables shell persistence, and on macOS also enables launchctl persistence.',
     '  `--persist-shell-env` also writes export AGENTICOS_HOME=... to the detected shell profile.',
     '  `--persist-launchctl-env` also runs `launchctl setenv` on macOS for GUI/session inheritance.',
+    '  `--auto-configure-hooks` adds the Claude Code PostToolUse hook used to align shell PWD after agenticos_switch.',
     '  Workspace selection is explicit: use `--workspace <path>` or set AGENTICOS_HOME beforehand.',
     '',
     'Supported agent ids: claude-code, codex, cursor, gemini-cli',
@@ -318,6 +344,14 @@ export function buildDryRunLines(
   }
   if (options.persistLaunchctlEnv) {
     lines.push('- launchctl: run `launchctl setenv AGENTICOS_HOME ...` (macOS only)');
+  }
+  if (selected.includes('claude-code')) {
+    const settingsPath = `${homeDir}/${CLAUDE_SETTINGS_PATH}`;
+    if (options.autoConfigureHooks) {
+      lines.push(`- claude-pwd-hook: add agenticos_switch PostToolUse hook to ${settingsPath}`);
+    } else {
+      lines.push(`- claude-pwd-hook: inspect ${settingsPath}; rerun with --auto-configure-hooks --apply to add it`);
+    }
   }
   lines.push('', 'Re-run with `--apply` to perform these actions.');
   return lines;
@@ -483,6 +517,50 @@ function persistLaunchctlEnv(
   };
 }
 
+function configureClaudePwdAlignmentHook(
+  options: CliOptions,
+  deps: BootstrapCliDeps,
+): HookConfigResult {
+  const settingsPath = `${deps.homeDir}/${CLAUDE_SETTINGS_PATH}`;
+  const existing = deps.readFile(settingsPath);
+  const inspection = inspectClaudePwdAlignmentHook(existing);
+
+  if (inspection.status === 'configured') {
+    return {
+      ok: true,
+      fatal: false,
+      detail: inspection.detail,
+    };
+  }
+
+  if (!options.autoConfigureHooks) {
+    return {
+      ok: false,
+      fatal: false,
+      detail: `${inspection.detail} Rerun with --auto-configure-hooks --apply to add it to ${settingsPath}.`,
+    };
+  }
+
+  try {
+    deps.mkdirp(`${deps.homeDir}/.claude`);
+    const merged = mergeClaudePwdAlignmentHook(existing);
+    deps.writeFile(settingsPath, merged.content);
+    return {
+      ok: true,
+      fatal: false,
+      detail: merged.changed
+        ? `updated ${settingsPath}`
+        : `already configured in ${settingsPath}`,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      fatal: true,
+      detail: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
 function verifyLaunchctlEnv(
   workspace: string,
   deps: BootstrapCliDeps,
@@ -515,6 +593,7 @@ function persistBootstrapState(
   agentResults: ApplyResult[],
   shellProfileResult: { ok: boolean; detail: string } | null,
   launchctlResult: { ok: boolean; detail: string } | null,
+  hookConfigResult: HookConfigResult | null,
   deps: BootstrapCliDeps,
 ): { ok: boolean; detail: string } {
   try {
@@ -525,6 +604,7 @@ function persistBootstrapState(
     const status = agentResults.every((result) => result.ok)
       && (!shellProfileResult || shellProfileResult.ok)
       && (!launchctlResult || launchctlResult.ok)
+      && (!hookConfigResult || !hookConfigResult.fatal)
       ? 'success'
       : 'partial-failure';
 
@@ -542,6 +622,14 @@ function persistBootstrapState(
         failed_agents: failedAgents,
         persist_shell_env: options.persistShellEnv,
         persist_launchctl_env: options.persistLaunchctlEnv,
+        auto_configure_hooks: options.autoConfigureHooks,
+        claude_pwd_hook: hookConfigResult
+          ? {
+            ok: hookConfigResult.ok,
+            fatal: hookConfigResult.fatal,
+            detail: hookConfigResult.detail,
+          }
+          : null,
         shell_profile_path: options.persistShellEnv
           ? (options.shellProfile || detectDefaultShellProfile(deps.env.SHELL, deps.homeDir))
           : null,

--- a/mcp-server/src/utils/claude-pwd-hook.ts
+++ b/mcp-server/src/utils/claude-pwd-hook.ts
@@ -1,0 +1,133 @@
+export const CLAUDE_SETTINGS_PATH = '.claude/settings.json';
+export const CLAUDE_PWD_ALIGNMENT_HOOK_MATCHER = 'mcp__agenticos__agenticos_switch';
+export const CLAUDE_PWD_ALIGNMENT_HOOK_COMMAND = 'cd "$(echo \'$ARGUMENTS\' | jq -r \'.tool_response.path // empty\' 2>/dev/null)" 2>/dev/null || true';
+
+export type ClaudePwdHookStatus = 'configured' | 'missing' | 'unset' | 'unavailable';
+
+export interface ClaudePwdHookInspection {
+  status: ClaudePwdHookStatus;
+  detail: string;
+}
+
+export interface ClaudePwdHookMergeResult {
+  changed: boolean;
+  content: string;
+}
+
+const CLAUDE_PWD_ALIGNMENT_HOOK_ENTRY = {
+  matcher: CLAUDE_PWD_ALIGNMENT_HOOK_MATCHER,
+  hooks: [
+    {
+      type: 'command',
+      command: CLAUDE_PWD_ALIGNMENT_HOOK_COMMAND,
+      shell: 'bash',
+      timeout: 5,
+    },
+  ],
+} as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function parseSettings(content: string): unknown {
+  return JSON.parse(content);
+}
+
+export function hasClaudePwdAlignmentHook(settings: unknown): boolean {
+  if (!isRecord(settings)) return false;
+  const hooks = settings.hooks;
+  if (!isRecord(hooks)) return false;
+  const postToolUse = hooks.PostToolUse;
+  if (!Array.isArray(postToolUse)) return false;
+
+  return postToolUse.some((entry) => {
+    if (!isRecord(entry)) return false;
+    const matcher = entry.matcher;
+    if (typeof matcher !== 'string' || !matcher.includes('agenticos_switch')) {
+      return false;
+    }
+    const nestedHooks = entry.hooks;
+    if (!Array.isArray(nestedHooks)) return false;
+    return nestedHooks.some((hook) => {
+      if (!isRecord(hook)) return false;
+      return hook.type === 'command'
+        && typeof hook.command === 'string'
+        && hook.command.includes('tool_response.path');
+    });
+  });
+}
+
+export function inspectClaudePwdAlignmentHook(settingsContent: string | null): ClaudePwdHookInspection {
+  if (settingsContent === null) {
+    return {
+      status: 'missing',
+      detail: 'Claude Code settings file is missing.',
+    };
+  }
+
+  try {
+    const parsed = parseSettings(settingsContent);
+    return hasClaudePwdAlignmentHook(parsed)
+      ? {
+        status: 'configured',
+        detail: 'Detected PostToolUse hook for agenticos_switch PWD alignment.',
+      }
+      : {
+        status: 'unset',
+        detail: 'Claude Code settings exist but no agenticos_switch PWD alignment hook was detected.',
+      };
+  } catch {
+    return {
+      status: 'unavailable',
+      detail: 'Claude Code settings could not be parsed as JSON.',
+    };
+  }
+}
+
+export function mergeClaudePwdAlignmentHook(settingsContent: string | null): ClaudePwdHookMergeResult {
+  const parsed = settingsContent?.trim()
+    ? parseSettings(settingsContent)
+    : {};
+
+  if (!isRecord(parsed)) {
+    throw new Error('Claude Code settings must be a JSON object.');
+  }
+
+  if (hasClaudePwdAlignmentHook(parsed)) {
+    return {
+      changed: false,
+      content: settingsContent?.endsWith('\n') ? settingsContent : `${settingsContent || '{}'}\n`,
+    };
+  }
+
+  const hooks = parsed.hooks === undefined
+    ? {}
+    : parsed.hooks;
+  if (!isRecord(hooks)) {
+    throw new Error('Claude Code settings hooks must be a JSON object.');
+  }
+
+  const postToolUse = hooks.PostToolUse === undefined
+    ? []
+    : hooks.PostToolUse;
+  if (!Array.isArray(postToolUse)) {
+    throw new Error('Claude Code settings hooks.PostToolUse must be an array.');
+  }
+
+  const next = {
+    ...parsed,
+    hooks: {
+      ...hooks,
+      PostToolUse: [
+        ...postToolUse,
+        CLAUDE_PWD_ALIGNMENT_HOOK_ENTRY,
+      ],
+    },
+  };
+
+  return {
+    changed: true,
+    content: `${JSON.stringify(next, null, 2)}\n`,
+  };
+}

--- a/mcp-server/src/utils/claude-pwd-hook.ts
+++ b/mcp-server/src/utils/claude-pwd-hook.ts
@@ -95,9 +95,10 @@ export function mergeClaudePwdAlignmentHook(settingsContent: string | null): Cla
   }
 
   if (hasClaudePwdAlignmentHook(parsed)) {
+    const configuredContent = settingsContent as string;
     return {
       changed: false,
-      content: settingsContent?.endsWith('\n') ? settingsContent : `${settingsContent || '{}'}\n`,
+      content: configuredContent.endsWith('\n') ? configuredContent : `${configuredContent}\n`,
     };
   }
 

--- a/mcp-server/src/utils/config-audit.ts
+++ b/mcp-server/src/utils/config-audit.ts
@@ -1,5 +1,9 @@
 import { join } from 'path';
 import { detectDefaultShellProfile } from './bootstrap-helper.js';
+import {
+  CLAUDE_PWD_ALIGNMENT_HOOK_MATCHER,
+  inspectClaudePwdAlignmentHook,
+} from './claude-pwd-hook.js';
 
 export type ConfigAuditAction = 'show' | 'validate';
 export type ConfigAuditScope = 'all' | 'runtime' | 'mcp' | 'homebrew';
@@ -31,6 +35,7 @@ export interface ConfigSourceRecord {
   location: string;
   fix_target: string;
   detail: string;
+  contributes_to_workspace?: boolean;
 }
 
 export interface ConfigAuditResult {
@@ -72,7 +77,9 @@ export function runConfigAudit(
   const sources = scope === 'all'
     ? allSources
     : allSources.filter((source) => source.scope === scope);
-  const configuredSources = sources.filter((source) => source.status === 'configured' && source.value);
+  const configuredSources = sources.filter((source) => source.status === 'configured'
+    && source.value
+    && source.contributes_to_workspace !== false);
   const canonicalWorkspace = configuredSources.find((source) => source.id === 'process_env')?.value
     || configuredSources[0]?.value
     || null;
@@ -189,11 +196,30 @@ function collectConfigSources(deps: ConfigAuditDeps): ConfigSourceRecord[] {
     readShellProfileSource(deps),
     readLaunchctlSource(deps),
     readClaudeSettingsSource(deps),
+    readClaudePwdAlignmentHookSource(deps),
     readClaudeLegacySource(deps),
     readCodexConfigSource(deps),
     readCursorConfigSource(deps),
     ...readHomebrewSources(deps),
   ];
+}
+
+function readClaudePwdAlignmentHookSource(deps: ConfigAuditDeps): ConfigSourceRecord {
+  const filePath = join(deps.homeDir, '.claude', 'settings.json');
+  const inspection = inspectClaudePwdAlignmentHook(deps.readFile(filePath));
+  return {
+    id: 'claude_pwd_alignment_hook',
+    label: 'Claude Code PWD alignment hook',
+    scope: 'mcp',
+    status: inspection.status,
+    value: inspection.status === 'configured' ? CLAUDE_PWD_ALIGNMENT_HOOK_MATCHER : null,
+    location: filePath,
+    fix_target: 'agenticos-bootstrap --agent claude-code --auto-configure-hooks --apply',
+    detail: inspection.status === 'configured'
+      ? inspection.detail
+      : `${inspection.detail} Rerun bootstrap with --auto-configure-hooks to add it.`,
+    contributes_to_workspace: false,
+  };
 }
 
 function readProcessEnvSource(deps: ConfigAuditDeps): ConfigSourceRecord {


### PR DESCRIPTION
## Summary

- add Claude Code PWD alignment hook inspection/merge helper
- surface hook status in agenticos-config without treating it as an AGENTICOS_HOME canonical source
- add agenticos-bootstrap --auto-configure-hooks for dry-run guidance and settings.json injection
- document the hook flow in README and Homebrew caveats

## Test plan

- npm test -- --run src/utils/__tests__/bootstrap-cli.test.ts src/utils/__tests__/config-audit.test.ts src/utils/__tests__/homebrew-bootstrap-docs.test.ts
- npm run lint

Fixes #406