### PR TITLE
chore: sync source formula to v0.4.25

### DIFF
--- a/homebrew-tap/Formula/agenticos.rb
+++ b/homebrew-tap/Formula/agenticos.rb
@@ -3,9 +3,9 @@ require "language/node"
 class Agenticos < Formula
   desc "AI-native project management MCP server for coding agents"
   homepage "https://github.com/madlouse/AgenticOS"
-  url "https://github.com/madlouse/AgenticOS/releases/download/v0.4.24/agenticos-mcp.tgz"
-  version "0.4.24"
-  sha256 "e3dcf2c029772cbfc1b5d9d9a871d59d5640b4ff3ec86ec8ccb1b30a8b0e7622"
+  url "https://github.com/madlouse/AgenticOS/releases/download/v0.4.25/agenticos-mcp.tgz"
+  version "0.4.25"
+  sha256 "eadc75c8967d7cdefa8a20c590ec8f81be4eeb8ba69967362f12ed377e7a5229"
   license "MIT"
 
   depends_on "node"


### PR DESCRIPTION
Fixes #436

## Summary
- Sync the source repository copy of the Homebrew formula to the published v0.4.25 asset.
- Keep the source formula in line with the manually updated external tap commit madlouse/homebrew-agenticos@394e562.

## Verification
- ruby -c homebrew-tap/Formula/agenticos.rb
- git diff --check
- agenticos_pr_scope_check PASS