### PR TITLE
feat: add durable task MCP API

### DIFF
--- a/mcp-server/src/__tests__/mcp-regression-baseline.json
+++ b/mcp-server/src/__tests__/mcp-regression-baseline.json
@@ -1,5 +1,5 @@
 {
-  "capturedAt": "2026-05-21T06:58:00.000Z",
+  "capturedAt": "2026-05-21T10:57:58.448Z",
   "version": "0.4.25",
   "serverInfo": {
     "name": "agenticos-mcp",
@@ -14,6 +14,10 @@
     "agenticos_init",
     "agenticos_switch",
     "agenticos_list",
+    "agenticos_task_create",
+    "agenticos_task_update",
+    "agenticos_task_list",
+    "agenticos_task_close",
     "agenticos_record",
     "agenticos_record_case",
     "agenticos_list_cases",
@@ -39,5 +43,5 @@
     "agenticos_enforce_git_policy",
     "agenticos_worktree_cleanup"
   ],
-  "toolCount": 27
+  "toolCount": 31
 }

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -16,7 +16,7 @@ import {
   ListResourcesRequestSchema,
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { initProject, switchProject, listProjects, getStatus, saveState, recordSession, runPreflight, runIssueBootstrap, runBranchBootstrap, runPrScopeCheck, runHealth, runCanonicalSync, runConfig, runEditGuard, runEntrySurfaceRefresh, runStandardKitAdopt, runStandardKitUpgradeCheck, runStandardKitConformanceCheck, runNonCodeEvaluate, runArchiveImportEvaluate, runRecordCase, runListCases, runValidateDelegation, runCoverageCheck, runCoverageGenerate, runMultiAgentReview, runEnforceGitPolicy, runWorktreeCleanup } from './tools/index.js';
+import { initProject, switchProject, listProjects, getStatus, saveState, recordSession, runPreflight, runIssueBootstrap, runBranchBootstrap, runPrScopeCheck, runHealth, runCanonicalSync, runConfig, runEditGuard, runEntrySurfaceRefresh, runStandardKitAdopt, runStandardKitUpgradeCheck, runStandardKitConformanceCheck, runNonCodeEvaluate, runArchiveImportEvaluate, runRecordCase, runListCases, runValidateDelegation, runCoverageCheck, runCoverageGenerate, runMultiAgentReview, runEnforceGitPolicy, runWorktreeCleanup, runTaskCreate, runTaskUpdate, runTaskList, runTaskClose } from './tools/index.js';
 import { getProjectContext } from './resources/index.js';
 import { isDirectExecution, resolveCliPrelude } from './utils/mcp-server-cli.js';
 
@@ -69,6 +69,76 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
       name: 'agenticos_list',
       description: 'List all AgenticOS projects',
       inputSchema: { type: 'object', properties: {} },
+    },
+    {
+      name: 'agenticos_task_create',
+      description: 'Create a durable AgenticOS topic/project task under tasks/<task_id>.yaml and synchronize state.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          project: { type: 'string', description: 'Optional project ID, name, or path. If omitted, uses the current session project.' },
+          project_path: { type: 'string', description: 'Optional absolute project checkout path.' },
+          id: { type: 'string', description: 'Optional filesystem-safe task id. Defaults to a sanitized title.' },
+          title: { type: 'string', description: 'Task title.' },
+          status: { type: 'string', enum: ['open', 'in_progress', 'blocked', 'done', 'canceled'], description: 'Initial task status. Defaults to open.' },
+          priority: { type: 'string', enum: ['low', 'medium', 'high', 'urgent'], description: 'Task priority. Defaults to medium.' },
+          source: { type: 'object', description: 'Task source object with kind, origin, optional source_id, and optional dedupe_key.' },
+          acceptance_criteria: { type: 'array', items: { type: 'string' }, description: 'Observable completion criteria.' },
+          refs: { type: 'array', items: { type: 'object' }, description: 'Optional related references.' },
+          description: { type: 'string', description: 'Optional short task context. Do not include raw transcripts or secrets.' },
+          labels: { type: 'array', items: { type: 'string' }, description: 'Optional routing labels.' },
+          blocked_reason: { type: 'string', description: 'Required when status is blocked.' },
+        },
+        required: ['title', 'acceptance_criteria'],
+      },
+    },
+    {
+      name: 'agenticos_task_update',
+      description: 'Update a durable AgenticOS task and synchronize current/resume state.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          project: { type: 'string', description: 'Optional project ID, name, or path. If omitted, uses the current session project.' },
+          project_path: { type: 'string', description: 'Optional absolute project checkout path.' },
+          task_id: { type: 'string', description: 'Task id to update.' },
+          title: { type: 'string' },
+          status: { type: 'string', enum: ['open', 'in_progress', 'blocked', 'done', 'canceled'] },
+          priority: { type: 'string', enum: ['low', 'medium', 'high', 'urgent'] },
+          source: { type: 'object' },
+          acceptance_criteria: { type: 'array', items: { type: 'string' } },
+          refs: { type: 'array', items: { type: 'object' } },
+          description: { type: 'string' },
+          labels: { type: 'array', items: { type: 'string' } },
+          blocked_reason: { type: 'string' },
+        },
+        required: ['task_id'],
+      },
+    },
+    {
+      name: 'agenticos_task_list',
+      description: 'List durable AgenticOS tasks from tasks/*.yaml.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          project: { type: 'string', description: 'Optional project ID, name, or path. If omitted, uses the current session project.' },
+          project_path: { type: 'string', description: 'Optional absolute project checkout path.' },
+          status: { type: 'string', enum: ['open', 'in_progress', 'blocked', 'done', 'canceled'], description: 'Optional status filter.' },
+        },
+      },
+    },
+    {
+      name: 'agenticos_task_close',
+      description: 'Close a durable AgenticOS task as done or canceled and clear matching current/resume state.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          project: { type: 'string', description: 'Optional project ID, name, or path. If omitted, uses the current session project.' },
+          project_path: { type: 'string', description: 'Optional absolute project checkout path.' },
+          task_id: { type: 'string', description: 'Task id to close.' },
+          status: { type: 'string', enum: ['done', 'canceled'], description: 'Close status. Defaults to done.' },
+        },
+        required: ['task_id'],
+      },
     },
     {
       name: 'agenticos_record',
@@ -494,6 +564,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       return { content: [{ type: 'text', text: await switchProject(args) }] };
     case 'agenticos_list':
       return { content: [{ type: 'text', text: await listProjects() }] };
+    case 'agenticos_task_create':
+      return { content: [{ type: 'text', text: await runTaskCreate(args ?? {}) }] };
+    case 'agenticos_task_update':
+      return { content: [{ type: 'text', text: await runTaskUpdate(args ?? {}) }] };
+    case 'agenticos_task_list':
+      return { content: [{ type: 'text', text: await runTaskList(args ?? {}) }] };
+    case 'agenticos_task_close':
+      return { content: [{ type: 'text', text: await runTaskClose(args ?? {}) }] };
     case 'agenticos_record':
       return { content: [{ type: 'text', text: await recordSession(args) }] };
     case 'agenticos_record_case':

--- a/mcp-server/src/tools/__tests__/task.test.ts
+++ b/mcp-server/src/tools/__tests__/task.test.ts
@@ -1,0 +1,363 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import yaml from 'yaml';
+
+const fsMock = vi.hoisted(() => ({
+  files: new Map<string, string>(),
+  mkdir: vi.fn(),
+  readFile: vi.fn(),
+  readdir: vi.fn(),
+  writeFile: vi.fn(),
+}));
+const projectTargetMock = vi.hoisted(() => ({
+  resolveManagedProjectTarget: vi.fn(),
+  resolveManagedProjectContextPaths: vi.fn(),
+}));
+
+vi.mock('fs/promises', () => ({
+  mkdir: fsMock.mkdir,
+  readFile: fsMock.readFile,
+  readdir: fsMock.readdir,
+  writeFile: fsMock.writeFile,
+}));
+
+vi.mock('../../utils/project-target.js', () => ({
+  resolveManagedProjectTarget: projectTargetMock.resolveManagedProjectTarget,
+  resolveManagedProjectContextPaths: projectTargetMock.resolveManagedProjectContextPaths,
+}));
+
+import { runTaskClose, runTaskCreate, runTaskList, runTaskUpdate } from '../task.js';
+
+const projectPath = '/workspace/projects/topic';
+const tasksDir = `${projectPath}/tasks`;
+const statePath = `${projectPath}/.context/state.yaml`;
+
+function parseResult(value: string): any {
+  return JSON.parse(value);
+}
+
+function parseYamlFile(path: string): any {
+  return yaml.parse(fsMock.files.get(path) || '{}');
+}
+
+function seedTask(task: any): void {
+  fsMock.files.set(`${tasksDir}/${task.id}.yaml`, yaml.stringify(task));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fsMock.files.clear();
+  projectTargetMock.resolveManagedProjectTarget.mockResolvedValue({
+    projectId: 'topic',
+    projectName: 'Topic',
+    projectPath,
+    projectYaml: {
+      meta: { id: 'topic', name: 'Topic' },
+      source_control: { topology: 'local_directory_only' },
+    },
+    statePath,
+  });
+  projectTargetMock.resolveManagedProjectContextPaths.mockReturnValue({
+    tasksDir,
+  });
+  fsMock.mkdir.mockResolvedValue(undefined);
+  fsMock.readFile.mockImplementation(async (path: string) => {
+    if (!fsMock.files.has(path)) {
+      throw new Error(`ENOENT: ${path}`);
+    }
+    return fsMock.files.get(path);
+  });
+  fsMock.readdir.mockImplementation(async (path: string) => {
+    if (path !== tasksDir) {
+      throw new Error(`ENOENT: ${path}`);
+    }
+    return [...fsMock.files.keys()]
+      .filter((filePath) => filePath.startsWith(`${tasksDir}/`))
+      .map((filePath) => filePath.slice(`${tasksDir}/`.length));
+  });
+  fsMock.writeFile.mockImplementation(async (path: string, content: string) => {
+    fsMock.files.set(path, content);
+  });
+});
+
+describe('AgenticOS task MCP API', () => {
+  it('creates a task file and resume state with default project kind', async () => {
+    const result = parseResult(await runTaskCreate({
+      title: 'Research sleep routine',
+      acceptance_criteria: ['Capture the next experiment'],
+      source: { kind: 'hermes', origin: 'chat', dedupe_key: 'sleep-routine' },
+      refs: [{ type: 'gbrain', uri: 'gbrain://topic/sleep', visibility: 'private' }],
+    }));
+
+    expect(result.status).toBe('CREATED');
+    expect(result.project_kind).toBe('project');
+    expect(result.task.id).toBe('research-sleep-routine');
+    expect(result.task_path).toBe(`${tasksDir}/research-sleep-routine.yaml`);
+    expect(fsMock.mkdir).toHaveBeenCalledWith(tasksDir, { recursive: true });
+    expect(fsMock.mkdir).toHaveBeenCalledWith(`${projectPath}/.context`, { recursive: true });
+    expect(parseYamlFile(`${tasksDir}/research-sleep-routine.yaml`).source.kind).toBe('hermes');
+    expect(parseYamlFile(statePath).resume.task_id).toBe('research-sleep-routine');
+    expect(parseYamlFile(statePath).current_task).toBeUndefined();
+  });
+
+  it('creates an in-progress topic task and synchronizes current_task', async () => {
+    projectTargetMock.resolveManagedProjectTarget.mockResolvedValueOnce({
+      projectId: 'topic',
+      projectName: 'Topic',
+      projectPath,
+      projectYaml: { agenticos: { project_kind: 'topic' } },
+      statePath,
+    });
+
+    const result = parseResult(await runTaskCreate({
+      id: '#Sleep/Plan',
+      title: 'Sleep Plan',
+      status: 'in_progress',
+      priority: 'high',
+      acceptance_criteria: ['Pick the next experiment'],
+      source: { kind: 'codex', origin: 'mcp' },
+      labels: ['personal'],
+    }));
+
+    expect(result.status).toBe('CREATED');
+    expect(result.project_kind).toBe('topic');
+    expect(result.task.id).toBe('sleep-plan');
+    expect(result.task.priority).toBe('high');
+    expect(parseYamlFile(statePath).current_task).toMatchObject({
+      id: 'sleep-plan',
+      title: 'Sleep Plan',
+      status: 'in_progress',
+      next_step: 'Pick the next experiment',
+    });
+  });
+
+  it('returns an existing duplicate task without overwriting it', async () => {
+    const existing = {
+      id: 'sleep-plan',
+      title: 'Sleep Plan',
+      status: 'open',
+      priority: 'medium',
+      source: { kind: 'hermes', origin: 'chat', dedupe_key: 'same-key' },
+      acceptance_criteria: ['Existing criterion'],
+      refs: [],
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+    };
+    seedTask(existing);
+
+    const result = parseResult(await runTaskCreate({
+      title: 'Different title',
+      acceptance_criteria: ['New criterion'],
+      source: { kind: 'hermes', origin: 'chat', dedupe_key: 'same-key' },
+    }));
+
+    expect(result.status).toBe('EXISTING');
+    expect(result.duplicate).toBe(true);
+    expect(result.task.title).toBe('Sleep Plan');
+    expect(parseYamlFile(`${tasksDir}/sleep-plan.yaml`).acceptance_criteria).toEqual(['Existing criterion']);
+  });
+
+  it('rejects invalid create payloads and secret-looking input', async () => {
+    const missingCriteria = parseResult(await runTaskCreate({ title: 'No criteria' }));
+    expect(missingCriteria.status).toBe('ERROR');
+    expect(missingCriteria.errors.join(' ')).toContain('acceptance_criteria');
+
+    const secret = parseResult(await runTaskCreate({
+      title: 'Store token=abc123',
+      acceptance_criteria: ['Persist safely'],
+    }));
+    expect(secret.status).toBe('ERROR');
+    expect(secret.errors.join(' ')).toContain('secret');
+
+    const secretId = parseResult(await runTaskCreate({
+      id: 'token=abc123',
+      title: 'Safe title',
+      acceptance_criteria: ['Persist safely'],
+    }));
+    expect(secretId.status).toBe('ERROR');
+    expect(secretId.errors.join(' ')).toContain('secret');
+  });
+
+  it('rejects invalid source, refs, status, priority, labels, and blocked tasks without a reason', async () => {
+    const result = parseResult(await runTaskCreate({
+      title: 'Bad task',
+      status: 'waiting',
+      priority: 'later',
+      source: { kind: 'robot', origin: 'unknown' },
+      refs: [{ type: 'note' }, 'bad-ref'],
+      labels: ['ok', 3],
+      acceptance_criteria: ['Check it'],
+    }));
+
+    expect(result.status).toBe('ERROR');
+    expect(result.errors.join(' ')).toContain('status');
+    expect(result.errors.join(' ')).toContain('priority');
+    expect(result.errors.join(' ')).toContain('source.kind');
+    expect(result.errors.join(' ')).toContain('source.origin');
+    expect(result.errors.join(' ')).toContain('refs entries');
+    expect(result.errors.join(' ')).toContain('labels');
+
+    const blocked = parseResult(await runTaskCreate({
+      title: 'Blocked task',
+      status: 'blocked',
+      acceptance_criteria: ['Needs input'],
+    }));
+    expect(blocked.status).toBe('ERROR');
+    expect(blocked.errors.join(' ')).toContain('blocked_reason');
+  });
+
+  it('updates a task and refreshes current state', async () => {
+    seedTask({
+      id: 'sleep-plan',
+      title: 'Sleep Plan',
+      status: 'open',
+      priority: 'medium',
+      source: { kind: 'manual', origin: 'manual' },
+      acceptance_criteria: ['Old'],
+      refs: [],
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+    });
+
+    const result = parseResult(await runTaskUpdate({
+      task_id: 'sleep-plan',
+      title: 'Sleep Plan v2',
+      status: 'in_progress',
+      priority: 'urgent',
+      acceptance_criteria: ['New step'],
+      refs: [{ type: 'knowledge', uri: 'knowledge/sleep.md', title: 'Sleep', visibility: 'public' }],
+      description: 'Short context',
+      labels: ['health'],
+    }));
+
+    expect(result.status).toBe('UPDATED');
+    expect(result.task.title).toBe('Sleep Plan v2');
+    expect(result.task.priority).toBe('urgent');
+    expect(parseYamlFile(statePath).current_task.title).toBe('Sleep Plan v2');
+    expect(parseYamlFile(`${tasksDir}/sleep-plan.yaml`).refs[0].uri).toBe('knowledge/sleep.md');
+  });
+
+  it('rejects invalid updates and missing task ids', async () => {
+    const missingId = parseResult(await runTaskUpdate({}));
+    expect(missingId.status).toBe('ERROR');
+    expect(missingId.errors.join(' ')).toContain('task_id');
+
+    const missingTask = parseResult(await runTaskUpdate({ task_id: 'missing' }));
+    expect(missingTask.status).toBe('ERROR');
+    expect(missingTask.errors.join(' ')).toContain('not found');
+
+    seedTask({
+      id: 'sleep-plan',
+      title: 'Sleep Plan',
+      status: 'open',
+      priority: 'medium',
+      source: { kind: 'manual', origin: 'manual' },
+      acceptance_criteria: ['Old'],
+      refs: [],
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+    });
+    const invalid = parseResult(await runTaskUpdate({
+      task_id: 'sleep-plan',
+      title: '',
+      status: 'blocked',
+      priority: 'later',
+      acceptance_criteria: [],
+      source: { kind: 'bad', origin: 'bad' },
+      refs: { uri: 'nope' },
+      description: '',
+      labels: [],
+    }));
+
+    expect(invalid.status).toBe('ERROR');
+    expect(invalid.errors.join(' ')).toContain('title');
+    expect(invalid.errors.join(' ')).toContain('priority');
+    expect(invalid.errors.join(' ')).toContain('blocked_reason');
+    expect(invalid.errors.join(' ')).toContain('refs');
+  });
+
+  it('lists tasks and filters by status', async () => {
+    seedTask({
+      id: 'a-open',
+      title: 'A',
+      status: 'open',
+      priority: 'medium',
+      source: { kind: 'manual', origin: 'manual' },
+      acceptance_criteria: ['A'],
+      refs: [],
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+    });
+    seedTask({
+      id: 'b-done',
+      title: 'B',
+      status: 'done',
+      priority: 'medium',
+      source: { kind: 'manual', origin: 'manual' },
+      acceptance_criteria: ['B'],
+      refs: [],
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+      closed_at: '2026-01-02T00:00:00.000Z',
+    });
+    fsMock.files.set(`${tasksDir}/ignored.txt`, 'ignore');
+
+    const all = parseResult(await runTaskList({}));
+    expect(all.status).toBe('OK');
+    expect(all.count).toBe(2);
+
+    const open = parseResult(await runTaskList({ status: 'open' }));
+    expect(open.count).toBe(1);
+    expect(open.tasks[0].id).toBe('a-open');
+
+    const invalid = parseResult(await runTaskList({ status: 'waiting' }));
+    expect(invalid.status).toBe('ERROR');
+  });
+
+  it('closes a task and clears matching current and resume state', async () => {
+    seedTask({
+      id: 'sleep-plan',
+      title: 'Sleep Plan',
+      status: 'in_progress',
+      priority: 'medium',
+      source: { kind: 'manual', origin: 'manual' },
+      acceptance_criteria: ['Finish'],
+      refs: [],
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+    });
+    fsMock.files.set(statePath, yaml.stringify({
+      current_task: { id: 'sleep-plan', title: 'Sleep Plan', status: 'in_progress' },
+      resume: { task_id: 'sleep-plan' },
+    }));
+
+    const result = parseResult(await runTaskClose({ task_id: 'sleep-plan' }));
+
+    expect(result.status).toBe('UPDATED');
+    expect(result.task.status).toBe('done');
+    expect(result.task.closed_at).toBeTruthy();
+    expect(parseYamlFile(statePath).current_task).toBeNull();
+    expect(parseYamlFile(statePath).resume).toBeUndefined();
+
+    const invalid = parseResult(await runTaskClose({ task_id: 'sleep-plan', status: 'open' }));
+    expect(invalid.status).toBe('ERROR');
+  });
+
+  it('returns structured errors for project resolution and invalid project_kind', async () => {
+    projectTargetMock.resolveManagedProjectTarget.mockRejectedValueOnce(new Error('No project provided'));
+    expect(parseResult(await runTaskList({})).errors[0]).toContain('No project provided');
+
+    projectTargetMock.resolveManagedProjectTarget.mockResolvedValueOnce({
+      projectId: 'topic',
+      projectName: 'Topic',
+      projectPath,
+      projectYaml: { agenticos: { project_kind: 'workflow' } },
+      statePath,
+    });
+    const invalidKind = parseResult(await runTaskCreate({
+      title: 'Task',
+      acceptance_criteria: ['Do it'],
+    }));
+    expect(invalidKind.status).toBe('ERROR');
+    expect(invalidKind.errors[0]).toContain('agenticos.project_kind');
+  });
+});

