### PR TITLE
fix: read runtime bootstrap state in status

### DIFF
--- a/mcp-server/src/tools/__tests__/project.test.ts
+++ b/mcp-server/src/tools/__tests__/project.test.ts
@@ -2013,6 +2013,59 @@ describe('getStatus', () => {
     expect(result).toContain('decision 1');
   });
 
+  it('surfaces bootstrap failures from the runtime workspace state file', async () => {
+    bindSessionProject({
+      projectId: 'test-project',
+      projectName: 'Test Project',
+      projectPath: '/home/testuser/AgenticOS/projects/test-project',
+    });
+
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: null,
+      projects: [
+        {
+          id: 'test-project',
+          name: 'Test Project',
+          path: '/home/testuser/AgenticOS/projects/test-project',
+          status: 'active' as const,
+          created: '2025-01-01',
+        },
+      ],
+    });
+
+    fsPromisesMock.readFile.mockImplementation(async (path: string) => {
+      if (path.endsWith('/.project.yaml')) {
+        return JSON.stringify({
+          meta: { id: 'test-project', name: 'Test Project' },
+          source_control: { topology: 'local_directory_only' },
+        });
+      }
+      if (path === '/home/testuser/AgenticOS/.agent-workspace/bootstrap-state.yaml') {
+        return JSON.stringify({ failed_agents: ['codex'] });
+      }
+      return JSON.stringify({
+        current_task: { title: 'Runtime status', status: 'in_progress' },
+        working_memory: { pending: [], decisions: [] },
+      });
+    });
+    loadLatestGuardrailStateMock.mockResolvedValue({
+      source: 'committed',
+      state: {
+        current_task: { title: 'Runtime status', status: 'in_progress' },
+        working_memory: { pending: [], decisions: [] },
+      },
+      state_path: '/mock/state.yaml',
+    });
+
+    const result = await getStatus();
+
+    expect(result).toContain('⚠️ Bootstrap Issues:');
+    expect(result).toContain('codex: verification failed');
+    expect(result).toContain('agenticos-bootstrap --verify');
+  });
+
   it('uses configured canonical state paths for self-hosting status output', async () => {
     bindSessionProject({
       projectId: 'agenticos',

--- a/mcp-server/src/tools/project.ts
+++ b/mcp-server/src/tools/project.ts
@@ -265,6 +265,22 @@ async function buildWorktreeTopologySummaryLines(projectPath: string, projectYam
   return lines;
 }
 
+async function readBootstrapState(projectPath: string): Promise<any | null> {
+  const paths = [
+    join(getAgenticOSHome(), '.agent-workspace', 'bootstrap-state.yaml'),
+    join(projectPath, '.agent-workspace', 'bootstrap-state.yaml'),
+  ];
+  const uniquePaths = Array.from(new Set(paths));
+
+  for (const bootstrapStatePath of uniquePaths) {
+    try {
+      return yaml.parse(await readFile(bootstrapStatePath, 'utf-8')) || null;
+    } catch {}
+  }
+
+  return null;
+}
+
 function extractQuickStartSummary(quickStart?: string): string | null {
   if (!quickStart) return null;
 
@@ -690,20 +706,15 @@ export async function getStatus(args: any = {}): Promise<string> {
     }
   }
 
-  // Check bootstrap state for failures
-  const bootstrapStatePath = `${resolved.projectPath}/.agent-workspace/bootstrap-state.yaml`;
-  try {
-    const bootstrapContent = await readFile(bootstrapStatePath, 'utf-8');
-    const bootstrapState = yaml.parse(bootstrapContent) as any;
-    if (bootstrapState?.failed_agents?.length > 0) {
-      lines.push('');
-      lines.push('⚠️ Bootstrap Issues:');
-      for (const agent of bootstrapState.failed_agents as string[]) {
-        lines.push(`   - ${agent}: verification failed`);
-      }
-      lines.push('   Run: agenticos-bootstrap --verify');
+  const bootstrapState = await readBootstrapState(resolved.projectPath);
+  if (bootstrapState?.failed_agents?.length > 0) {
+    lines.push('');
+    lines.push('⚠️ Bootstrap Issues:');
+    for (const agent of bootstrapState.failed_agents as string[]) {
+      lines.push(`   - ${agent}: verification failed`);
     }
-  } catch {}
+    lines.push('   Run: agenticos-bootstrap --verify');
+  }
 
   return lines.join('\n');
 }


### PR DESCRIPTION
## Summary
- read bootstrap-state from the runtime AGENTICOS_HOME workspace before legacy project-local fallback
- keep compatibility with the old `<project>/.agent-workspace/bootstrap-state.yaml` location
- add status coverage proving runtime bootstrap failures are surfaced

Fixes #420.

## Verification
- `cd mcp-server && npm ci`
- `cd mcp-server && npm test -- --run src/tools/__tests__/project.test.ts`
- `cd mcp-server && npm run lint`
- `cd mcp-server && npm test -- --run`
- `./tools/coverage-preflight.sh`

## Release review note
This closes the bootstrap-state visibility gap found during the v0.4.22..HEAD release review.