### PR TITLE
test: add durable topic task smoke coverage

### DIFF
--- a/mcp-server/src/__tests__/durable-topic-task-smoke.test.ts
+++ b/mcp-server/src/__tests__/durable-topic-task-smoke.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync } from 'fs';
+import { mkdtemp } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import yaml from 'yaml';
+import { spawnMcpServer, type McpSession } from './fixtures/mcp-session.js';
+
+interface TaskToolResult {
+  status: string;
+  project_id?: string;
+  project_kind?: 'topic' | 'project';
+  task_path?: string;
+  state_path?: string;
+  duplicate?: boolean;
+  errors?: string[];
+  task?: {
+    id: string;
+    title: string;
+    status: string;
+    priority: string;
+    closed_at?: string;
+  };
+}
+
+function toolText(result: { content: Array<{ type: string; text: string }> }): string {
+  expect(result.content).toHaveLength(1);
+  expect(result.content[0]).toMatchObject({ type: 'text' });
+  return result.content[0].text;
+}
+
+function readYamlFile(path: string): any {
+  return yaml.parse(readFileSync(path, 'utf-8'));
+}
+
+describe('durable topic task MCP smoke flow', () => {
+  let agenticosHome: string;
+  let session: McpSession;
+
+  beforeEach(async () => {
+    agenticosHome = await mkdtemp(join(tmpdir(), 'agenticos-topic-smoke-'));
+    session = spawnMcpServer([], {
+      env: {
+        AGENTICOS_HOME: agenticosHome,
+      },
+    });
+    await session.sendInitialize({ name: 'durable-topic-smoke', version: '1.0.0' });
+    session.sendInitializedNotification();
+    const tools = await session.sendToolsList();
+    expect(tools.map((tool) => tool.name)).toEqual(expect.arrayContaining([
+      'agenticos_task_create',
+      'agenticos_task_list',
+      'agenticos_task_close',
+    ]));
+  });
+
+  afterEach(() => {
+    session.kill();
+    rmSync(agenticosHome, { recursive: true, force: true });
+  });
+
+  async function callText(name: string, args: Record<string, unknown> = {}): Promise<string> {
+    return toolText(await session.sendToolCall(name, args));
+  }
+
+  async function callJson(name: string, args: Record<string, unknown> = {}): Promise<TaskToolResult> {
+    return JSON.parse(await callText(name, args)) as TaskToolResult;
+  }
+
+  async function initProject(name: string, projectKind: 'topic' | 'project'): Promise<string> {
+    const projectPath = join(agenticosHome, 'projects', name.toLowerCase().replace(/\s+/g, '-'));
+    mkdirSync(projectPath, { recursive: true });
+    const text = await callText('agenticos_init', {
+      name,
+      path: projectPath,
+      project_kind: projectKind,
+      topology: 'local_directory_only',
+    });
+    expect(text).toContain(`Project Kind: ${projectKind}`);
+    return projectPath;
+  }
+
+  it('creates, deduplicates, and closes a Hermes-style durable topic task through MCP', async () => {
+    const topicPath = await initProject('Hermes Sleep Topic', 'topic');
+
+    const created = await callJson('agenticos_task_create', {
+      project: 'hermes-sleep-topic',
+      id: 'sleep-experiment',
+      title: 'Sleep Experiment',
+      status: 'in_progress',
+      priority: 'high',
+      source: {
+        kind: 'hermes',
+        origin: 'chat',
+        source_id: 'hermes-message-1',
+        dedupe_key: 'hermes:sleep:experiment',
+      },
+      acceptance_criteria: ['The next sleep experiment is captured as an actionable task'],
+      refs: [{ type: 'gbrain', uri: 'gbrain://topics/sleep', visibility: 'private' }],
+    });
+
+    expect(created.status).toBe('CREATED');
+    expect(created.project_kind).toBe('topic');
+    expect(created.task).toMatchObject({
+      id: 'sleep-experiment',
+      title: 'Sleep Experiment',
+      status: 'in_progress',
+      priority: 'high',
+    });
+    expect(created.task_path).toBe(join(topicPath, 'tasks', 'sleep-experiment.yaml'));
+    expect(readYamlFile(created.task_path!).source.kind).toBe('hermes');
+
+    const stateAfterCreate = readYamlFile(join(topicPath, '.context', 'state.yaml'));
+    expect(stateAfterCreate.current_task).toMatchObject({
+      id: 'sleep-experiment',
+      status: 'in_progress',
+      next_step: 'The next sleep experiment is captured as an actionable task',
+    });
+    expect(stateAfterCreate.resume.task_id).toBe('sleep-experiment');
+
+    const duplicate = await callJson('agenticos_task_create', {
+      project: 'hermes-sleep-topic',
+      title: 'Sleep Experiment, repeated prompt',
+      source: {
+        kind: 'hermes',
+        origin: 'chat',
+        dedupe_key: 'hermes:sleep:experiment',
+      },
+      acceptance_criteria: ['A repeated prompt must not create a second task'],
+    });
+
+    expect(duplicate.status).toBe('EXISTING');
+    expect(duplicate.duplicate).toBe(true);
+    expect(duplicate.task?.id).toBe('sleep-experiment');
+    expect(readdirSync(join(topicPath, 'tasks')).filter((entry) => entry.endsWith('.yaml'))).toEqual(['sleep-experiment.yaml']);
+
+    const closed = await callJson('agenticos_task_close', {
+      project: 'hermes-sleep-topic',
+      task_id: 'sleep-experiment',
+    });
+
+    expect(closed.status).toBe('UPDATED');
+    expect(closed.task).toMatchObject({
+      id: 'sleep-experiment',
+      status: 'done',
+    });
+    expect(closed.task?.closed_at).toBeTruthy();
+    expect(readYamlFile(join(topicPath, 'tasks', 'sleep-experiment.yaml')).status).toBe('done');
+
+    const stateAfterClose = readYamlFile(join(topicPath, '.context', 'state.yaml'));
+    expect(stateAfterClose.current_task).toBeNull();
+    expect(stateAfterClose.resume).toBeUndefined();
+  });
+
+  it('routes topic and project tasks by project_kind', async () => {
+    const topicPath = await initProject('Hermes Finance Topic', 'topic');
+    const projectPath = await initProject('Agentic CI API', 'project');
+
+    const topicTask = await callJson('agenticos_task_create', {
+      project: 'hermes-finance-topic',
+      title: 'Review household budget',
+      acceptance_criteria: ['Budget topic has an active follow-up task'],
+    });
+    expect(topicTask.status).toBe('CREATED');
+    expect(topicTask.project_kind).toBe('topic');
+    expect(topicTask.task_path).toBe(join(topicPath, 'tasks', 'review-household-budget.yaml'));
+
+    const projectTask = await callJson('agenticos_task_create', {
+      project: 'agentic-ci-api',
+      title: 'Add CI retry policy',
+      acceptance_criteria: ['Repository project has an implementation task'],
+    });
+    expect(projectTask.status).toBe('CREATED');
+    expect(projectTask.project_kind).toBe('project');
+    expect(projectTask.task_path).toBe(join(projectPath, 'tasks', 'add-ci-retry-policy.yaml'));
+  });
+
+  it('does not claim success when project context is unavailable or secret-looking input is rejected', async () => {
+    const noProject = await callJson('agenticos_task_create', {
+      title: 'Create without project',
+      acceptance_criteria: ['This must not be reported as success'],
+    });
+    expect(noProject.status).toBe('ERROR');
+    expect(noProject.errors?.join(' ')).toContain('No project provided');
+    expect(existsSync(join(agenticosHome, 'projects'))).toBe(false);
+
+    const topicPath = await initProject('Hermes Secret Topic', 'topic');
+    const failedSwitch = await callText('agenticos_switch', { project: 'missing-topic' });
+    expect(failedSwitch).toContain('not found');
+
+    const afterFailedSwitch = await callJson('agenticos_task_create', {
+      title: 'Create after failed switch',
+      acceptance_criteria: ['A failed switch must not bind context'],
+    });
+    expect(afterFailedSwitch.status).toBe('ERROR');
+    expect(afterFailedSwitch.errors?.join(' ')).toContain('No project provided');
+
+    const secret = await callJson('agenticos_task_create', {
+      project: 'hermes-secret-topic',
+      title: 'Store token=abc123',
+      acceptance_criteria: ['Raw secret material must not be written'],
+    });
+    expect(secret.status).toBe('ERROR');
+    expect(secret.errors?.join(' ')).toContain('secret');
+
+    const taskFiles = readdirSync(join(topicPath, 'tasks')).filter((entry) => entry.endsWith('.yaml'));
+    expect(taskFiles).toEqual([]);
+  });
+});

