### PR TITLE
feat: add agent activation skill bootstrap

### DIFF
--- a/.meta/bootstrap/agent-bootstrap-matrix.yaml
+++ b/.meta/bootstrap/agent-bootstrap-matrix.yaml
@@ -4,6 +4,15 @@ verification_contract:
   canonical_runtime_entrypoint: agenticos-mcp
   legacy_source_checkout_paths_unsupported: true
   automation_boundary: manual_agent_cli
+  activation_skill_model:
+    design_source: GBrain/Hermes-style Skill routing with MCP execution
+    contract:
+      - Skill is a pre-tool routing hint, not the runtime source of truth
+      - MCP remains authoritative for project identity, session binding, project path, and workdir guidance
+      - Homebrew/bootstrap may install or update managed Skill files by content hash
+      - user-modified Skill files require explicit `--force-skills` before overwrite
+    install_command: agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent <id> --install-skills --apply
+    verify_command: agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent <id> --install-skills --verify
   automation_rationale:
     - official MCP registrations live in agent-owned user config outside AGENTICOS_HOME
     - agenticos_health remains repo/project scoped and does not rewrite per-agent MCP settings
@@ -21,9 +30,16 @@ supported_agents:
     canonical_bootstrap_method: cli-command
     canonical_config_location: claude-managed user MCP config via `claude mcp add --scope user`
     bootstrap_command: claude mcp add --transport stdio --scope user -e AGENTICOS_HOME="$AGENTICOS_HOME" agenticos -- agenticos-mcp
+    activation_skill:
+      support: official
+      path: ~/.claude/skills/agenticos/SKILL.md
+      install_command: agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent claude-code --install-skills --apply
+      verify_command: agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent claude-code --install-skills --verify
+      purpose: route project switch/status/pwd prompts through AgenticOS MCP before filesystem guessing
     verification:
       - run `claude mcp list`
       - run `/mcp` inside Claude Code
+      - run `agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent claude-code --install-skills --verify` when natural-language routing is required
       - confirm `agenticos` is present and call `agenticos_list`
     transport_debug:
       - if `agenticos` is missing from `claude mcp list`, MCP registration failed
@@ -32,7 +48,8 @@ supported_agents:
       - if `claude mcp get agenticos` shows `Command: node` with a legacy source-checkout build path, remove and re-add the server with `agenticos-mcp`
       - if `claude mcp get agenticos` does not show `AGENTICOS_HOME`, treat the registration as incomplete and re-add it with explicit env injection
     routing_debug:
-      - if tools are available but project-intent prompts do not trigger routing, load the project `CLAUDE.md` and `AGENTS.md`
+      - if tools are available but project-intent prompts do not trigger routing, verify the AgenticOS activation Skill is installed and reload/restart Claude Code
+      - load the project `CLAUDE.md` and `AGENTS.md`
       - call the relevant `agenticos_*` tool explicitly before treating the problem as transport failure
     repair:
       - run `claude mcp get agenticos`
@@ -47,8 +64,15 @@ supported_agents:
     canonical_bootstrap_method: cli-command
     canonical_config_location: ~/.codex/config.toml managed via `codex mcp add`
     bootstrap_command: codex mcp add --env AGENTICOS_HOME="$AGENTICOS_HOME" agenticos -- agenticos-mcp
+    activation_skill:
+      support: official
+      path: ~/.codex/skills/agenticos/SKILL.md
+      install_command: agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent codex --install-skills --apply
+      verify_command: agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent codex --install-skills --verify
+      purpose: route project switch/status/pwd prompts through AgenticOS MCP before filesystem guessing
     verification:
       - run `codex mcp list`
+      - run `agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent codex --install-skills --verify` when natural-language routing is required
       - confirm `agenticos` appears in the configured server list
       - call `agenticos_list` explicitly from a Codex session
     transport_debug:
@@ -59,6 +83,7 @@ supported_agents:
       - if `codex mcp get agenticos` shows `env: -`, treat the registration as incomplete and re-add it with explicit `AGENTICOS_HOME`
     routing_debug:
       - Codex transport success does not guarantee natural-language project-intent routing
+      - if routing is weak, verify the AgenticOS activation Skill is installed and restart or reload Codex skills
       - if routing is weak, use explicit `agenticos_*` tool calls and ensure project instructions are loaded
     repair:
       - run `codex mcp list`
@@ -94,6 +119,7 @@ supported_agents:
       - if using `cursor-agent`, compare `cursor-agent mcp list` with the editor view to rule out config-scope confusion
     routing_debug:
       - project-specific `.cursor/mcp.json` exists, but AgenticOS bootstrap should stay user-global by default
+      - AgenticOS activation Skill install is not supported for Cursor in this bootstrap version
       - if tools appear but intent routing is weak, use explicit `agenticos_*` tool calls and rely on project instructions
   - id: gemini-cli
     label: Gemini CLI
@@ -113,6 +139,7 @@ supported_agents:
       - if the stored server environment does not include `AGENTICOS_HOME`, treat the registration as incomplete and re-add it with explicit env injection
     routing_debug:
       - transport registration only proves MCP availability, not project-intent recognition
+      - AgenticOS activation Skill install is not supported for Gemini CLI in this bootstrap version
       - if intent routing does not trigger, use explicit `agenticos_*` calls and ensure the project instructions are loaded
 experimental_agents:
   - id: generic-mcp-tool

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ agenticos-bootstrap --workspace "$AGENTICOS_HOME" --first-run
 # 3. Verify — restart your AI tool, then ask it to run agenticos_list
 ```
 
+`--first-run` also installs the AgenticOS activation Skill for Codex and
+Claude Code when those clients are selected, so natural-language requests like
+"switch to 360Teams" or "切换到 360Teams 项目" are routed through AgenticOS MCP
+instead of raw filesystem guessing.
+
 For full documentation, agent-specific setup, and advanced configuration,
 see [mcp-server/README.md](mcp-server/README.md).
 
@@ -61,8 +66,9 @@ The official bootstrap surface currently covers:
 Bootstrap is complete only when:
 
 1. the MCP server is registered for the target agent
-2. the agent has been restarted if required
-3. `agenticos_list` succeeds
+2. the activation Skill is installed for Codex or Claude Code when natural-language routing is required
+3. the agent has been restarted or reloaded if required
+4. `agenticos_list` succeeds
 
 ## Homebrew Bootstrap Contract
 
@@ -81,23 +87,27 @@ agenticos-bootstrap --workspace "$AGENTICOS_HOME" --first-run --auto-configure-h
 ```
 
 On macOS, `--first-run` also sets up `launchctl` persistence so GUI tools
-inherit `AGENTICOS_HOME` across sessions. `--auto-configure-hooks` adds the
-Claude Code PostToolUse hook that reads the `agenticos_switch` result from hook
-stdin and feeds the selected project path back into Claude as explicit cwd
-guidance. The hook cannot mutate a parent shell process; keep using the
-reported project path as the explicit workdir and run `cd <path>` when your
-client shell PWD differs. Then restart your AI tool and run:
+inherit `AGENTICOS_HOME` across sessions. It installs the AgenticOS activation
+Skill for local-skill-capable agents, currently Codex and Claude Code.
+`--auto-configure-hooks` adds the Claude Code PostToolUse hook that reads the
+`agenticos_switch` result from hook stdin and feeds the selected project path
+back into Claude as explicit cwd guidance. The hook cannot mutate a parent
+shell process; keep using the reported project path as the explicit workdir
+and run `cd <path>` when your client shell PWD differs. Then restart your AI
+tool and run:
 
 ```bash
 agenticos-config --validate
-agenticos-bootstrap --workspace "$AGENTICOS_HOME" --all --verify
+agenticos-bootstrap --workspace "$AGENTICOS_HOME" --all --install-skills --verify
 ```
 
 Then confirm the server appears in the tool's MCP diagnostics and
 `agenticos_list` succeeds.
 
-Use `agenticos-bootstrap --workspace "$AGENTICOS_HOME" --all --verify` to
-audit the current state without mutating anything.
+Use `agenticos-bootstrap --workspace "$AGENTICOS_HOME" --all --install-skills --verify`
+to audit the current transport and activation-skill state without mutating
+anything. If you have intentionally edited the generated Skill, bootstrap will
+not overwrite it unless you pass `--force-skills`.
 
 ### Alternative: Per-agent manual setup
 
@@ -154,6 +164,11 @@ AgenticOS MCP `agenticos_switch` before shell directory search. In Codex-like
 clients where MCP tools may be deferred, use `tool_search` to discover
 AgenticOS MCP tools first. Fall back to shell directory search only when
 AgenticOS MCP is unavailable or cannot resolve the requested project.
