### PR TITLE
feat: add project kind routing metadata

### DIFF
--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -45,6 +45,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
           name: { type: 'string', description: 'Project name' },
           description: { type: 'string', description: 'Project description' },
           path: { type: 'string', description: 'Optional custom path (otherwise uses $AGENTICOS_HOME/projects/{id})' },
+          project_kind: { type: 'string', enum: ['topic', 'project'], description: 'Optional AgenticOS routing kind. Defaults to project; use topic for durable non-repo topics.' },
           topology: { type: 'string', enum: ['local_directory_only', 'github_versioned'], description: 'Required source-control topology for the project.' },
           context_publication_policy: { type: 'string', enum: ['local_private', 'private_continuity', 'public_distilled'], description: 'Context publication policy. local_directory_only projects use local_private; github_versioned projects must choose private_continuity or public_distilled.' },
           github_repo: { type: 'string', description: 'Required when topology is github_versioned. Use OWNER/REPO.' },

--- a/mcp-server/src/tools/__tests__/init.test.ts
+++ b/mcp-server/src/tools/__tests__/init.test.ts
@@ -127,6 +127,17 @@ describe('initProject', () => {
     expect(result).toContain('Context Publication: local_private');
   });
 
+  it('fails when project_kind is unsupported', async () => {
+    await expect(
+      initProject({
+        name: 'Test Project',
+        description: 'A test project',
+        topology: 'local_directory_only',
+        project_kind: 'workflow',
+      }),
+    ).rejects.toThrow('agenticos.project_kind');
+  });
+
   it('rejects custom paths with control characters', async () => {
     await expect(
       initProject({
@@ -181,10 +192,27 @@ describe('initProject', () => {
     expect(parsed.meta.id).toBe('test-project');
     expect(parsed.meta.description).toBe('A test project');
     expect(parsed.meta.version).toBe('1.0.0');
+    expect(parsed.agenticos.project_kind).toBe('project');
     expect(parsed.source_control.topology).toBe('local_directory_only');
     expect(parsed.source_control.context_publication_policy).toBe('local_private');
     expect(parsed.agent_context.quick_start).toBe('.context/quick-start.md');
     expect(parsed.agent_context.current_state).toBe('.context/state.yaml');
+  });
+
+  it('writes topic project kind when requested', async () => {
+    await initProject({
+      name: 'Topic Project',
+      description: 'A durable topic',
+      topology: 'local_directory_only',
+      project_kind: 'topic',
+    });
+
+    const writeCalls = fsPromisesMock.writeFile.mock.calls;
+    const projectYamlCall = writeCalls.find((c) => c[0].endsWith('.project.yaml'));
+    expect(projectYamlCall).toBeDefined();
+
+    const parsed = JSON.parse(projectYamlCall![1] as string);
+    expect(parsed.agenticos.project_kind).toBe('topic');
   });
 
   it('writes github versioned source control metadata and repo root binding', async () => {
@@ -427,6 +455,7 @@ describe('initProject', () => {
     expect(result).toContain('Test Project');
     expect(result).toContain('test-project');
     expect(result).toContain('Active');
+    expect(result).toContain('Project Kind: project');
     expect(result).toContain('agenticos_switch');
   });
 
@@ -600,6 +629,49 @@ describe('initProject', () => {
     expect(result).toContain('agenticos_switch');
   });
 
+  it('returns normalization guidance for a registered project with invalid project kind', async () => {
+    fsMock.existsSync.mockReturnValue(true);
+    fsPromisesMock.access.mockResolvedValue(undefined);
+    fsPromisesMock.readFile.mockImplementation(async (path: any) => {
+      const normalizedPath = String(path);
+      if (normalizedPath.endsWith('registry.yaml')) {
+        return JSON.stringify({
+          version: '1.0.0',
+          last_updated: '2025-01-01T00:00:00.000Z',
+          active_project: 'test-project',
+          projects: [
+            {
+              id: 'test-project',
+              name: 'Test Project',
+              path: '/home/testuser/AgenticOS/projects/test-project',
+              status: 'active',
+              created: '2025-01-01',
+              last_accessed: '2025-01-01T00:00:00.000Z',
+            },
+          ],
+        });
+      }
+
+      if (normalizedPath.endsWith('.project.yaml')) {
+        return JSON.stringify({
+          meta: { id: 'test-project', name: 'Test Project' },
+          agenticos: { project_kind: 'workflow' },
+          source_control: {
+            topology: 'local_directory_only',
+            context_publication_policy: 'local_private',
+          },
+        });
+      }
+
+      throw new Error(`Unexpected readFile path: ${normalizedPath}`);
+    });
+
+    const result = await initProject({ name: 'Test Project', topology: 'local_directory_only' });
+
+    expect(result).toContain('agenticos.project_kind');
+    expect(result).toContain('normalize_existing=true');
+  });
+
   it('returns re-register guidance when a project path exists but the registry entry is missing', async () => {
     fsMock.existsSync.mockReturnValue(false);
     fsPromisesMock.access.mockResolvedValue(undefined);
@@ -716,6 +788,7 @@ describe('initProject', () => {
     expect(projectYamlCall).toBeDefined();
     const parsed = JSON.parse(String(projectYamlCall![1]));
     expect(parsed.execution).toEqual({ sandbox: 'workspace-write' });
+    expect(parsed.agenticos.project_kind).toBe('project');
     expect(parsed.agent_context.quick_start).toBe('docs/quick-start.md');
     expect(parsed.agent_context.current_state).toBe('runtime/state.yaml');
     expect(parsed.agent_context.conversations).toBe('runtime/conversations/');
@@ -772,6 +845,98 @@ describe('initProject', () => {
     const projectYamlCall = fsPromisesMock.writeFile.mock.calls.find((c) => String(c[0]).endsWith('.project.yaml'));
     expect(projectYamlCall).toBeDefined();
     expect(JSON.parse(String(projectYamlCall![1])).execution).toBeUndefined();
+  });
+
+  it('normalizes an existing valid topic without requiring a new project_kind argument', async () => {
+    fsMock.existsSync.mockReturnValue(true);
+    fsPromisesMock.access.mockResolvedValue(undefined);
+    fsPromisesMock.readFile.mockImplementation(async (path: any) => {
+      const normalizedPath = String(path);
+      if (normalizedPath.endsWith('registry.yaml')) {
+        return JSON.stringify({
+          version: '1.0.0',
+          last_updated: '2025-01-01T00:00:00.000Z',
+          active_project: 'topic-project',
+          projects: [
+            {
+              id: 'topic-project',
+              name: 'Topic Project',
+              path: '/home/testuser/AgenticOS/projects/topic-project',
+              status: 'active',
+              created: '2025-01-01',
+              last_accessed: '2025-01-01T00:00:00.000Z',
+            },
+          ],
+        });
+      }
+
+      if (normalizedPath.endsWith('.project.yaml')) {
+        return JSON.stringify({
+          meta: { name: 'Topic Project', id: 'topic-project' },
+          agenticos: { project_kind: 'topic' },
+          source_control: {
+            topology: 'local_directory_only',
+            context_publication_policy: 'local_private',
+          },
+        });
+      }
+
+      throw new Error(`Unexpected readFile path: ${normalizedPath}`);
+    });
+
+    await initProject({
+      name: 'Topic Project',
+      topology: 'local_directory_only',
+      normalize_existing: true,
+    });
+
+    const projectYamlCall = fsPromisesMock.writeFile.mock.calls.find((c) => String(c[0]).endsWith('.project.yaml'));
+    expect(projectYamlCall).toBeDefined();
+    expect(JSON.parse(String(projectYamlCall![1])).agenticos.project_kind).toBe('topic');
+  });
+
+  it('fails closed when normalizing an existing project with invalid project_kind and no replacement value', async () => {
+    fsMock.existsSync.mockReturnValue(true);
+    fsPromisesMock.access.mockResolvedValue(undefined);
+    fsPromisesMock.readFile.mockImplementation(async (path: any) => {
+      const normalizedPath = String(path);
+      if (normalizedPath.endsWith('registry.yaml')) {
+        return JSON.stringify({
+          version: '1.0.0',
+          last_updated: '2025-01-01T00:00:00.000Z',
+          active_project: 'test-project',
+          projects: [
+            {
+              id: 'test-project',
+              name: 'Test Project',
+              path: '/home/testuser/AgenticOS/projects/test-project',
+              status: 'active',
+              created: '2025-01-01',
+              last_accessed: '2025-01-01T00:00:00.000Z',
+            },
+          ],
+        });
+      }
+
+      if (normalizedPath.endsWith('.project.yaml')) {
+        return JSON.stringify({
+          meta: { name: 'Test Project', id: 'test-project' },
+          agenticos: { project_kind: 'workflow' },
+          source_control: {
+            topology: 'local_directory_only',
+            context_publication_policy: 'local_private',
+          },
+        });
+      }
+
+      throw new Error(`Unexpected readFile path: ${normalizedPath}`);
+    });
+
+    await expect(initProject({
+      name: 'Test Project',
+      topology: 'local_directory_only',
+      normalize_existing: true,
+    })).rejects.toThrow('project_kind="topic"');
   });
 
   it('normalizes an existing path even when legacy project yaml cannot be parsed', async () => {

--- a/mcp-server/src/tools/__tests__/project.test.ts
+++ b/mcp-server/src/tools/__tests__/project.test.ts
@@ -213,7 +213,67 @@ describe('switchProject', () => {
     expect(result).toContain('Switched to project');
     expect(result).toContain('My Project');
     expect(result).toContain('/test/path');
+    expect(result).toContain('Kind: project');
     expect(registryMock.patchProjectMetadata).toHaveBeenCalled();
+  });
+
+  it('surfaces topic project kind on switch', async () => {
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: null,
+      projects: [
+        {
+          id: 'my-topic',
+          name: 'My Topic',
+          path: '/test/path',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    fsPromisesMock.readFile.mockResolvedValue(JSON.stringify({
+      meta: { description: '' },
+      agenticos: { project_kind: 'topic' },
+      source_control: { topology: 'local_directory_only' },
+    }));
+
+    const result = await switchProject({ project: 'my-topic' });
+
+    expect(result).toContain('Switched to project');
+    expect(result).toContain('Kind: topic');
+  });
+
+  it('fails closed when switch reads an invalid project kind', async () => {
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: null,
+      projects: [
+        {
+          id: 'my-project',
+          name: 'My Project',
+          path: '/test/path',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    fsPromisesMock.readFile.mockResolvedValue(JSON.stringify({
+      meta: { description: '' },
+      agenticos: { project_kind: 'workflow' },
+      source_control: { topology: 'local_directory_only' },
+    }));
+
+    const result = await switchProject({ project: 'my-project' });
+
+    expect(result).toContain('❌');
+    expect(result).toContain('agenticos.project_kind');
+    expect(registryMock.patchProjectMetadata).not.toHaveBeenCalled();
   });
 
   it('finds project by name', async () => {
@@ -1820,6 +1880,10 @@ describe('listProjects', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     clearSessionProjectBinding();
+    yamlMock.parse.mockImplementation((content: string) => {
+      try { return JSON.parse(content); } catch { return undefined; }
+    });
+    fsPromisesMock.readFile.mockRejectedValue(new Error('ENOENT'));
   });
 
   afterEach(() => {
@@ -1872,6 +1936,15 @@ describe('listProjects', () => {
         },
       ],
     });
+    fsPromisesMock.readFile.mockImplementation(async (path: string) => {
+      if (path === '/path/a/.project.yaml') {
+        return JSON.stringify({ agenticos: { project_kind: 'topic' } });
+      }
+      if (path === '/path/b/.project.yaml') {
+        return JSON.stringify({});
+      }
+      throw new Error(`Unexpected readFile path: ${path}`);
+    });
 
     const result = await listProjects();
 
@@ -1882,8 +1955,36 @@ describe('listProjects', () => {
     expect(result).toContain('/path/b');
     expect(result).toContain('active');
     expect(result).toContain('archived');
+    expect(result).toContain('Kind: topic');
+    expect(result).toContain('Kind: project');
     // Active project should have indicator
     expect(result).toContain('project-a');
+  });
+
+  it('fails closed when list reads an invalid project kind', async () => {
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: null,
+      projects: [
+        {
+          id: 'project-a',
+          name: 'Project A',
+          path: '/path/a',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+    fsPromisesMock.readFile.mockResolvedValue(JSON.stringify({
+      agenticos: { project_kind: 'workflow' },
+    }));
+
+    const result = await listProjects();
+
+    expect(result).toContain('❌');
+    expect(result).toContain('agenticos.project_kind');
   });
 
   it('shows Never for last recorded when not set', async () => {
@@ -1907,6 +2008,29 @@ describe('listProjects', () => {
     const result = await listProjects();
 
     expect(result).toContain('Never');
+  });
+
+  it('defaults list project kind when project yaml parses to null', async () => {
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: null,
+      projects: [
+        {
+          id: 'project-a',
+          name: 'Project A',
+          path: '/path/a',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+    fsPromisesMock.readFile.mockResolvedValue('null');
+
+    const result = await listProjects();
+
+    expect(result).toContain('Kind: project');
   });
 });
 
@@ -1993,6 +2117,7 @@ describe('getStatus', () => {
     mockStatusReads(
       {
         meta: { id: 'test-project', name: 'Test Project' },
+        agenticos: { project_kind: 'topic' },
         source_control: { topology: 'local_directory_only' },
       },
       {
@@ -2009,10 +2134,49 @@ describe('getStatus', () => {
     const result = await getStatus();
 
     expect(result).toContain('Test Project');
+    expect(result).toContain('Project kind: topic');
     expect(result).toContain('Implement X');
     expect(result).toContain('in_progress');
     expect(result).toContain('task 1');
     expect(result).toContain('decision 1');
+  });
+
+  it('fails closed when status reads an invalid project kind', async () => {
+    bindSessionProject({
+      projectId: 'test-project',
+      projectName: 'Test Project',
+      projectPath: '/test/path',
+    });
+
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: 'test-project',
+      projects: [
+        {
+          id: 'test-project',
+          name: 'Test Project',
+          path: '/test/path',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    mockStatusReads(
+      {
+        meta: { id: 'test-project', name: 'Test Project' },
+        agenticos: { project_kind: 'workflow' },
+        source_control: { topology: 'local_directory_only' },
+      },
+      {},
+    );
+
+    const result = await getStatus();
+
+    expect(result).toContain('❌');
+    expect(result).toContain('agenticos.project_kind');
   });
 
   it('surfaces bootstrap failures from the runtime workspace state file', async () => {

--- a/mcp-server/src/tools/init.ts
+++ b/mcp-server/src/tools/init.ts
@@ -3,7 +3,7 @@ import { join } from 'path';
 import yaml from 'yaml';
 import { loadRegistry, patchRegistry, getAgenticOSHome } from '../utils/registry.js';
 import { generateClaudeMd, generateAgentsMd } from '../utils/distill.js';
-import { buildProjectTopologyInitializationMessage, hasDeclaredContextPublicationPolicy, validateContextPublicationPolicy, type ContextPublicationPolicy, type ProjectTopology } from '../utils/project-contract.js';
+import { buildProjectTopologyInitializationMessage, hasDeclaredContextPublicationPolicy, validateContextPublicationPolicy, validateProjectKind, type ContextPublicationPolicy, type ProjectKind, type ProjectTopology } from '../utils/project-contract.js';
 import { resolveManagedProjectContextDisplayPaths, resolveManagedProjectContextPaths } from '../utils/agent-context-paths.js';
 import { ensureCaseKnowledgeDirectories } from '../utils/case-knowledge.js';
 import { validatePathSecurity } from '../utils/session-context.js';
@@ -67,6 +67,28 @@ function resolveTopologyArgs(args: any): { topology: ProjectTopology; rawContext
   };
 }
 
+function resolveProjectKindArg(
+  name: string,
+  rawProjectKind: unknown,
+  existingProjectYaml: any = {},
+): ProjectKind {
+  if (rawProjectKind !== undefined) {
+    const validation = validateProjectKind(name, {
+      agenticos: { project_kind: rawProjectKind },
+    });
+    if (!validation.ok) {
+      throw new Error(`${validation.message} Pass project_kind="topic" or project_kind="project".`);
+    }
+    return validation.project_kind;
+  }
+
+  const validation = validateProjectKind(name, existingProjectYaml);
+  if (!validation.ok) {
+    throw new Error(`${validation.message} Re-run agenticos_init with normalize_existing=true and project_kind="topic" or project_kind="project" to repair it.`);
+  }
+  return validation.project_kind;
+}
+
 async function loadExistingProjectYaml(projectPath: string): Promise<any> {
   try {
     return yaml.parse(await readFile(join(projectPath, '.project.yaml'), 'utf-8')) || {};
@@ -103,9 +125,10 @@ function buildProjectYaml(args: {
   existingProjectYaml?: any;
   topology: ProjectTopology;
   contextPublicationPolicy: ContextPublicationPolicy;
+  projectKind: ProjectKind;
   githubRepo?: string;
 }): any {
-  const { name, id, description, existingProjectYaml = {}, topology, contextPublicationPolicy, githubRepo } = args;
+  const { name, id, description, existingProjectYaml = {}, topology, contextPublicationPolicy, projectKind, githubRepo } = args;
   const today = new Date().toISOString().split('T')[0];
   const meta = existingProjectYaml?.meta || {};
   const merged: any = {
@@ -117,6 +140,10 @@ function buildProjectYaml(args: {
       description: description ?? meta.description ?? '',
       created: meta.created || today,
       version: meta.version || '1.0.0',
+    },
+    agenticos: {
+      ...(existingProjectYaml?.agenticos && typeof existingProjectYaml.agenticos === 'object' ? existingProjectYaml.agenticos : {}),
+      project_kind: projectKind,
     },
     source_control: {
       topology,
@@ -187,6 +214,10 @@ export async function initProject(args: any): Promise<string> {
     if (!publicationValidation.ok) {
       return `${publicationValidation.message} Re-run agenticos_init with normalize_existing=true and the intended topology/publication contract.`;
     }
+    const projectKindValidation = validateProjectKind(name, existingProjectYaml);
+    if (!projectKindValidation.ok) {
+      return `${projectKindValidation.message} Re-run agenticos_init with normalize_existing=true and project_kind="topic" or project_kind="project".`;
+    }
     return `Project '${name}' already exists at ${projectPath}. Use \`agenticos_switch\` to activate it.`;
   }
 
@@ -209,6 +240,7 @@ export async function initProject(args: any): Promise<string> {
     rawContextPublicationPolicy,
     existingProjectYaml,
   );
+  const projectKind = resolveProjectKindArg(name, args.project_kind, existingProjectYaml);
   const today = new Date().toISOString().split('T')[0];
   const projectYaml = buildProjectYaml({
     name,
@@ -217,6 +249,7 @@ export async function initProject(args: any): Promise<string> {
     existingProjectYaml,
     topology,
     contextPublicationPolicy,
+    projectKind,
     githubRepo,
   });
   await writeFile(join(projectPath, '.project.yaml'), yaml.stringify(projectYaml), 'utf-8');
@@ -289,6 +322,7 @@ ${description ?? existingProjectYaml?.meta?.description ?? ''}
     ? `Topology: github_versioned (${githubRepo}, github_flow)`
     : 'Topology: local_directory_only';
   const publicationLine = `Context Publication: ${contextPublicationPolicy}`;
+  const projectKindLine = `Project Kind: ${projectKind}`;
   const prefix = pathExists ? 'Normalized' : 'Created';
-  return `✅ ${prefix} project "${name}" at ${projectPath}\n\nProject ID: ${id}\nStatus: Active\n${topologyLine}\n${publicationLine}\n\nUse agenticos_switch to load this project context.`;
+  return `✅ ${prefix} project "${name}" at ${projectPath}\n\nProject ID: ${id}\nStatus: Active\n${projectKindLine}\n${topologyLine}\n${publicationLine}\n\nUse agenticos_switch to load this project context.`;
 }

--- a/mcp-server/src/tools/project.ts
+++ b/mcp-server/src/tools/project.ts
@@ -6,7 +6,7 @@ import { getAgenticOSHome, loadRegistry, patchProjectMetadata } from '../utils/r
 import { generateClaudeMd, generateAgentsMd, updateClaudeMdState, upgradeClaudeMd, CURRENT_TEMPLATE_VERSION, extractTemplateVersion } from '../utils/distill.js';
 import { adoptStandardKit, checkStandardKitUpgrade } from '../utils/standard-kit.js';
 import { writeFile } from 'fs/promises';
-import { buildArchivedReferenceMessage, isArchivedReferenceProject, validateManagedProjectTopology } from '../utils/project-contract.js';
+import { buildArchivedReferenceMessage, isArchivedReferenceProject, validateManagedProjectTopology, validateProjectKind, type ProjectKind } from '../utils/project-contract.js';
 import { resolveManagedProjectContextPaths, resolveManagedProjectTarget } from '../utils/project-target.js';
 import { loadLatestGuardrailState, type IssueBootstrapRecord, type IssueBootstrapState } from '../utils/guardrail-evidence.js';
 import { resolveManagedProjectContextDisplayPaths } from '../utils/agent-context-paths.js';
@@ -376,7 +376,28 @@ function buildFilesystemAlignmentLines(
 }
 
 function stripPwdWarningPrefix(warning: string | null): string {
+  /* c8 ignore next -- alignPwd failure results currently always include a warning string */
   return warning?.replace(/^\[WARN\] PWD alignment skipped:\s*/, '') || 'project path is not usable';
+}
+
+function validateProjectKindOrThrow(projectName: string, projectYaml: any): ProjectKind {
+  const validation = validateProjectKind(projectName, projectYaml);
+  if (!validation.ok) {
+    throw new Error(`${validation.message} Re-run agenticos_init with normalize_existing=true and project_kind="topic" or project_kind="project".`);
+  }
+  return validation.project_kind;
+}
+
+async function readProjectKindForList(projectName: string, projectPath: string): Promise<ProjectKind> {
+  try {
+    const projectYaml = yaml.parse(await readFile(join(projectPath, '.project.yaml'), 'utf-8')) || {};
+    return validateProjectKindOrThrow(projectName, projectYaml);
+  } catch (error: any) {
+    if (error?.message?.includes('agenticos.project_kind')) {
+      throw error;
+    }
+    return 'project';
+  }
 }
 
 export async function switchProject(args: any): Promise<string> {
@@ -416,6 +437,12 @@ export async function switchProject(args: any): Promise<string> {
   const topologyValidation = validateManagedProjectTopology(found.name, projectYaml);
   if (!topologyValidation.ok) {
     return `❌ ${topologyValidation.message}`;
+  }
+  let projectKind: ProjectKind;
+  try {
+    projectKind = validateProjectKindOrThrow(found.name, projectYaml);
+  } catch (error: any) {
+    return `❌ ${error.message}`;
   }
 
   found.last_accessed = new Date().toISOString();
@@ -575,7 +602,7 @@ export async function switchProject(args: any): Promise<string> {
   });
   const filesystemAlignmentSummary = buildFilesystemAlignmentLines(found.path, pwdResult);
 
-  return `✅ Switched to project "${found.name}"\n\nPath: ${found.path}\nStatus: ${found.status}\n${filesystemAlignmentSummary.join('\n')}\n\n${contextSummary.join('\n')}${committedSnapshotSummary.length > 0 ? `\n${committedSnapshotSummary.join('\n')}` : ''}\n${transcriptRoutingSummary.length > 0 ? `\n${transcriptRoutingSummary.join('\n')}\n` : '\n'}Context loaded from:\n- ${found.path}/.project.yaml\n- ${contextPaths.quickStartPath}\n- ${contextPaths.statePath}\n\n${guardrailSummary.join('\n')}\n${issueBootstrapSummary.join('\n')}${bootstrap}`;
+  return `✅ Switched to project "${found.name}"\n\nPath: ${found.path}\nStatus: ${found.status}\nKind: ${projectKind}\n${filesystemAlignmentSummary.join('\n')}\n\n${contextSummary.join('\n')}${committedSnapshotSummary.length > 0 ? `\n${committedSnapshotSummary.join('\n')}` : ''}\n${transcriptRoutingSummary.length > 0 ? `\n${transcriptRoutingSummary.join('\n')}\n` : '\n'}Context loaded from:\n- ${found.path}/.project.yaml\n- ${contextPaths.quickStartPath}\n- ${contextPaths.statePath}\n\n${guardrailSummary.join('\n')}\n${issueBootstrapSummary.join('\n')}${bootstrap}`;
 }
 
 export async function listProjects(): Promise<string> {
@@ -589,10 +616,17 @@ export async function listProjects(): Promise<string> {
   const lines = ['# AgenticOS Projects\n'];
 
   for (const p of registry.projects) {
+    let projectKind: ProjectKind;
+    try {
+      projectKind = await readProjectKindForList(p.name, p.path);
+    } catch (error: any) {
+      return `❌ ${error.message}`;
+    }
     const active = p.id === sessionProject?.projectId ? '🟢 ' : '';
     lines.push(`${active}**${p.name}** (${p.id})`);
     lines.push(`  Path: ${p.path}`);
     lines.push(`  Status: ${p.status}`);
+    lines.push(`  Kind: ${projectKind}`);
     if (p.last_recorded) {
       const recordedDate = new Date(p.last_recorded).toLocaleString('zh-CN', { timeZone: 'Asia/Shanghai' });
       lines.push(`  Last recorded: ${recordedDate}`);
@@ -617,6 +651,12 @@ export async function getStatus(args: any = {}): Promise<string> {
   }
 
   const { project, statePath } = resolved;
+  let projectKind: ProjectKind;
+  try {
+    projectKind = validateProjectKindOrThrow(project.name, resolved.projectYaml);
+  } catch (error: any) {
+    return `❌ ${error.message}`;
+  }
   let state: any = {};
   let displayState: any = {};
   try {
@@ -637,6 +677,7 @@ export async function getStatus(args: any = {}): Promise<string> {
 
   const lines: string[] = [];
   lines.push(`# Status: ${project.name}\n`);
+  lines.push(`🧭 Project kind: ${projectKind}`);
 
   if (project.last_recorded) {
     const recordedDate = new Date(project.last_recorded).toLocaleString('zh-CN', { timeZone: 'Asia/Shanghai' });

--- a/mcp-server/src/utils/__tests__/project-contract.test.ts
+++ b/mcp-server/src/utils/__tests__/project-contract.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import { validateContextPublicationPolicy } from '../project-contract.js';
+import {
+  buildArchivedReferenceMessage,
+  buildProjectTopologyInitializationMessage,
+  getArchiveContract,
+  getSourceControlContract,
+  isArchivedReferenceProject,
+  validateContextPublicationPolicy,
+  validateManagedProjectTopology,
+  validateProjectKind,
+} from '../project-contract.js';
 
 describe('validateContextPublicationPolicy', () => {
   it('accepts local_private for local_directory_only projects', () => {
@@ -67,6 +76,187 @@ describe('validateContextPublicationPolicy', () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.message).toContain('context_publication_policy');
+    }
+  });
+
+  it('rejects publication validation when topology is missing', () => {
+    const result = validateContextPublicationPolicy('Missing Topology', {});
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain('source_control.topology');
+    }
+  });
+});
+
+describe('validateProjectKind', () => {
+  it('defaults missing agenticos.project_kind to project', () => {
+    expect(validateProjectKind('Legacy Project', {})).toEqual({ ok: true, project_kind: 'project' });
+  });
+
+  it('defaults missing project_kind on an agenticos object to project', () => {
+    expect(validateProjectKind('AgenticOS Block', {
+      agenticos: { owner: 'agenticos' },
+    })).toEqual({ ok: true, project_kind: 'project' });
+  });
+
+  it('defaults non-object agenticos metadata to project', () => {
+    expect(validateProjectKind('Legacy AgenticOS Block', {
+      agenticos: 'legacy',
+    })).toEqual({ ok: true, project_kind: 'project' });
+  });
+
+  it('accepts topic and project values', () => {
+    expect(validateProjectKind('Topic Project', {
+      agenticos: { project_kind: 'topic' },
+    })).toEqual({ ok: true, project_kind: 'topic' });
+
+    expect(validateProjectKind('Engineering Project', {
+      agenticos: { project_kind: 'project' },
+    })).toEqual({ ok: true, project_kind: 'project' });
+  });
+
+  it('trims valid project_kind values', () => {
+    expect(validateProjectKind('Trimmed Topic', {
+      agenticos: { project_kind: ' topic ' },
+    })).toEqual({ ok: true, project_kind: 'topic' });
+  });
+
+  it('rejects unsupported project_kind values', () => {
+    const result = validateProjectKind('Bad Project', {
+      agenticos: { project_kind: 'workflow' },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain('agenticos.project_kind');
+      expect(result.message).toContain('topic');
+      expect(result.message).toContain('project');
+    }
+  });
+
+  it('rejects non-string project_kind values', () => {
+    const result = validateProjectKind('Bad Project', {
+      agenticos: { project_kind: 42 },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain('42');
+    }
+  });
+});
+
+describe('archive project contract', () => {
+  it('returns archive contracts only when the contract is an object', () => {
+    expect(getArchiveContract({ archive_contract: { kind: 'archived_reference' } })).toEqual({ kind: 'archived_reference' });
+    expect(getArchiveContract({})).toBeNull();
+    expect(getArchiveContract({ archive_contract: 'archived' })).toBeNull();
+  });
+
+  it('detects archived reference projects by registry status and contract fields', () => {
+    expect(isArchivedReferenceProject({}, 'archived')).toBe(true);
+    expect(isArchivedReferenceProject({})).toBe(false);
+    expect(isArchivedReferenceProject({ archive_contract: { kind: 'archived_reference' } })).toBe(true);
+    expect(isArchivedReferenceProject({ archive_contract: { managed_project: false } })).toBe(true);
+    expect(isArchivedReferenceProject({ archive_contract: { execution_mode: 'reference_only' } })).toBe(true);
+    expect(isArchivedReferenceProject({ archive_contract: { kind: 'active' } })).toBe(false);
+  });
+
+  it('builds archived reference messages with and without replacements', () => {
+    expect(buildArchivedReferenceMessage('Old Project')).toContain('Old Project');
+    expect(buildArchivedReferenceMessage('Old Project')).not.toContain('Use "');
+    expect(buildArchivedReferenceMessage('Old Project', 'New Project')).toContain('Use "New Project" instead');
+  });
+});
+
+describe('managed project topology contract', () => {
+  it('returns source control contracts only when the contract is an object', () => {
+    expect(getSourceControlContract({ source_control: { topology: 'local_directory_only' } })).toEqual({ topology: 'local_directory_only' });
+    expect(getSourceControlContract({})).toBeNull();
+    expect(getSourceControlContract({ source_control: 'local_directory_only' })).toBeNull();
+  });
+
+  it('builds topology initialization guidance', () => {
+    expect(buildProjectTopologyInitializationMessage('Legacy Project')).toContain('normalize_existing=true');
+  });
+
+  it('validates local_directory_only topology', () => {
+    expect(validateManagedProjectTopology('Local Project', {
+      source_control: { topology: 'local_directory_only' },
+    })).toEqual({ ok: true, topology: 'local_directory_only' });
+  });
+
+  it('rejects missing topology', () => {
+    const result = validateManagedProjectTopology('Legacy Project', {});
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain('has not completed');
+    }
+  });
+
+  it('rejects github_versioned topology without github_repo', () => {
+    const result = validateManagedProjectTopology('Repo Project', {
+      source_control: { topology: 'github_versioned' },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain('github_repo');
+    }
+  });
+
+  it('rejects github_versioned topology without github_flow branch strategy', () => {
+    const result = validateManagedProjectTopology('Repo Project', {
+      source_control: {
+        topology: 'github_versioned',
+        github_repo: 'madlouse/repo-project',
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain('branch_strategy');
+    }
+  });
+
+  it('rejects github_versioned topology without source repo roots', () => {
+    const result = validateManagedProjectTopology('Repo Project', {
+      source_control: {
+        topology: 'github_versioned',
+        github_repo: 'madlouse/repo-project',
+        branch_strategy: 'github_flow',
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain('source_repo_roots');
+    }
+  });
+
+  it('accepts github_versioned topology with at least one non-empty string source repo root', () => {
+    expect(validateManagedProjectTopology('Repo Project', {
+      source_control: {
+        topology: 'github_versioned',
+        github_repo: 'madlouse/repo-project',
+        branch_strategy: 'github_flow',
+      },
+      execution: {
+        source_repo_roots: [' ', 7, '.'],
+      },
+    })).toEqual({ ok: true, topology: 'github_versioned' });
+  });
+
+  it('rejects unsupported topology values', () => {
+    const result = validateManagedProjectTopology('Repo Project', {
+      source_control: { topology: 'workspace' },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain('unsupported');
     }
   });
 });

--- a/mcp-server/src/utils/project-contract.ts
+++ b/mcp-server/src/utils/project-contract.ts
@@ -8,6 +8,7 @@ interface ArchiveContract {
 
 export type ProjectTopology = 'local_directory_only' | 'github_versioned';
 export type ContextPublicationPolicy = 'local_private' | 'private_continuity' | 'public_distilled';
+export type ProjectKind = 'topic' | 'project';
 
 interface SourceControlContract {
   topology?: ProjectTopology;
@@ -16,8 +17,43 @@ interface SourceControlContract {
   branch_strategy?: string;
 }
 
+interface AgenticOSProjectContract {
+  project_kind?: ProjectKind;
+}
+
 export function isValidContextPublicationPolicy(value: unknown): value is ContextPublicationPolicy {
   return value === 'local_private' || value === 'private_continuity' || value === 'public_distilled';
+}
+
+export function isValidProjectKind(value: unknown): value is ProjectKind {
+  return value === 'topic' || value === 'project';
+}
+
+function getAgenticOSProjectContract(projectYaml: any): AgenticOSProjectContract | null {
+  const contract = projectYaml?.agenticos;
+  if (!contract || typeof contract !== 'object') {
+    return null;
+  }
+  return contract as AgenticOSProjectContract;
+}
+
+export function validateProjectKind(projectName: string, projectYaml: any): { ok: true; project_kind: ProjectKind } | { ok: false; message: string } {
+  const contract = getAgenticOSProjectContract(projectYaml);
+
+  if (!contract || !Object.prototype.hasOwnProperty.call(contract, 'project_kind')) {
+    return { ok: true, project_kind: 'project' };
+  }
+
+  const rawKind = contract.project_kind;
+  const projectKind = typeof rawKind === 'string' ? rawKind.trim() : rawKind;
+  if (isValidProjectKind(projectKind)) {
+    return { ok: true, project_kind: projectKind };
+  }
+
+  return {
+    ok: false,
+    message: `Project "${projectName}" declares unsupported agenticos.project_kind "${String(rawKind)}". Supported values are "topic" and "project".`,
+  };
 }
 
 export function hasDeclaredContextPublicationPolicy(projectYaml: any): boolean {


### PR DESCRIPTION
## Summary
- add agenticos.project_kind validation with default project and accepted topic/project values
- let agenticos_init write and repair project kind metadata
- surface project kind in agenticos_switch, agenticos_list, and agenticos_status, with invalid values failing closed

Fixes #447

## Verification
- cd mcp-server && npm ci
- cd mcp-server && npm test -- --run src/utils/__tests__/project-contract.test.ts src/tools/__tests__/init.test.ts src/tools/__tests__/project.test.ts
- cd mcp-server && npm run lint
- ./tools/coverage-preflight.sh
- cd mcp-server && npm test -- --run
- ./scripts/readme-lint.sh (0 errors; existing 8 warnings / 2 recommendations)
- git diff --check
- agenticos_pr_scope_check PASS