--- a/mcp-server/src/__tests__/fixtures/mcp-session.ts
+++ b/mcp-server/src/__tests__/fixtures/mcp-session.ts
@@ -30,8 +30,10 @@ import { join as joinPosix } from 'path';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-// MONOREPO_ROOT = worktree root (parent of mcp-server/)
-const MONOREPO_ROOT = join(__dirname, '..', '..', '..');
+// MONOREPO_ROOT = worktree root (parent of mcp-server/).
+// This fixture lives under src/__tests__/fixtures in source form and
+// build/__tests__/fixtures in compiled form, so it needs four parent hops.
+const MONOREPO_ROOT = join(__dirname, '..', '..', '..', '..');
 const BUILD_INDEX = join(MONOREPO_ROOT, 'mcp-server', 'build', 'index.js');
 const PKG_JSON = join(MONOREPO_ROOT, 'mcp-server', 'package.json');
 
@@ -164,6 +166,11 @@ export interface McpSession {
   sendToolsList(): Promise<Array<{ name: string; description?: string }>>;
 
   /**
+   * Sends a `tools/call` request and returns the raw MCP tool result.
+   */
+  sendToolCall(name: string, args?: Record<string, unknown>): Promise<{ content: Array<{ type: string; text: string }> }>;
+
+  /**
    * Sends a `shutdown` request and waits for the null result.
    */
   sendShutdown(): Promise<unknown>;
@@ -174,6 +181,10 @@ export interface McpSession {
   kill(): void;
 }
 
+export interface McpSessionOptions {
+  env?: NodeJS.ProcessEnv;
+}
+
 /**
  * Spawns the MCP server as a child process and returns an McpSession handle.
  *
@@ -181,9 +192,10 @@ export interface McpSession {
  * (matching the Homebrew install path pattern). The temporary directory is
  * cleaned up when kill() is called.
  *
- * @param args  Extra CLI arguments to pass to the server.
+ * @param args     Extra CLI arguments to pass to the server.
+ * @param options  Optional process environment overrides.
  */
-export function spawnMcpServer(args: string[] = []): McpSession {
+export function spawnMcpServer(args: string[] = [], options: McpSessionOptions = {}): McpSession {
   const workDir = mkdtempSync(joinPosix(tmpdir(), 'agenticos-mcp-fixture-'));
   const symlinkPath = joinPosix(workDir, 'agenticos-mcp');
 
@@ -197,7 +209,7 @@ export function spawnMcpServer(args: string[] = []): McpSession {
   const binary = symlinkCreated ? symlinkPath : _MCP_BINARY;
   const proc = spawn(binary, args, {
     stdio: ['pipe', 'pipe', 'pipe'],
-    env: { ...process.env, AGENTICOS_HOME: MONOREPO_ROOT },
+    env: { ...process.env, AGENTICOS_HOME: MONOREPO_ROOT, ...(options.env ?? {}) },
   }) as McpProcess;
 
   return {
@@ -229,6 +241,18 @@ export function spawnMcpServer(args: string[] = []): McpSession {
       if (resp.error) throw new Error(`tools/list error: ${resp.error.message}`);
       const result = resp.result as { tools: Array<{ name: string; description?: string }> };
       return result.tools ?? [];
+    },
+
+    async sendToolCall(name: string, args: Record<string, unknown> = {}) {
+      const resp = await sendMessage(proc, {
+        method: 'tools/call',
+        params: {
+          name,
+          arguments: args,
+        },
+      });
+      if (resp.error) throw new Error(`tools/call ${name} error: ${resp.error.message}`);
+      return resp.result as { content: Array<{ type: string; text: string }> };
     },
 
     async sendShutdown() {


### PR DESCRIPTION
Fixes #449.

## Summary
- add a real MCP smoke test for durable topic task create, duplicate idempotency, close, and state sync
- cover topic vs project routing through project_kind
- verify failed switch/no project and secret-looking input return errors without writing task files
- extend the MCP session fixture to call tools and run the current worktree build with temporary AGENTICOS_HOME

## Verification
- cd mcp-server && npm ci
- cd mcp-server && npm run lint
- cd mcp-server && npm test -- --run
- GITHUB_EVENT_NAME=pull_request GITHUB_BASE_REF=main ./tools/coverage-preflight.sh
- git diff --check
- agenticos_preflight: PASS
- agenticos_edit_guard: PASS
- agenticos_pr_scope_check: PASS