### PR TITLE
fix: shell-escape PWD alignment instructions

### DIFF
--- a/mcp-server/src/tools/__tests__/project.test.ts
+++ b/mcp-server/src/tools/__tests__/project.test.ts
@@ -1365,7 +1365,7 @@ describe('switchProject', () => {
       const result = await switchProject({ project: 'my-project' });
 
       expect(result).toContain('📍 Client alignment hint:');
-      expect(result).toContain('cd /test/path');
+      expect(result).toContain("cd '/test/path'");
       expect(result).toContain('Treat this as a hint; verify the client shell PWD');
     } finally {
       if (previousClaudeCode === undefined) delete process.env.CLAUDE_CODE;

--- a/mcp-server/src/tools/__tests__/switch.test.ts
+++ b/mcp-server/src/tools/__tests__/switch.test.ts
@@ -195,7 +195,7 @@ describe('switchProject — agenticos_switch tests', () => {
         expect(result).toContain('Codex current-session cwd cannot be changed by MCP output');
         expect(result).toContain('Use this project path as explicit workdir');
         expect(result).toContain('To start a new Codex session in this project, run:');
-        expect(result).toContain('codex -C /test/path');
+        expect(result).toContain("codex -C '/test/path'");
         expect(result).not.toContain('To align your shell PWD, run:');
       } finally {
         if (previousCodex === undefined) delete process.env.CODEX;
@@ -221,7 +221,7 @@ describe('switchProject — agenticos_switch tests', () => {
         const result = await switchProject({ project: 'test-project' });
 
         expect(result).toContain('Codex current-session cwd cannot be changed by MCP output');
-        expect(result).toContain('codex -C /test/path');
+        expect(result).toContain("codex -C '/test/path'");
       } finally {
         if (previousCodex === undefined) delete process.env.CODEX;
         else process.env.CODEX = previousCodex;

--- a/mcp-server/src/utils/__tests__/session-context.test.ts
+++ b/mcp-server/src/utils/__tests__/session-context.test.ts
@@ -179,6 +179,7 @@ describe('session-context', () => {
 
   describe('alignPwd', () => {
     it('shell-quotes paths for copyable instructions', () => {
+      expect(shellQuote('')).toBe("''");
       expect(shellQuote('/tmp/simple')).toBe("'/tmp/simple'");
       expect(shellQuote('/tmp/work space')).toBe("'/tmp/work space'");
       expect(shellQuote("/tmp/project's path")).toBe("'/tmp/project'\\''s path'");

--- a/mcp-server/src/utils/__tests__/session-context.test.ts
+++ b/mcp-server/src/utils/__tests__/session-context.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
-import { alignPwd, bindSessionProject, checkIsGitRepo, clearSessionProjectBinding, getSessionProjectBinding, validatePathSecurity, validatePathInAgenticosHome } from '../session-context.js';
+import { mkdirSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { alignPwd, bindSessionProject, checkIsGitRepo, clearSessionProjectBinding, getSessionProjectBinding, shellQuote, validatePathSecurity, validatePathInAgenticosHome } from '../session-context.js';
 
 const execFileMock = vi.hoisted(() => vi.fn());
 const agenticosHomeMock = vi.hoisted(() => ({ value: '/test/home' }));
@@ -175,6 +178,13 @@ describe('session-context', () => {
   });
 
   describe('alignPwd', () => {
+    it('shell-quotes paths for copyable instructions', () => {
+      expect(shellQuote('/tmp/simple')).toBe("'/tmp/simple'");
+      expect(shellQuote('/tmp/work space')).toBe("'/tmp/work space'");
+      expect(shellQuote("/tmp/project's path")).toBe("'/tmp/project'\\''s path'");
+      expect(shellQuote('/tmp/a; echo hacked $(pwd)')).toBe("'/tmp/a; echo hacked $(pwd)'");
+    });
+
     it('returns failure for relative path', async () => {
       const result = await alignPwd('relative/path');
       expect(result.success).toBe(false);
@@ -192,7 +202,7 @@ describe('session-context', () => {
     it('returns instruction with warning for accessible directory outside AGENTICOS_HOME', async () => {
       const result = await alignPwd('/tmp');
       expect(result.success).toBe(true);
-      expect(result.instruction).toContain('cd /tmp');
+      expect(result.instruction).toContain("cd '/tmp'");
       expect(result.warning).toContain('not under AGENTICOS_HOME');
     });
 
@@ -202,7 +212,7 @@ describe('session-context', () => {
       const result = await alignPwd('/tmp');
 
       expect(result.success).toBe(true);
-      expect(result.instruction).toBe('cd /tmp');
+      expect(result.instruction).toBe("cd '/tmp'");
       expect(result.warning).toBeNull();
     });
 
@@ -212,7 +222,7 @@ describe('session-context', () => {
       const result = await alignPwd('/tmp');
 
       expect(result.success).toBe(true);
-      expect(result.instruction).toBe('cd /tmp');
+      expect(result.instruction).toBe("cd '/tmp'");
       expect(result.instructionKind).toBe('current-session');
     });
 
@@ -222,8 +232,32 @@ describe('session-context', () => {
       const result = await alignPwd('/tmp');
 
       expect(result.success).toBe(true);
-      expect(result.instruction).toBe('codex -C /tmp');
+      expect(result.instruction).toBe("codex -C '/tmp'");
       expect(result.instructionKind).toBe('new-session');
+    });
+
+    it('escapes shell metacharacters in Claude Code instructions', async () => {
+      process.env.CLAUDE_CODE = '1';
+      const projectPath = join(tmpdir(), "agenticos work space/project's; echo hacked $(pwd)");
+      mkdirSync(projectPath, { recursive: true });
+
+      const result = await alignPwd(projectPath);
+
+      expect(result.success).toBe(true);
+      expect(result.instruction).toBe(`cd ${shellQuote(projectPath)}`);
+      rmSync(projectPath, { recursive: true, force: true });
+    });
+
+    it('escapes shell metacharacters in Codex startup instructions', async () => {
+      process.env.CODEX = '1';
+      const projectPath = join(tmpdir(), "agenticos codex space/project's; echo hacked $(pwd)");
+      mkdirSync(projectPath, { recursive: true });
+
+      const result = await alignPwd(projectPath);
+
+      expect(result.success).toBe(true);
+      expect(result.instruction).toBe(`codex -C ${shellQuote(projectPath)}`);
+      rmSync(projectPath, { recursive: true, force: true });
     });
 
     it('does not shell-verify accessible directories', async () => {
@@ -239,7 +273,7 @@ describe('session-context', () => {
       const result = await alignPwd('/tmp');
 
       expect(result.success).toBe(true);
-      expect(result.instruction).toBe('cd /tmp');
+      expect(result.instruction).toBe("cd '/tmp'");
       expect(result.warning).toContain('not under AGENTICOS_HOME');
     });
   });

--- a/mcp-server/src/utils/session-context.ts
+++ b/mcp-server/src/utils/session-context.ts
@@ -89,6 +89,11 @@ export function detectAgentType(): 'claude-code' | 'codex' | 'other' {
   return 'other';
 }
 
+export function shellQuote(value: string): string {
+  if (value.length === 0) return "''";
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
 export async function checkIsGitRepo(dirPath: string): Promise<boolean> {
   return new Promise((resolve) => {
     execFile('git', ['-C', dirPath, 'rev-parse', '--git-dir'], (error) => {
@@ -131,15 +136,16 @@ export async function alignPwd(projectPath: string): Promise<PwdAlignmentResult>
 
   let instruction: string | null = null;
   let instructionKind: PwdAlignmentResult['instructionKind'] = null;
+  const quotedProjectPath = shellQuote(projectPath);
 
   if (agentType === 'claude-code') {
-    instruction = `cd ${projectPath}`;
+    instruction = `cd ${quotedProjectPath}`;
     instructionKind = 'current-session';
   } else if (agentType === 'codex') {
-    instruction = `codex -C ${projectPath}`;
+    instruction = `codex -C ${quotedProjectPath}`;
     instructionKind = 'new-session';
   } else {
-    instruction = `cd ${projectPath}`;
+    instruction = `cd ${quotedProjectPath}`;
     instructionKind = 'manual-cd';
   }
 


### PR DESCRIPTION
## Summary
- quote project paths before emitting copyable `cd` and `codex -C` instructions
- add shell quoting coverage for spaces, single quotes, semicolons, and command-substitution characters
- update switch/project output expectations to the quoted form

Fixes #418.

## Verification
- `cd mcp-server && npm ci`
- `cd mcp-server && npm test -- --run src/utils/__tests__/session-context.test.ts src/tools/__tests__/switch.test.ts src/tools/__tests__/project.test.ts`
- `cd mcp-server && npm run lint`
- `cd mcp-server && npm test -- --run`
- `./tools/coverage-preflight.sh`

## Release review note
This removes the PWD instruction command-injection/broken-command finding from the v0.4.22..HEAD release review. Release remains blocked until all release-blocker PRs merge and final release metadata/test gates pass.