--- a/mcp-server/src/tools/__tests__/task.test.ts
+++ b/mcp-server/src/tools/__tests__/task.test.ts
@@ -26,6 +26,7 @@ vi.mock('../../utils/project-target.js', () => ({
 }));
 
 import { runTaskClose, runTaskCreate, runTaskList, runTaskUpdate } from '../task.js';
+import * as toolExports from '../index.js';
 
 const projectPath = '/workspace/projects/topic';
 const tasksDir = `${projectPath}/tasks`;
@@ -80,12 +81,25 @@ beforeEach(() => {
 });
 
 describe('AgenticOS task MCP API', () => {
+  it('exports task tools from the public tools barrel', () => {
+    expect(toolExports.runTaskCreate).toBe(runTaskCreate);
+    expect(toolExports.runTaskUpdate).toBe(runTaskUpdate);
+    expect(toolExports.runTaskList).toBe(runTaskList);
+    expect(toolExports.runTaskClose).toBe(runTaskClose);
+  });
+
   it('creates a task file and resume state with default project kind', async () => {
+    fsMock.files.set(statePath, '');
+
     const result = parseResult(await runTaskCreate({
       title: 'Research sleep routine',
       acceptance_criteria: ['Capture the next experiment'],
-      source: { kind: 'hermes', origin: 'chat', dedupe_key: 'sleep-routine' },
-      refs: [{ type: 'gbrain', uri: 'gbrain://topic/sleep', visibility: 'private' }],
+      source: { kind: 'hermes', origin: 'chat', source_id: 'chat-1', dedupe_key: 'sleep-routine' },
+      refs: [
+        { type: 'gbrain', uri: 'gbrain://topic/sleep', visibility: 'private' },
+        { type: 'knowledge', uri: 'knowledge/sleep.md' },
+      ],
+      description: 'Short context',
     }));
 
     expect(result.status).toBe('CREATED');
@@ -95,6 +109,9 @@ describe('AgenticOS task MCP API', () => {
     expect(fsMock.mkdir).toHaveBeenCalledWith(tasksDir, { recursive: true });
     expect(fsMock.mkdir).toHaveBeenCalledWith(`${projectPath}/.context`, { recursive: true });
     expect(parseYamlFile(`${tasksDir}/research-sleep-routine.yaml`).source.kind).toBe('hermes');
+    expect(parseYamlFile(`${tasksDir}/research-sleep-routine.yaml`).source.source_id).toBe('chat-1');
+    expect(parseYamlFile(`${tasksDir}/research-sleep-routine.yaml`).refs[1].visibility).toBeUndefined();
+    expect(parseYamlFile(`${tasksDir}/research-sleep-routine.yaml`).description).toBe('Short context');
     expect(parseYamlFile(statePath).resume.task_id).toBe('research-sleep-routine');
     expect(parseYamlFile(statePath).current_task).toBeUndefined();
   });
@@ -154,9 +171,39 @@ describe('AgenticOS task MCP API', () => {
     expect(result.duplicate).toBe(true);
     expect(result.task.title).toBe('Sleep Plan');
     expect(parseYamlFile(`${tasksDir}/sleep-plan.yaml`).acceptance_criteria).toEqual(['Existing criterion']);
+
+    seedTask({
+      id: 'no-next-step',
+      title: 'No Next Step',
+      status: 'in_progress',
+      priority: 'medium',
+      source: { kind: 'manual', origin: 'manual' },
+      acceptance_criteria: [],
+      refs: [],
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+    });
+    const noNext = parseResult(await runTaskCreate({
+      id: 'no-next-step',
+      title: 'No Next Step',
+      acceptance_criteria: ['New criterion'],
+    }));
+    expect(noNext.status).toBe('EXISTING');
+    expect(parseYamlFile(statePath).current_task.next_step).toBeNull();
   });
 
   it('rejects invalid create payloads and secret-looking input', async () => {
+    const missingTitle = parseResult(await runTaskCreate({ acceptance_criteria: ['Criterion'] }));
+    expect(missingTitle.status).toBe('ERROR');
+    expect(missingTitle.errors.join(' ')).toContain('title');
+
+    const emptyId = parseResult(await runTaskCreate({
+      title: '!!!',
+      acceptance_criteria: ['Criterion'],
+    }));
+    expect(emptyId.status).toBe('ERROR');
+    expect(emptyId.errors.join(' ')).toContain('alphanumeric');
+
     const missingCriteria = parseResult(await runTaskCreate({ title: 'No criteria' }));
     expect(missingCriteria.status).toBe('ERROR');
     expect(missingCriteria.errors.join(' ')).toContain('acceptance_criteria');
@@ -183,7 +230,7 @@ describe('AgenticOS task MCP API', () => {
       status: 'waiting',
       priority: 'later',
       source: { kind: 'robot', origin: 'unknown' },
-      refs: [{ type: 'note' }, 'bad-ref'],
+      refs: [{ type: 'note' }, { uri: 'missing-type' }, { type: 'note', uri: 'x', visibility: 'secret' }, 'bad-ref'],
       labels: ['ok', 3],
       acceptance_criteria: ['Check it'],
     }));
@@ -203,6 +250,26 @@ describe('AgenticOS task MCP API', () => {
     }));
     expect(blocked.status).toBe('ERROR');
     expect(blocked.errors.join(' ')).toContain('blocked_reason');
+  });
+
+  it('creates blocked and already-closed tasks with lifecycle metadata', async () => {
+    const blocked = parseResult(await runTaskCreate({
+      title: 'Blocked task',
+      status: 'blocked',
+      blocked_reason: 'Waiting on user input',
+      acceptance_criteria: ['Resume once unblocked'],
+    }));
+    expect(blocked.status).toBe('CREATED');
+    expect(blocked.task.blocked_reason).toBe('Waiting on user input');
+    expect(blocked.task.closed_at).toBeUndefined();
+
+    const closed = parseResult(await runTaskCreate({
+      title: 'Already finished',
+      status: 'done',
+      acceptance_criteria: ['Verified'],
+    }));
+    expect(closed.status).toBe('CREATED');
+    expect(closed.task.closed_at).toBeTruthy();
   });
 
   it('updates a task and refreshes current state', async () => {
@@ -234,6 +301,25 @@ describe('AgenticOS task MCP API', () => {
     expect(result.task.priority).toBe('urgent');
     expect(parseYamlFile(statePath).current_task.title).toBe('Sleep Plan v2');
     expect(parseYamlFile(`${tasksDir}/sleep-plan.yaml`).refs[0].uri).toBe('knowledge/sleep.md');
+
+    seedTask({
+      id: 'done-task',
+      title: 'Done Task',
+      status: 'done',
+      priority: 'medium',
+      source: { kind: 'manual', origin: 'manual' },
+      acceptance_criteria: ['Done'],
+      refs: [],
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+      closed_at: '2026-01-02T00:00:00.000Z',
+    });
+    const reopened = parseResult(await runTaskUpdate({
+      task_id: 'done-task',
+      status: 'open',
+    }));
+    expect(reopened.status).toBe('UPDATED');
+    expect(reopened.task.closed_at).toBeUndefined();
   });
 
   it('rejects invalid updates and missing task ids', async () => {
@@ -266,6 +352,7 @@ describe('AgenticOS task MCP API', () => {
       refs: { uri: 'nope' },
       description: '',
       labels: [],
+      blocked_reason: '',
     }));
 
     expect(invalid.status).toBe('ERROR');
@@ -273,9 +360,46 @@ describe('AgenticOS task MCP API', () => {
     expect(invalid.errors.join(' ')).toContain('priority');
     expect(invalid.errors.join(' ')).toContain('blocked_reason');
     expect(invalid.errors.join(' ')).toContain('refs');
+
+    const invalidStatus = parseResult(await runTaskUpdate({
+      task_id: 'sleep-plan',
+      status: 3,
+      priority: 3,
+    }));
+    expect(invalidStatus.status).toBe('ERROR');
+    expect(invalidStatus.errors.join(' ')).toContain('status');
+    expect(invalidStatus.errors.join(' ')).toContain('priority');
+
+    const blocked = parseResult(await runTaskUpdate({
+      task_id: 'sleep-plan',
+      status: 'blocked',
+      blocked_reason: 'Waiting on input',
+    }));
+    expect(blocked.status).toBe('UPDATED');
+    expect(blocked.task.blocked_reason).toBe('Waiting on input');
+
+    const secret = parseResult(await runTaskUpdate({
+      task_id: 'sleep-plan',
+      description: 'token=abc123',
+    }));
+    expect(secret.status).toBe('ERROR');
+    expect(secret.errors.join(' ')).toContain('secret');
+
+    fsMock.writeFile.mockRejectedValueOnce(new Error(''));
+    const failedWrite = parseResult(await runTaskUpdate({
+      task_id: 'sleep-plan',
+      title: 'Cannot persist',
+    }));
+    expect(failedWrite.status).toBe('ERROR');
+    expect(failedWrite.errors[0]).toBe('failed to update task');
   });
 
   it('lists tasks and filters by status', async () => {
+    fsMock.readdir.mockRejectedValueOnce(new Error('missing'));
+    const empty = parseResult(await runTaskList({}));
+    expect(empty.status).toBe('OK');
+    expect(empty.count).toBe(0);
+
     seedTask({
       id: 'a-open',
       title: 'A',
@@ -300,6 +424,7 @@ describe('AgenticOS task MCP API', () => {
       closed_at: '2026-01-02T00:00:00.000Z',
     });
     fsMock.files.set(`${tasksDir}/ignored.txt`, 'ignore');
+    fsMock.files.set(`${tasksDir}/empty.yaml`, '');
 
     const all = parseResult(await runTaskList({}));
     expect(all.status).toBe('OK');
@@ -345,6 +470,15 @@ describe('AgenticOS task MCP API', () => {
   it('returns structured errors for project resolution and invalid project_kind', async () => {
     projectTargetMock.resolveManagedProjectTarget.mockRejectedValueOnce(new Error('No project provided'));
     expect(parseResult(await runTaskList({})).errors[0]).toContain('No project provided');
+
+    projectTargetMock.resolveManagedProjectTarget.mockRejectedValueOnce(new Error(''));
+    expect(parseResult(await runTaskList({})).errors[0]).toBe('failed to list tasks');
+
+    projectTargetMock.resolveManagedProjectTarget.mockRejectedValueOnce(new Error(''));
+    expect(parseResult(await runTaskCreate({
+      title: 'Task',
+      acceptance_criteria: ['Do it'],
+    })).errors[0]).toBe('failed to create task');
 
     projectTargetMock.resolveManagedProjectTarget.mockResolvedValueOnce({
       projectId: 'topic',

--- a/mcp-server/src/tools/index.ts
+++ b/mcp-server/src/tools/index.ts
@@ -20,3 +20,4 @@ export { runCoverageCheck, runCoverageGenerate } from './coverage-check.js';
 export { runMultiAgentReview } from './multi-agent-review.js';
 export { runEnforceGitPolicy } from './git-policy-enforce.js';
 export { runWorktreeCleanup } from './worktree-cleanup.js';
+export { runTaskCreate, runTaskUpdate, runTaskList, runTaskClose } from './task.js';

--- a/mcp-server/src/tools/task.ts
+++ b/mcp-server/src/tools/task.ts
@@ -1,0 +1,509 @@
+import { mkdir, readFile, readdir, writeFile } from 'fs/promises';
+import { dirname, join } from 'path';
+import yaml from 'yaml';
+import { validateProjectKind, type ProjectKind } from '../utils/project-contract.js';
+import { resolveManagedProjectContextPaths, resolveManagedProjectTarget } from '../utils/project-target.js';
+
+type TaskStatus = 'open' | 'in_progress' | 'blocked' | 'done' | 'canceled';
+type TaskPriority = 'low' | 'medium' | 'high' | 'urgent';
+
+interface TaskRef {
+  type: string;
+  uri: string;
+  title?: string;
+  visibility?: 'public' | 'private' | 'restricted';
+}
+
+interface TaskSource {
+  kind: string;
+  origin: string;
+  source_id?: string;
+  dedupe_key?: string;
+}
+
+interface AgenticOSTask {
+  id: string;
+  title: string;
+  status: TaskStatus;
+  priority: TaskPriority;
+  source: TaskSource;
+  acceptance_criteria: string[];
+  refs: TaskRef[];
+  created_at: string;
+  updated_at: string;
+  description?: string;
+  labels?: string[];
+  blocked_reason?: string;
+  closed_at?: string;
+  related_tasks?: string[];
+}
+
+interface TaskCommandContext {
+  project_id: string;
+  project_name: string;
+  project_kind: ProjectKind;
+  tasks_dir: string;
+  state_path: string;
+}
+
+const TASK_STATUSES = new Set<TaskStatus>(['open', 'in_progress', 'blocked', 'done', 'canceled']);
+const CLOSE_STATUSES = new Set<TaskStatus>(['done', 'canceled']);
+const PRIORITIES = new Set<TaskPriority>(['low', 'medium', 'high', 'urgent']);
+const SOURCE_KINDS = new Set(['user', 'hermes', 'codex', 'claude_code', 'agenticos_mcp', 'github', 'manual']);
+const SOURCE_ORIGINS = new Set(['chat', 'mcp', 'github_issue', 'gbrain', 'capture', 'manual', 'import']);
+const REF_VISIBILITIES = new Set(['public', 'private', 'restricted']);
+const SECRET_PATTERNS = [
+  /\b(?:api[_-]?key|token|password|secret|private[_-]?key)\s*[:=]\s*["']?[^"'\s]+/i,
+  /\bsk-[a-z0-9]{20,}\b/i,
+  /-----BEGIN [A-Z ]*PRIVATE KEY-----/,
+];
+
+function jsonResult(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function sanitizeTaskId(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80)
+    .replace(/-+$/g, '');
+}
+
+function normalizeText(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]+/g, '')
+    .replace(/\s+/g, ' ');
+}
+
+function hasSecretLikeValue(value: unknown): boolean {
+  if (typeof value === 'string') {
+    return SECRET_PATTERNS.some((pattern) => pattern.test(value));
+  }
+  if (Array.isArray(value)) {
+    return value.some((item) => hasSecretLikeValue(item));
+  }
+  if (value && typeof value === 'object') {
+    return Object.values(value).some((item) => hasSecretLikeValue(item));
+  }
+  return false;
+}
+
+function ensureStringArray(value: unknown, field: string, errors: string[]): string[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    errors.push(`${field} must be a non-empty array of strings`);
+    return [];
+  }
+
+  const values = value
+    .filter((item): item is string => typeof item === 'string')
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+  if (values.length !== value.length || values.length === 0) {
+    errors.push(`${field} must contain only non-empty strings`);
+  }
+  return values;
+}
+
+function normalizeSource(value: unknown, errors: string[]): TaskSource {
+  const source = value && typeof value === 'object' ? value as Record<string, unknown> : {};
+  const kind = typeof source.kind === 'string' ? source.kind.trim() : 'manual';
+  const origin = typeof source.origin === 'string' ? source.origin.trim() : 'manual';
+
+  if (!SOURCE_KINDS.has(kind)) {
+    errors.push('source.kind must be one of user, hermes, codex, claude_code, agenticos_mcp, github, manual');
+  }
+  if (!SOURCE_ORIGINS.has(origin)) {
+    errors.push('source.origin must be one of chat, mcp, github_issue, gbrain, capture, manual, import');
+  }
+
+  const normalized: TaskSource = { kind, origin };
+  if (typeof source.source_id === 'string' && source.source_id.trim()) {
+    normalized.source_id = source.source_id.trim();
+  }
+  if (typeof source.dedupe_key === 'string' && source.dedupe_key.trim()) {
+    normalized.dedupe_key = source.dedupe_key.trim();
+  }
+  return normalized;
+}
+
+function normalizeRefs(value: unknown, errors: string[]): TaskRef[] {
+  if (value === undefined) {
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    errors.push('refs must be an array');
+    return [];
+  }
+
+  const refs: TaskRef[] = [];
+  for (const item of value) {
+    if (!item || typeof item !== 'object') {
+      errors.push('refs entries must be objects');
+      continue;
+    }
+    const ref = item as Record<string, unknown>;
+    const type = typeof ref.type === 'string' ? ref.type.trim() : '';
+    const uri = typeof ref.uri === 'string' ? ref.uri.trim() : '';
+    const visibility = typeof ref.visibility === 'string' ? ref.visibility.trim() : undefined;
+    if (!type || !uri) {
+      errors.push('refs entries require type and uri');
+      continue;
+    }
+    if (visibility !== undefined && !REF_VISIBILITIES.has(visibility)) {
+      errors.push('refs.visibility must be public, private, or restricted');
+      continue;
+    }
+    refs.push({
+      type,
+      uri,
+      ...(typeof ref.title === 'string' && ref.title.trim() ? { title: ref.title.trim() } : {}),
+      ...(visibility ? { visibility: visibility as TaskRef['visibility'] } : {}),
+    });
+  }
+  return refs;
+}
+
+function deriveDedupeKey(task: Pick<AgenticOSTask, 'title' | 'source' | 'refs'>): string {
+  if (task.source.dedupe_key) {
+    return task.source.dedupe_key;
+  }
+  const refs = [...task.refs]
+    .sort((a, b) => `${a.type}:${a.uri}`.localeCompare(`${b.type}:${b.uri}`))
+    .map((ref) => `${ref.type}:${ref.uri}`)
+    .join('|');
+  return [normalizeText(task.title), task.source.kind, task.source.origin, refs].join('|');
+}
+
+function validateProjectKindOrThrow(projectName: string, projectYaml: any): ProjectKind {
+  const validation = validateProjectKind(projectName, projectYaml);
+  if (!validation.ok) {
+    throw new Error(validation.message);
+  }
+  return validation.project_kind;
+}
+
+async function resolveTaskContext(args: any): Promise<TaskCommandContext> {
+  const resolved = await resolveManagedProjectTarget({
+    project: args?.project,
+    projectPath: args?.project_path,
+    commandName: 'agenticos_task',
+  });
+  const contextPaths = resolveManagedProjectContextPaths(resolved.projectPath, resolved.projectYaml);
+  return {
+    project_id: resolved.projectId,
+    project_name: resolved.projectName,
+    project_kind: validateProjectKindOrThrow(resolved.projectName, resolved.projectYaml),
+    tasks_dir: contextPaths.tasksDir,
+    state_path: resolved.statePath,
+  };
+}
+
+function taskPath(context: TaskCommandContext, taskId: string): string {
+  return join(context.tasks_dir, `${taskId}.yaml`);
+}
+
+async function readTaskFile(path: string): Promise<AgenticOSTask | null> {
+  try {
+    return yaml.parse(await readFile(path, 'utf-8')) as AgenticOSTask || null;
+  } catch {
+    return null;
+  }
+}
+
+async function listTaskFiles(context: TaskCommandContext): Promise<AgenticOSTask[]> {
+  let entries: string[];
+  try {
+    entries = await readdir(context.tasks_dir);
+  } catch {
+    return [];
+  }
+
+  const tasks: AgenticOSTask[] = [];
+  for (const entry of entries.filter((item) => item.endsWith('.yaml')).sort()) {
+    const task = await readTaskFile(join(context.tasks_dir, entry));
+    if (task) {
+      tasks.push(task);
+    }
+  }
+  return tasks;
+}
+
+async function readState(statePath: string): Promise<any> {
+  try {
+    return yaml.parse(await readFile(statePath, 'utf-8')) || {};
+  } catch {
+    return {};
+  }
+}
+
+function taskNextStep(task: AgenticOSTask): string | null {
+  return task.acceptance_criteria[0] || null;
+}
+
+async function syncState(context: TaskCommandContext, task: AgenticOSTask): Promise<void> {
+  const state = await readState(context.state_path);
+  if (CLOSE_STATUSES.has(task.status)) {
+    if (state.current_task?.id === task.id) {
+      state.current_task = null;
+    }
+    if (state.resume?.task_id === task.id) {
+      delete state.resume;
+    }
+  } else {
+    state.resume = {
+      task_id: task.id,
+      reason: `Continue ${task.title}`,
+      updated_at: task.updated_at,
+    };
+    if (task.status === 'in_progress' || state.current_task?.id === task.id) {
+      state.current_task = {
+        id: task.id,
+        title: task.title,
+        status: task.status,
+        updated: task.updated_at,
+        next_step: taskNextStep(task),
+      };
+    }
+  }
+  await mkdir(dirname(context.state_path), { recursive: true });
+  await writeFile(context.state_path, yaml.stringify(state), 'utf-8');
+}
+
+function buildTaskFromCreateArgs(args: any, now: string): { task?: AgenticOSTask; errors: string[] } {
+  const errors: string[] = [];
+  const title = typeof args?.title === 'string' ? args.title.trim() : '';
+  if (!title) {
+    errors.push('title is required');
+  }
+
+  const rawTaskId = typeof args?.id === 'string' && args.id.trim() ? args.id : title;
+  const taskId = sanitizeTaskId(rawTaskId);
+  if (!taskId) {
+    errors.push('id or title must contain at least one alphanumeric character');
+  }
+
+  const status = typeof args?.status === 'string' && args.status.trim() ? args.status.trim() : 'open';
+  if (!TASK_STATUSES.has(status as TaskStatus)) {
+    errors.push('status must be one of open, in_progress, blocked, done, canceled');
+  }
+
+  const priority = typeof args?.priority === 'string' && args.priority.trim() ? args.priority.trim() : 'medium';
+  if (!PRIORITIES.has(priority as TaskPriority)) {
+    errors.push('priority must be one of low, medium, high, urgent');
+  }
+
+  const acceptanceCriteria = ensureStringArray(args?.acceptance_criteria, 'acceptance_criteria', errors);
+  const source = normalizeSource(args?.source, errors);
+  const refs = normalizeRefs(args?.refs, errors);
+  const description = typeof args?.description === 'string' && args.description.trim() ? args.description.trim() : undefined;
+  const labels = args?.labels === undefined ? undefined : ensureStringArray(args.labels, 'labels', errors);
+
+  if (status === 'blocked' && !(typeof args?.blocked_reason === 'string' && args.blocked_reason.trim())) {
+    errors.push('blocked_reason is required when status is blocked');
+  }
+
+  const blockedReason = typeof args?.blocked_reason === 'string' && args.blocked_reason.trim() ? args.blocked_reason.trim() : undefined;
+  if (hasSecretLikeValue({ rawTaskId, title, source, refs, description, acceptanceCriteria, labels, blockedReason })) {
+    errors.push('task input appears to contain raw secret material; store a safe reference instead');
+  }
+
+  if (errors.length > 0) {
+    return { errors };
+  }
+
+  const task: AgenticOSTask = {
+    id: taskId,
+    title,
+    status: status as TaskStatus,
+    priority: priority as TaskPriority,
+    source,
+    acceptance_criteria: acceptanceCriteria,
+    refs,
+    created_at: now,
+    updated_at: now,
+    ...(description ? { description } : {}),
+    ...(labels && labels.length > 0 ? { labels } : {}),
+    ...(blockedReason ? { blocked_reason: blockedReason } : {}),
+  };
+  if (CLOSE_STATUSES.has(task.status)) {
+    task.closed_at = now;
+  }
+  return { task, errors };
+}
+
+function findDuplicateTask(tasks: AgenticOSTask[], task: AgenticOSTask): AgenticOSTask | null {
+  const dedupeKey = deriveDedupeKey(task);
+  return tasks.find((candidate) => (
+    candidate.id === task.id || deriveDedupeKey(candidate) === dedupeKey
+  )) || null;
+}
+
+function taskResponse(status: string, context: TaskCommandContext, task: AgenticOSTask, extra: Record<string, unknown> = {}): string {
+  return jsonResult({
+    status,
+    project_id: context.project_id,
+    project_kind: context.project_kind,
+    task_path: taskPath(context, task.id),
+    state_path: context.state_path,
+    task,
+    ...extra,
+  });
+}
+
+function errorResponse(errors: string[]): string {
+  return jsonResult({ status: 'ERROR', errors });
+}
+
+export async function runTaskCreate(args: any = {}): Promise<string> {
+  try {
+    const context = await resolveTaskContext(args);
+    const built = buildTaskFromCreateArgs(args, nowIso());
+    if (!built.task) {
+      return errorResponse(built.errors);
+    }
+    await mkdir(context.tasks_dir, { recursive: true });
+    const existing = findDuplicateTask(await listTaskFiles(context), built.task);
+    if (existing) {
+      await syncState(context, existing);
+      return taskResponse('EXISTING', context, existing, { duplicate: true });
+    }
+    await writeFile(taskPath(context, built.task.id), yaml.stringify(built.task), 'utf-8');
+    await syncState(context, built.task);
+    return taskResponse('CREATED', context, built.task);
+  } catch (error: any) {
+    return errorResponse([error.message || 'failed to create task']);
+  }
+}
+
+function applyTaskUpdates(existing: AgenticOSTask, args: any, now: string): { task?: AgenticOSTask; errors: string[] } {
+  const errors: string[] = [];
+  const next: AgenticOSTask = { ...existing, updated_at: now };
+
+  if (args.title !== undefined) {
+    if (typeof args.title !== 'string' || !args.title.trim()) {
+      errors.push('title must be a non-empty string');
+    } else {
+      next.title = args.title.trim();
+    }
+  }
+  if (args.status !== undefined) {
+    const status = typeof args.status === 'string' ? args.status.trim() : '';
+    if (!TASK_STATUSES.has(status as TaskStatus)) {
+      errors.push('status must be one of open, in_progress, blocked, done, canceled');
+    } else {
+      next.status = status as TaskStatus;
+    }
+  }
+  if (args.priority !== undefined) {
+    const priority = typeof args.priority === 'string' ? args.priority.trim() : '';
+    if (!PRIORITIES.has(priority as TaskPriority)) {
+      errors.push('priority must be one of low, medium, high, urgent');
+    } else {
+      next.priority = priority as TaskPriority;
+    }
+  }
+  if (args.acceptance_criteria !== undefined) {
+    next.acceptance_criteria = ensureStringArray(args.acceptance_criteria, 'acceptance_criteria', errors);
+  }
+  if (args.source !== undefined) {
+    next.source = normalizeSource(args.source, errors);
+  }
+  if (args.refs !== undefined) {
+    next.refs = normalizeRefs(args.refs, errors);
+  }
+  if (args.description !== undefined) {
+    next.description = typeof args.description === 'string' && args.description.trim() ? args.description.trim() : undefined;
+  }
+  if (args.labels !== undefined) {
+    const labels = ensureStringArray(args.labels, 'labels', errors);
+    next.labels = labels.length > 0 ? labels : undefined;
+  }
+  if (args.blocked_reason !== undefined) {
+    next.blocked_reason = typeof args.blocked_reason === 'string' && args.blocked_reason.trim() ? args.blocked_reason.trim() : undefined;
+  }
+
+  if (next.status === 'blocked' && !next.blocked_reason) {
+    errors.push('blocked_reason is required when status is blocked');
+  }
+  if (CLOSE_STATUSES.has(next.status) && !next.closed_at) {
+    next.closed_at = now;
+  }
+  if (!CLOSE_STATUSES.has(next.status)) {
+    delete next.closed_at;
+  }
+  if (hasSecretLikeValue(next)) {
+    errors.push('task input appears to contain raw secret material; store a safe reference instead');
+  }
+
+  return errors.length > 0 ? { errors } : { task: next, errors };
+}
+
+function requestedTaskId(args: any): string {
+  return sanitizeTaskId(typeof args?.task_id === 'string' && args.task_id.trim() ? args.task_id : String(args?.id || ''));
+}
+
+export async function runTaskUpdate(args: any = {}): Promise<string> {
+  try {
+    const context = await resolveTaskContext(args);
+    const taskId = requestedTaskId(args);
+    if (!taskId) {
+      return errorResponse(['task_id is required']);
+    }
+    const existing = await readTaskFile(taskPath(context, taskId));
+    if (!existing) {
+      return errorResponse([`task "${taskId}" not found`]);
+    }
+    const updated = applyTaskUpdates(existing, args, nowIso());
+    if (!updated.task) {
+      return errorResponse(updated.errors);
+    }
+    await writeFile(taskPath(context, updated.task.id), yaml.stringify(updated.task), 'utf-8');
+    await syncState(context, updated.task);
+    return taskResponse('UPDATED', context, updated.task);
+  } catch (error: any) {
+    return errorResponse([error.message || 'failed to update task']);
+  }
+}
+
+export async function runTaskList(args: any = {}): Promise<string> {
+  try {
+    const context = await resolveTaskContext(args);
+    const statusFilter = typeof args?.status === 'string' && args.status.trim() ? args.status.trim() : null;
+    if (statusFilter && !TASK_STATUSES.has(statusFilter as TaskStatus)) {
+      return errorResponse(['status must be one of open, in_progress, blocked, done, canceled']);
+    }
+    const tasks = (await listTaskFiles(context))
+      .filter((task) => !statusFilter || task.status === statusFilter)
+      .sort((a, b) => a.id.localeCompare(b.id));
+    return jsonResult({
+      status: 'OK',
+      project_id: context.project_id,
+      project_kind: context.project_kind,
+      tasks_dir: context.tasks_dir,
+      count: tasks.length,
+      tasks,
+    });
+  } catch (error: any) {
+    return errorResponse([error.message || 'failed to list tasks']);
+  }
+}
+
+export async function runTaskClose(args: any = {}): Promise<string> {
+  const status = typeof args?.status === 'string' && args.status.trim() ? args.status.trim() : 'done';
+  if (!CLOSE_STATUSES.has(status as TaskStatus)) {
+    return errorResponse(['close status must be done or canceled']);
+  }
+  return runTaskUpdate({
+    ...args,
+    status,
+  });
+}


### PR DESCRIPTION
Fixes #448.

## Summary
- add durable task MCP tools: create, update, list, and close
- persist tasks as tasks/<task_id>.yaml with idempotent duplicate detection
- synchronize .context/state.yaml resume/current_task and validate topic/project metadata
- reject secret-looking task input and update MCP regression baseline for the new tools

## Verification
- cd mcp-server && npm ci
- cd mcp-server && npm run lint
- cd mcp-server && npm test -- --run
- ./tools/coverage-preflight.sh
- git diff --check
- agenticos_preflight: PASS
- agenticos_edit_guard: PASS
- agenticos_pr_scope_check: PASS