### PR TITLE
chore: prepare v0.4.24 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No unreleased changes._
 
+## [0.4.24] — 2026-05-20
+
+### Fixed
+- mcp-server: `agenticos_switch` now validates the registered project path before binding session context, so stale or missing paths fail closed instead of producing a successful switch.
+- mcp-server: path validation now rejects control characters and uses path-aware containment checks for `AGENTICOS_HOME` instead of raw prefix matching.
+- mcp-server: Claude Code cwd guidance now shell-quotes project paths and suppresses unsafe hook output for control-character paths.
+
+### Changed
+- mcp-server: switch output now describes the project path as the recommended explicit workdir for tool calls and clarifies that MCP output cannot mutate the client shell PWD.
+- bootstrap: `--verify` now checks the Claude Code cwd guidance hook and reports recovery commands when the hook is missing.
+
 ## [0.4.23] — 2026-05-20
 
 ### Added

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenticos-mcp",
-  "version": "0.4.23",
+  "version": "0.4.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenticos-mcp",
-      "version": "0.4.23",
+      "version": "0.4.24",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-mcp",
-  "version": "0.4.23",
+  "version": "0.4.24",
   "description": "MCP Server for AgenticOS - AI-native project management system",
   "type": "module",
   "bin": {

--- a/mcp-server/src/__tests__/mcp-regression-baseline.json
+++ b/mcp-server/src/__tests__/mcp-regression-baseline.json
@@ -1,9 +1,9 @@
 {
-  "capturedAt": "2026-05-15T11:26:50.074Z",
-  "version": "0.4.23",
+  "capturedAt": "2026-05-20T10:16:34.000Z",
+  "version": "0.4.24",
   "serverInfo": {
     "name": "agenticos-mcp",
-    "version": "0.4.23"
+    "version": "0.4.24"
   },
   "protocolVersion": "2025-11-25",
   "capabilities": {


### PR DESCRIPTION
Fixes #430.

## Summary
- Bump agenticos-mcp package and lockfile metadata to 0.4.24.
- Update MCP regression baseline version to 0.4.24.
- Add v0.4.24 release notes to CHANGELOG.md for the #428 cwd guidance fix.

## Verification
- npm ci
- npm test -- --run src/__tests__/mcp-regression.test.ts src/utils/__tests__/mcp-server-cli.test.ts
- npm run lint
- npm test -- --run
- ./tools/coverage-preflight.sh
- ./scripts/readme-lint.sh (0 errors; existing warnings/recommendations)
- git diff --check
- agenticos_preflight PASS
- agenticos_edit_guard PASS
- agenticos_pr_scope_check PASS

## Release plan
After this PR lands and main CI is green, tag v0.4.24 from the merge commit and push the tag to trigger the release workflow.

## Rollback
Revert this release metadata merge commit before tagging if final release gates fail. If the tag has already been pushed, do not force-push; publish a follow-up patch release.
