### PR TITLE
docs: review AgenticOS goal completion

### DIFF
--- a/standards/knowledge/agenticos-goal-completion-and-hermes-gbrain-matrix-review-2026-05-21.md
+++ b/standards/knowledge/agenticos-goal-completion-and-hermes-gbrain-matrix-review-2026-05-21.md
@@ -1,0 +1,191 @@
+# AgenticOS Goal Completion And Hermes/GBrain Matrix Review - 2026-05-21
+
+## Purpose
+
+Issue #439 asks whether AgenticOS is actually reaching the intended "OS for
+agents" goal, and whether the Hermes/GBrain capability matrix fits the
+AgenticOS product design.
+
+This review uses these evidence sources:
+
+- AgenticOS product design: `standards/knowledge/complete-design.md`.
+- AgenticOS integration policy:
+  `standards/knowledge/integration-mode-matrix-2026-03-25.md`.
+- Knowledge-evolution audit:
+  `standards/knowledge/agenticos-knowledge-evolution-audit-2026-05-21.md`.
+- Hermes-side evidence:
+  `/Users/jeking/dev/AgenticOS/projects/hermes-agent/knowledge/hermes-capability-matrix.md`.
+- Personal-agent architecture:
+  `/Users/jeking/dev/AgenticOS/projects/hermes-agent/knowledge/personal-agent-brain-architecture.md`.
+- GitHub issue and PR evidence through #442.
+
+## Bottom Line
+
+AgenticOS has reached a strong engineering-project OS shape. The issue-first
+workflow, isolated worktrees, guardrail preflight/edit checks, project boundary
+resolution, release discipline, and cross-agent bootstrap surfaces are real and
+actively used.
+
+It has not yet fully reached the broader personal/topic OS goal. The missing
+piece is not another memory database. The missing piece is a first-class
+lightweight topic lifecycle that connects Hermes-side assistant work, GBrain
+durable knowledge, and AgenticOS project/topic state without forcing every
+long-running personal subject into a full engineering project.
+
+The correct product split is:
+
+| Layer | Primary role | Assessment |
+| --- | --- | --- |
+| Hermes | Lightweight assistant, entry point, triage, communication, first-pass research | Integration side, not canonical project OS |
+| GBrain | Shared durable knowledge and semantic memory across agents | Complementary memory substrate |
+| AgenticOS MCP | Canonical project/topic identity, state, tasks, guardrails, switch/status, explicit workdir guidance | Primary AgenticOS runtime |
+| AgenticOS Skills | Pre-tool routing and activation so agents discover AgenticOS before lazy-load failure | Assistive fallback, not data plane |
+| Codex / Claude Code | Production execution agents for code, docs, tests, releases, and deeper research artifacts | Execution clients governed by AgenticOS workflow |
+
+## Goal Completion Matrix
+
+Scale:
+
+- `5` means the capability is dependable in real work.
+- `3` means the capability exists but still needs manual interpretation or
+  operational care.
+- `1` means the capability is mostly conceptual.
+
+| Goal | Score | Status | Evidence | Remaining gap |
+| --- | ---: | --- | --- | --- |
+| Agent First plus Human Readable project surfaces | 4 | Strong | `complete-design.md` defines `.project.yaml`, `.context`, `knowledge`, `tasks`, and `artifacts`; standard-kit surfaces exist across projects | Downstream adapter surfaces can be stale, especially older `AGENTS.md`/`CLAUDE.md` copies |
+| MCP-native project switching and session binding | 4 | Strong | #260/#262 removed home-global active-project authority; #428/#429 validate registered paths and clarify explicit workdir guidance | MCP cannot mutate parent-shell cwd; agents still need activation guidance before tool discovery |
+| Issue-first execution and rollback-friendly workflow | 5 | Complete for engineering work | #33, #36, #113, #158, #179 plus current strict issue bootstrap/preflight/edit guard/scope check flow | Requires agent compliance; still benefits from clearer surfaced failure recovery |
+| Project boundary and worktree isolation | 5 | Complete for active product work | #160, #164, #268, #297 and runtime worktree cleanup are actively used | False blocks can still happen when canonical checkout and issue worktree paths are mixed |
+| Guardrail evidence and status visibility | 4 | Strong | #62, #74, #76, #97, #345 show guardrail evidence and coverage workflow | Freshness checks are present but not yet a complete knowledge-evolution health surface |
+| Context publication and raw transcript privacy | 4 | Strong | #244, #245, #246, #363 establish private/public continuity and capture/distill split | No measurable ledger yet showing whether each capture was distilled, converted to task, or ignored |
+| Knowledge evolution across sessions | 3 | Partially complete | #440/#442 found strong durable synthesis and execution closure in AgenticOS, hermes-agent, and Agentic CI/API | Entry state freshness, dirty-WIP visibility, and distillation status are not first-class |
+| Cross-agent bootstrap and lazy-load resilience | 4 | Strong but young | #432/#433 and v0.4.25 added managed activation Skills for Codex and Claude Code, with Homebrew/bootstrap docs | Needs field validation across agents after install/upgrade; Skills must remain assistive, not canonical state |
+| Homebrew/release distribution | 3 | Operational but brittle | v0.4.23-v0.4.25 fixed release formula sync, source formula sync, activation Skill packaging, and metadata | #438 remains open because `HOMEBREW_TAP_PAT` existed but release saw an empty token; release workflow needs early secret guard |
+| Hermes-side personal/topic continuity | 2 | Mostly conceptual | Hermes and GBrain architecture exists; #441 is open to define AgenticOS topic integration | AgenticOS lacks a lightweight durable-topic model distinct from full engineering projects |
+
+## Issue And PR Alignment
+
+The current issue history maps cleanly to the design layers:
+
+| Design area | Representative issues/PRs | Result |
+| --- | --- | --- |
+| Universal project contract | #26, #31, #34, #35, #72, #118, #313 | Durable project files and standard-kit expectations are defined and executable |
+| MCP-native runtime | #23, #62, #97, #260, #262, #363 | Session-local project state and guardrail evidence are now runtime concepts |
+| Issue-first workflow | #32, #33, #36, #113, #158, #179 | Agents are expected to bootstrap issue context before implementation |
+| Boundary isolation | #160, #164, #268, #297, #311 | Product source, workspace home, and worktree roots are separated |
+| Project switch/cwd | #379, #393, #397, #407, #409, #428, PR #429 | Switch now binds MCP session and returns authoritative explicit workdir guidance |
+| Lazy-load activation | #432, PR #433, v0.4.25 | Codex and Claude Code get managed AgenticOS activation Skills |
+| Knowledge evolution | #440, PR #442 | Real-project audit exists; follow-up surfaces are identified |
+| Release/Homebrew | #400, #402, #416, #423, #426, #434, #436, #438 | Release path is much better, but Homebrew tap credential handling still needs an operator-verified guard |
+
+This alignment supports the product direction. Most AgenticOS issues are not
+random fixes; they close concrete gaps in the same layered OS model.
+
+## Hermes/GBrain Matrix Alignment
+
+Hermes' current capability matrix says:
+
+```text
+Hermes = life/work assistant + retrieval + coordination
+Codex / Claude Code = production tools
+GBrain = shared second brain
+```
+
+That is compatible with AgenticOS if AgenticOS keeps its own boundary:
+
+| Hermes/GBrain capability | AgenticOS fit | Assessment |
+| --- | --- | --- |
+| ChatGPT/Codex subscription model routing | Adjacent | Useful for Hermes economics and model access, but not an AgenticOS project-state concern |
+| GBrain second brain | Complementary | GBrain should hold durable semantic knowledge; AgenticOS should hold workflow state, tasks, issue history, and project/topic context |
+| Hermes access to GBrain MCP | Complementary | Hermes can capture and retrieve memory, then route durable work into AgenticOS when stateful execution is needed |
+| Codex access to GBrain MCP | Complementary | Codex can use GBrain for background knowledge, but should still use AgenticOS for project switch, worktree, preflight, and PR flow |
+| Claude Code access to GBrain MCP | Complementary | Same as Codex; GBrain augments knowledge, AgenticOS governs execution context |
+| Remote MCP access to GBrain | Adjacent | Useful for multi-device memory; should not become an implicit AgenticOS project registry |
+| Weixin/Feishu entries | Hermes-side only | Good assistant entry points; escalation into AgenticOS should be explicit when a durable topic or project emerges |
+| Gateway daemon | Hermes-side only | Runtime hosting detail, not an AgenticOS product surface |
+| Productivity Skills | Strong alignment | Mirrors #432/#433: Skills are activation and routing aids before MCP lazy-load, not a second data plane |
+| Secret boundary | Strong alignment | Hermes' "no raw secrets in memory/logs" rule matches AgenticOS' public/private continuity and secret-handling posture |
+
+## Design Fit
+
+The best integrated architecture is a three-memory-plus-execution model:
+
+1. Hermes local memory keeps assistant preferences, identity cues, and short
+   conversational continuity.
+2. GBrain durable knowledge keeps cross-agent semantic memory: people, concepts,
+   decisions, research summaries, and references to where credentials live.
+3. AgenticOS project/topic context keeps operational continuity: current state,
+   tasks, artifacts, issue/PR evidence, guardrail evidence, and distilled
+   project knowledge.
+4. Codex and Claude Code execute implementation, deep research artifacts,
+   validation, PRs, releases, and rollback-friendly changes.
+
+This preserves the AgenticOS integration-mode decision:
+
+- MCP-native remains the canonical primary mode.
+- MCP + Skills Assist is supported for routing and operator ergonomics.
+- CLI wrappers remain diagnostics/bootstrap fallback.
+- Skills-only guidance is not a supported runtime mode.
+
+## Current Mismatches
+
+1. Hermes and GBrain are memory-centered, while AgenticOS is workflow-centered.
+   That is healthy, but the boundary is not yet documented as a product model.
+2. AgenticOS can preserve project knowledge, but it cannot yet show a fresh
+   end-to-end "session capture -> distilled knowledge/task -> current topic
+   state" chain.
+3. AgenticOS handles engineering projects well; it lacks a lightweight topic
+   type for personal growth, recurring research, and assistant-mediated life
+   workflows.
+4. The activation Skill solves a real lazy-load problem, but it must remain a
+   pointer to AgenticOS MCP. If Skills start carrying state or replacing switch
+   semantics, the product will split into conflicting modes.
+5. Release automation is close but still operationally fragile while #438 is
+   open. A missing/empty Homebrew tap token should fail early with a clear
+   operator checklist.
+
+## Product Recommendations
+
+1. Complete #441 before adding more Hermes-side implementation. The product
+   needs a durable-topic model before agents improvise inconsistent behavior.
+2. Add a knowledge-evolution health surface. It should compare latest sidecar
+   capture, latest state refresh, latest knowledge update, adapter template
+   freshness, and dirty worktree state.
+3. Add a distillation ledger. Session records should have statuses like
+   `captured`, `distilled_to_knowledge`, `converted_to_task`, `superseded`, or
+   `ignored_with_reason`.
+4. Add a freshness reconciliation warning for registry/session/state drift.
+   `agenticos_status` or `agenticos_health` should make stale entry state hard
+   to miss.
+5. Keep GBrain integration as a knowledge substrate, not as the AgenticOS
+   registry. AgenticOS can write distilled facts to GBrain, but project identity
+   and execution state should remain under AgenticOS.
+6. Keep activation Skills small and managed. The v0.4.25 design is correct:
+   install/update the Skill through bootstrap/Homebrew, hash managed content,
+   and ask the agent to discover MCP before shell guessing.
+7. Add a release workflow early guard for `HOMEBREW_TAP_PAT` as a follow-up to
+   #438 after the operator confirms the secret setup.
+
+## Prioritized Backlog
+
+| Priority | Backlog item | Existing issue | Why it comes next |
+| --- | --- | --- | --- |
+| P0 | Define AgenticOS integration model for Hermes-side durable topics | #441 | Required boundary before personal/topic OS work can be implemented coherently |
+| P1 | Add knowledge-evolution health/status surface | New follow-up | Directly addresses #440's evidence gap around freshness and WIP visibility |
+| P1 | Add session distillation ledger | New follow-up | Turns capture/distill from a convention into an auditable lifecycle |
+| P1 | Add status freshness reconciliation warnings | New follow-up | Prevents stale `.context/state.yaml` and registry/session drift from misleading agents |
+| P2 | Add standard-kit refresh issue path for stale downstream adapters | New follow-up | Recurring stale `AGENTS.md`/`CLAUDE.md` evidence appeared in #440 |
+| P2 | Add release early-fail guard for missing Homebrew tap token | #438 follow-up | Avoids another release that reaches Homebrew bump before discovering missing credentials |
+
+## Conclusion
+
+AgenticOS is no longer just a design sketch. It already works as a serious
+agentic engineering OS: issues, worktrees, guardrails, PRs, tests, releases,
+and project context are tied together in a repeatable way.
+
+The next step is to widen that OS carefully. Hermes and GBrain should not blur
+AgenticOS' execution contract; they should feed it. #441 should define the
+lightweight durable-topic path so personal and cognitive-growth work can gain
+state, tasks, and knowledge evolution without pretending every topic is a
+software repository.


### PR DESCRIPTION
Fixes #439

## Summary
- Adds a standards knowledge review of AgenticOS goal completion against the Hermes/GBrain capability matrix.
- Scores core AgenticOS goals across project state, MCP-native switching, issue-first workflow, guardrails, knowledge evolution, Homebrew release reliability, and Hermes-side topic continuity.
- Maps Hermes/GBrain capabilities to AgenticOS product boundaries and records a prioritized backlog led by #441.

## Verification
- ./scripts/readme-lint.sh (0 errors; existing warnings/recommendations remain)
- git diff --check
- grep coverage for #441, Hermes/GBrain, MCP-native, Skills Assist, and prioritized backlog
- cd mcp-server && npm ci
- cd mcp-server && npm run lint
- cd mcp-server && npm test -- --run (65 files, 910 tests)
- agenticos_pr_scope_check PASS