### PR TITLE
fix: sync v0.4.23 formula metadata

### DIFF
--- a/homebrew-tap/Formula/agenticos.rb
+++ b/homebrew-tap/Formula/agenticos.rb
@@ -3,9 +3,9 @@ require "language/node"
 class Agenticos < Formula
   desc "AI-native project management MCP server for coding agents"
   homepage "https://github.com/madlouse/AgenticOS"
-  url "https://github.com/madlouse/AgenticOS/releases/download/v0.4.20/agenticos-mcp.tgz"
-  version "0.4.20"
-  sha256 "d9206c2e6634269dd7ea7f5f76ac93e3a0c83e7c2a7d9bccda087ccfe8cbe877"
+  url "https://github.com/madlouse/AgenticOS/releases/download/v0.4.23/agenticos-mcp.tgz"
+  version "0.4.23"
+  sha256 "dc0c546ea5d93d58a2bcb92490b8ded4c3b9ced26c64124f9153d06200514caf"
   license "MIT"
 
   depends_on "node"

--- a/standards/.context/release-process.md
+++ b/standards/.context/release-process.md
@@ -98,6 +98,12 @@ For automated Homebrew bumps, the repository needs:
 |--------|---------|
 | `HOMEBREW_TAP_PAT` | PAT with `repo` scope for `mislav/bump-homebrew-formula-action` to create PRs |
 
+If `HOMEBREW_TAP_PAT` is absent or empty, the release can still create the
+GitHub Release artifact, but the Homebrew tap update will fail and the source
+formula sync step will be skipped. In that case, manually update both formula
+locations to the release artifact URL and SHA256 before considering the release
+complete.
+
 ## Post-release
 
 - [ ] MCP registration verified in Claude Code and other agents


### PR DESCRIPTION
Fixes #426.

## Summary
- Sync source Homebrew formula to the published v0.4.23 release artifact and SHA256.
- Document the manual recovery path when HOMEBREW_TAP_PAT is absent and Homebrew automation skips source sync.

## External tap
- Updated madlouse/homebrew-agenticos main manually: commit 23999bf.

## Verification
- ruby -c homebrew-tap/Formula/agenticos.rb
- git diff --check
- agenticos_pr_scope_check PASS

## Rollback
Revert this source formula sync commit and restore the external tap formula if validation fails.