### PR TITLE
fix: clarify project switch cwd guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ first managed project:
    `agenticos_init` with a name and topology, e.g.
    `agenticos_init(name: "my-project", topology: "local_directory_only")`
 2. **Switch to it** — ask the tool to run `agenticos_switch(project: "my-project")`
+   Switching binds AgenticOS context; it does not guarantee the client shell cwd changed.
 3. **Do real work** — complete a task across two or more sessions
 4. **Verify persistence** — on the second session, ask the tool to run
    `agenticos_status` and confirm it shows your previous context

--- a/mcp-server/src/tools/__tests__/init.test.ts
+++ b/mcp-server/src/tools/__tests__/init.test.ts
@@ -98,10 +98,33 @@ describe('initProject', () => {
     ).rejects.toThrow('github_repo is required');
   });
 
+  it('fails when github_repo is not OWNER/REPO', async () => {
+    await expect(
+      initProject({ name: 'Test Project', description: 'A test project', topology: 'github_versioned', context_publication_policy: 'private_continuity', github_repo: 'not-a-repo' }),
+    ).rejects.toThrow('OWNER/REPO');
+  });
+
   it('fails when github_versioned is missing context_publication_policy', async () => {
     await expect(
       initProject({ name: 'Test Project', description: 'A test project', topology: 'github_versioned', github_repo: 'madlouse/test-project' }),
     ).rejects.toThrow('context_publication_policy is required');
+  });
+
+  it('fails when local_directory_only uses a non-local_private publication policy', async () => {
+    await expect(
+      initProject({ name: 'Test Project', description: 'A test project', topology: 'local_directory_only', context_publication_policy: 'public_distilled' }),
+    ).rejects.toThrow('local_private');
+  });
+
+  it('accepts explicit local_private publication policy for local_directory_only projects', async () => {
+    const result = await initProject({
+      name: 'Test Project',
+      description: 'A test project',
+      topology: 'local_directory_only',
+      context_publication_policy: 'local_private',
+    });
+
+    expect(result).toContain('Context Publication: local_private');
   });
 
   it('rejects custom paths with control characters', async () => {
@@ -212,6 +235,47 @@ describe('initProject', () => {
     expect(gitignoreCall).toBeDefined();
     expect(String(gitignoreCall![1])).toContain('.private/');
     expect(String(gitignoreCall![1])).toContain('.meta/transcripts/');
+  });
+
+  it('does not rewrite gitignore when public_distilled private entries already exist', async () => {
+    fsPromisesMock.readFile.mockImplementation(async (path: any) => {
+      if (String(path).endsWith('/.gitignore')) {
+        return '# existing\n.private/\n.meta/transcripts/\n';
+      }
+      throw new Error('ENOENT');
+    });
+
+    await initProject({
+      name: 'Public Project',
+      description: 'A public distilled project',
+      topology: 'github_versioned',
+      context_publication_policy: 'public_distilled',
+      github_repo: 'madlouse/public-project',
+    });
+
+    const gitignoreCall = fsPromisesMock.writeFile.mock.calls.find((c) => String(c[0]).endsWith('/.gitignore'));
+    expect(gitignoreCall).toBeUndefined();
+  });
+
+  it('appends public_distilled gitignore entries after existing content without a trailing newline', async () => {
+    fsPromisesMock.readFile.mockImplementation(async (path: any) => {
+      if (String(path).endsWith('/.gitignore')) {
+        return 'node_modules';
+      }
+      throw new Error('ENOENT');
+    });
+
+    await initProject({
+      name: 'Public Project',
+      description: 'A public distilled project',
+      topology: 'github_versioned',
+      context_publication_policy: 'public_distilled',
+      github_repo: 'madlouse/public-project',
+    });
+
+    const gitignoreCall = fsPromisesMock.writeFile.mock.calls.find((c) => String(c[0]).endsWith('/.gitignore'));
+    expect(gitignoreCall).toBeDefined();
+    expect(String(gitignoreCall![1])).toContain('node_modules\n\n# AgenticOS private runtime surfaces');
   });
 
   it('writes state.yaml with correct structure', async () => {
@@ -451,4 +515,300 @@ describe('initProject', () => {
     expect(result).toContain('context_publication_policy');
     expect(result).toContain('normalize_existing=true');
   });
-});
+
+  it('returns validation guidance for a registered project with an invalid publication policy', async () => {
+    fsMock.existsSync.mockReturnValue(true);
+    fsPromisesMock.access.mockResolvedValue(undefined);
+    fsPromisesMock.readFile.mockImplementation(async (path: any) => {
+      const normalizedPath = String(path);
+      if (normalizedPath.endsWith('registry.yaml')) {
+        return JSON.stringify({
+          version: '1.0.0',
+          last_updated: '2025-01-01T00:00:00.000Z',
+          active_project: 'test-project',
+          projects: [
+            {
+              id: 'test-project',
+              name: 'Test Project',
+              path: '/home/testuser/AgenticOS/projects/test-project',
+              status: 'active',
+              created: '2025-01-01',
+              last_accessed: '2025-01-01T00:00:00.000Z',
+            },
+          ],
+        });
+      }
+
+      if (normalizedPath.endsWith('.project.yaml')) {
+        return JSON.stringify({
+          meta: { id: 'test-project', name: 'Test Project' },
+          source_control: {
+            topology: 'local_directory_only',
+            context_publication_policy: 'public_distilled',
+          },
+        });
+      }
+
+      throw new Error(`Unexpected readFile path: ${normalizedPath}`);
+    });
+
+    const result = await initProject({ name: 'Test Project', topology: 'local_directory_only' });
+
+    expect(result).toContain('must use source_control.context_publication_policy="local_private"');
+    expect(result).toContain('normalize_existing=true');
+  });
+
+  it('returns the already-exists switch guidance for a registered normalized project', async () => {
+    fsMock.existsSync.mockReturnValue(true);
+    fsPromisesMock.access.mockResolvedValue(undefined);
+    fsPromisesMock.readFile.mockImplementation(async (path: any) => {
+      const normalizedPath = String(path);
+      if (normalizedPath.endsWith('registry.yaml')) {
+        return JSON.stringify({
+          version: '1.0.0',
+          last_updated: '2025-01-01T00:00:00.000Z',
+          active_project: 'test-project',
+          projects: [
+            {
+              id: 'test-project',
+              name: 'Test Project',
+              path: '/home/testuser/AgenticOS/projects/test-project',
+              status: 'active',
+              created: '2025-01-01',
+              last_accessed: '2025-01-01T00:00:00.000Z',
+            },
+          ],
+        });
+      }
+
+      if (normalizedPath.endsWith('.project.yaml')) {
+        return JSON.stringify({
+          meta: { id: 'test-project', name: 'Test Project' },
+          source_control: {
+            topology: 'local_directory_only',
+            context_publication_policy: 'local_private',
+          },
+        });
+      }
+
+      throw new Error(`Unexpected readFile path: ${normalizedPath}`);
+    });
+
+    const result = await initProject({ name: 'Test Project', topology: 'local_directory_only' });
+
+    expect(result).toContain("Project 'Test Project' already exists");
+    expect(result).toContain('agenticos_switch');
+  });
+
+  it('returns re-register guidance when a project path exists but the registry entry is missing', async () => {
+    fsMock.existsSync.mockReturnValue(false);
+    fsPromisesMock.access.mockResolvedValue(undefined);
+    fsPromisesMock.readFile.mockImplementation(async (path: any) => {
+      if (String(path).endsWith('registry.yaml')) {
+        return JSON.stringify({
+          version: '1.0.0',
+          last_updated: '2025-01-01T00:00:00.000Z',
+          active_project: null,
+          projects: [],
+        });
+      }
+      throw new Error(`Unexpected readFile path: ${String(path)}`);
+    });
+
+    const result = await initProject({ name: 'Test Project', topology: 'local_directory_only' });
+
+    expect(result).toContain('already exists');
+    expect(result).toContain('is not registered');
+    expect(result).toContain('normalize_existing=true');
+  });
+
+  it('drops stale registry entries before recreating a missing project path', async () => {
+    fsMock.existsSync.mockReturnValue(false);
+    fsPromisesMock.access.mockRejectedValue(new Error('ENOENT'));
+    fsPromisesMock.readFile.mockImplementation(async (path: any) => {
+      if (String(path).endsWith('registry.yaml')) {
+        return JSON.stringify({
+          version: '1.0.0',
+          last_updated: '2025-01-01T00:00:00.000Z',
+          active_project: 'test-project',
+          projects: [
+            {
+              id: 'test-project',
+              name: 'Old Test Project',
+              path: '/home/testuser/AgenticOS/projects/test-project',
+              status: 'active',
+              created: '2025-01-01',
+              last_accessed: '2025-01-01T00:00:00.000Z',
+            },
+          ],
+        });
+      }
+      throw new Error('ENOENT');
+    });
+
+    const result = await initProject({ name: 'Test Project', topology: 'local_directory_only' });
+
+    const registryWrites = fsPromisesMock.writeFile.mock.calls
+      .filter((c) => String(c[0]).includes('registry.yaml.tmp'))
+      .map((c) => JSON.parse(String(c[1])));
+    expect(registryWrites.some((registrySnapshot) => (
+      registrySnapshot.active_project === null
+      && registrySnapshot.projects.every((project: any) => project.id !== 'test-project')
+    ))).toBe(true);
+    expect(result).toContain('Created project "Test Project"');
+  });
+
+  it('normalizes a local project by removing source_repo_roots while preserving other execution keys and agent context paths', async () => {
+    fsMock.existsSync.mockReturnValue(true);
+    fsPromisesMock.access.mockResolvedValue(undefined);
+    fsPromisesMock.readFile.mockImplementation(async (path: any) => {
+      const normalizedPath = String(path);
+      if (normalizedPath.endsWith('registry.yaml')) {
+        return JSON.stringify({
+          version: '1.0.0',
+          last_updated: '2025-01-01T00:00:00.000Z',
+          active_project: 'test-project',
+          projects: [
+            {
+              id: 'test-project',
+              name: 'Test Project',
+              path: '/home/testuser/AgenticOS/projects/test-project',
+              status: 'active',
+              created: '2025-01-01',
+              last_accessed: '2025-01-01T00:00:00.000Z',
+            },
+          ],
+        });
+      }
+
+      if (normalizedPath.endsWith('.project.yaml')) {
+        return JSON.stringify({
+          meta: { name: 'Test Project', id: 'test-project', description: 'Existing description' },
+          source_control: {
+            topology: 'local_directory_only',
+            context_publication_policy: 'local_private',
+          },
+          execution: {
+            source_repo_roots: ['.'],
+            sandbox: 'workspace-write',
+          },
+          agent_context: {
+            quick_start: 'docs/quick-start.md',
+            current_state: 'runtime/state.yaml',
+            conversations: 'runtime/conversations/',
+            knowledge: 'docs/knowledge/',
+            tasks: 'docs/tasks/',
+            artifacts: 'docs/artifacts/',
+          },
+        });
+      }
+
+      throw new Error(`Unexpected readFile path: ${normalizedPath}`);
+    });
+
+    await initProject({
+      name: 'Test Project',
+      topology: 'local_directory_only',
+      normalize_existing: true,
+    });
+
+    const projectYamlCall = fsPromisesMock.writeFile.mock.calls.find((c) => String(c[0]).endsWith('.project.yaml'));
+    expect(projectYamlCall).toBeDefined();
+    const parsed = JSON.parse(String(projectYamlCall![1]));
+    expect(parsed.execution).toEqual({ sandbox: 'workspace-write' });
+    expect(parsed.agent_context.quick_start).toBe('docs/quick-start.md');
+    expect(parsed.agent_context.current_state).toBe('runtime/state.yaml');
+    expect(parsed.agent_context.conversations).toBe('runtime/conversations/');
+    expect(parsed.agent_context.knowledge).toBe('docs/knowledge/');
+    expect(parsed.agent_context.tasks).toBe('docs/tasks/');
+    expect(parsed.agent_context.artifacts).toBe('docs/artifacts/');
+  });
+
+  it('removes an empty execution block when normalizing local source_repo_roots', async () => {
+    fsMock.existsSync.mockReturnValue(true);
+    fsPromisesMock.access.mockResolvedValue(undefined);
+    fsPromisesMock.readFile.mockImplementation(async (path: any) => {
+      const normalizedPath = String(path);
+      if (normalizedPath.endsWith('registry.yaml')) {
+        return JSON.stringify({
+          version: '1.0.0',
+          last_updated: '2025-01-01T00:00:00.000Z',
+          active_project: 'test-project',
+          projects: [
+            {
+              id: 'test-project',
+              name: 'Test Project',
+              path: '/home/testuser/AgenticOS/projects/test-project',
+              status: 'active',
+              created: '2025-01-01',
+              last_accessed: '2025-01-01T00:00:00.000Z',
+            },
+          ],
+        });
+      }
+
+      if (normalizedPath.endsWith('.project.yaml')) {
+        return JSON.stringify({
+          meta: { name: 'Test Project', id: 'test-project' },
+          source_control: {
+            topology: 'local_directory_only',
+            context_publication_policy: 'local_private',
+          },
+          execution: {
+            source_repo_roots: ['.'],
+          },
+        });
+      }
+
+      throw new Error(`Unexpected readFile path: ${normalizedPath}`);
+    });
+
+    await initProject({
+      name: 'Test Project',
+      topology: 'local_directory_only',
+      normalize_existing: true,
+    });
+
+    const projectYamlCall = fsPromisesMock.writeFile.mock.calls.find((c) => String(c[0]).endsWith('.project.yaml'));
+    expect(projectYamlCall).toBeDefined();
+    expect(JSON.parse(String(projectYamlCall![1])).execution).toBeUndefined();
+  });
+
+  it('normalizes an existing path even when legacy project yaml cannot be parsed', async () => {
+    fsMock.existsSync.mockReturnValue(false);
+    fsPromisesMock.access.mockResolvedValue(undefined);
+    fsPromisesMock.readFile.mockImplementation(async (path: any) => {
+      if (String(path).endsWith('.project.yaml')) {
+        throw new Error('legacy yaml unreadable');
+      }
+      throw new Error('ENOENT');
+    });
+
+    const result = await initProject({
+      name: 'Test Project',
+      topology: 'local_directory_only',
+      normalize_existing: true,
+    });
+
+    expect(result).toContain('Normalized project "Test Project"');
+  });
+
+  it('normalizes an existing path when legacy project yaml parses to null', async () => {
+    fsMock.existsSync.mockReturnValue(false);
+    fsPromisesMock.access.mockResolvedValue(undefined);
+    fsPromisesMock.readFile.mockImplementation(async (path: any) => {
+      if (String(path).endsWith('.project.yaml')) {
+        return 'null';
+      }
+      throw new Error('ENOENT');
+    });
+
+    const result = await initProject({
+      name: 'Test Project',
+      topology: 'local_directory_only',
+      normalize_existing: true,
+    });
+
+    expect(result).toContain('Normalized project "Test Project"');
+  });
+  });