+
+The AgenticOS activation Skill exists for this routing layer only. It should
+make the agent remember to discover and call AgenticOS MCP; it must not replace
+MCP as the source of truth for project identity, session binding, or workdir
+guidance.
 
 For a full walkthrough with `agenticos-bootstrap --first-run`, see
 [mcp-server/README.md](mcp-server/README.md).

--- a/homebrew-tap/Formula/agenticos.rb
+++ b/homebrew-tap/Formula/agenticos.rb
@@ -23,10 +23,11 @@ class Agenticos < Formula
     ohai "Add the following to your shell profile (~/.zshrc or ~/.bashrc):"
     ohai "  export AGENTICOS_HOME=\"#{var}/agenticos\""
     ohai ""
-    ohai "Then run: agenticos-bootstrap --workspace \"#{var}/agenticos\" --first-run"
+    ohai "Then run: agenticos-bootstrap --workspace \"#{var}/agenticos\" --first-run --auto-configure-hooks"
+    ohai "First-run mode installs AgenticOS activation Skills for Codex/Claude Code when selected."
     ohai "On macOS, first-run mode also enables launchctl persistence for GUI/session inheritance."
     ohai "To audit the current Homebrew/runtime bootstrap state without changes, use: agenticos-config --validate"
-    ohai "Then run: agenticos-bootstrap --workspace \"#{var}/agenticos\" --all --verify"
+    ohai "Then run: agenticos-bootstrap --workspace \"#{var}/agenticos\" --all --install-skills --verify"
     ohai "Or bootstrap your agent manually (see caveats below) and restart the tool."
   end
 
@@ -48,6 +49,12 @@ class Agenticos < Formula
          Recommended helper
            agenticos-bootstrap --workspace "$AGENTICOS_HOME" --first-run --auto-configure-hooks
 
+           First-run mode registers MCP, persists AGENTICOS_HOME where applicable,
+           and installs the AgenticOS activation Skill for Codex/Claude Code when
+           those agents are selected. The Skill helps natural-language requests
+           such as "switch to 360Teams" or "切换到 360Teams 项目" discover and
+           call AgenticOS MCP before filesystem guessing.
+
          macOS GUI/session helper
            agenticos-bootstrap --workspace "$AGENTICOS_HOME" --persist-shell-env --persist-launchctl-env --apply
 
@@ -56,6 +63,13 @@ class Agenticos < Formula
 
            The hook reads Claude Code PostToolUse stdin and feeds the switched
            project path back into Claude. It cannot mutate a parent shell PWD.
+
+         Activation Skill install/update
+           agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent codex --install-skills --apply
+           agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent claude-code --install-skills --apply
+
+           AgenticOS-managed Skill files are updated by content hash. User-modified
+           files are not overwritten unless you rerun with --force-skills.
 
          Claude Code
            claude mcp add --transport stdio --scope user -e AGENTICOS_HOME="$AGENTICOS_HOME" agenticos -- agenticos-mcp
@@ -83,7 +97,7 @@ class Agenticos < Formula
 
       4. Verify the Homebrew/runtime bootstrap state:
            agenticos-config --validate
-           agenticos-bootstrap --workspace "$AGENTICOS_HOME" --all --verify
+           agenticos-bootstrap --workspace "$AGENTICOS_HOME" --all --install-skills --verify
 
          Then confirm the server is listed in the tool's MCP diagnostics and explicitly call
          agenticos_list.

--- a/homebrew-tap/README.md
+++ b/homebrew-tap/README.md
@@ -22,15 +22,16 @@ Homebrew does **not**:
 - restart your AI tool
 - verify activation for you
 
-After installation, set `AGENTICOS_HOME` explicitly, bootstrap one officially supported agent, restart it, and verify the Homebrew/runtime bootstrap state before relying on `agenticos_list`:
+After installation, set `AGENTICOS_HOME` explicitly, bootstrap one officially supported agent, restart it, and verify the Homebrew/runtime bootstrap state before relying on `agenticos_list`.
+The recommended bootstrap also installs the AgenticOS activation Skill for Codex and Claude Code when selected, which helps route "switch project", `pwd`, and "切换到 ... 项目" prompts through AgenticOS MCP:
 
 ```bash
 # Example default workspace path for a Homebrew-only install
 mkdir -p "$(brew --prefix)/var/agenticos"
 export AGENTICOS_HOME="$(brew --prefix)/var/agenticos"
 
-# Recommended: detect supported agents and register them automatically
-agenticos-bootstrap --workspace "$AGENTICOS_HOME" --first-run
+# Recommended: detect supported agents, register MCP, and install activation Skills
+agenticos-bootstrap --workspace "$AGENTICOS_HOME" --first-run --auto-configure-hooks
 
 # Claude Code
 claude mcp add --transport stdio --scope user -e AGENTICOS_HOME="$AGENTICOS_HOME" agenticos -- agenticos-mcp
@@ -62,14 +63,15 @@ Then restart the AI tool and verify the Homebrew/runtime bootstrap state:
 
 ```bash
 agenticos-config --validate
-agenticos-bootstrap --workspace "$AGENTICOS_HOME" --all --verify
+agenticos-bootstrap --workspace "$AGENTICOS_HOME" --all --install-skills --verify
 ```
 
 Then confirm the server appears in the tool's MCP diagnostics and verify `agenticos_list` works.
 If you prefer not to edit your shell profile, omit `--first-run` and use the explicit MCP commands above instead.
 On macOS, `--first-run` also enables `launchctl` persistence so GUI/session processes inherit `AGENTICOS_HOME`.
+For Codex and Claude Code, `--first-run` implies `--install-skills`; bootstrap updates AgenticOS-managed Skill files by content hash and refuses to overwrite user-modified files unless you pass `--force-skills`.
 For Claude Code PWD guidance after `agenticos_switch`, run `agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent claude-code --auto-configure-hooks --apply` or include `--auto-configure-hooks` with `--first-run`. The hook reads Claude's PostToolUse stdin payload and feeds the switched project path back into Claude; it does not mutate a parent shell process.
-Use `agenticos-bootstrap --workspace "$AGENTICOS_HOME" --all --verify` with the same flags to audit the current machine state without mutating it.
+Use `agenticos-bootstrap --workspace "$AGENTICOS_HOME" --all --install-skills --verify` with the same flags to audit the current machine state without mutating it.
 
 `AGENTICOS_HOME` may also be a long-term self-hosting workspace home. The
 Homebrew example path above is a default example, not the only valid workspace

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -20,7 +20,8 @@ A project management system designed for AI collaboration. When you work on comp
 
 Install AgenticOS, set `AGENTICOS_HOME` explicitly, then either run `agenticos-bootstrap --workspace "$AGENTICOS_HOME" --first-run` or bootstrap one supported agent manually, restart that agent, and explicitly verify `agenticos_list` works before relying on project-intent routing.
 On macOS, `--first-run` also enables `launchctl` persistence for GUI/session inheritance.
-Use `agenticos-config --validate` and `agenticos-bootstrap --workspace "$AGENTICOS_HOME" --all --verify` to audit the Homebrew/runtime bootstrap state and optional persistence layers without mutating them.
+It also installs the AgenticOS activation Skill for local-skill-capable agents, currently Codex and Claude Code, so switch/status/pwd prompts route to AgenticOS MCP before filesystem guessing.
+Use `agenticos-config --validate` and `agenticos-bootstrap --workspace "$AGENTICOS_HOME" --all --install-skills --verify` to audit the Homebrew/runtime bootstrap state, activation Skill state, and optional persistence layers without mutating them.
 `--apply` and `--first-run` also record bootstrap metadata in `$AGENTICOS_HOME/.agent-workspace/bootstrap-state.yaml`.
 
 After any local upgrade, reinstall, or source rebuild of `agenticos-mcp`, restart the current AI client before assuming its MCP tools reflect the new server behavior.
@@ -103,21 +104,51 @@ my-project/
 Bootstrap is complete only when:
 
 1. the MCP server is registered for the target agent
-2. the agent has been restarted if required
-3. `agenticos_list` succeeds
+2. the activation Skill is installed for local-skill-capable agents when natural-language routing is required
+3. the agent has been restarted or reloaded if required
+4. `agenticos_list` succeeds
 
 Transport bootstrap and project-intent routing are different concerns.
 
 - **transport bootstrap** proves the tool is registered and callable
 - **routing** proves the agent is reading project instructions and choosing the tool when appropriate
 
+### Activation Skill Layer
+
+AgenticOS follows the same split seen in GBrain/Hermes-style integrations:
+Skills sit in the agent's pre-tool routing layer, while MCP remains the
+execution and state surface. The activation Skill is deliberately small. It
+teaches the agent to discover and call AgenticOS MCP for project switching,
+`pwd`, current-project, project-status, and worktree-status requests before
+using raw `cd`, filesystem search, or git branch inference.
+
+Bootstrap installs the Skill only on agents that currently have a local Skill
+surface:
+
+- Codex: `~/.codex/skills/agenticos/SKILL.md`
+- Claude Code: `~/.claude/skills/agenticos/SKILL.md`
+
+Install or update it with:
+
+```bash
+agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent codex --install-skills --apply
+agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent claude-code --install-skills --apply
+```
+
+`--first-run` implies `--install-skills`. Managed Skill files carry a content
+hash so bootstrap can update stale AgenticOS-managed copies while refusing to
+overwrite user-modified files. Pass `--force-skills` only when you intentionally
+want to replace a local edit.
+
 ### Claude Code
 
 - canonical bootstrap: `claude mcp add --transport stdio --scope user -e AGENTICOS_HOME="$AGENTICOS_HOME" agenticos -- agenticos-mcp`
 - canonical config location: `~/.claude/settings.json`
+- activation Skill: `~/.claude/skills/agenticos/SKILL.md`
 - verify:
   - `claude mcp list`
   - `/mcp`
+  - `agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent claude-code --install-skills --verify`
   - explicit `agenticos_list`
 - debug split:
   - if `agenticos` is missing from `claude mcp list`, fix MCP registration first
@@ -127,8 +158,10 @@ Transport bootstrap and project-intent routing are different concerns.
 
 - canonical bootstrap: `codex mcp add --env AGENTICOS_HOME="$AGENTICOS_HOME" agenticos -- agenticos-mcp`
 - canonical config location: `~/.codex/config.toml`
+- activation Skill: `~/.codex/skills/agenticos/SKILL.md`
 - verify:
   - `codex mcp list`
+  - `agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent codex --install-skills --verify`
   - explicit `agenticos_list`
 - debug split:
   - if `agenticos` is missing from `codex mcp list`, registration did not land in the active config
@@ -210,6 +243,12 @@ agenticos-bootstrap --workspace "$AGENTICOS_HOME" --first-run
 ```
 
 Restart your AI tool and verify with `agenticos_list`.
