### PR TITLE
fix: sanitize branch bootstrap issue ids

### DIFF
--- a/mcp-server/src/tools/__tests__/branch-bootstrap.test.ts
+++ b/mcp-server/src/tools/__tests__/branch-bootstrap.test.ts
@@ -118,6 +118,156 @@ describe('runBranchBootstrap', () => {
     }));
   });
 
+  it('sanitizes issue ids before deriving branch and worktree names', async () => {
+    execAsyncMock.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('rev-parse origin/main')) {
+        return { stdout: 'base123\n', stderr: '' };
+      }
+      if (cmd.includes('rev-parse --show-toplevel')) {
+        return { stdout: '/repo/mcp-server\n', stderr: '' };
+      }
+      if (cmd.includes('rev-parse --git-common-dir')) {
+        return { stdout: '/repo/.git\n', stderr: '' };
+      }
+      if (cmd.includes('config --get remote.origin.url')) {
+        return { stdout: 'https://github.com/madlouse/AgenticOS.git\n', stderr: '' };
+      }
+      if (cmd.includes('show-ref --verify --quiet refs/heads/fix/441-durable-topic')) {
+        throw new Error('branch missing');
+      }
+      if (cmd.includes('worktree add "/workspace/worktrees/agenticos/repo-441-durable-topic" -b fix/441-durable-topic base123')) {
+        return { stdout: 'Preparing worktree\n', stderr: '' };
+      }
+      throw new Error(`Unexpected command: ${cmd}`);
+    });
+
+    const result = JSON.parse(await runBranchBootstrap({
+      issue_id: '#441',
+      branch_type: 'fix',
+      slug: 'durable topic',
+      repo_path: '/repo/mcp-server',
+      remote_base_branch: 'origin/main',
+    })) as {
+      status: string;
+      branch_name: string;
+      sanitized_issue_id: string;
+      worktree_path: string;
+      notes: string[];
+    };
+
+    expect(result.status).toBe('CREATED');
+    expect(result.sanitized_issue_id).toBe('441');
+    expect(result.branch_name).toBe('fix/441-durable-topic');
+    expect(result.worktree_path).toBe('/workspace/worktrees/agenticos/repo-441-durable-topic');
+    expect(result.branch_name).not.toMatch(/[#\s\x00-\x1f]/);
+    expect(result.worktree_path).not.toMatch(/[#\s\x00-\x1f]/);
+    expect(result.notes.join(' ')).toContain('sanitized issue_id "#441" to "441"');
+  });
+
+  it('blocks issue ids that normalize to an empty segment', async () => {
+    const result = JSON.parse(await runBranchBootstrap({
+      issue_id: '###',
+      branch_type: 'fix',
+      slug: 'durable topic',
+      repo_path: '/repo/mcp-server',
+      remote_base_branch: 'origin/main',
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons).toContain('issue_id must contain at least one alphanumeric character');
+    expect(execAsyncMock).not.toHaveBeenCalled();
+  });
+
+  it('removes path separators, spaces, and control characters from issue id segments', async () => {
+    execAsyncMock.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('rev-parse origin/main')) {
+        return { stdout: 'base123\n', stderr: '' };
+      }
+      if (cmd.includes('rev-parse --show-toplevel')) {
+        return { stdout: '/repo/mcp-server\n', stderr: '' };
+      }
+      if (cmd.includes('rev-parse --git-common-dir')) {
+        return { stdout: '/repo/.git\n', stderr: '' };
+      }
+      if (cmd.includes('config --get remote.origin.url')) {
+        return { stdout: 'https://github.com/madlouse/AgenticOS.git\n', stderr: '' };
+      }
+      if (cmd.includes('show-ref --verify --quiet refs/heads/fix/gh-441-topic')) {
+        throw new Error('branch missing');
+      }
+      if (cmd.includes('worktree add "/workspace/worktrees/agenticos/repo-gh-441-topic" -b fix/gh-441-topic base123')) {
+        return { stdout: 'Preparing worktree\n', stderr: '' };
+      }
+      throw new Error(`Unexpected command: ${cmd}`);
+    });
+
+    const result = JSON.parse(await runBranchBootstrap({
+      issue_id: ' GH/441\n',
+      branch_type: 'fix',
+      slug: 'topic',
+      repo_path: '/repo/mcp-server',
+    })) as { status: string; branch_name: string; sanitized_issue_id: string; worktree_path: string };
+
+    expect(result.status).toBe('CREATED');
+    expect(result.sanitized_issue_id).toBe('gh-441');
+    expect(result.branch_name).toBe('fix/gh-441-topic');
+    expect(result.worktree_path).toBe('/workspace/worktrees/agenticos/repo-gh-441-topic');
+  });
+
+  it('blocks branch types that normalize to an empty segment', async () => {
+    const result = JSON.parse(await runBranchBootstrap({
+      issue_id: '445',
+      branch_type: '///',
+      slug: 'safe branch names',
+      repo_path: '/repo/mcp-server',
+    })) as { status: string; block_reasons: string[] };
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.block_reasons).toContain('branch_type must contain at least one alphanumeric character');
+    expect(execAsyncMock).not.toHaveBeenCalled();
+  });
+
+  it('sanitizes branch types before deriving branch names', async () => {
+    execAsyncMock.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('rev-parse origin/main')) {
+        return { stdout: 'base123\n', stderr: '' };
+      }
+      if (cmd.includes('rev-parse --show-toplevel')) {
+        return { stdout: '/repo/mcp-server\n', stderr: '' };
+      }
+      if (cmd.includes('rev-parse --git-common-dir')) {
+        return { stdout: '/repo/.git\n', stderr: '' };
+      }
+      if (cmd.includes('config --get remote.origin.url')) {
+        return { stdout: 'https://github.com/madlouse/AgenticOS.git\n', stderr: '' };
+      }
+      if (cmd.includes('show-ref --verify --quiet refs/heads/fix-bug/441-topic')) {
+        throw new Error('branch missing');
+      }
+      if (cmd.includes('worktree add "/workspace/worktrees/agenticos/repo-441-topic" -b fix-bug/441-topic base123')) {
+        return { stdout: 'Preparing worktree\n', stderr: '' };
+      }
+      throw new Error(`Unexpected command: ${cmd}`);
+    });
+
+    const result = JSON.parse(await runBranchBootstrap({
+      issue_id: '441',
+      branch_type: 'Fix Bug',
+      slug: 'topic',
+      repo_path: '/repo/mcp-server',
+    })) as {
+      status: string;
+      branch_name: string;
+      sanitized_branch_type: string;
+      notes: string[];
+    };
+
+    expect(result.status).toBe('CREATED');
+    expect(result.sanitized_branch_type).toBe('fix-bug');
+    expect(result.branch_name).toBe('fix-bug/441-topic');
+    expect(result.notes.join(' ')).toContain('sanitized branch_type "Fix Bug" to "fix-bug"');
+  });
+
   it('accepts a deprecated override when it normalizes to the derived root', async () => {
     execAsyncMock.mockImplementation(async (cmd: string) => {
       if (cmd.includes('rev-parse origin/main')) {

--- a/mcp-server/src/tools/branch-bootstrap.ts
+++ b/mcp-server/src/tools/branch-bootstrap.ts
@@ -25,6 +25,8 @@ interface BranchBootstrapResult {
   branch_name: string;
   base_commit: string;
   worktree_path: string;
+  sanitized_issue_id: string;
+  sanitized_branch_type: string;
   notes: string[];
   block_reasons: string[];
   persistence?: GuardrailPersistenceResult;
@@ -58,6 +60,8 @@ function makeBaseResult(): BranchBootstrapResult {
     branch_name: '',
     base_commit: '',
     worktree_path: '',
+    sanitized_issue_id: '',
+    sanitized_branch_type: '',
     notes: [],
     block_reasons: [],
   };
@@ -111,9 +115,21 @@ export async function runBranchBootstrap(args: BranchBootstrapArgs): Promise<str
     return JSON.stringify(result, null, 2);
   }
 
+  const sanitizedIssueId = sanitizeSegment(issue_id);
+  const sanitizedBranchType = sanitizeSegment(branch_type);
   const sanitizedSlug = sanitizeSegment(slug);
+  result.sanitized_issue_id = sanitizedIssueId;
+  result.sanitized_branch_type = sanitizedBranchType;
+  if (!sanitizedIssueId) {
+    result.block_reasons.push('issue_id must contain at least one alphanumeric character');
+  }
+  if (!sanitizedBranchType) {
+    result.block_reasons.push('branch_type must contain at least one alphanumeric character');
+  }
   if (!sanitizedSlug) {
     result.block_reasons.push('slug must contain at least one alphanumeric character');
+  }
+  if (result.block_reasons.length > 0) {
     result.persistence = await persistGuardrailEvidence({
       command: 'agenticos_branch_bootstrap',
       repo_path,
@@ -136,6 +152,12 @@ export async function runBranchBootstrap(args: BranchBootstrapArgs): Promise<str
       },
     });
     return JSON.stringify(result, null, 2);
+  }
+  if (sanitizedIssueId !== issue_id) {
+    result.notes.push(`sanitized issue_id "${issue_id}" to "${sanitizedIssueId}"`);
+  }
+  if (sanitizedBranchType !== branch_type) {
+    result.notes.push(`sanitized branch_type "${branch_type}" to "${sanitizedBranchType}"`);
   }
 
   const projectResolution = await resolveGuardrailProjectTarget({
@@ -215,8 +237,8 @@ export async function runBranchBootstrap(args: BranchBootstrapArgs): Promise<str
     gitRemoteOrigin = await runGit(repo_path, 'config --get remote.origin.url').catch(() => '');
     const repoName = sanitizeSegment(basename(gitCommonRepoRoot)) || sanitizeSegment(basename(repo_path)) || 'repo';
 
-    result.branch_name = `${branch_type}/${issue_id}-${sanitizedSlug}`;
-    result.worktree_path = join(worktreeRoot, `${repoName}-${issue_id}-${sanitizedSlug}`);
+    result.branch_name = `${sanitizedBranchType}/${sanitizedIssueId}-${sanitizedSlug}`;
+    result.worktree_path = join(worktreeRoot, `${repoName}-${sanitizedIssueId}-${sanitizedSlug}`);
     result.base_commit = await runGit(repo_path, `rev-parse ${remote_base_branch}`);
 
     const repoIdentity = validateGuardrailRepoIdentity({


### PR DESCRIPTION
Fixes #445

## Summary
- Sanitize `issue_id` and `branch_type` before deriving branch and worktree names in `agenticos_branch_bootstrap`.
- Surface `sanitized_issue_id` and `sanitized_branch_type` in the bootstrap output.
- Add regression tests for leading `#`, path separators, spaces, control characters, and empty sanitized issue ids.

## Verification
- cd mcp-server && npm ci
- cd mcp-server && npm test -- --run src/tools/__tests__/branch-bootstrap.test.ts (21 tests)
- cd mcp-server && npm run lint
- cd mcp-server && npm test -- --run (65 files, 913 tests)
- ./tools/coverage-preflight.sh (aggregate pass true, changed-scope pass true)
- git diff --check
- agenticos_pr_scope_check PASS