### PR TITLE
feat: add knowledge evolution health warnings

### DIFF
--- a/mcp-server/src/tools/__tests__/health.test.ts
+++ b/mcp-server/src/tools/__tests__/health.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const runHealthCheckMock = vi.hoisted(() => vi.fn());
+const assessKnowledgeEvolutionHealthMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../utils/health.js', () => ({
+  runHealthCheck: runHealthCheckMock,
+}));
+
+vi.mock('../../utils/knowledge-evolution-health.js', () => ({
+  assessKnowledgeEvolutionHealth: assessKnowledgeEvolutionHealthMock,
+}));
+
+import { runHealth } from '../health.js';
+
+function baseHealthResult(status: 'PASS' | 'WARN' | 'BLOCK', recoveryActions?: string[]): any {
+  return {
+    command: 'agenticos_health',
+    status,
+    repo_path: '/repo',
+    project_path: '/project',
+    remote_base_branch: 'origin/main',
+    checkout_role: 'canonical',
+    checked_at: '2026-05-21T00:00:00.000Z',
+    gates: [{ gate: 'repo_sync', status: 'PASS', summary: 'Repo is clean.' }],
+    repo_sync: {
+      branch_line: '## main...origin/main',
+      branch_status: 'aligned',
+      dirty_paths: [],
+      runtime_dirty_paths: [],
+      source_dirty_paths: [],
+    },
+    ...(recoveryActions === undefined ? {} : { recovery_actions: recoveryActions }),
+  };
+}
+
+function knowledgeResult(status: 'PASS' | 'WARN'): any {
+  return {
+    status,
+    summary: status === 'PASS' ? 'Knowledge evolution signals are fresh.' : 'Knowledge evolution has 1 warning(s).',
+    recovery_actions: status === 'PASS' ? [] : ['refresh knowledge evolution signals'],
+  };
+}
+
+describe('agenticos health tool wrapper', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('keeps PASS when canonical health and knowledge evolution both pass', async () => {
+    runHealthCheckMock.mockResolvedValue(baseHealthResult('PASS', []));
+    assessKnowledgeEvolutionHealthMock.mockResolvedValue(knowledgeResult('PASS'));
+
+    const result = JSON.parse(await runHealth({ repo_path: '/repo' }));
+
+    expect(result.status).toBe('PASS');
+    expect(result.gates).toContainEqual({
+      gate: 'knowledge_evolution',
+      status: 'PASS',
+      summary: 'Knowledge evolution signals are fresh.',
+    });
+    expect(result.recovery_actions).toEqual([]);
+    expect(assessKnowledgeEvolutionHealthMock).toHaveBeenCalledWith({
+      projectPath: '/project',
+      repoPath: '/repo',
+      repoSync: {
+        branch_line: '## main...origin/main',
+        branch_status: 'aligned',
+        dirty_paths: [],
+        runtime_dirty_paths: [],
+        source_dirty_paths: [],
+      },
+    });
+  });
+
+  it('escalates PASS to WARN when knowledge evolution warns and preserves missing recovery_actions', async () => {
+    runHealthCheckMock.mockResolvedValue(baseHealthResult('PASS'));
+    assessKnowledgeEvolutionHealthMock.mockResolvedValue(knowledgeResult('WARN'));
+
+    const result = JSON.parse(await runHealth({ repo_path: '/repo' }));
+
+    expect(result.status).toBe('WARN');
+    expect(result.recovery_actions).toEqual(['refresh knowledge evolution signals']);
+  });
+
+  it('preserves BLOCK when the underlying health check blocks', async () => {
+    runHealthCheckMock.mockResolvedValue(baseHealthResult('BLOCK', ['fix branch alignment']));
+    assessKnowledgeEvolutionHealthMock.mockResolvedValue(knowledgeResult('WARN'));
+
+    const result = JSON.parse(await runHealth({ repo_path: '/repo' }));
+
+    expect(result.status).toBe('BLOCK');
+    expect(result.recovery_actions).toEqual([
+      'fix branch alignment',
+      'refresh knowledge evolution signals',
+    ]);
+  });
+});

--- a/mcp-server/src/tools/__tests__/project.test.ts
+++ b/mcp-server/src/tools/__tests__/project.test.ts
@@ -23,6 +23,7 @@ vi.mock('fs/promises', () => ({
   access: vi.fn(),
   rename: vi.fn(),
   rm: vi.fn(),
+  readdir: vi.fn(),
   stat: vi.fn(),
 }));
 