+If you rely on natural-language project switching, verify the activation Skill
+as well:
+
+```bash
+agenticos-bootstrap --workspace "$AGENTICOS_HOME" --all --install-skills --verify
+```
 
 ### Repairing a stale Homebrew tap
 
@@ -550,6 +589,21 @@ Get complete context for the current session project.
    ```
 3. Restart the AI tool completely (not just the current session)
 4. Try `agenticos_list` again
+
+### Tools appear but natural-language switch does not use AgenticOS
+
+This is a routing problem, not necessarily a transport problem. Install or
+verify the activation Skill for Codex or Claude Code:
+
+```bash
+agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent codex --install-skills --verify
+agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent claude-code --install-skills --verify
+```
+
+If verification fails, rerun the same command with `--apply`, restart or reload
+the agent's skills, then retry the user-facing prompt. The Skill should make
+requests like "switch to 360Teams", "pwd", and "切换到 360Teams 项目" discover
+and call `agenticos_switch` or `agenticos_status` before shell directory search.
 
 ### `AGENTICOS_HOME` is not inherited by GUI tools
 

--- a/mcp-server/src/utils/__tests__/agent-skill.test.ts
+++ b/mcp-server/src/utils/__tests__/agent-skill.test.ts
@@ -79,6 +79,35 @@ describe('agent skill bootstrap', () => {
     expect(result.status).toBe('current');
   });
 
+  it('reports stale managed content from a different template version', () => {
+    const harness = createDeps();
+    const path = '/Users/tester/.codex/skills/agenticos/SKILL.md';
+    installAgentSkill('codex', '/Users/tester', harness.deps);
+    const staleWithoutHash = (harness.files.get(path) || '')
+      .replace(/^<!-- agenticos-skill-managed-sha256: [a-f0-9]{64} -->\n?/, '')
+      .replace('agenticos-skill-template: v1', 'agenticos-skill-template: v99');
+    const staleHash = createHash('sha256').update(staleWithoutHash, 'utf-8').digest('hex');
+    harness.files.set(path, `<!-- agenticos-skill-managed-sha256: ${staleHash} -->\n${staleWithoutHash}`);
+
+    const inspection = inspectAgentSkill('codex', '/Users/tester', harness.deps.readFile);
+
+    expect(inspection.status).toBe('stale-managed');
+    expect(inspection.detail).toContain('is v99; expected v1');
+  });
+
+  it('does not rewrite a current managed Skill', () => {
+    const harness = createDeps();
+    installAgentSkill('codex', '/Users/tester', harness.deps);
+    harness.dirs.length = 0;
+
+    const result = installAgentSkill('codex', '/Users/tester', harness.deps);
+
+    expect(result.ok).toBe(true);
+    expect(result.wrote).toBe(false);
+    expect(result.status).toBe('current');
+    expect(harness.dirs).toEqual([]);
+  });
+
   it('refuses to overwrite user-modified Skill content unless forced', () => {
     const harness = createDeps();
     const path = '/Users/tester/.codex/skills/agenticos/SKILL.md';

--- a/mcp-server/src/utils/__tests__/agent-skill.test.ts
+++ b/mcp-server/src/utils/__tests__/agent-skill.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+import { createHash } from 'crypto';
+import {
+  installAgentSkill,
+  inspectAgentSkill,
+  isAgentSkillOkForVerify,
+  renderAgenticosSkillContent,
+  resolveAgentSkillTarget,
+} from '../agent-skill.js';
+
+function createDeps() {
+  const files = new Map<string, string>();
+  const dirs: string[] = [];
+
+  return {
+    files,
+    dirs,
+    deps: {
+      readFile(path: string) {
+        return files.get(path) ?? null;
+      },
+      writeFile(path: string, content: string) {
+        files.set(path, content);
+      },
+      mkdirp(path: string) {
+        dirs.push(path);
+      },
+    },
+  };
+}
+
+describe('agent skill bootstrap', () => {
+  it('resolves Codex and Claude Code Skill targets', () => {
+    expect(resolveAgentSkillTarget('codex', '/Users/tester').path)
+      .toBe('/Users/tester/.codex/skills/agenticos/SKILL.md');
+    expect(resolveAgentSkillTarget('claude-code', '/Users/tester').path)
+      .toBe('/Users/tester/.claude/skills/agenticos/SKILL.md');
+    expect(resolveAgentSkillTarget('cursor', '/Users/tester').supported).toBe(false);
+  });
+
+  it('renders a managed Skill with project switch triggers and hash marker', () => {
+    const content = renderAgenticosSkillContent();
+
+    expect(content).toMatch(/^<!-- agenticos-skill-managed-sha256: [a-f0-9]{64} -->/);
+    expect(content).toContain('name: agenticos');
+    expect(content).toContain('agenticos_switch');
+    expect(content).toContain('切换到');
+    expect(content).toContain('tool discovery for AgenticOS MCP tools');
+  });
+
+  it('installs and verifies a missing managed Skill', () => {
+    const harness = createDeps();
+
+    const result = installAgentSkill('codex', '/Users/tester', harness.deps);
+
+    expect(result.ok).toBe(true);
+    expect(result.wrote).toBe(true);
+    expect(result.status).toBe('current');
+    expect(harness.dirs).toEqual(['/Users/tester/.codex/skills/agenticos']);
+    expect(harness.files.get('/Users/tester/.codex/skills/agenticos/SKILL.md')).toContain('AgenticOS Activation');
+    expect(isAgentSkillOkForVerify(inspectAgentSkill('codex', '/Users/tester', harness.deps.readFile))).toBe(true);
+  });
+
+  it('updates stale managed content without force', () => {
+    const harness = createDeps();
+    const path = '/Users/tester/.codex/skills/agenticos/SKILL.md';
+    installAgentSkill('codex', '/Users/tester', harness.deps);
+    const stale = (harness.files.get(path) || '').replace('project status', 'project context');
+    const staleWithoutHash = stale.replace(/^<!-- agenticos-skill-managed-sha256: [a-f0-9]{64} -->\n?/, '');
+    const staleHash = createHash('sha256').update(staleWithoutHash, 'utf-8').digest('hex');
+    const managedStale = `<!-- agenticos-skill-managed-sha256: ${staleHash} -->\n${staleWithoutHash}`;
+    harness.files.set(path, managedStale);
+
+    expect(inspectAgentSkill('codex', '/Users/tester', harness.deps.readFile).status).toBe('stale-managed');
+    const result = installAgentSkill('codex', '/Users/tester', harness.deps);
+
+    expect(result.ok).toBe(true);
+    expect(result.wrote).toBe(true);
+    expect(result.status).toBe('current');
+  });
+
+  it('refuses to overwrite user-modified Skill content unless forced', () => {
+    const harness = createDeps();
+    const path = '/Users/tester/.codex/skills/agenticos/SKILL.md';
+    harness.files.set(path, '# custom agenticos notes\n');
+
+    const blocked = installAgentSkill('codex', '/Users/tester', harness.deps);
+
+    expect(blocked.ok).toBe(false);
+    expect(blocked.status).toBe('modified-user');
+    expect(blocked.detail).toContain('--force-skills');
+    expect(harness.files.get(path)).toBe('# custom agenticos notes\n');
+
+    const forced = installAgentSkill('codex', '/Users/tester', harness.deps, { force: true });
+    expect(forced.ok).toBe(true);
+    expect(forced.status).toBe('current');
+    expect(harness.files.get(path)).toContain('agenticos-skill-managed-sha256');
+  });
+
+  it('marks tampered managed content as user modified', () => {
+    const harness = createDeps();
+    const path = '/Users/tester/.claude/skills/agenticos/SKILL.md';
+    installAgentSkill('claude-code', '/Users/tester', harness.deps);
+    harness.files.set(path, `${harness.files.get(path)}\nextra local note\n`);
+
+    const inspection = inspectAgentSkill('claude-code', '/Users/tester', harness.deps.readFile);
+
+    expect(inspection.status).toBe('modified-user');
+    expect(isAgentSkillOkForVerify(inspection)).toBe(false);
+  });
+
+  it('skips unsupported agents without failing verification', () => {
+    const harness = createDeps();
+
+    const result = installAgentSkill('gemini-cli', '/Users/tester', harness.deps);
+
+    expect(result.ok).toBe(true);
+    expect(result.skipped).toBe(true);
+    expect(result.status).toBe('unsupported');
+    expect(isAgentSkillOkForVerify(result)).toBe(true);
+  });
+});

--- a/mcp-server/src/utils/__tests__/bootstrap-cli.test.ts
+++ b/mcp-server/src/utils/__tests__/bootstrap-cli.test.ts
@@ -73,7 +73,10 @@ describe('bootstrap cli', () => {
     expect(runBootstrapCli(['--help'], harness.deps)).toBe(0);
     expect(harness.stdout.join('\n')).toContain('agenticos-bootstrap');
     expect(buildHelpLines().join('\n')).toContain('--auto-configure-hooks');
+    expect(buildHelpLines().join('\n')).toContain('--install-skills');
     expect(parseCliArgs(['--all', '--auto-configure-hooks']).all).toBe(true);
+    expect(parseCliArgs(['--install-skills', '--force-skills']).installSkills).toBe(true);
+    expect(parseCliArgs(['--install-skills', '--force-skills']).forceSkills).toBe(true);
     expect(() => parseCliArgs(['--workspace'])).toThrow('--workspace requires a path.');
     expect(() => parseCliArgs(['--agent'])).toThrow('--agent requires a value.');
     expect(() => parseCliArgs(['--shell-profile'])).toThrow('--shell-profile requires a path.');
@@ -114,6 +117,8 @@ describe('bootstrap cli', () => {
         persistShellEnv: false,
         persistLaunchctlEnv: false,
         autoConfigureHooks: false,
+        installSkills: false,
+        forceSkills: false,
       },
       [
         { id: 'codex', label: 'Codex', installed: true, detection_hint: 'test' },
@@ -132,6 +137,8 @@ describe('bootstrap cli', () => {
         persistShellEnv: false,
         persistLaunchctlEnv: false,
         autoConfigureHooks: false,
+        installSkills: false,
+        forceSkills: false,
       },
       [
         { id: 'codex', label: 'Codex', installed: true, detection_hint: 'test' },
@@ -159,6 +166,8 @@ describe('bootstrap cli', () => {
         persistShellEnv: true,
         persistLaunchctlEnv: true,
         autoConfigureHooks: true,
+        installSkills: true,
+        forceSkills: false,
       },
       undefined,
       '/Users/tester',
@@ -353,6 +362,44 @@ describe('bootstrap cli', () => {
     expect(settings.hooks.PostToolUse[0].matcher).toBe('mcp__agenticos__agenticos_switch');
     expect(settings.hooks.PostToolUse[0].hooks[0].command).toBe('agenticos-claude-pwd-hook');
     expect(harness.stdout.some((line) => line.includes('OK claude-pwd-hook'))).toBe(true);
+  });
+
+  it('installs AgenticOS activation Skills during apply when requested', () => {
+    const harness = createDeps();
+
+    const exitCode = runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'codex', '--install-skills', '--apply'],
+      harness.deps,
+    );
+
+    expect(exitCode).toBe(0);
+    const skill = harness.files.get('/Users/tester/.codex/skills/agenticos/SKILL.md');
+    expect(skill).toContain('agenticos-skill-managed-sha256');
+    expect(skill).toContain('AgenticOS Activation');
+    expect(harness.stdout.some((line) => line.includes('OK codex-skill'))).toBe(true);
+    const bootstrapState = yaml.parse(harness.files.get('/tmp/workspace/.agent-workspace/bootstrap-state.yaml') || '');
+    expect(bootstrapState.install_skills).toBe(true);
+    expect(bootstrapState.agenticos_skills[0].status).toBe('current');
+  });
+
+  it('fails Skill install on user-modified files unless force is requested', () => {
+    const harness = createDeps();
+    harness.files.set('/Users/tester/.codex/skills/agenticos/SKILL.md', '# custom skill\n');
+
+    expect(runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'codex', '--install-skills', '--apply'],
+      harness.deps,
+    )).toBe(1);
+    expect(harness.stdout.some((line) => line.includes('FAIL codex-skill'))).toBe(true);
+    expect(harness.files.get('/Users/tester/.codex/skills/agenticos/SKILL.md')).toBe('# custom skill\n');
+
+    const forceHarness = createDeps();
+    forceHarness.files.set('/Users/tester/.codex/skills/agenticos/SKILL.md', '# custom skill\n');
+    expect(runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'codex', '--install-skills', '--force-skills', '--apply'],
+      forceHarness.deps,
+    )).toBe(0);
+    expect(forceHarness.files.get('/Users/tester/.codex/skills/agenticos/SKILL.md')).toContain('AgenticOS Activation');
   });
 
   it('warns but does not fail when Claude hook is missing and auto configure is not requested', () => {
@@ -616,6 +663,31 @@ describe('bootstrap cli', () => {
     expect(harness.stdout.some((line) => line.includes('OK shell-profile'))).toBe(true);
     expect(harness.stdout.some((line) => line.includes('OK launchctl'))).toBe(true);
     expect(harness.files.has('/tmp/workspace/.agent-workspace/bootstrap-state.yaml')).toBe(false);
+  });
+
+  it('verifies activation Skill state when requested', () => {
+    const harness = createDeps();
+    expect(runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'codex', '--install-skills', '--apply'],
+      harness.deps,
+    )).toBe(0);
+
+    harness.stdout.length = 0;
+    const exitCode = runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'codex', '--install-skills', '--verify'],
+      harness.deps,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(harness.stdout.some((line) => line.includes('OK codex-skill'))).toBe(true);
+
+    const missingHarness = createDeps();
+    expect(runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'codex', '--install-skills', '--verify'],
+      missingHarness.deps,
+    )).toBe(1);
+    expect(missingHarness.stdout.some((line) => line.includes('FAIL codex-skill'))).toBe(true);
+    expect(missingHarness.stdout.some((line) => line.includes('--install-skills --apply'))).toBe(true);
   });
 
   it('verifies shell profile through the default shell path', () => {

--- a/mcp-server/src/utils/__tests__/bootstrap-cli.test.ts
+++ b/mcp-server/src/utils/__tests__/bootstrap-cli.test.ts
@@ -177,6 +177,35 @@ describe('bootstrap cli', () => {
     expect(lines.join('\n')).toContain('launchctl setenv AGENTICOS_HOME');
   });
 
+  it('renders dry-run Skill skip and force overwrite actions', () => {
+    const lines = buildDryRunLines(
+      '/tmp/workspace',
+      'explicit --workspace',
+      [
+        { id: 'cursor', label: 'Cursor', installed: true, detection_hint: 'test' },
+      ],
+      ['cursor'],
+      {
+        apply: false,
+        verify: false,
+        firstRun: false,
+        all: false,
+        agents: ['cursor'],
+        help: false,
+        persistShellEnv: false,
+        persistLaunchctlEnv: false,
+        autoConfigureHooks: false,
+        installSkills: true,
+        forceSkills: true,
+      },
+      undefined,
+      '/Users/tester',
+    );
+
+    expect(lines.join('\n')).toContain('cursor-skill: skip');
+    expect(lines.join('\n')).toContain('overwrite user-modified managed Skill files');
+  });
+
   it('reports non-Error thrown failures', () => {
     const detectHarness = createDeps();
     detectHarness.deps.commandExists = () => {
@@ -382,6 +411,18 @@ describe('bootstrap cli', () => {
     expect(bootstrapState.agenticos_skills[0].status).toBe('current');
   });
 
+  it('skips unsupported activation Skill installs without failing apply', () => {
+    const harness = createDeps();
+
+    const exitCode = runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'cursor', '--install-skills', '--apply'],
+      harness.deps,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(harness.stdout.some((line) => line.includes('SKIP cursor-skill'))).toBe(true);
+  });
+
   it('fails Skill install on user-modified files unless force is requested', () => {
     const harness = createDeps();
     harness.files.set('/Users/tester/.codex/skills/agenticos/SKILL.md', '# custom skill\n');
@@ -400,6 +441,33 @@ describe('bootstrap cli', () => {
       forceHarness.deps,
     )).toBe(0);
     expect(forceHarness.files.get('/Users/tester/.codex/skills/agenticos/SKILL.md')).toContain('AgenticOS Activation');
+  });
+
+  it('reports Skill install write errors during apply', () => {
+    const harness = createDeps();
+    harness.deps.writeFile = (path: string, content: string) => {
+      if (path.includes('/.codex/skills/agenticos/')) throw new Error('skill path locked');
+      harness.files.set(path, content);
+    };
+
+    const exitCode = runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'codex', '--install-skills', '--apply'],
+      harness.deps,
+    );
+
+    expect(exitCode).toBe(1);
+    expect(harness.stdout.some((line) => line.includes('FAIL codex-skill: skill path locked'))).toBe(true);
+
+    const stringHarness = createDeps();
+    stringHarness.deps.writeFile = (path: string, content: string) => {
+      if (path.includes('/.codex/skills/agenticos/')) throw 'skill path string lock';
+      stringHarness.files.set(path, content);
+    };
+    expect(runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'codex', '--install-skills', '--apply'],
+      stringHarness.deps,
+    )).toBe(1);
+    expect(stringHarness.stdout.some((line) => line.includes('FAIL codex-skill: skill path string lock'))).toBe(true);
   });
 
   it('warns but does not fail when Claude hook is missing and auto configure is not requested', () => {
@@ -688,6 +756,21 @@ describe('bootstrap cli', () => {
     )).toBe(1);
     expect(missingHarness.stdout.some((line) => line.includes('FAIL codex-skill'))).toBe(true);
     expect(missingHarness.stdout.some((line) => line.includes('--install-skills --apply'))).toBe(true);
+
+    const unsupportedHarness = createDeps();
+    expect(runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'cursor', '--install-skills', '--verify'],
+      unsupportedHarness.deps,
+    )).toBe(1);
+    expect(unsupportedHarness.stdout.some((line) => line.includes('SKIP cursor-skill'))).toBe(true);
+
+    const modifiedHarness = createDeps();
+    modifiedHarness.files.set('/Users/tester/.codex/skills/agenticos/SKILL.md', '# local edit\n');
+    expect(runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'codex', '--install-skills', '--verify'],
+      modifiedHarness.deps,
+    )).toBe(1);
+    expect(modifiedHarness.stdout.some((line) => line.includes('--force-skills --apply'))).toBe(true);
   });
 
   it('verifies shell profile through the default shell path', () => {

--- a/mcp-server/src/utils/__tests__/config-audit.test.ts
+++ b/mcp-server/src/utils/__tests__/config-audit.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { renderConfigAuditResult, runConfigAudit } from '../config-audit.js';
+import { renderAgenticosSkillContent } from '../agent-skill.js';
 
 function createDeps() {
   const files = new Map<string, string>();
@@ -53,6 +54,8 @@ describe('config audit', () => {
     expect(result.canonical_workspace).toBe('/runtime/home');
     expect(rendered).toContain('process.env AGENTICOS_HOME');
     expect(rendered).toContain('Claude Code settings env');
+    expect(rendered).toContain('Claude Code AgenticOS activation Skill');
+    expect(rendered).toContain('Codex AgenticOS activation Skill');
     expect(rendered).toContain('Cursor MCP config');
     expect(rendered).toContain('/opt/homebrew/var/agenticos');
   });
@@ -171,6 +174,33 @@ describe('config audit', () => {
     expect(hook?.status).toBe('configured');
     expect(hook?.value).toBe('mcp__agenticos__agenticos_switch');
     expect(hook?.detail).toContain('Detected PostToolUse hook');
+  });
+
+  it('reports activation Skill status without making it canonical workspace input', () => {
+    const harness = createDeps();
+    harness.files.set('/Users/tester/.codex/skills/agenticos/SKILL.md', renderAgenticosSkillContent());
+
+    const result = runConfigAudit({ action: 'show', scope: 'mcp' }, harness.deps);
+    const codexSkill = result.sources.find((source) => source.id === 'codex_activation_skill');
+    const claudeSkill = result.sources.find((source) => source.id === 'claude-code_activation_skill');
+
+    expect(result.canonical_workspace).toBeNull();
+    expect(codexSkill?.status).toBe('configured');
+    expect(codexSkill?.value).toBe('agenticos-skill:v1');
+    expect(codexSkill?.contributes_to_workspace).toBe(false);
+    expect(claudeSkill?.status).toBe('missing');
+    expect(claudeSkill?.fix_target).toContain('--install-skills');
+  });
+
+  it('reports user-modified activation Skills as present with force recovery', () => {
+    const harness = createDeps();
+    harness.files.set('/Users/tester/.codex/skills/agenticos/SKILL.md', '# custom activation\n');
+
+    const result = runConfigAudit({ action: 'show', scope: 'mcp' }, harness.deps);
+    const codexSkill = result.sources.find((source) => source.id === 'codex_activation_skill');
+
+    expect(codexSkill?.status).toBe('present');
+    expect(codexSkill?.fix_target).toContain('--force-skills');
   });
 
   it('reports missing Claude Code cwd guidance hook when hooks do not match', () => {

--- a/mcp-server/src/utils/__tests__/homebrew-bootstrap-docs.test.ts
+++ b/mcp-server/src/utils/__tests__/homebrew-bootstrap-docs.test.ts
@@ -56,7 +56,8 @@ describe('homebrew bootstrap docs', () => {
       expect(doc).toContain('AGENTICOS_HOME');
       expect(doc).toContain('AGENTICOS_HOME="$AGENTICOS_HOME"');
       expect(doc).toContain('agenticos-config --validate');
-      expect(doc).toContain('agenticos-bootstrap --workspace "$AGENTICOS_HOME" --all --verify');
+      expect(doc).toContain('agenticos-bootstrap --workspace "$AGENTICOS_HOME" --all --install-skills --verify');
+      expect(doc).toContain('--install-skills');
       expect(doc).not.toContain('agenticos-bootstrap --verify');
       expect(normalized).not.toContain('seed workspace');
       expect(normalized).not.toContain('default: ~/agenticos');

--- a/mcp-server/src/utils/agent-skill.ts
+++ b/mcp-server/src/utils/agent-skill.ts
@@ -1,0 +1,290 @@
+import { createHash } from 'crypto';
+import { dirname, join } from 'path';
+import type { SupportedAgentId } from './bootstrap-helper.js';
+
+export const AGENTICOS_SKILL_TEMPLATE_VERSION = 1;
+export const AGENTICOS_SKILL_NAME = 'agenticos';
+
+const HASH_MARKER_RE = /^<!-- agenticos-skill-managed-sha256: ([a-f0-9]{64}) -->\n?/m;
+const VERSION_MARKER_RE = /<!-- agenticos-skill-template: v(\d+) -->/;
+
+export type AgentSkillStatus =
+  | 'unsupported'
+  | 'missing'
+  | 'current'
+  | 'stale-managed'
+  | 'modified-user';
+
+export interface AgentSkillTarget {
+  agentId: SupportedAgentId;
+  label: string;
+  supported: boolean;
+  path: string | null;
+  reloadHint: string;
+}
+
+export interface AgentSkillInspection {
+  agentId: SupportedAgentId;
+  target: AgentSkillTarget;
+  status: AgentSkillStatus;
+  installedVersion: number | null;
+  expectedVersion: number;
+  detail: string;
+}
+
+export interface AgentSkillInstallResult extends AgentSkillInspection {
+  ok: boolean;
+  wrote: boolean;
+  skipped: boolean;
+}
+
+export interface AgentSkillFileDeps {
+  readFile(path: string): string | null;
+  writeFile(path: string, content: string): void;
+  mkdirp(path: string): void;
+}
+
+export function resolveAgentSkillTarget(
+  agentId: SupportedAgentId,
+  homeDir: string,
+): AgentSkillTarget {
+  switch (agentId) {
+    case 'codex':
+      return {
+        agentId,
+        label: 'Codex AgenticOS activation Skill',
+        supported: true,
+        path: join(homeDir, '.codex', 'skills', AGENTICOS_SKILL_NAME, 'SKILL.md'),
+        reloadHint: 'Restart Codex or reload skills so the AgenticOS activation Skill is indexed.',
+      };
+    case 'claude-code':
+      return {
+        agentId,
+        label: 'Claude Code AgenticOS activation Skill',
+        supported: true,
+        path: join(homeDir, '.claude', 'skills', AGENTICOS_SKILL_NAME, 'SKILL.md'),
+        reloadHint: 'Restart Claude Code or reload skills so the AgenticOS activation Skill is indexed.',
+      };
+    case 'cursor':
+      return {
+        agentId,
+        label: 'Cursor AgenticOS activation Skill',
+        supported: false,
+        path: null,
+        reloadHint: 'Cursor Skill installation is not supported by AgenticOS bootstrap yet.',
+      };
+    case 'gemini-cli':
+      return {
+        agentId,
+        label: 'Gemini CLI AgenticOS activation Skill',
+        supported: false,
+        path: null,
+        reloadHint: 'Gemini CLI Skill installation is not supported by AgenticOS bootstrap yet.',
+      };
+  }
+}
+
+export function renderAgenticosSkillContent(): string {
+  const withoutHash = renderAgenticosSkillContentWithoutHash();
+  const hash = sha256(withoutHash);
+  return `<!-- agenticos-skill-managed-sha256: ${hash} -->\n${withoutHash}`;
+}
+
+export function inspectAgentSkill(
+  agentId: SupportedAgentId,
+  homeDir: string,
+  readFile: (path: string) => string | null,
+): AgentSkillInspection {
+  const target = resolveAgentSkillTarget(agentId, homeDir);
+  if (!target.supported || !target.path) {
+    return {
+      agentId,
+      target,
+      status: 'unsupported',
+      installedVersion: null,
+      expectedVersion: AGENTICOS_SKILL_TEMPLATE_VERSION,
+      detail: `${target.label} is not supported by this bootstrap version.`,
+    };
+  }
+
+  const content = readFile(target.path);
+  if (content === null) {
+    return {
+      agentId,
+      target,
+      status: 'missing',
+      installedVersion: null,
+      expectedVersion: AGENTICOS_SKILL_TEMPLATE_VERSION,
+      detail: `missing ${target.path}`,
+    };
+  }
+
+  const installedVersion = extractSkillTemplateVersion(content);
+  const storedHash = extractStoredHash(content);
+  const withoutHash = stripHashMarker(content);
+  const expectedWithoutHash = renderAgenticosSkillContentWithoutHash();
+
+  if (!installedVersion || !storedHash) {
+    return {
+      agentId,
+      target,
+      status: 'modified-user',
+      installedVersion,
+      expectedVersion: AGENTICOS_SKILL_TEMPLATE_VERSION,
+      detail: `${target.path} exists but is not a managed AgenticOS Skill.`,
+    };
+  }
+
+  if (sha256(withoutHash) !== storedHash) {
+    return {
+      agentId,
+      target,
+      status: 'modified-user',
+      installedVersion,
+      expectedVersion: AGENTICOS_SKILL_TEMPLATE_VERSION,
+      detail: `${target.path} was modified after AgenticOS installed it.`,
+    };
+  }
+
+  if (withoutHash === expectedWithoutHash) {
+    return {
+      agentId,
+      target,
+      status: 'current',
+      installedVersion,
+      expectedVersion: AGENTICOS_SKILL_TEMPLATE_VERSION,
+      detail: `current v${installedVersion} at ${target.path}`,
+    };
+  }
+
+  return {
+    agentId,
+    target,
+    status: 'stale-managed',
+    installedVersion,
+    expectedVersion: AGENTICOS_SKILL_TEMPLATE_VERSION,
+    detail: installedVersion === AGENTICOS_SKILL_TEMPLATE_VERSION
+      ? `managed Skill at ${target.path} differs from the current v${AGENTICOS_SKILL_TEMPLATE_VERSION} template`
+      : `managed Skill at ${target.path} is v${installedVersion}; expected v${AGENTICOS_SKILL_TEMPLATE_VERSION}`,
+  };
+}
+
+export function installAgentSkill(
+  agentId: SupportedAgentId,
+  homeDir: string,
+  deps: AgentSkillFileDeps,
+  options: { force?: boolean } = {},
+): AgentSkillInstallResult {
+  const inspection = inspectAgentSkill(agentId, homeDir, deps.readFile);
+  if (!inspection.target.supported || !inspection.target.path) {
+    return {
+      ...inspection,
+      ok: true,
+      wrote: false,
+      skipped: true,
+    };
+  }
+
+  if (inspection.status === 'current') {
+    return {
+      ...inspection,
+      ok: true,
+      wrote: false,
+      skipped: false,
+    };
+  }
+
+  if (inspection.status === 'modified-user' && !options.force) {
+    return {
+      ...inspection,
+      ok: false,
+      wrote: false,
+      skipped: true,
+      detail: `${inspection.detail} Rerun with --force-skills to overwrite.`,
+    };
+  }
+
+  deps.mkdirp(dirname(inspection.target.path));
+  deps.writeFile(inspection.target.path, renderAgenticosSkillContent());
+  return {
+    ...inspectAgentSkill(agentId, homeDir, deps.readFile),
+    ok: true,
+    wrote: true,
+    skipped: false,
+    detail: `installed v${AGENTICOS_SKILL_TEMPLATE_VERSION} at ${inspection.target.path}. ${inspection.target.reloadHint}`,
+  };
+}
+
+export function isAgentSkillOkForVerify(inspection: AgentSkillInspection): boolean {
+  return inspection.status === 'unsupported' || inspection.status === 'current';
+}
+
+function renderAgenticosSkillContentWithoutHash(): string {
+  return `<!-- agenticos-skill-template: v${AGENTICOS_SKILL_TEMPLATE_VERSION} -->
+---
+name: agenticos
+description: Use when the user asks to switch, enter, continue, inspect, or verify an AgenticOS project; asks pwd/current project/project status/worktree status; or says 切换到/进入/继续项目. Discover and call AgenticOS MCP first.
+version: 1.0.0
+triggers:
+  - "switch project"
+  - "switch to project"
+  - "enter project"
+  - "continue project"
+  - "current project"
+  - "project status"
+  - "worktree status"
+  - "pwd"
+  - "AgenticOS"
+  - "切换项目"
+  - "切换到"
+  - "进入项目"
+  - "继续项目"
+metadata:
+  agenticos:
+    managed: true
+    template_version: ${AGENTICOS_SKILL_TEMPLATE_VERSION}
+---
+
+# AgenticOS Activation
+
+## When To Use
+
+Use this Skill whenever the user asks to switch, enter, continue, inspect, or verify an AgenticOS-managed project or worktree. This includes natural-language requests like "switch to 360Teams", "切换到 360Teams 项目", "pwd", "current project", or "what project am I in?".
+
+## Contract
+
+AgenticOS MCP is the source of truth for project identity, project path, session binding, and explicit workdir guidance.
+
+Before using shell directory search, raw cd behavior, git branch inspection, or guessed repository paths:
+
+1. Use AgenticOS MCP project tools if they are visible. Prefer \`agenticos_status\` for current state and \`agenticos_switch\` for project switching.
+2. In Codex-like runtimes where tools may be deferred, use tool discovery for AgenticOS MCP tools before falling back to shell-only behavior.
+3. After \`agenticos_switch\` succeeds, treat its returned project path and recommended explicit workdir as authoritative for subsequent tool calls.
+4. If AgenticOS MCP tools are unavailable, say that the switch was not completed through AgenticOS. Provide recovery: run \`agenticos-bootstrap --workspace "$AGENTICOS_HOME" --all --install-skills --verify\`, repair MCP registration if needed, and restart or reload the agent.
+
+## Do Not
+
+- Do not claim that a project was switched only because a directory was found.
+- Do not substitute \`cd\`, raw filesystem search, or git branch detection for \`agenticos_switch\`.
+- Do not ignore AgenticOS output when it differs from the client shell PWD.
+- Do not continue implementation work until AgenticOS project/session alignment is clear.
+`;
+}
+
+function extractSkillTemplateVersion(content: string): number | null {
+  const match = content.match(VERSION_MARKER_RE);
+  return match ? Number(match[1]) : null;
+}
+
+function extractStoredHash(content: string): string | null {
+  const match = content.match(HASH_MARKER_RE);
+  return match ? match[1] : null;
+}
+
+function stripHashMarker(content: string): string {
+  return content.replace(HASH_MARKER_RE, '');
+}
+
+function sha256(content: string): string {
+  return createHash('sha256').update(content, 'utf-8').digest('hex');
+}