--- a/mcp-server/src/tools/__tests__/init.test.ts
+++ b/mcp-server/src/tools/__tests__/init.test.ts
@@ -104,6 +104,16 @@ describe('initProject', () => {
     ).rejects.toThrow('context_publication_policy is required');
   });
 
+  it('rejects custom paths with control characters', async () => {
+    await expect(
+      initProject({
+        name: 'Test Project',
+        path: '/home/testuser/AgenticOS/projects/test-project\nINJECT',
+        topology: 'local_directory_only',
+      }),
+    ).rejects.toThrow('control characters');
+  });
+
   it('creates directories with correct structure', async () => {
     fsMock.existsSync.mockReturnValue(false);
     fsPromisesMock.access.mockRejectedValue(new Error('ENOENT'));

--- a/mcp-server/src/tools/__tests__/project.test.ts
+++ b/mcp-server/src/tools/__tests__/project.test.ts
@@ -79,7 +79,7 @@ import * as fsPromises from 'fs/promises';
 import * as registry from '../../utils/registry.js';
 import * as distill from '../../utils/distill.js';
 import * as fs from 'fs';
-import { bindSessionProject, clearSessionProjectBinding } from '../../utils/session-context.js';
+import { bindSessionProject, clearSessionProjectBinding, getSessionProjectBinding } from '../../utils/session-context.js';
 
 const fsPromisesMock = fsPromises as typeof fsPromises & {
   readFile: ReturnType<typeof vi.fn>;
@@ -123,8 +123,10 @@ describe('switchProject', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     clearSessionProjectBinding();
-    // By default, mock existsSync to return false (no CLAUDE.md/AGENTS.md)
-    fsMock.existsSync.mockReturnValue(false);
+    // By default, only the registered project root exists; entry surfaces are absent.
+    fsMock.existsSync.mockImplementation((path: string) => (
+      path === '/test/path' || path === '/workspace/projects/agenticos'
+    ));
     yamlMock.parse.mockImplementation((content: string) => {
       try { return JSON.parse(content); } catch { return undefined; }
     });
@@ -1373,7 +1375,7 @@ describe('switchProject', () => {
     }
   });
 
-  it('uses explicit workdir fallback when non-Codex alignment has no instruction', async () => {
+  it('does not bind a session when the registered project path is missing', async () => {
     const previousClaudeCode = process.env.CLAUDE_CODE;
     process.env.CLAUDE_CODE = '1';
     try {
@@ -1408,9 +1410,9 @@ describe('switchProject', () => {
 
       const result = await switchProject({ project: 'my-project' });
 
-      expect(result).toContain('[WARN] PWD alignment skipped: target directory does not exist');
-      expect(result).toContain('Use this project path as explicit workdir for every filesystem operation.');
-      expect(result).toContain('Avoid relative-path edits until your client shell PWD is verified.');
+      expect(result).toContain('❌ Project "My Project" cannot be switched');
+      expect(result).toContain('target directory does not exist');
+      expect(getSessionProjectBinding()).toBeNull();
     } finally {
       if (previousClaudeCode === undefined) delete process.env.CLAUDE_CODE;
       else process.env.CLAUDE_CODE = previousClaudeCode;

--- a/mcp-server/src/tools/__tests__/switch.test.ts
+++ b/mcp-server/src/tools/__tests__/switch.test.ts
@@ -128,7 +128,7 @@ describe('switchProject — agenticos_switch tests', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     clearSessionProjectBinding();
-    fsMock.existsSync.mockReturnValue(false);
+    fsMock.existsSync.mockImplementation((path: string) => path === '/test/path');
     yamlMock.parse.mockImplementation((content: string) => {
       try { return JSON.parse(content); } catch { return undefined; }
     });
@@ -170,12 +170,22 @@ describe('switchProject — agenticos_switch tests', () => {
       expect(result).toContain('Path: /test/path');
       expect(result).toContain('Status: active');
       expect(result).toContain('🧰 Project path: /test/path');
-      expect(result).toContain('🧰 Filesystem workdir for tool calls: /test/path');
+      expect(result).toContain('🧰 Recommended explicit workdir for tool calls: /test/path');
       expect(result).toContain('Client shell PWD: unavailable to MCP');
-      // New PWD alignment behavior: shows warning when directory doesn't exist
-      expect(result).toContain('[WARN] PWD alignment skipped');
       expect(result.indexOf('Status: active')).toBeLessThan(result.indexOf('🧰 Project path: /test/path'));
       expect(result.indexOf('🧰 Project path: /test/path')).toBeLessThan(result.indexOf('Context loaded from:'));
+    });
+
+    it('does not bind or report success when the registered project path is missing', async () => {
+      fsMock.existsSync.mockReturnValue(false);
+      registryMock.loadRegistry.mockResolvedValue(buildRegistry());
+
+      const result = await switchProject({ project: 'test-project' });
+
+      expect(result).toContain('❌ Project "Test Project" cannot be switched');
+      expect(result).toContain('target directory does not exist');
+      expect(getSessionProjectBinding()).toBeNull();
+      expect(registryMock.patchProjectMetadata).not.toHaveBeenCalled();
     });
 
     it('does not imply Codex current-session cwd changed after switch', async () => {

--- a/mcp-server/src/tools/init.ts
+++ b/mcp-server/src/tools/init.ts
@@ -6,6 +6,7 @@ import { generateClaudeMd, generateAgentsMd } from '../utils/distill.js';
 import { buildProjectTopologyInitializationMessage, hasDeclaredContextPublicationPolicy, validateContextPublicationPolicy, type ContextPublicationPolicy, type ProjectTopology } from '../utils/project-contract.js';
 import { resolveManagedProjectContextDisplayPaths, resolveManagedProjectContextPaths } from '../utils/agent-context-paths.js';
 import { ensureCaseKnowledgeDirectories } from '../utils/case-knowledge.js';
+import { validatePathSecurity } from '../utils/session-context.js';
 
 function isValidGithubRepo(value: string): boolean {
   return /^[^/\s]+\/[^/\s]+$/.test(value);
@@ -157,6 +158,10 @@ export async function initProject(args: any): Promise<string> {
   const id = name.toLowerCase().replace(/\s+/g, '-');
 
   const projectPath = customPath || join(getAgenticOSHome(), 'projects', id);
+  const pathSecurity = validatePathSecurity(projectPath);
+  if (!pathSecurity.valid) {
+    throw new Error(`Invalid project path: ${pathSecurity.error}`);
+  }
 
   let pathExists = false;
   try {

--- a/mcp-server/src/tools/project.ts
+++ b/mcp-server/src/tools/project.ts
@@ -366,13 +366,10 @@ function buildFilesystemAlignmentLines(
       lines.push('   To start a new Codex session in this project, run:');
       lines.push(`   ${pwdResult.instruction}`);
     }
-  } else if (pwdResult.instruction) {
+  } else {
     lines.push('📍 Client alignment hint:');
     lines.push(`   ${pwdResult.instruction}`);
     lines.push('   Treat this as a hint; verify the client shell PWD before using relative paths.');
-  } else {
-    lines.push('   Use this project path as explicit workdir for every filesystem operation.');
-    lines.push('   Avoid relative-path edits until your client shell PWD is verified.');
   }
 
   return lines;

--- a/mcp-server/src/tools/project.ts
+++ b/mcp-server/src/tools/project.ts
@@ -347,7 +347,7 @@ function buildFilesystemAlignmentLines(
 ): string[] {
   const lines = [
     `🧰 Project path: ${projectPath}`,
-    `🧰 Filesystem workdir for tool calls: ${projectPath}`,
+    `🧰 Recommended explicit workdir for tool calls: ${projectPath}`,
   ];
 
   const relation = pwdResult.observedMcpProcessPwd === projectPath ? 'matches project path' : 'differs from project path';
@@ -378,6 +378,10 @@ function buildFilesystemAlignmentLines(
   return lines;
 }
 
+function stripPwdWarningPrefix(warning: string | null): string {
+  return warning?.replace(/^\[WARN\] PWD alignment skipped:\s*/, '') || 'project path is not usable';
+}
+
 export async function switchProject(args: any): Promise<string> {
   const { project } = args;
   const registry = await loadRegistry();
@@ -388,6 +392,19 @@ export async function switchProject(args: any): Promise<string> {
 
   if (!found) {
     return `❌ Project "${project}" not found.\n\nAvailable projects:\n${registry.projects.map((p) => `- ${p.name} (${p.id})`).join('\n')}`;
+  }
+
+  // Validate the project path before loading context or binding the MCP session.
+  // A stale registry entry should not produce a successful switch.
+  const pwdResult = await alignPwd(found.path);
+  if (!pwdResult.success) {
+    return [
+      `❌ Project "${found.name}" cannot be switched because its registered path is not usable.`,
+      '',
+      `Path: ${JSON.stringify(found.path)}`,
+      `Reason: ${stripPwdWarningPrefix(pwdResult.warning)}`,
+      'Recovery: repair or re-register the project path, then run agenticos_switch again.',
+    ].join('\n');
   }
 
   let projectYaml: any = {};
@@ -412,9 +429,6 @@ export async function switchProject(args: any): Promise<string> {
     projectName: found.name,
     projectPath: found.path,
   });
-
-  // Get PWD alignment instruction
-  const pwdResult = await alignPwd(found.path);
 
   // Check if entry surface writes are allowed in this checkout
   const writeProtection = await detectCanonicalMainWriteProtection(found.path);

--- a/mcp-server/src/utils/__tests__/bootstrap-cli.test.ts
+++ b/mcp-server/src/utils/__tests__/bootstrap-cli.test.ts
@@ -336,10 +336,10 @@ describe('bootstrap cli', () => {
     expect(exitCode).toBe(0);
     expect(harness.files.has('/Users/tester/.claude/settings.json')).toBe(false);
     expect(harness.stdout.some((line) => line.includes('claude-pwd-hook'))).toBe(true);
-    expect(harness.stdout.some((line) => line.includes('add agenticos_switch PostToolUse hook'))).toBe(true);
+    expect(harness.stdout.some((line) => line.includes('add agenticos_switch PostToolUse cwd guidance hook'))).toBe(true);
   });
 
-  it('adds Claude PWD alignment hook during apply when requested', () => {
+  it('adds Claude cwd guidance hook during apply when requested', () => {
     const harness = createDeps();
 
     const exitCode = runBootstrapCli(
@@ -369,7 +369,7 @@ describe('bootstrap cli', () => {
     expect(bootstrapState.claude_pwd_hook.fatal).toBe(false);
   });
 
-  it('does not duplicate an existing Claude PWD alignment hook', () => {
+  it('does not duplicate an existing Claude cwd guidance hook', () => {
     const harness = createDeps();
     harness.files.set('/Users/tester/.claude/settings.json', JSON.stringify({
       hooks: {
@@ -706,6 +706,42 @@ describe('bootstrap cli', () => {
     expect(exitCode).toBe(1);
     expect(harness.stdout.some((line) => line.includes('FAIL claude-code'))).toBe(true);
     expect(harness.stdout.some((line) => line.includes('Recovery: claude mcp add'))).toBe(true);
+  });
+
+  it('verifies the Claude cwd guidance hook when claude-code is selected', () => {
+    const harness = createDeps();
+    harness.files.set('/Users/tester/.claude/settings.json', JSON.stringify({
+      hooks: {
+        PostToolUse: [
+          {
+            matcher: 'mcp__agenticos__agenticos_switch',
+            hooks: [{ type: 'command', command: 'agenticos-claude-pwd-hook' }],
+          },
+        ],
+      },
+    }));
+
+    const exitCode = runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'claude-code', '--verify'],
+      harness.deps,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(harness.stdout.some((line) => line.includes('OK claude-code'))).toBe(true);
+    expect(harness.stdout.some((line) => line.includes('OK claude-pwd-hook'))).toBe(true);
+  });
+
+  it('fails Claude verification when the cwd guidance hook is missing', () => {
+    const harness = createDeps();
+
+    const exitCode = runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'claude-code', '--verify'],
+      harness.deps,
+    );
+
+    expect(exitCode).toBe(1);
+    expect(harness.stdout.some((line) => line.includes('FAIL claude-pwd-hook'))).toBe(true);
+    expect(harness.stdout.some((line) => line.includes('--auto-configure-hooks --apply'))).toBe(true);
   });
 
   it('verifies gemini and cursor agents', () => {

--- a/mcp-server/src/utils/__tests__/claude-pwd-hook.test.ts
+++ b/mcp-server/src/utils/__tests__/claude-pwd-hook.test.ts
@@ -132,7 +132,19 @@ describe('claude-pwd-hook', () => {
 
     expect(response.hookSpecificOutput.hookEventName).toBe('PostToolUse');
     expect(response.hookSpecificOutput.additionalContext).toContain('/tmp/work space');
-    expect(response.hookSpecificOutput.additionalContext).toContain('cd "/tmp/work space"');
+    expect(response.hookSpecificOutput.additionalContext).toContain("cd '/tmp/work space'");
+    expect(response.hookSpecificOutput.additionalContext).toContain('cwd guidance only');
+  });
+
+  it('does not render hook output for unsafe project paths', () => {
+    const output = runClaudePwdHook(JSON.stringify({
+      tool_name: 'mcp__agenticos__agenticos_switch',
+      tool_response: {
+        path: '/tmp/project\nINJECT',
+      },
+    }));
+
+    expect(output).toBeNull();
   });
 
   it('executes the hook payload parser against realistic stdin JSON', () => {

--- a/mcp-server/src/utils/__tests__/config-audit.test.ts
+++ b/mcp-server/src/utils/__tests__/config-audit.test.ts
@@ -131,7 +131,7 @@ describe('config audit', () => {
     expect(result.sources.find((source) => source.id === 'claude_pwd_alignment_hook')?.status).toBe('unset');
   });
 
-  it('detects Claude Code PWD alignment hook without making it canonical workspace input', () => {
+  it('detects Claude Code cwd guidance hook without making it canonical workspace input', () => {
     const harness = createDeps();
     harness.files.set('/Users/tester/.claude/settings.json', JSON.stringify({
       hooks: {
@@ -152,7 +152,7 @@ describe('config audit', () => {
     expect(hookSource?.value).toBe('mcp__agenticos__agenticos_switch');
   });
 
-  it('reports configured Claude Code PWD alignment hooks', () => {
+  it('reports configured Claude Code cwd guidance hooks', () => {
     const harness = createDeps();
     harness.files.set('/Users/tester/.claude/settings.json', JSON.stringify({
       hooks: {
@@ -173,7 +173,7 @@ describe('config audit', () => {
     expect(hook?.detail).toContain('Detected PostToolUse hook');
   });
 
-  it('reports missing Claude Code PWD alignment hook when hooks do not match', () => {
+  it('reports missing Claude Code cwd guidance hook when hooks do not match', () => {
     const harness = createDeps();
     harness.files.set('/Users/tester/.claude/settings.json', JSON.stringify({
       hooks: {
@@ -188,7 +188,7 @@ describe('config audit', () => {
     const hook = result.sources.find((source) => source.id === 'claude_pwd_alignment_hook');
 
     expect(hook?.status).toBe('unset');
-    expect(hook?.detail).toContain('no agenticos_switch PWD alignment hook');
+    expect(hook?.detail).toContain('no agenticos_switch cwd guidance hook');
   });
 
   it('accepts generic Codex AGENTICOS_HOME entries outside a focused agent block', () => {

--- a/mcp-server/src/utils/__tests__/session-context.test.ts
+++ b/mcp-server/src/utils/__tests__/session-context.test.ts
@@ -186,6 +186,14 @@ describe('session-context', () => {
       expect(shellQuote('/tmp/a; echo hacked $(pwd)')).toBe("'/tmp/a; echo hacked $(pwd)'");
     });
 
+    it('rejects paths with control characters before rendering guidance', async () => {
+      const result = await alignPwd('/tmp/project\nINJECT');
+
+      expect(result.success).toBe(false);
+      expect(result.instruction).toBeNull();
+      expect(result.warning).toContain('control characters');
+    });
+
     it('returns failure for relative path', async () => {
       const result = await alignPwd('relative/path');
       expect(result.success).toBe(false);
@@ -205,6 +213,17 @@ describe('session-context', () => {
       expect(result.success).toBe(true);
       expect(result.instruction).toContain("cd '/tmp'");
       expect(result.warning).toContain('not under AGENTICOS_HOME');
+    });
+
+    it('uses path containment instead of raw prefix matching for AGENTICOS_HOME warnings', async () => {
+      agenticosHomeMock.value = join(tmpdir(), 'agenticos');
+      const projectPath = join(tmpdir(), 'agenticos-evil');
+      mkdirSync(projectPath, { recursive: true });
+      const result = await alignPwd(projectPath);
+
+      expect(result.success).toBe(true);
+      expect(result.warning).toContain('not under AGENTICOS_HOME');
+      rmSync(projectPath, { recursive: true, force: true });
     });
 
     it('returns null warning for accessible directory inside AGENTICOS_HOME', async () => {

--- a/mcp-server/src/utils/__tests__/session-context.test.ts
+++ b/mcp-server/src/utils/__tests__/session-context.test.ts
@@ -154,6 +154,12 @@ describe('session-context', () => {
       expect(result.error).toContain('absolute');
     });
 
+    it('rejects paths with control characters', () => {
+      const result = validatePathInAgenticosHome('/test/home/project\nINJECT');
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('control characters');
+    });
+
     it('accepts path after normalization', () => {
       const result = validatePathInAgenticosHome('/test/home/../other');
       expect(result.valid).toBe(true);

--- a/mcp-server/src/utils/bootstrap-cli.ts
+++ b/mcp-server/src/utils/bootstrap-cli.ts
@@ -253,7 +253,7 @@ export function buildHelpLines(): string[] {
     '  `--first-run` is a convenience mode: it implies `--apply`, enables shell persistence, and on macOS also enables launchctl persistence.',
     '  `--persist-shell-env` also writes export AGENTICOS_HOME=... to the detected shell profile.',
     '  `--persist-launchctl-env` also runs `launchctl setenv` on macOS for GUI/session inheritance.',
-    '  `--auto-configure-hooks` adds the Claude Code PostToolUse hook used to align shell PWD after agenticos_switch.',
+    '  `--auto-configure-hooks` adds the Claude Code PostToolUse hook used to provide cwd guidance after agenticos_switch.',
     '  Workspace selection is explicit: use `--workspace <path>` or set AGENTICOS_HOME beforehand.',
     '',
     'Supported agent ids: claude-code, codex, cursor, gemini-cli',
@@ -348,7 +348,7 @@ export function buildDryRunLines(
   if (selected.includes('claude-code')) {
     const settingsPath = `${homeDir}/${CLAUDE_SETTINGS_PATH}`;
     if (options.autoConfigureHooks) {
-      lines.push(`- claude-pwd-hook: add agenticos_switch PostToolUse hook to ${settingsPath}`);
+      lines.push(`- claude-pwd-hook: add agenticos_switch PostToolUse cwd guidance hook to ${settingsPath}`);
     } else {
       lines.push(`- claude-pwd-hook: inspect ${settingsPath}; rerun with --auto-configure-hooks --apply to add it`);
     }
@@ -406,6 +406,16 @@ function runVerification(
     const marker = result.ok ? 'OK' : 'FAIL';
     lines.push(`${marker} launchctl: ${result.detail}`);
     if (!result.ok) ok = false;
+  }
+
+  if (selected.includes('claude-code')) {
+    const result = verifyClaudePwdGuidanceHook(deps);
+    const marker = result.ok ? 'OK' : 'FAIL';
+    lines.push(`${marker} claude-pwd-hook: ${result.detail}`);
+    if (!result.ok) {
+      ok = false;
+      lines.push('   Recovery: agenticos-bootstrap --agent claude-code --auto-configure-hooks --apply');
+    }
   }
 
   return { ok, lines };
@@ -582,6 +592,14 @@ function verifyLaunchctlEnv(
     ok: true,
     detail: 'session env verified via `launchctl getenv AGENTICOS_HOME`',
   };
+}
+
+function verifyClaudePwdGuidanceHook(deps: BootstrapCliDeps): { ok: boolean; detail: string } {
+  const settingsPath = `${deps.homeDir}/${CLAUDE_SETTINGS_PATH}`;
+  const inspection = inspectClaudePwdAlignmentHook(deps.readFile(settingsPath));
+  return inspection.status === 'configured'
+    ? { ok: true, detail: inspection.detail }
+    : { ok: false, detail: `${inspection.detail} Expected cwd guidance hook in ${settingsPath}.` };
 }
 
 function persistBootstrapState(

--- a/mcp-server/src/utils/claude-pwd-hook.ts
+++ b/mcp-server/src/utils/claude-pwd-hook.ts
@@ -1,3 +1,5 @@
+import { shellQuote, validatePathSecurity } from './session-context.js';
+
 export const CLAUDE_SETTINGS_PATH = '.claude/settings.json';
 export const CLAUDE_PWD_ALIGNMENT_HOOK_MATCHER = 'mcp__agenticos__agenticos_switch';
 export const CLAUDE_PWD_ALIGNMENT_HOOK_COMMAND = 'agenticos-claude-pwd-hook';
@@ -72,7 +74,8 @@ export function renderClaudePwdHookResponse(projectPath: string): ClaudePostTool
       additionalContext: [
         `AgenticOS switched project path: ${projectPath}`,
         'Use this path as the explicit workdir for subsequent filesystem operations.',
-        `If the client shell PWD differs, run: cd ${JSON.stringify(projectPath)}`,
+        'This hook provides cwd guidance only; it cannot mutate a parent shell PWD.',
+        `If the client shell PWD differs, run: cd ${shellQuote(projectPath)}`,
       ].join('\n'),
     },
   };
@@ -88,6 +91,7 @@ export function runClaudePwdHook(input: string): string | null {
 
   const projectPath = extractProjectPathFromClaudeHookPayload(parsed);
   if (!projectPath) return null;
+  if (!validatePathSecurity(projectPath).valid) return null;
 
   return `${JSON.stringify(renderClaudePwdHookResponse(projectPath))}\n`;
 }
@@ -129,11 +133,11 @@ export function inspectClaudePwdAlignmentHook(settingsContent: string | null): C
     return hasClaudePwdAlignmentHook(parsed)
       ? {
         status: 'configured',
-        detail: 'Detected PostToolUse hook for agenticos_switch PWD alignment.',
+        detail: 'Detected PostToolUse hook for agenticos_switch cwd guidance.',
       }
       : {
         status: 'unset',
-        detail: 'Claude Code settings exist but no agenticos_switch PWD alignment hook was detected.',
+        detail: 'Claude Code settings exist but no agenticos_switch cwd guidance hook was detected.',
       };
   } catch {
     return {

--- a/mcp-server/src/utils/config-audit.ts
+++ b/mcp-server/src/utils/config-audit.ts
@@ -209,7 +209,7 @@ function readClaudePwdAlignmentHookSource(deps: ConfigAuditDeps): ConfigSourceRe
   const inspection = inspectClaudePwdAlignmentHook(deps.readFile(filePath));
   return {
     id: 'claude_pwd_alignment_hook',
-    label: 'Claude Code PWD alignment hook',
+    label: 'Claude Code cwd guidance hook',
     scope: 'mcp',
     status: inspection.status,
     value: inspection.status === 'configured' ? CLAUDE_PWD_ALIGNMENT_HOOK_MATCHER : null,

--- a/mcp-server/src/utils/session-context.ts
+++ b/mcp-server/src/utils/session-context.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'fs';
-import { isAbsolute, normalize } from 'path';
+import { isAbsolute, normalize, relative } from 'path';
 import { execFile } from 'child_process';
 import { getAgenticOSHome } from './registry.js';
 
@@ -41,7 +41,15 @@ export function clearSessionProjectBinding(): void {
   currentSessionProject = null;
 }
 
+export function containsControlCharacters(value: string): boolean {
+  return /[\u0000-\u001F\u007F]/.test(value);
+}
+
 export function validatePathSecurity(targetPath: string): { valid: boolean; error?: string } {
+  if (containsControlCharacters(targetPath)) {
+    return { valid: false, error: 'Path must not contain control characters' };
+  }
+
   // Must be absolute
   if (!isAbsolute(targetPath)) {
     return { valid: false, error: 'Path must be absolute' };
@@ -59,6 +67,10 @@ export function validatePathSecurity(targetPath: string): { valid: boolean; erro
 export function validatePathInAgenticosHome(targetPath: string): { valid: boolean; error?: string; warning?: string } {
   const home = getAgenticOSHome();
 
+  if (containsControlCharacters(targetPath)) {
+    return { valid: false, error: 'Path must not contain control characters' };
+  }
+
   // Must be absolute
   if (!isAbsolute(targetPath)) {
     return { valid: false, error: 'Path must be absolute' };
@@ -71,7 +83,9 @@ export function validatePathInAgenticosHome(targetPath: string): { valid: boolea
   }
 
   // Advisory check: path should be under AGENTICOS_HOME
-  if (!targetPath.startsWith(home)) {
+  const relativeToHome = relative(home, targetPath);
+  const isInsideHome = relativeToHome === '' || (!relativeToHome.startsWith('..') && !isAbsolute(relativeToHome));
+  if (!isInsideHome) {
     return { valid: true, warning: `Path is not under AGENTICOS_HOME (${home})` };
   }
 


### PR DESCRIPTION
## Summary
- validate the registered project path before binding AgenticOS session context during `agenticos_switch`
- clarify that project switch provides a recommended explicit tool workdir, not a guaranteed parent-shell cwd mutation
- harden path validation and Claude Code cwd guidance hook handling for unsafe/control-character paths
- update bootstrap/config audit verification and README guidance

Fixes #428

## Verification
- npm test -- --run src/utils/__tests__/session-context.test.ts src/utils/__tests__/claude-pwd-hook.test.ts src/tools/__tests__/switch.test.ts src/tools/__tests__/project.test.ts src/utils/__tests__/bootstrap-cli.test.ts src/utils/__tests__/config-audit.test.ts src/tools/__tests__/init.test.ts
- npm run lint
- npm test -- --run
- ./tools/coverage-preflight.sh
- ./scripts/readme-lint.sh
- git diff --check
- agenticos_pr_scope_check: PASS