@@ -84,6 +85,8 @@ import { bindSessionProject, clearSessionProjectBinding, getSessionProjectBindin
 const fsPromisesMock = fsPromises as typeof fsPromises & {
   readFile: ReturnType<typeof vi.fn>;
   writeFile: ReturnType<typeof vi.fn>;
+  readdir: ReturnType<typeof vi.fn>;
+  stat: ReturnType<typeof vi.fn>;
 };
 const registryMock = registry as typeof registry & {
   loadRegistry: ReturnType<typeof vi.fn>;
@@ -130,6 +133,8 @@ describe('switchProject', () => {
     yamlMock.parse.mockImplementation((content: string) => {
       try { return JSON.parse(content); } catch { return undefined; }
     });
+    fsPromisesMock.readdir.mockResolvedValue([]);
+    fsPromisesMock.stat.mockRejectedValue(new Error('not found'));
     loadLatestGuardrailStateMock.mockResolvedValue({
       source: null,
       state: {},

--- a/mcp-server/src/tools/health.ts
+++ b/mcp-server/src/tools/health.ts
@@ -1,6 +1,33 @@
 import { runHealthCheck } from '../utils/health.js';
+import { assessKnowledgeEvolutionHealth } from '../utils/knowledge-evolution-health.js';
 
 export async function runHealth(args: any): Promise<string> {
   const result = await runHealthCheck(args ?? {});
-  return JSON.stringify(result, null, 2);
+  const knowledgeEvolution = await assessKnowledgeEvolutionHealth({
+    projectPath: result.project_path,
+    repoPath: args?.repo_path,
+    repoSync: result.repo_sync,
+  });
+  const status = result.status === 'BLOCK'
+    ? 'BLOCK'
+    : result.status === 'WARN' || knowledgeEvolution.status === 'WARN'
+      ? 'WARN'
+      : 'PASS';
+  return JSON.stringify({
+    ...result,
+    status,
+    gates: [
+      ...result.gates,
+      {
+        gate: 'knowledge_evolution',
+        status: knowledgeEvolution.status,
+        summary: knowledgeEvolution.summary,
+      },
+    ],
+    knowledge_evolution: knowledgeEvolution,
+    recovery_actions: [
+      ...(result.recovery_actions ?? []),
+      ...knowledgeEvolution.recovery_actions,
+    ],
+  }, null, 2);
 }

--- a/mcp-server/src/tools/project.ts
+++ b/mcp-server/src/tools/project.ts
@@ -27,6 +27,7 @@ import {
 } from '../utils/issue-bootstrap-continuity.js';
 import { deriveExpectedWorktreeRoot, inspectProjectWorktreeTopology } from '../utils/worktree-topology.js';
 import { detectCanonicalMainWriteProtection } from '../utils/canonical-main-guard.js';
+import { assessKnowledgeEvolutionHealth, buildKnowledgeEvolutionStatusLines } from '../utils/knowledge-evolution-health.js';
 
 type GuardrailCommand = 'agenticos_preflight' | 'agenticos_branch_bootstrap' | 'agenticos_pr_scope_check';
 
@@ -728,6 +729,14 @@ export async function getStatus(args: any = {}): Promise<string> {
   }));
   try {
     lines.push(...await buildWorktreeTopologySummaryLines(resolved.projectPath, resolved.projectYaml));
+  } catch {}
+  try {
+    lines.push(...buildKnowledgeEvolutionStatusLines(await assessKnowledgeEvolutionHealth({
+      projectPath: resolved.projectPath,
+      repoPath: resolved.projectPath,
+      projectYaml: resolved.projectYaml,
+      state,
+    })));
   } catch {}
 
   lines.push('');

--- a/mcp-server/src/utils/__tests__/health.test.ts
+++ b/mcp-server/src/utils/__tests__/health.test.ts
@@ -26,6 +26,7 @@ const standardKitMock = vi.hoisted(() => ({
 
 const registryMock = vi.hoisted(() => ({
   getAgenticOSHome: vi.fn(() => '/workspace'),
+  loadRegistry: vi.fn(),
 }));
 
 const repoBoundaryMock = vi.hoisted(() => ({
@@ -47,6 +48,7 @@ vi.mock('../standard-kit.js', async (importOriginal) => {
 
 vi.mock('../registry.js', () => ({
   getAgenticOSHome: registryMock.getAgenticOSHome,
+  loadRegistry: registryMock.loadRegistry,
 }));
 
 vi.mock('../repo-boundary.js', () => ({
@@ -84,6 +86,12 @@ describe('health command', () => {
     // Default exec mock — individual tests override this
     execMock.mockReset();
     spawnMock.mockReset();
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2026-03-25T00:00:00.000Z',
+      active_project: null,
+      projects: [],
+    });
 
     // Default exec mock: 'which agenticos-mcp' returns a path so spawn is called
     execMock.mockImplementation((command: string, cb: Function) => {
@@ -183,9 +191,10 @@ describe('health command', () => {
     const wrapped = JSON.parse(await runHealth({
       repo_path: '/repo',
       project_path: projectRoot,
-    })) as { command: string; status: string };
+    })) as { command: string; status: string; knowledge_evolution: { status: string } };
     expect(wrapped.command).toBe('agenticos_health');
-    expect(wrapped.status).toBe('PASS');
+    expect(wrapped.status).toBe('WARN');
+    expect(wrapped.knowledge_evolution.status).toBe('WARN');
   });
 
   it('reports branch misalignment separately from runtime drift and source edits', async () => {

--- a/mcp-server/src/utils/__tests__/knowledge-evolution-health.test.ts
+++ b/mcp-server/src/utils/__tests__/knowledge-evolution-health.test.ts
@@ -171,6 +171,43 @@ describe('knowledge evolution health', () => {
     expect(result.summary).toContain('warning');
   });
 
+  it('uses nested tracked file mtimes and session refresh fallback', async () => {
+    const projectRoot = await setupProject({
+      captureAt: recent,
+      refreshAt: null,
+      knowledgeAt: null,
+      taskAt: null,
+      agentsVersion: null,
+    });
+    await writeFile(join(projectRoot, 'standards', '.context', 'state.yaml'), yaml.stringify({
+      session: { last_entry_surface_refresh: recent.toISOString() },
+    }), 'utf-8');
+    await mkdir(join(projectRoot, 'knowledge', 'nested'), { recursive: true });
+    await touch(join(projectRoot, 'knowledge', 'nested', 'summary.markdown'), recent);
+    await writeFile(join(projectRoot, 'knowledge', 'notes.txt'), 'ignored\n', 'utf-8');
+    await writeFile(join(projectRoot, 'knowledge', 'README'), 'ignored\n', 'utf-8');
+    await mkdir(join(projectRoot, 'tasks', 'nested'), { recursive: true });
+    await touch(join(projectRoot, 'tasks', 'nested', 'task.json'), recent);
+
+    const result = await assessKnowledgeEvolutionHealth({
+      projectPath: projectRoot,
+      repoSync: {
+        branch_line: '## main...origin/main',
+        branch_status: 'aligned',
+        dirty_paths: [],
+        runtime_dirty_paths: [],
+        source_dirty_paths: [],
+      },
+      now,
+    });
+
+    expect(result.latest_entry_state_refresh_at).toBe(recent.toISOString());
+    expect(result.latest_knowledge_update_at).toBe(recent.toISOString());
+    expect(result.latest_task_update_at).toBe(recent.toISOString());
+    expect(result.adapter_template_freshness.adapters.find((adapter) => adapter.path.endsWith('AGENTS.md'))?.status).toBe('missing');
+    expect(result.warnings).toContain(`${join(projectRoot, 'AGENTS.md')} adapter template is missing`);
+  });
+
   it('warns for dirty worktree summaries', async () => {
     const projectRoot = await setupProject();
     const result = await assessKnowledgeEvolutionHealth({
@@ -211,6 +248,147 @@ describe('knowledge evolution health', () => {
 
     expect(result.adapter_template_freshness.adapters.find((adapter) => adapter.path.endsWith('CLAUDE.md'))?.status).toBe('stale');
     expect(result.warnings.some((warning) => warning.includes('CLAUDE.md'))).toBe(true);
+  });
+
+  it('warns when project yaml or state cannot be read and repo sync is unknown', async () => {
+    home = await mkdtemp(join(tmpdir(), 'agenticos-knowledge-health-'));
+    process.env.AGENTICOS_HOME = home;
+    const projectRoot = join(home, 'projects', 'unreadable-project');
+    await mkdir(projectRoot, { recursive: true });
+
+    const result = await assessKnowledgeEvolutionHealth({
+      projectPath: projectRoot,
+      repoPath: projectRoot,
+      now,
+    });
+
+    expect(result.status).toBe('WARN');
+    expect(result.dirty_worktree.status).toBe('UNKNOWN');
+    expect(result.registry_state_drift.summary).toContain('meta.id');
+    expect(result.adapter_template_freshness.adapters.every((adapter) => adapter.status === 'missing')).toBe(true);
+  });
+
+  it('warns when the configured state file cannot be read', async () => {
+    home = await mkdtemp(join(tmpdir(), 'agenticos-knowledge-health-'));
+    process.env.AGENTICOS_HOME = home;
+    const projectRoot = join(home, 'projects', 'missing-state-project');
+    await mkdir(projectRoot, { recursive: true });
+    await writeFile(join(projectRoot, '.project.yaml'), yaml.stringify({
+      meta: { id: 'missing-state-project', name: 'Missing State Project' },
+      agent_context: {
+        current_state: 'standards/.context/state.yaml',
+        knowledge: 'knowledge/',
+        tasks: 'tasks/',
+      },
+    }), 'utf-8');
+
+    const result = await assessKnowledgeEvolutionHealth({
+      projectPath: projectRoot,
+      repoSync: {
+        branch_line: '## main...origin/main',
+        branch_status: 'aligned',
+        dirty_paths: [],
+        runtime_dirty_paths: [],
+        source_dirty_paths: [],
+      },
+      now,
+    });
+
+    expect(result.latest_entry_state_refresh_at).toBeNull();
+    expect(result.warnings).toContain('entry-state refresh is missing');
+  });
+
+  it('handles null project/state yaml, invalid timestamps, absent repo sync input, and blank project ids', async () => {
+    home = await mkdtemp(join(tmpdir(), 'agenticos-knowledge-health-'));
+    process.env.AGENTICOS_HOME = home;
+    const projectRoot = join(home, 'projects', 'null-surfaces-project');
+    await mkdir(join(projectRoot, 'standards', '.context'), { recursive: true });
+    await writeFile(join(projectRoot, '.project.yaml'), 'null\n', 'utf-8');
+    await writeFile(join(projectRoot, 'standards', '.context', 'state.yaml'), 'null\n', 'utf-8');
+
+    const nullYamlResult = await assessKnowledgeEvolutionHealth({
+      projectPath: projectRoot,
+      now,
+    });
+    expect(nullYamlResult.dirty_worktree.status).toBe('UNKNOWN');
+    expect(nullYamlResult.registry_state_drift.summary).toContain('meta.id');
+
+    const invalidTimestampResult = await assessKnowledgeEvolutionHealth({
+      projectPath: projectRoot,
+      projectYaml: { meta: { id: '   ' } },
+      state: { entry_surface_refresh: { refreshed_at: 'not-a-date' } },
+      repoSync: {
+        branch_line: '## main...origin/main',
+        branch_status: 'aligned',
+        dirty_paths: [],
+        runtime_dirty_paths: [],
+        source_dirty_paths: [],
+      },
+      now,
+    });
+    expect(invalidTimestampResult.latest_entry_state_refresh_at).toBeNull();
+    expect(invalidTimestampResult.registry_state_drift.summary).toContain('meta.id');
+
+    await writeFile(join(projectRoot, '.project.yaml'), yaml.stringify({
+      meta: { id: 'null-surfaces-project', name: 'Null Surfaces Project' },
+      agent_context: { current_state: 'standards/.context/state.yaml' },
+    }), 'utf-8');
+    const nullStateResult = await assessKnowledgeEvolutionHealth({
+      projectPath: projectRoot,
+      repoSync: {
+        branch_line: '## main...origin/main',
+        branch_status: 'aligned',
+        dirty_paths: [],
+        runtime_dirty_paths: [],
+        source_dirty_paths: [],
+      },
+      now,
+    });
+    expect(nullStateResult.latest_entry_state_refresh_at).toBeNull();
+  });
+
+  it('warns when registry drift cannot be determined', async () => {
+    const projectRoot = await setupProject();
+    process.env.AGENTICOS_HOME = '';
+
+    const result = await assessKnowledgeEvolutionHealth({
+      projectPath: projectRoot,
+      projectYaml: { meta: {}, agent_context: { current_state: 'standards/.context/state.yaml' } },
+      state: {},
+      repoSync: {
+        branch_line: '## main...origin/main',
+        branch_status: 'aligned',
+        dirty_paths: [],
+        runtime_dirty_paths: [],
+        source_dirty_paths: [],
+      },
+      now,
+    });
+
+    expect(result.registry_state_drift.status).toBe('WARN');
+    expect(result.registry_state_drift.summary).toBe('Registry/state drift could not be determined.');
+  });
+
+  it('reports null project_path when registry drift cannot be determined without a project path', async () => {
+    home = await mkdtemp(join(tmpdir(), 'agenticos-knowledge-health-'));
+    process.env.AGENTICOS_HOME = '';
+
+    const result = await assessKnowledgeEvolutionHealth({
+      projectPath: null,
+      projectYaml: { meta: {} },
+      state: {},
+      repoSync: {
+        branch_line: '## main...origin/main',
+        branch_status: 'aligned',
+        dirty_paths: [],
+        runtime_dirty_paths: [],
+        source_dirty_paths: [],
+      },
+      now,
+    });
+
+    expect(result.registry_state_drift.project_path).toBeNull();
+    expect(result.registry_state_drift.summary).toBe('Registry/state drift could not be determined.');
   });
 
   it('warns for registry/state drift', async () => {

--- a/mcp-server/src/utils/__tests__/knowledge-evolution-health.test.ts
+++ b/mcp-server/src/utils/__tests__/knowledge-evolution-health.test.ts
@@ -1,0 +1,272 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdir, mkdtemp, stat, utimes, writeFile } from 'fs/promises';
+import { rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import yaml from 'yaml';
+import { CURRENT_TEMPLATE_VERSION } from '../distill.js';
+import { assessKnowledgeEvolutionHealth, buildKnowledgeEvolutionStatusLines } from '../knowledge-evolution-health.js';
+
+const originalHome = process.env.AGENTICOS_HOME;
+const now = new Date('2026-05-21T00:00:00.000Z');
+const recent = new Date('2026-05-20T00:00:00.000Z');
+const stale = new Date('2026-04-01T00:00:00.000Z');
+
+let home: string | null = null;
+
+async function touch(path: string, date: Date): Promise<void> {
+  await writeFile(path, `updated ${date.toISOString()}\n`, 'utf-8');
+  await utimes(path, date, date);
+}
+
+async function writeRegistry(projectRoot: string, options: { activeProject?: string | null; path?: string } = {}): Promise<void> {
+  await mkdir(join(home!, '.agent-workspace'), { recursive: true });
+  await writeFile(join(home!, '.agent-workspace', 'registry.yaml'), yaml.stringify({
+    version: '1.0.0',
+    last_updated: now.toISOString(),
+    active_project: options.activeProject === undefined ? 'health-project' : options.activeProject,
+    projects: [{
+      id: 'health-project',
+      name: 'Health Project',
+      path: options.path ?? projectRoot,
+      status: 'active',
+      created: '2026-01-01',
+      last_accessed: now.toISOString(),
+    }],
+  }), 'utf-8');
+}
+
+async function setupProject(options: {
+  captureAt?: Date | null;
+  refreshAt?: Date | null;
+  knowledgeAt?: Date | null;
+  taskAt?: Date | null;
+  claudeVersion?: number | null;
+  agentsVersion?: number | null;
+  registryActiveProject?: string | null;
+  registryPath?: string;
+} = {}): Promise<string> {
+  home = await mkdtemp(join(tmpdir(), 'agenticos-knowledge-health-'));
+  process.env.AGENTICOS_HOME = home;
+  const projectRoot = join(home, 'projects', 'health-project');
+  await mkdir(join(projectRoot, 'standards', '.context'), { recursive: true });
+  await mkdir(join(projectRoot, 'knowledge'), { recursive: true });
+  await mkdir(join(projectRoot, 'tasks'), { recursive: true });
+  await writeFile(join(projectRoot, '.project.yaml'), yaml.stringify({
+    meta: { id: 'health-project', name: 'Health Project' },
+    source_control: { topology: 'github_versioned', context_publication_policy: 'public_distilled' },
+    agent_context: {
+      current_state: 'standards/.context/state.yaml',
+      knowledge: 'knowledge/',
+      tasks: 'tasks/',
+    },
+  }), 'utf-8');
+  await writeFile(join(projectRoot, 'standards', '.context', 'state.yaml'), yaml.stringify({
+    entry_surface_refresh: options.refreshAt === null ? {} : { refreshed_at: (options.refreshAt ?? recent).toISOString() },
+  }), 'utf-8');
+
+  if (options.captureAt !== null) {
+    const captureDir = join(home, '.agent-workspace', 'projects', 'health-project', 'captures', 'conversations');
+    await mkdir(captureDir, { recursive: true });
+    await touch(join(captureDir, '2026-05-20.md'), options.captureAt ?? recent);
+  }
+  if (options.knowledgeAt !== null) {
+    await touch(join(projectRoot, 'knowledge', 'summary.md'), options.knowledgeAt ?? recent);
+  }
+  if (options.taskAt !== null) {
+    await touch(join(projectRoot, 'tasks', 'task.yaml'), options.taskAt ?? recent);
+  }
+
+  if (options.claudeVersion !== null) {
+    await writeFile(join(projectRoot, 'CLAUDE.md'), `<!-- agenticos-template: v${options.claudeVersion ?? CURRENT_TEMPLATE_VERSION} -->\n`, 'utf-8');
+  }
+  if (options.agentsVersion !== null) {
+    await writeFile(join(projectRoot, 'AGENTS.md'), `<!-- agenticos-template: v${options.agentsVersion ?? CURRENT_TEMPLATE_VERSION} -->\n`, 'utf-8');
+  }
+  await writeRegistry(projectRoot, {
+    activeProject: options.registryActiveProject,
+    path: options.registryPath,
+  });
+  return projectRoot;
+}
+
+afterEach(() => {
+  process.env.AGENTICOS_HOME = originalHome;
+  if (home) rmSync(home, { recursive: true, force: true });
+  home = null;
+});
+
+describe('knowledge evolution health', () => {
+  it('passes when capture, entry refresh, knowledge, tasks, adapters, registry, and worktree are fresh', async () => {
+    const projectRoot = await setupProject();
+    const result = await assessKnowledgeEvolutionHealth({
+      projectPath: projectRoot,
+      repoSync: {
+        branch_line: '## main...origin/main',
+        branch_status: 'aligned',
+        dirty_paths: [],
+        runtime_dirty_paths: [],
+        source_dirty_paths: [],
+      },
+      now,
+    });
+
+    expect(result.status).toBe('PASS');
+    expect(result.summary).toBe('Knowledge evolution signals are fresh.');
+    expect(result.latest_sidecar_capture_at).toBe(recent.toISOString());
+    expect(result.latest_entry_state_refresh_at).toBe(recent.toISOString());
+    expect(result.latest_knowledge_update_at).toBe(recent.toISOString());
+    expect(result.latest_task_update_at).toBe(recent.toISOString());
+    expect(result.dirty_worktree.status).toBe('PASS');
+    expect(result.registry_state_drift.status).toBe('PASS');
+    expect(result.adapter_template_freshness.adapters.every((adapter) => adapter.status === 'current')).toBe(true);
+    expect(result.warnings).toEqual([]);
+    expect(buildKnowledgeEvolutionStatusLines(result)[0]).toContain('Knowledge evolution: PASS');
+  });
+
+  it('warns when freshness signals are stale', async () => {
+    const projectRoot = await setupProject({
+      captureAt: stale,
+      refreshAt: stale,
+      knowledgeAt: stale,
+      taskAt: stale,
+    });
+    const result = await assessKnowledgeEvolutionHealth({
+      projectPath: projectRoot,
+      repoSync: {
+        branch_line: '## main...origin/main',
+        branch_status: 'aligned',
+        dirty_paths: [],
+        runtime_dirty_paths: [],
+        source_dirty_paths: [],
+      },
+      now,
+    });
+
+    expect(result.status).toBe('WARN');
+    expect(result.warnings).toEqual(expect.arrayContaining([
+      'sidecar capture is stale',
+      'entry-state refresh is stale',
+      'knowledge update is stale',
+      'task update is stale',
+    ]));
+  });
+
+  it('warns for a missing sidecar capture without blocking', async () => {
+    const projectRoot = await setupProject({ captureAt: null });
+    const result = await assessKnowledgeEvolutionHealth({
+      projectPath: projectRoot,
+      repoSync: {
+        branch_line: '## main...origin/main',
+        branch_status: 'aligned',
+        dirty_paths: [],
+        runtime_dirty_paths: [],
+        source_dirty_paths: [],
+      },
+      now,
+    });
+
+    expect(result.status).toBe('WARN');
+    expect(result.warnings).toContain('sidecar capture is missing');
+    expect(result.summary).toContain('warning');
+  });
+
+  it('warns for dirty worktree summaries', async () => {
+    const projectRoot = await setupProject();
+    const result = await assessKnowledgeEvolutionHealth({
+      projectPath: projectRoot,
+      repoSync: {
+        branch_line: '## main...origin/main',
+        branch_status: 'aligned',
+        dirty_paths: ['standards/.context/state.yaml', 'README.md'],
+        runtime_dirty_paths: ['standards/.context/state.yaml'],
+        source_dirty_paths: ['README.md'],
+      },
+      now,
+    });
+
+    expect(result.status).toBe('WARN');
+    expect(result.dirty_worktree).toMatchObject({
+      status: 'WARN',
+      dirty_path_count: 2,
+      runtime_dirty_path_count: 1,
+      source_dirty_path_count: 1,
+    });
+    expect(result.warnings).toContain('Dirty worktree has 2 path(s): runtime 1, source 1.');
+  });
+
+  it('warns for stale adapter templates', async () => {
+    const projectRoot = await setupProject({ claudeVersion: CURRENT_TEMPLATE_VERSION - 1 });
+    const result = await assessKnowledgeEvolutionHealth({
+      projectPath: projectRoot,
+      repoSync: {
+        branch_line: '## main...origin/main',
+        branch_status: 'aligned',
+        dirty_paths: [],
+        runtime_dirty_paths: [],
+        source_dirty_paths: [],
+      },
+      now,
+    });
+
+    expect(result.adapter_template_freshness.adapters.find((adapter) => adapter.path.endsWith('CLAUDE.md'))?.status).toBe('stale');
+    expect(result.warnings.some((warning) => warning.includes('CLAUDE.md'))).toBe(true);
+  });
+
+  it('warns for registry/state drift', async () => {
+    const projectRoot = await setupProject({
+      registryActiveProject: 'other-project',
+    });
+    await writeRegistry(projectRoot, {
+      activeProject: 'other-project',
+      path: join(projectRoot, '..', 'wrong-path'),
+    });
+    const result = await assessKnowledgeEvolutionHealth({
+      projectPath: projectRoot,
+      repoSync: {
+        branch_line: '## main...origin/main',
+        branch_status: 'aligned',
+        dirty_paths: [],
+        runtime_dirty_paths: [],
+        source_dirty_paths: [],
+      },
+      now,
+    });
+
+    expect(result.status).toBe('WARN');
+    expect(result.registry_state_drift.status).toBe('WARN');
+    expect(result.registry_state_drift.summary).toContain('active_project');
+    expect(result.registry_state_drift.summary).toContain('registry path differs');
+  });
+
+  it('reports unknowns for missing project context and can derive dirty status from git', async () => {
+    home = await mkdtemp(join(tmpdir(), 'agenticos-knowledge-health-'));
+    process.env.AGENTICOS_HOME = home;
+    const repo = join(home, 'repo');
+    await mkdir(repo, { recursive: true });
+    await writeFile(join(repo, 'README.md'), 'dirty\n', 'utf-8');
+    await execFile('git init', repo);
+
+    const result = await assessKnowledgeEvolutionHealth({
+      projectPath: null,
+      repoPath: repo,
+      now,
+    });
+
+    expect(result.status).toBe('WARN');
+    expect(result.dirty_worktree.status).toBe('WARN');
+    expect(result.registry_state_drift.summary).toContain('meta.id');
+    expect(result.adapter_template_freshness.adapters.every((adapter) => adapter.status === 'missing')).toBe(true);
+    expect(buildKnowledgeEvolutionStatusLines(result).some((line) => line.includes('Adapter templates'))).toBe(true);
+  });
+});
+
+async function execFile(command: string, cwd: string): Promise<void> {
+  const { exec } = await import('child_process');
+  await new Promise<void>((resolve, reject) => {
+    exec(command, { cwd }, (error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}

--- a/mcp-server/src/utils/knowledge-evolution-health.ts
+++ b/mcp-server/src/utils/knowledge-evolution-health.ts
@@ -1,0 +1,362 @@
+import { exec } from 'child_process';
+import { readFile, readdir, stat } from 'fs/promises';
+import { join, resolve } from 'path';
+import yaml from 'yaml';
+import { analyzeCanonicalRepoSync, type CanonicalRepoSyncDetails } from './canonical-checkout-sync.js';
+import { resolveManagedProjectContextPaths } from './agent-context-paths.js';
+import { CURRENT_TEMPLATE_VERSION, extractTemplateVersion } from './distill.js';
+import { getRuntimeCaptureConversationDir } from './record-capture.js';
+import { loadRegistry } from './registry.js';
+
+export interface KnowledgeEvolutionAdapterFreshness {
+  path: string;
+  status: 'current' | 'missing' | 'stale';
+  installed_version: number | null;
+  expected_version: number;
+}
+
+export interface KnowledgeEvolutionHealth {
+  status: 'PASS' | 'WARN';
+  summary: string;
+  latest_sidecar_capture_at: string | null;
+  latest_entry_state_refresh_at: string | null;
+  latest_knowledge_update_at: string | null;
+  latest_task_update_at: string | null;
+  adapter_template_freshness: {
+    expected_version: number;
+    adapters: KnowledgeEvolutionAdapterFreshness[];
+  };
+  dirty_worktree: {
+    status: 'PASS' | 'WARN' | 'UNKNOWN';
+    dirty_path_count: number | null;
+    runtime_dirty_path_count: number | null;
+    source_dirty_path_count: number | null;
+    summary: string;
+  };
+  registry_state_drift: {
+    status: 'PASS' | 'WARN';
+    active_project_id: string | null;
+    target_project_id: string | null;
+    registry_path: string | null;
+    project_path: string | null;
+    summary: string;
+  };
+  warnings: string[];
+  recovery_actions: string[];
+}
+
+interface KnowledgeEvolutionArgs {
+  projectPath?: string | null;
+  repoPath?: string | null;
+  projectYaml?: any | null;
+  state?: any | null;
+  repoSync?: CanonicalRepoSyncDetails | null;
+  now?: Date;
+  staleAfterDays?: number;
+}
+
+interface DirectoryEntry {
+  name: string;
+  isDirectory(): boolean;
+  isFile(): boolean;
+}
+
+const DEFAULT_STALE_AFTER_DAYS = 14;
+const TRACKED_EXTENSIONS = new Set(['.md', '.markdown', '.yaml', '.yml', '.json']);
+
+function execCommand(command: string): Promise<string> {
+  return new Promise((resolvePromise, reject) => {
+    exec(command, (error, stdout, stderr) => {
+      if (error) {
+        reject(new Error(stderr || stdout || error.message));
+        return;
+      }
+      resolvePromise(stdout);
+    });
+  });
+}
+
+function normalizeIso(value: unknown): string | null {
+  if (typeof value !== 'string' || value.trim().length === 0) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+function latestIso(values: Array<string | null>): string | null {
+  const sorted = values
+    .filter((value): value is string => Boolean(value))
+    .sort((a, b) => new Date(b).getTime() - new Date(a).getTime());
+  return sorted[0] ?? null;
+}
+
+function isStale(value: string | null, now: Date, staleAfterDays: number): boolean {
+  if (!value) return true;
+  const ageMs = now.getTime() - new Date(value).getTime();
+  return ageMs > staleAfterDays * 24 * 60 * 60 * 1000;
+}
+
+function extensionOf(path: string): string {
+  const dot = path.lastIndexOf('.');
+  return dot >= 0 ? path.slice(dot).toLowerCase() : '';
+}
+
+async function latestTrackedFileMtime(dir: string | null, depth = 4): Promise<string | null> {
+  if (!dir || depth < 0) return null;
+  let entries: DirectoryEntry[];
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+
+  const candidates: string[] = [];
+  for (const entry of entries) {
+    const entryPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      const nested = await latestTrackedFileMtime(entryPath, depth - 1);
+      if (nested) candidates.push(nested);
+      continue;
+    }
+    if (!entry.isFile() || !TRACKED_EXTENSIONS.has(extensionOf(entry.name))) {
+      continue;
+    }
+    try {
+      candidates.push((await stat(entryPath)).mtime.toISOString());
+    } catch {
+      // Ignore files that disappeared between readdir and stat.
+    }
+  }
+  return latestIso(candidates);
+}
+
+async function readProjectYaml(projectPath: string | null | undefined): Promise<any | null> {
+  if (!projectPath) return null;
+  try {
+    return yaml.parse(await readFile(join(projectPath, '.project.yaml'), 'utf-8')) || null;
+  } catch {
+    return null;
+  }
+}
+
+async function readState(projectPath: string | null | undefined, projectYaml: any | null): Promise<any | null> {
+  if (!projectPath || !projectYaml) return null;
+  try {
+    const statePath = resolveManagedProjectContextPaths(projectPath, projectYaml).statePath;
+    return yaml.parse(await readFile(statePath, 'utf-8')) || null;
+  } catch {
+    return null;
+  }
+}
+
+async function inspectAdapters(projectPath: string | null): Promise<KnowledgeEvolutionAdapterFreshness[]> {
+  const adapterNames = ['CLAUDE.md', 'AGENTS.md'];
+  const adapters: KnowledgeEvolutionAdapterFreshness[] = [];
+  for (const name of adapterNames) {
+    const path = projectPath ? join(projectPath, name) : name;
+    let installedVersion: number | null = null;
+    let status: KnowledgeEvolutionAdapterFreshness['status'] = 'missing';
+    if (projectPath) {
+      try {
+        installedVersion = extractTemplateVersion(await readFile(path, 'utf-8'));
+        status = installedVersion >= CURRENT_TEMPLATE_VERSION ? 'current' : 'stale';
+      } catch {
+        status = 'missing';
+      }
+    }
+    adapters.push({
+      path,
+      status,
+      installed_version: installedVersion,
+      expected_version: CURRENT_TEMPLATE_VERSION,
+    });
+  }
+  return adapters;
+}
+
+async function resolveRepoSync(args: KnowledgeEvolutionArgs): Promise<CanonicalRepoSyncDetails | null> {
+  if (args.repoSync) return args.repoSync;
+  if (!args.repoPath) return null;
+  try {
+    const statusOutput = await execCommand(`git -C "${args.repoPath}" status --short --branch --untracked-files=all`);
+    return analyzeCanonicalRepoSync({
+      statusOutput,
+      remoteBaseBranch: 'origin/main',
+      runtimeManagedEntries: ['.context/', 'standards/.context/', 'CLAUDE.md', 'AGENTS.md'],
+    }).details;
+  } catch {
+    return null;
+  }
+}
+
+function buildDirtyWorktree(repoSync: CanonicalRepoSyncDetails | null): KnowledgeEvolutionHealth['dirty_worktree'] {
+  if (!repoSync) {
+    return {
+      status: 'UNKNOWN',
+      dirty_path_count: null,
+      runtime_dirty_path_count: null,
+      source_dirty_path_count: null,
+      summary: 'Dirty worktree status could not be determined.',
+    };
+  }
+  const dirtyCount = repoSync.dirty_paths.length;
+  return {
+    status: dirtyCount > 0 ? 'WARN' : 'PASS',
+    dirty_path_count: dirtyCount,
+    runtime_dirty_path_count: repoSync.runtime_dirty_paths.length,
+    source_dirty_path_count: repoSync.source_dirty_paths.length,
+    summary: dirtyCount > 0
+      ? `Dirty worktree has ${dirtyCount} path(s): runtime ${repoSync.runtime_dirty_paths.length}, source ${repoSync.source_dirty_paths.length}.`
+      : 'Worktree is clean.',
+  };
+}
+
+async function buildRegistryDrift(projectPath: string | null, projectId: string | null): Promise<KnowledgeEvolutionHealth['registry_state_drift']> {
+  try {
+    const registry = await loadRegistry();
+    const project = projectId ? registry.projects.find((candidate) => candidate.id === projectId) ?? null : null;
+    const normalizedProjectPath = projectPath ? resolve(projectPath) : null;
+    const normalizedRegistryPath = project?.path ? resolve(project.path) : null;
+    const driftReasons: string[] = [];
+    if (!projectId) {
+      driftReasons.push('project meta.id is unavailable');
+    } else if (!project) {
+      driftReasons.push(`project "${projectId}" is missing from registry`);
+    }
+    if (registry.active_project && projectId && registry.active_project !== projectId) {
+      driftReasons.push(`registry active_project is "${registry.active_project}"`);
+    }
+    if (normalizedProjectPath && normalizedRegistryPath && normalizedProjectPath !== normalizedRegistryPath) {
+      driftReasons.push('registry path differs from project_path');
+    }
+    return {
+      status: driftReasons.length > 0 ? 'WARN' : 'PASS',
+      active_project_id: registry.active_project || null,
+      target_project_id: projectId,
+      registry_path: normalizedRegistryPath,
+      project_path: normalizedProjectPath,
+      summary: driftReasons.length > 0 ? `Registry/state drift: ${driftReasons.join('; ')}.` : 'Registry entry matches project identity.',
+    };
+  } catch {
+    return {
+      status: 'WARN',
+      active_project_id: null,
+      target_project_id: projectId,
+      registry_path: null,
+      project_path: projectPath ? resolve(projectPath) : null,
+      summary: 'Registry/state drift could not be determined.',
+    };
+  }
+}
+
+function addFreshnessWarnings(args: {
+  warnings: string[];
+  latestSidecar: string | null;
+  latestEntryRefresh: string | null;
+  latestKnowledge: string | null;
+  latestTask: string | null;
+  now: Date;
+  staleAfterDays: number;
+}): void {
+  if (isStale(args.latestSidecar, args.now, args.staleAfterDays)) {
+    args.warnings.push(args.latestSidecar ? 'sidecar capture is stale' : 'sidecar capture is missing');
+  }
+  if (isStale(args.latestEntryRefresh, args.now, args.staleAfterDays)) {
+    args.warnings.push(args.latestEntryRefresh ? 'entry-state refresh is stale' : 'entry-state refresh is missing');
+  }
+  if (isStale(args.latestKnowledge, args.now, args.staleAfterDays)) {
+    args.warnings.push(args.latestKnowledge ? 'knowledge update is stale' : 'knowledge update is missing');
+  }
+  if (isStale(args.latestTask, args.now, args.staleAfterDays)) {
+    args.warnings.push(args.latestTask ? 'task update is stale' : 'task update is missing');
+  }
+}
+
+export async function assessKnowledgeEvolutionHealth(args: KnowledgeEvolutionArgs): Promise<KnowledgeEvolutionHealth> {
+  const now = args.now ?? new Date();
+  const staleAfterDays = args.staleAfterDays ?? DEFAULT_STALE_AFTER_DAYS;
+  const projectPath = args.projectPath ?? null;
+  const projectYaml = args.projectYaml ?? await readProjectYaml(projectPath);
+  const state = args.state ?? await readState(projectPath, projectYaml);
+  const projectId = typeof projectYaml?.meta?.id === 'string' ? projectYaml.meta.id.trim() || null : null;
+  const contextPaths = projectPath && projectYaml ? resolveManagedProjectContextPaths(projectPath, projectYaml) : null;
+  const latestSidecar = projectId ? await latestTrackedFileMtime(getRuntimeCaptureConversationDir(projectId)) : null;
+  const latestEntryRefresh = latestIso([
+    normalizeIso(state?.entry_surface_refresh?.refreshed_at),
+    normalizeIso(state?.session?.last_entry_surface_refresh),
+  ]);
+  const latestKnowledge = await latestTrackedFileMtime(contextPaths?.knowledgeDir ?? null);
+  const latestTask = await latestTrackedFileMtime(contextPaths?.tasksDir ?? null);
+  const adapterTemplateFreshness = {
+    expected_version: CURRENT_TEMPLATE_VERSION,
+    adapters: await inspectAdapters(projectPath),
+  };
+  const dirtyWorktree = buildDirtyWorktree(await resolveRepoSync(args));
+  const registryStateDrift = await buildRegistryDrift(projectPath, projectId);
+  const warnings: string[] = [];
+
+  addFreshnessWarnings({
+    warnings,
+    latestSidecar,
+    latestEntryRefresh,
+    latestKnowledge,
+    latestTask,
+    now,
+    staleAfterDays,
+  });
+
+  for (const adapter of adapterTemplateFreshness.adapters) {
+    if (adapter.status !== 'current') {
+      warnings.push(`${adapter.path} adapter template is ${adapter.status}`);
+    }
+  }
+  if (dirtyWorktree.status !== 'PASS') warnings.push(dirtyWorktree.summary);
+  if (registryStateDrift.status === 'WARN') warnings.push(registryStateDrift.summary);
+
+  const recoveryActions = warnings.length > 0
+    ? [
+        'run agenticos_record or agenticos_task_* to refresh task/knowledge continuity',
+        'run agenticos_refresh_entry_surfaces after important state changes',
+        'review adapter templates and registry binding before relying on cross-session memory',
+      ]
+    : [];
+
+  return {
+    status: warnings.length > 0 ? 'WARN' : 'PASS',
+    summary: warnings.length > 0
+      ? `Knowledge evolution has ${warnings.length} warning(s).`
+      : 'Knowledge evolution signals are fresh.',
+    latest_sidecar_capture_at: latestSidecar,
+    latest_entry_state_refresh_at: latestEntryRefresh,
+    latest_knowledge_update_at: latestKnowledge,
+    latest_task_update_at: latestTask,
+    adapter_template_freshness: adapterTemplateFreshness,
+    dirty_worktree: dirtyWorktree,
+    registry_state_drift: registryStateDrift,
+    warnings,
+    recovery_actions: recoveryActions,
+  };
+}
+
+function displayTimestamp(value: string | null): string {
+  return value ?? 'missing';
+}
+
+export function buildKnowledgeEvolutionStatusLines(assessment: KnowledgeEvolutionHealth): string[] {
+  const lines = [
+    `🧠 Knowledge evolution: ${assessment.status} - ${assessment.summary}`,
+    `   Sidecar capture: ${displayTimestamp(assessment.latest_sidecar_capture_at)}`,
+    `   Entry-state refresh: ${displayTimestamp(assessment.latest_entry_state_refresh_at)}`,
+    `   Knowledge update: ${displayTimestamp(assessment.latest_knowledge_update_at)}`,
+    `   Task update: ${displayTimestamp(assessment.latest_task_update_at)}`,
+    `   Dirty worktree: ${assessment.dirty_worktree.summary}`,
+    `   Registry/state: ${assessment.registry_state_drift.summary}`,
+  ];
+  const staleAdapters = assessment.adapter_template_freshness.adapters.filter((adapter) => adapter.status !== 'current');
+  lines.push(staleAdapters.length > 0
+    ? `   Adapter templates: ${staleAdapters.length} warning(s)`
+    : '   Adapter templates: current');
+  for (const warning of assessment.warnings.slice(0, 5)) {
+    lines.push(`   Warning: ${warning}`);
+  }
+  return lines;
+}

--- a/mcp-server/src/utils/knowledge-evolution-health.ts
+++ b/mcp-server/src/utils/knowledge-evolution-health.ts
@@ -68,6 +68,7 @@ function execCommand(command: string): Promise<string> {
   return new Promise((resolvePromise, reject) => {
     exec(command, (error, stdout, stderr) => {
       if (error) {
+        /* c8 ignore next -- stderr/stdout/error.message fallback shape depends on child_process internals. */
         reject(new Error(stderr || stdout || error.message));
         return;
       }
@@ -120,10 +121,11 @@ async function latestTrackedFileMtime(dir: string | null, depth = 4): Promise<st
     if (!entry.isFile() || !TRACKED_EXTENSIONS.has(extensionOf(entry.name))) {
       continue;
     }
+    /* c8 ignore next 5 -- race-only path when a file disappears between readdir and stat. */
     try {
       candidates.push((await stat(entryPath)).mtime.toISOString());
     } catch {
-      // Ignore files that disappeared between readdir and stat.
+      continue;
     }
   }
   return latestIso(candidates);


### PR DESCRIPTION
Fixes #450.

## Summary
- Add WARN-only knowledge-evolution health assessment for capture, entry-state, knowledge, task, adapter, worktree, and registry/state freshness.
- Surface the assessment through `agenticos_health` as a `knowledge_evolution` gate and through project status output.
- Cover fresh, stale, missing, dirty worktree, stale adapter, registry drift, and missing-context cases.

## Verification
- `cd mcp-server && npm ci`
- `cd mcp-server && npm run lint`
- `cd mcp-server && npm test -- --run src/utils/__tests__/knowledge-evolution-health.test.ts src/utils/__tests__/health.test.ts src/tools/__tests__/project.test.ts`
- `cd mcp-server && npm test -- --run`
- `GITHUB_EVENT_NAME=pull_request GITHUB_BASE_REF=main ./tools/coverage-preflight.sh`
- `git diff --check`
- `agenticos_pr_scope_check` PASS
