### PR TITLE
chore: prepare v0.4.25 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No unreleased changes._
 
+## [0.4.25] — 2026-05-21
+
+### Added
+- bootstrap: managed AgenticOS activation Skills can now be installed for Codex and Claude Code with `agenticos-bootstrap --install-skills`; `--first-run` installs them by default for supported agents.
+- bootstrap: `--force-skills` explicitly overwrites user-modified AgenticOS Skill files, while normal installs update only missing or AgenticOS-managed stale copies.
+- config audit: AgenticOS activation Skill state is now reported alongside MCP registration and cwd guidance hook state.
+
+### Changed
+- docs: Homebrew, bootstrap matrix, and README guidance now document the GBrain/Hermes-style split where Skills provide pre-tool routing and MCP remains the source of truth for project switching, status, and workdir guidance.
+
 ## [0.4.24] — 2026-05-20
 
 ### Fixed

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenticos-mcp",
-  "version": "0.4.24",
+  "version": "0.4.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenticos-mcp",
-      "version": "0.4.24",
+      "version": "0.4.25",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-mcp",
-  "version": "0.4.24",
+  "version": "0.4.25",
   "description": "MCP Server for AgenticOS - AI-native project management system",
   "type": "module",
   "bin": {

--- a/mcp-server/src/__tests__/mcp-regression-baseline.json
+++ b/mcp-server/src/__tests__/mcp-regression-baseline.json
@@ -1,9 +1,9 @@
 {
-  "capturedAt": "2026-05-20T10:16:34.000Z",
-  "version": "0.4.24",
+  "capturedAt": "2026-05-21T06:58:00.000Z",
+  "version": "0.4.25",
   "serverInfo": {
     "name": "agenticos-mcp",
-    "version": "0.4.24"
+    "version": "0.4.25"
   },
   "protocolVersion": "2025-11-25",
   "capabilities": {


### PR DESCRIPTION
Fixes #434.

## Summary
- Bump `agenticos-mcp` package metadata to `0.4.25`.
- Add CHANGELOG entry for the AgenticOS activation Skill bootstrap work from #432/#433.
- Refresh MCP regression baseline version metadata for `0.4.25`.

## Verification
- `cd mcp-server && npm ci`
- `cd mcp-server && npm run lint`
- `cd mcp-server && npm test -- --run`
- `GITHUB_EVENT_NAME=pull_request GITHUB_BASE_REF=main GITHUB_SHA=$(git rev-parse HEAD) GITHUB_REF_NAME=chore/434-release-0-4-25-metadata ./tools/coverage-preflight.sh`
- `./scripts/readme-lint.sh` (0 errors; existing warnings/recommendations remain)
- `git diff --check`
- `agenticos_pr_scope_check`: PASS