--- a/mcp-server/src/utils/bootstrap-cli.ts
+++ b/mcp-server/src/utils/bootstrap-cli.ts
@@ -6,6 +6,12 @@ import {
   inspectClaudePwdAlignmentHook,
   mergeClaudePwdAlignmentHook,
 } from './claude-pwd-hook.js';
+import {
+  installAgentSkill,
+  inspectAgentSkill,
+  isAgentSkillOkForVerify,
+  type AgentSkillInstallResult,
+} from './agent-skill.js';
 
 export interface CliOptions {
   apply: boolean;
@@ -19,6 +25,8 @@ export interface CliOptions {
   persistLaunchctlEnv: boolean;
   shellProfile?: string;
   autoConfigureHooks: boolean;
+  installSkills: boolean;
+  forceSkills: boolean;
 }
 
 export interface ApplyResult {
@@ -63,6 +71,8 @@ export function parseCliArgs(argv: string[]): CliOptions {
     persistShellEnv: false,
     persistLaunchctlEnv: false,
     autoConfigureHooks: false,
+    installSkills: false,
+    forceSkills: false,
   };
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -92,6 +102,12 @@ export function parseCliArgs(argv: string[]): CliOptions {
         break;
       case '--auto-configure-hooks':
         options.autoConfigureHooks = true;
+        break;
+      case '--install-skills':
+        options.installSkills = true;
+        break;
+      case '--force-skills':
+        options.forceSkills = true;
         break;
       case '--workspace': {
         const value = argv[index + 1];
@@ -193,6 +209,9 @@ export function runBootstrapCli(argv: string[], deps: BootstrapCliDeps): number 
     const hookConfigResult = selectedAgents.includes('claude-code')
       ? configureClaudePwdAlignmentHook(options, deps)
       : null;
+    const skillInstallResults = options.installSkills
+      ? selectedAgents.map((agentId) => applyAgentSkill(agentId, options, deps))
+      : null;
     const bootstrapStateResult = persistBootstrapState(
       workspaceSelection.workspace,
       selectedAgents,
@@ -201,6 +220,7 @@ export function runBootstrapCli(argv: string[], deps: BootstrapCliDeps): number 
       shellProfileResult,
       launchctlResult,
       hookConfigResult,
+      skillInstallResults,
       deps,
     );
 
@@ -221,6 +241,14 @@ export function runBootstrapCli(argv: string[], deps: BootstrapCliDeps): number 
       const marker = hookConfigResult.ok ? 'OK' : hookConfigResult.fatal ? 'FAIL' : 'WARN';
       deps.stdout(`${marker} claude-pwd-hook: ${hookConfigResult.detail}`);
     }
+    if (skillInstallResults) {
+      for (const result of skillInstallResults) {
+        const marker = result.ok
+          ? result.status === 'unsupported' ? 'SKIP' : 'OK'
+          : 'FAIL';
+        deps.stdout(`${marker} ${result.agentId}-skill: ${result.detail}`);
+      }
+    }
     {
       const marker = bootstrapStateResult.ok ? 'OK' : 'FAIL';
       deps.stdout(`${marker} bootstrap-state: ${bootstrapStateResult.detail}`);
@@ -230,6 +258,7 @@ export function runBootstrapCli(argv: string[], deps: BootstrapCliDeps): number 
       || (shellProfileResult && !shellProfileResult.ok)
       || (launchctlResult && !launchctlResult.ok)
       || (hookConfigResult && hookConfigResult.fatal)
+      || (skillInstallResults && skillInstallResults.some((result) => !result.ok))
       || !bootstrapStateResult.ok
       ? 1
       : 0;
@@ -244,16 +273,18 @@ export function buildHelpLines(): string[] {
     'agenticos-bootstrap — bootstrap AgenticOS MCP registrations',
     '',
     'Usage:',
-    '  agenticos-bootstrap [--workspace <path>] [--agent <id>] [--all] [--first-run] [--persist-shell-env] [--persist-launchctl-env] [--auto-configure-hooks] [--shell-profile <path>] [--verify] [--apply]',
+    '  agenticos-bootstrap [--workspace <path>] [--agent <id>] [--all] [--first-run] [--persist-shell-env] [--persist-launchctl-env] [--auto-configure-hooks] [--install-skills] [--force-skills] [--shell-profile <path>] [--verify] [--apply]',
     '',
     'Behavior:',
     '  Without `--apply`, prints a dry-run bootstrap plan.',
     '  With `--apply`, creates the workspace if needed and writes supported agent config.',
     '  With `--verify`, checks the selected agent registrations and optional persistence layers without mutating them.',
-    '  `--first-run` is a convenience mode: it implies `--apply`, enables shell persistence, and on macOS also enables launchctl persistence.',
+    '  `--first-run` is a convenience mode: it implies `--apply`, `--install-skills`, enables shell persistence, and on macOS also enables launchctl persistence.',
     '  `--persist-shell-env` also writes export AGENTICOS_HOME=... to the detected shell profile.',
     '  `--persist-launchctl-env` also runs `launchctl setenv` on macOS for GUI/session inheritance.',
     '  `--auto-configure-hooks` adds the Claude Code PostToolUse hook used to provide cwd guidance after agenticos_switch.',
+    '  `--install-skills` installs or updates the AgenticOS activation Skill for agents that support local skills.',
+    '  `--force-skills` allows `--install-skills` to overwrite a user-modified AgenticOS Skill.',
     '  Workspace selection is explicit: use `--workspace <path>` or set AGENTICOS_HOME beforehand.',
     '',
     'Supported agent ids: claude-code, codex, cursor, gemini-cli',
@@ -287,6 +318,7 @@ export function normalizeCliOptions(options: CliOptions, platform: string): CliO
   if (options.firstRun) {
     options.apply = true;
     options.persistShellEnv = true;
+    options.installSkills = true;
     if (platform === 'darwin') {
       options.persistLaunchctlEnv = true;
     }
@@ -344,6 +376,19 @@ export function buildDryRunLines(
   }
   if (options.persistLaunchctlEnv) {
     lines.push('- launchctl: run `launchctl setenv AGENTICOS_HOME ...` (macOS only)');
+  }
+  if (options.installSkills) {
+    for (const agentId of selected) {
+      const inspection = inspectAgentSkill(agentId, homeDir, () => null);
+      if (inspection.status === 'unsupported') {
+        lines.push(`- ${agentId}-skill: skip (${inspection.detail})`);
+      } else {
+        lines.push(`- ${agentId}-skill: install/update ${inspection.target.path}`);
+      }
+    }
+    if (options.forceSkills) {
+      lines.push('- agenticos-skill: overwrite user-modified managed Skill files if present');
+    }
   }
   if (selected.includes('claude-code')) {
     const settingsPath = `${homeDir}/${CLAUDE_SETTINGS_PATH}`;
@@ -418,6 +463,20 @@ function runVerification(
     }
   }
 
+  if (options.installSkills) {
+    for (const agentId of selected) {
+      const result = verifyAgentSkill(agentId, workspace, deps);
+      const marker = result.ok
+        ? result.unsupported ? 'SKIP' : 'OK'
+        : 'FAIL';
+      lines.push(`${marker} ${agentId}-skill: ${result.detail}`);
+      if (!result.ok) {
+        ok = false;
+        lines.push(`   Recovery: ${result.recovery}`);
+      }
+    }
+  }
+
   return { ok, lines };
 }
 
@@ -453,6 +512,27 @@ function applyCursor(workspace: string, deps: BootstrapCliDeps): ApplyResult {
     return { agentId: 'cursor', ok: merged.includes('"AGENTICOS_HOME"'), detail: `updated ${configPath}` };
   } catch (error) {
     return { agentId: 'cursor', ok: false, detail: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+function applyAgentSkill(
+  agentId: SupportedAgentId,
+  options: CliOptions,
+  deps: BootstrapCliDeps,
+): AgentSkillInstallResult {
+  try {
+    return installAgentSkill(agentId, deps.homeDir, deps, {
+      force: options.forceSkills,
+    });
+  } catch (error) {
+    const inspection = inspectAgentSkill(agentId, deps.homeDir, deps.readFile);
+    return {
+      ...inspection,
+      ok: false,
+      wrote: false,
+      skipped: false,
+      detail: error instanceof Error ? error.message : String(error),
+    };
   }
 }
 
@@ -602,6 +682,24 @@ function verifyClaudePwdGuidanceHook(deps: BootstrapCliDeps): { ok: boolean; det
     : { ok: false, detail: `${inspection.detail} Expected cwd guidance hook in ${settingsPath}.` };
 }
 
+function verifyAgentSkill(
+  agentId: SupportedAgentId,
+  workspace: string,
+  deps: BootstrapCliDeps,
+): { ok: boolean; unsupported: boolean; detail: string; recovery: string } {
+  const inspection = inspectAgentSkill(agentId, deps.homeDir, deps.readFile);
+  const ok = isAgentSkillOkForVerify(inspection);
+  const recoveryArgs = ['--workspace', workspace, '--agent', agentId, '--install-skills'];
+  if (inspection.status === 'modified-user') recoveryArgs.push('--force-skills');
+  recoveryArgs.push('--apply');
+  return {
+    ok,
+    unsupported: inspection.status === 'unsupported',
+    detail: inspection.detail,
+    recovery: formatCommand({ command: 'agenticos-bootstrap', args: recoveryArgs }),
+  };
+}
+
 function persistBootstrapState(
   workspace: string,
   selectedAgents: SupportedAgentId[],
@@ -610,6 +708,7 @@ function persistBootstrapState(
   shellProfileResult: { ok: boolean; detail: string } | null,
   launchctlResult: { ok: boolean; detail: string } | null,
   hookConfigResult: HookConfigResult | null,
+  skillInstallResults: AgentSkillInstallResult[] | null,
   deps: BootstrapCliDeps,
 ): { ok: boolean; detail: string } {
   try {
@@ -621,6 +720,7 @@ function persistBootstrapState(
       && (!shellProfileResult || shellProfileResult.ok)
       && (!launchctlResult || launchctlResult.ok)
       && (!hookConfigResult || !hookConfigResult.fatal)
+      && (!skillInstallResults || skillInstallResults.every((result) => result.ok))
       ? 'success'
       : 'partial-failure';
 
@@ -639,6 +739,8 @@ function persistBootstrapState(
         persist_shell_env: options.persistShellEnv,
         persist_launchctl_env: options.persistLaunchctlEnv,
         auto_configure_hooks: options.autoConfigureHooks,
+        install_skills: options.installSkills,
+        force_skills: options.forceSkills,
         claude_pwd_hook: hookConfigResult
           ? {
             ok: hookConfigResult.ok,
@@ -646,6 +748,17 @@ function persistBootstrapState(
             detail: hookConfigResult.detail,
           }
           : null,
+        agenticos_skills: skillInstallResults
+          ? skillInstallResults.map((result) => ({
+            agent_id: result.agentId,
+            ok: result.ok,
+            status: result.status,
+            wrote: result.wrote,
+            skipped: result.skipped,
+            path: result.target.path,
+            detail: result.detail,
+          }))
+          : [],
         shell_profile_path: options.persistShellEnv
           ? (options.shellProfile || detectDefaultShellProfile(deps.env.SHELL, deps.homeDir))
           : null,

--- a/mcp-server/src/utils/config-audit.ts
+++ b/mcp-server/src/utils/config-audit.ts
@@ -217,9 +217,7 @@ function readAgentSkillSource(
     ? 'configured'
     : inspection.status === 'missing'
       ? 'missing'
-      : inspection.status === 'unsupported'
-        ? 'unavailable'
-        : 'present';
+      : 'present';
   const fixTarget = `agenticos-bootstrap --agent ${agentId} --install-skills --apply`;
   return {
     id: `${agentId}_activation_skill`,
@@ -227,9 +225,9 @@ function readAgentSkillSource(
     scope: 'mcp',
     status,
     value: inspection.status === 'current'
-      ? `agenticos-skill:v${inspection.installedVersion || inspection.expectedVersion}`
+      ? `agenticos-skill:v${inspection.installedVersion}`
       : null,
-    location: inspection.target.path || `${agentId} local skills directory`,
+    location: inspection.target.path!,
     fix_target: inspection.status === 'modified-user'
       ? `${fixTarget} --force-skills`
       : fixTarget,

--- a/mcp-server/src/utils/config-audit.ts
+++ b/mcp-server/src/utils/config-audit.ts
@@ -4,6 +4,8 @@ import {
   CLAUDE_PWD_ALIGNMENT_HOOK_MATCHER,
   inspectClaudePwdAlignmentHook,
 } from './claude-pwd-hook.js';
+import { inspectAgentSkill } from './agent-skill.js';
+import type { SupportedAgentId } from './bootstrap-helper.js';
 
 export type ConfigAuditAction = 'show' | 'validate';
 export type ConfigAuditScope = 'all' | 'runtime' | 'mcp' | 'homebrew';
@@ -197,11 +199,45 @@ function collectConfigSources(deps: ConfigAuditDeps): ConfigSourceRecord[] {
     readLaunchctlSource(deps),
     readClaudeSettingsSource(deps),
     readClaudePwdAlignmentHookSource(deps),
+    readAgentSkillSource(deps, 'claude-code'),
     readClaudeLegacySource(deps),
     readCodexConfigSource(deps),
+    readAgentSkillSource(deps, 'codex'),
     readCursorConfigSource(deps),
     ...readHomebrewSources(deps),
   ];
+}
+
+function readAgentSkillSource(
+  deps: ConfigAuditDeps,
+  agentId: SupportedAgentId,
+): ConfigSourceRecord {
+  const inspection = inspectAgentSkill(agentId, deps.homeDir, deps.readFile);
+  const status = inspection.status === 'current'
+    ? 'configured'
+    : inspection.status === 'missing'
+      ? 'missing'
+      : inspection.status === 'unsupported'
+        ? 'unavailable'
+        : 'present';
+  const fixTarget = `agenticos-bootstrap --agent ${agentId} --install-skills --apply`;
+  return {
+    id: `${agentId}_activation_skill`,
+    label: inspection.target.label,
+    scope: 'mcp',
+    status,
+    value: inspection.status === 'current'
+      ? `agenticos-skill:v${inspection.installedVersion || inspection.expectedVersion}`
+      : null,
+    location: inspection.target.path || `${agentId} local skills directory`,
+    fix_target: inspection.status === 'modified-user'
+      ? `${fixTarget} --force-skills`
+      : fixTarget,
+    detail: status === 'configured'
+      ? inspection.detail
+      : `${inspection.detail} Rerun bootstrap with --install-skills to install or update it.`,
+    contributes_to_workspace: false,
+  };
 }
 
 function readClaudePwdAlignmentHookSource(deps: ConfigAuditDeps): ConfigSourceRecord {


### PR DESCRIPTION
Fixes #432.

## Summary
- Add a managed AgenticOS activation Skill template for Codex and Claude Code, with hash-based stale/update detection and user-modified overwrite protection.
- Extend `agenticos-bootstrap` with `--install-skills` and `--force-skills`; `--first-run` now installs supported activation Skills.
- Add config audit and bootstrap verification coverage for activation Skill state, plus Homebrew/README/bootstrap-matrix guidance based on the GBrain/Hermes Skill + MCP split.

## Verification
- `cd mcp-server && npm ci`
- `cd mcp-server && npm test -- --run src/utils/__tests__/agent-skill.test.ts src/utils/__tests__/bootstrap-cli.test.ts src/utils/__tests__/config-audit.test.ts src/utils/__tests__/homebrew-bootstrap-docs.test.ts src/utils/__tests__/bootstrap-matrix.test.ts src/utils/__tests__/integration-mode-docs.test.ts`
- `cd mcp-server && npm run lint`
- `cd mcp-server && npm test -- --run`
- `./tools/coverage-preflight.sh`
- `./scripts/readme-lint.sh` (0 errors; existing warnings/recommendations remain)
- `git diff --check`
- `agenticos_pr_scope_check`: PASS
