### PR TITLE
feat: add distillation ledger

### DIFF
--- a/mcp-server/src/tools/__tests__/record.test.ts
+++ b/mcp-server/src/tools/__tests__/record.test.ts
@@ -5,6 +5,9 @@ const yamlMock = vi.hoisted(() => ({
   parse: vi.fn(),
   stringify: vi.fn((obj: unknown) => JSON.stringify(obj)),
 }));
+const distillationLedgerMock = vi.hoisted(() => ({
+  recordCapturedDistillationEntry: vi.fn(),
+}));
 
 // Mock modules
 vi.mock('fs/promises', () => ({
@@ -41,6 +44,10 @@ vi.mock('../../utils/distill.js', () => ({
 
 vi.mock('../../utils/canonical-main-guard.js', () => ({
   detectCanonicalMainWriteProtection: vi.fn(),
+}));
+
+vi.mock('../../utils/distillation-ledger.js', () => ({
+  recordCapturedDistillationEntry: distillationLedgerMock.recordCapturedDistillationEntry,
 }));
 
 import { recordSession } from '../record.js';
@@ -147,6 +154,11 @@ describe('recordSession', () => {
     });
     registryMock.patchProjectMetadata.mockResolvedValue(undefined);
     canonicalMainGuardMock.mockResolvedValue({ blocked: false });
+    distillationLedgerMock.recordCapturedDistillationEntry.mockResolvedValue({
+      path: '/home/testuser/AgenticOS/.agent-workspace/projects/test-project/distillation-ledger.yaml',
+      entry: { id: 'capture-2026-05-21-1200-test', status: 'captured' },
+      created: true,
+    });
     mockProjectFiles();
   });
 
@@ -504,7 +516,15 @@ describe('recordSession', () => {
     expect(result).toContain('conversations/');
     expect(result).toContain('state.yaml');
     expect(result).toContain('CLAUDE.md');
+    expect(result).toContain('Distillation ledger: /home/testuser/AgenticOS/.agent-workspace/projects/test-project/distillation-ledger.yaml#capture-2026-05-21-1200-test');
     expect(result).toContain('✅ Session recorded');
+    expect(distillationLedgerMock.recordCapturedDistillationEntry).toHaveBeenCalledWith(expect.objectContaining({
+      projectId: 'test-project',
+      summary: 'test session',
+      capture: expect.objectContaining({
+        filePath: expect.stringContaining('/conversations/'),
+      }),
+    }));
   });
 
   it('routes raw transcripts to a private sidecar path for public_distilled projects', async () => {
@@ -532,6 +552,12 @@ describe('recordSession', () => {
     expect(convCall).toBeDefined();
     expect(result).toContain('Raw conversation: .private/conversations/');
     expect(result).toContain('Git recovery is distilled-only');
+    expect(distillationLedgerMock.recordCapturedDistillationEntry).toHaveBeenCalledWith(expect.objectContaining({
+      projectId: 'test-project',
+      capture: expect.objectContaining({
+        filePath: expect.stringContaining('/.private/conversations/'),
+      }),
+    }));
   });
 
   it('blocks when public_distilled raw transcript routing is misconfigured', async () => {

--- a/mcp-server/src/tools/record.ts
+++ b/mcp-server/src/tools/record.ts
@@ -84,8 +84,8 @@ async function applyTrackedContinuityPatch(args: {
 function renderCaptureOnlyResponse(args: {
   projectName: string;
   capturePath: string;
-  ledgerPath?: string;
-  ledgerEntryId?: string;
+  ledgerPath: string;
+  ledgerEntryId: string;
   planReason?: string;
   nextActions: string[];
 }): string {
@@ -94,7 +94,7 @@ function renderCaptureOnlyResponse(args: {
   return `✅ Session captured for "${args.projectName}"\n\n` +
     'Status: RECORDED_CAPTURE_ONLY\n' +
     `📝 Capture: ${args.capturePath}\n` +
-    (args.ledgerPath && args.ledgerEntryId ? `🧾 Distillation ledger: ${args.ledgerPath}#${args.ledgerEntryId}\n` : '') +
+    `🧾 Distillation ledger: ${args.ledgerPath}#${args.ledgerEntryId}\n` +
     '📊 Distill: skipped because tracked project writes are protected in this checkout\n' +
     (args.planReason ? `Reason: ${args.planReason}\n` : '') +
     nextActions;

--- a/mcp-server/src/tools/record.ts
+++ b/mcp-server/src/tools/record.ts
@@ -15,6 +15,7 @@ import {
   getRuntimeCaptureConversationDir,
   type RecordCapturePayload,
 } from '../utils/record-capture.js';
+import { recordCapturedDistillationEntry } from '../utils/distillation-ledger.js';
 import { type StateYamlSchema } from '../utils/yaml-schemas.js';
 
 function parseArray(val: unknown): string[] {
@@ -83,6 +84,8 @@ async function applyTrackedContinuityPatch(args: {
 function renderCaptureOnlyResponse(args: {
   projectName: string;
   capturePath: string;
+  ledgerPath?: string;
+  ledgerEntryId?: string;
   planReason?: string;
   nextActions: string[];
 }): string {
@@ -91,6 +94,7 @@ function renderCaptureOnlyResponse(args: {
   return `✅ Session captured for "${args.projectName}"\n\n` +
     'Status: RECORDED_CAPTURE_ONLY\n' +
     `📝 Capture: ${args.capturePath}\n` +
+    (args.ledgerPath && args.ledgerEntryId ? `🧾 Distillation ledger: ${args.ledgerPath}#${args.ledgerEntryId}\n` : '') +
     '📊 Distill: skipped because tracked project writes are protected in this checkout\n' +
     (args.planReason ? `Reason: ${args.planReason}\n` : '') +
     nextActions;
@@ -157,11 +161,19 @@ export async function recordSession(args: any): Promise<string> {
     now,
     ...payload,
   });
+  const ledgerCapture = await recordCapturedDistillationEntry({
+    projectId: project.id,
+    capture,
+    summary,
+    now,
+  });
 
   if (persistencePlan.mode === 'capture_only') {
     return renderCaptureOnlyResponse({
       projectName: project.name,
       capturePath: capture.filePath,
+      ledgerPath: ledgerCapture.path,
+      ledgerEntryId: ledgerCapture.entry.id,
       planReason: persistencePlan.writeProtectionReason,
       nextActions: persistencePlan.nextActions,
     });
@@ -183,6 +195,7 @@ export async function recordSession(args: any): Promise<string> {
   const routingNotes = buildConversationRoutingStatusLines(conversationRoutingPlan, legacyTranscriptStatus);
   return `✅ Session recorded for "${project.name}"\n\n` +
     `📝 Raw conversation: ${conversationRoutingPlan.raw_conversations_display_dir}${today}.md\n` +
+    `🧾 Distillation ledger: ${ledgerCapture.path}#${ledgerCapture.entry.id}\n` +
     `📊 State: ${contextPolicyPlan.trackedContextDisplayPaths.state} (updated)\n` +
     `📋 CLAUDE.md: Current State synced\n` +
     (routingNotes.length > 0 ? `\n${routingNotes.join('\n')}\n` : '');

--- a/mcp-server/src/utils/__tests__/distillation-ledger.test.ts
+++ b/mcp-server/src/utils/__tests__/distillation-ledger.test.ts
@@ -1,0 +1,233 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { dirname, join } from 'path';
+import yaml from 'yaml';
+import {
+  getDistillationLedgerPath,
+  loadDistillationLedger,
+  markDistillationLedgerEntry,
+  recordCapturedDistillationEntry,
+  saveDistillationLedger,
+  summarizeDistillationLedger,
+  type DistillationLedger,
+} from '../distillation-ledger.js';
+
+const originalHome = process.env.AGENTICOS_HOME;
+let home: string | null = null;
+
+async function setupHome(): Promise<string> {
+  home = await mkdtemp(join(tmpdir(), 'agenticos-ledger-'));
+  process.env.AGENTICOS_HOME = home;
+  return home;
+}
+
+afterEach(async () => {
+  process.env.AGENTICOS_HOME = originalHome;
+  if (home) {
+    await rm(home, { recursive: true, force: true });
+  }
+  home = null;
+});
+
+describe('distillation ledger', () => {
+  it('stores private runtime ledger entries for captured session records', async () => {
+    const root = await setupHome();
+    const now = new Date('2026-05-21T10:00:00.000Z');
+    const result = await recordCapturedDistillationEntry({
+      projectId: 'agenticos/core',
+      now,
+      summary: 'Captured private session',
+      capture: {
+        filePath: join(root, '.agent-workspace', 'projects', 'agenticos%2Fcore', 'captures', 'conversations', '2026-05-21.md'),
+        date: '2026-05-21',
+        time: '10:00',
+        entry: 'raw private capture',
+      },
+    });
+
+    expect(result.created).toBe(true);
+    expect(result.path).toBe(getDistillationLedgerPath('agenticos/core'));
+    expect(result.path).toContain('/.agent-workspace/projects/agenticos%2Fcore/distillation-ledger.yaml');
+    expect(result.entry).toMatchObject({
+      project_id: 'agenticos/core',
+      status: 'captured',
+      captured_at: now.toISOString(),
+      capture_date: '2026-05-21',
+      capture_time: '10:00',
+      summary: 'Captured private session',
+    });
+    expect(result.entry.refs?.[0]).toMatchObject({
+      type: 'runtime_capture',
+      visibility: 'private',
+    });
+
+    const stored = yaml.parse(await readFile(result.path, 'utf-8'));
+    expect(stored.entries).toHaveLength(1);
+    expect(String(stored.entries[0].capture_path)).toContain('/.agent-workspace/');
+    expect(String(stored.entries[0].capture_path)).not.toContain('/standards/.context/conversations/');
+  });
+
+  it('loads a missing ledger as an empty private runtime ledger', async () => {
+    await setupHome();
+    const loaded = await loadDistillationLedger('missing-project', new Date('2026-05-21T00:00:00.000Z'));
+    const health = await summarizeDistillationLedger({
+      projectId: 'missing-project',
+      now: new Date('2026-05-21T00:00:00.000Z'),
+    });
+
+    expect(loaded.exists).toBe(false);
+    expect(loaded.ledger.entries).toEqual([]);
+    expect(health).toMatchObject({
+      status: 'MISSING',
+      exists: false,
+      unprocessed_capture_count: 0,
+      stale_unprocessed_capture_count: 0,
+      warnings: [],
+    });
+  });
+
+  it('marks captured entries through promotion lifecycle statuses', async () => {
+    await setupHome();
+    const captured = await recordCapturedDistillationEntry({
+      projectId: 'agenticos',
+      now: new Date('2026-05-01T00:00:00.000Z'),
+      summary: 'Captured session',
+      capture: {
+        filePath: '/runtime/captures/2026-05-01.md',
+        date: '2026-05-01',
+        time: '00:00',
+        entry: 'capture',
+      },
+    });
+
+    const distilled = await markDistillationLedgerEntry({
+      projectId: 'agenticos',
+      entryId: captured.entry.id,
+      status: 'distilled_to_knowledge',
+      knowledge_paths: ['knowledge/session-summary.md'],
+      now: new Date('2026-05-02T00:00:00.000Z'),
+    });
+    expect(distilled.entry).toMatchObject({
+      status: 'distilled_to_knowledge',
+      knowledge_paths: ['knowledge/session-summary.md'],
+      processed_at: '2026-05-02T00:00:00.000Z',
+    });
+
+    const second = await recordCapturedDistillationEntry({
+      projectId: 'agenticos',
+      now: new Date('2026-05-03T00:00:00.000Z'),
+      summary: 'Task capture',
+      capture: {
+        filePath: '/runtime/captures/2026-05-03.md',
+        date: '2026-05-03',
+        time: '00:00',
+        entry: 'capture',
+      },
+    });
+    const converted = await markDistillationLedgerEntry({
+      projectId: 'agenticos',
+      entryId: second.entry.id,
+      status: 'converted_to_task',
+      task_id: 'follow-up-task',
+      now: new Date('2026-05-04T00:00:00.000Z'),
+    });
+    expect(converted.entry).toMatchObject({
+      status: 'converted_to_task',
+      task_id: 'follow-up-task',
+    });
+  });
+
+  it('validates required transition metadata and missing entries', async () => {
+    await setupHome();
+    const captured = await recordCapturedDistillationEntry({
+      projectId: 'agenticos',
+      now: new Date('2026-05-01T00:00:00.000Z'),
+      summary: 'Captured session',
+      capture: {
+        filePath: '/runtime/captures/2026-05-01.md',
+        date: '2026-05-01',
+        time: '00:00',
+        entry: 'capture',
+      },
+    });
+
+    await expect(markDistillationLedgerEntry({
+      projectId: 'agenticos',
+      entryId: 'missing',
+      status: 'ignored_with_reason',
+      reason: 'irrelevant',
+    })).rejects.toThrow('not found');
+    await expect(markDistillationLedgerEntry({
+      projectId: 'agenticos',
+      entryId: captured.entry.id,
+      status: 'ignored_with_reason',
+    })).rejects.toThrow('reason is required');
+    await expect(markDistillationLedgerEntry({
+      projectId: 'agenticos',
+      entryId: captured.entry.id,
+      status: 'superseded',
+    })).rejects.toThrow('superseded_by is required');
+  });
+
+  it('summarizes stale unprocessed captured entries', async () => {
+    await setupHome();
+    const ledger: DistillationLedger = {
+      version: '1.0.0',
+      project_id: 'agenticos',
+      updated_at: '2026-05-21T00:00:00.000Z',
+      entries: [
+        {
+          id: 'old-capture',
+          project_id: 'agenticos',
+          status: 'captured',
+          created_at: '2026-04-01T00:00:00.000Z',
+          updated_at: '2026-04-01T00:00:00.000Z',
+          captured_at: '2026-04-01T00:00:00.000Z',
+        },
+        {
+          id: 'done-capture',
+          project_id: 'agenticos',
+          status: 'ignored_with_reason',
+          created_at: '2026-04-01T00:00:00.000Z',
+          updated_at: '2026-04-02T00:00:00.000Z',
+          processed_at: '2026-04-02T00:00:00.000Z',
+          reason: 'duplicate',
+        },
+      ],
+    };
+    await saveDistillationLedger('agenticos', ledger, new Date('2026-05-21T00:00:00.000Z'));
+
+    const health = await summarizeDistillationLedger({
+      projectId: 'agenticos',
+      now: new Date('2026-05-21T00:00:00.000Z'),
+      staleAfterDays: 14,
+    });
+
+    expect(health.status).toBe('WARN');
+    expect(health.unprocessed_capture_count).toBe(1);
+    expect(health.stale_unprocessed_capture_count).toBe(1);
+    expect(health.oldest_unprocessed_capture_at).toBe('2026-04-01T00:00:00.000Z');
+    expect(health.warnings).toEqual(['distillation ledger has 1 stale captured entry pending promotion']);
+  });
+
+  it('normalizes malformed ledger content without leaking invalid entries', async () => {
+    await setupHome();
+    const path = getDistillationLedgerPath('agenticos');
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, yaml.stringify({
+      version: '0.1.0',
+      project_id: '',
+      entries: [
+        { id: '', status: 'captured' },
+        { id: 'valid', status: 'captured', created_at: 'bad-date', updated_at: '2026-05-20T00:00:00.000Z' },
+      ],
+    }), 'utf-8');
+
+    const loaded = await loadDistillationLedger('agenticos', new Date('2026-05-21T00:00:00.000Z'));
+
+    expect(loaded.exists).toBe(true);
+    expect(loaded.ledger.project_id).toBe('agenticos');
+    expect(loaded.ledger.entries.map((entry) => entry.id)).toEqual(['valid']);
+  });
+});

--- a/mcp-server/src/utils/__tests__/distillation-ledger.test.ts
+++ b/mcp-server/src/utils/__tests__/distillation-ledger.test.ts
@@ -68,6 +68,31 @@ describe('distillation ledger', () => {
     expect(String(stored.entries[0].capture_path)).not.toContain('/standards/.context/conversations/');
   });
 
+  it('returns the existing entry when the same capture is recorded again', async () => {
+    await setupHome();
+    const capture = {
+      filePath: '/runtime/captures/2026-05-21.md',
+      date: '2026-05-21',
+      time: '10:00',
+      entry: 'raw private capture',
+    };
+
+    const first = await recordCapturedDistillationEntry({
+      projectId: 'agenticos',
+      summary: 'Captured private session',
+      capture,
+    });
+    const second = await recordCapturedDistillationEntry({
+      projectId: 'agenticos',
+      summary: 'Captured private session',
+      capture,
+    });
+
+    expect(first.created).toBe(true);
+    expect(second.created).toBe(false);
+    expect(second.entry.id).toBe(first.entry.id);
+  });
+
   it('loads a missing ledger as an empty private runtime ledger', async () => {
     await setupHome();
     const loaded = await loadDistillationLedger('missing-project', new Date('2026-05-21T00:00:00.000Z'));
@@ -136,6 +161,61 @@ describe('distillation ledger', () => {
       status: 'converted_to_task',
       task_id: 'follow-up-task',
     });
+
+    const supersededCapture = await recordCapturedDistillationEntry({
+      projectId: 'agenticos',
+      now: new Date('2026-05-05T00:00:00.000Z'),
+      summary: 'Superseded capture',
+      capture: {
+        filePath: '/runtime/captures/2026-05-05.md',
+        date: '2026-05-05',
+        time: '00:00',
+        entry: 'capture',
+      },
+    });
+    const superseded = await markDistillationLedgerEntry({
+      projectId: 'agenticos',
+      entryId: supersededCapture.entry.id,
+      status: 'superseded',
+      superseded_by: captured.entry.id,
+      now: new Date('2026-05-06T00:00:00.000Z'),
+    });
+    expect(superseded.entry).toMatchObject({
+      status: 'superseded',
+      superseded_by: captured.entry.id,
+    });
+
+    const ignoredCapture = await recordCapturedDistillationEntry({
+      projectId: 'agenticos',
+      now: new Date('2026-05-07T00:00:00.000Z'),
+      summary: 'Ignored capture',
+      capture: {
+        filePath: '/runtime/captures/2026-05-07.md',
+        date: '2026-05-07',
+        time: '00:00',
+        entry: 'capture',
+      },
+    });
+    const ignored = await markDistillationLedgerEntry({
+      projectId: 'agenticos',
+      entryId: ignoredCapture.entry.id,
+      status: 'ignored_with_reason',
+      reason: 'duplicate of a promoted capture',
+      now: new Date('2026-05-08T00:00:00.000Z'),
+    });
+    expect(ignored.entry).toMatchObject({
+      status: 'ignored_with_reason',
+      reason: 'duplicate of a promoted capture',
+    });
+
+    const refreshed = await markDistillationLedgerEntry({
+      projectId: 'agenticos',
+      entryId: ignoredCapture.entry.id,
+      status: 'ignored_with_reason',
+      reason: 'duplicate of a promoted capture',
+      now: new Date('2026-05-09T00:00:00.000Z'),
+    });
+    expect(refreshed.entry.updated_at).toBe('2026-05-09T00:00:00.000Z');
   });
 
   it('validates required transition metadata and missing entries', async () => {
@@ -161,6 +241,16 @@ describe('distillation ledger', () => {
     await expect(markDistillationLedgerEntry({
       projectId: 'agenticos',
       entryId: captured.entry.id,
+      status: 'distilled_to_knowledge',
+    })).rejects.toThrow('knowledge_paths is required');
+    await expect(markDistillationLedgerEntry({
+      projectId: 'agenticos',
+      entryId: captured.entry.id,
+      status: 'converted_to_task',
+    })).rejects.toThrow('task_id is required');
+    await expect(markDistillationLedgerEntry({
+      projectId: 'agenticos',
+      entryId: captured.entry.id,
       status: 'ignored_with_reason',
     })).rejects.toThrow('reason is required');
     await expect(markDistillationLedgerEntry({
@@ -168,6 +258,30 @@ describe('distillation ledger', () => {
       entryId: captured.entry.id,
       status: 'superseded',
     })).rejects.toThrow('superseded_by is required');
+
+    const marked = await markDistillationLedgerEntry({
+      projectId: 'agenticos',
+      entryId: captured.entry.id,
+      status: 'captured',
+      now: new Date('2026-05-02T00:00:00.000Z'),
+    });
+    expect(marked.entry.status).toBe('captured');
+    expect(marked.entry.processed_at).toBeUndefined();
+
+    const distilled = await markDistillationLedgerEntry({
+      projectId: 'agenticos',
+      entryId: captured.entry.id,
+      status: 'distilled_to_knowledge',
+      knowledge_paths: ['knowledge/session-summary.md'],
+      now: new Date('2026-05-03T00:00:00.000Z'),
+    });
+    expect(distilled.entry.status).toBe('distilled_to_knowledge');
+    await expect(markDistillationLedgerEntry({
+      projectId: 'agenticos',
+      entryId: captured.entry.id,
+      status: 'converted_to_task',
+      task_id: 'other-task',
+    })).rejects.toThrow(`ledger entry "${captured.entry.id}" is already distilled_to_knowledge`);
   });
 
   it('summarizes stale unprocessed captured entries', async () => {
@@ -211,6 +325,130 @@ describe('distillation ledger', () => {
     expect(health.warnings).toEqual(['distillation ledger has 1 stale captured entry pending promotion']);
   });
 
+  it('summarizes plural stale captures and missing project ids', async () => {
+    await setupHome();
+    const missingProject = await summarizeDistillationLedger({ projectId: null });
+    expect(missingProject).toMatchObject({
+      status: 'MISSING',
+      path: '',
+      summary: 'Distillation ledger is unavailable because project_id is missing.',
+    });
+
+    const ledger: DistillationLedger = {
+      version: '1.0.0',
+      project_id: 'agenticos',
+      updated_at: '2026-05-21T00:00:00.000Z',
+      entries: [
+        {
+          id: 'old-one',
+          project_id: 'agenticos',
+          status: 'captured',
+          created_at: '2026-04-01T00:00:00.000Z',
+          updated_at: '2026-04-01T00:00:00.000Z',
+          captured_at: '2026-04-01T00:00:00.000Z',
+        },
+        {
+          id: 'old-two',
+          project_id: 'agenticos',
+          status: 'captured',
+          created_at: '2026-04-02T00:00:00.000Z',
+          updated_at: '2026-04-02T00:00:00.000Z',
+          captured_at: '2026-04-02T00:00:00.000Z',
+        },
+      ],
+    };
+    await saveDistillationLedger('agenticos', ledger, new Date('2026-05-21T00:00:00.000Z'));
+
+    const health = await summarizeDistillationLedger({
+      projectId: 'agenticos',
+      now: new Date('2026-05-21T00:00:00.000Z'),
+      staleAfterDays: 14,
+    });
+
+    expect(health.status).toBe('WARN');
+    expect(health.stale_unprocessed_capture_count).toBe(2);
+    expect(health.warnings).toEqual(['distillation ledger has 2 stale captured entries pending promotion']);
+  });
+
+  it('summarizes fresh and empty ledgers without warnings', async () => {
+    await setupHome();
+    await saveDistillationLedger('agenticos', {
+      version: '1.0.0',
+      project_id: 'agenticos',
+      updated_at: '2026-05-21T00:00:00.000Z',
+      entries: [],
+    }, new Date('2026-05-21T00:00:00.000Z'));
+
+    const empty = await summarizeDistillationLedger({
+      projectId: 'agenticos',
+      now: new Date('2026-05-21T00:00:00.000Z'),
+    });
+    expect(empty).toMatchObject({
+      status: 'PASS',
+      unprocessed_capture_count: 0,
+      oldest_unprocessed_capture_at: null,
+      latest_entry_at: null,
+      summary: 'Distillation ledger has 0 unprocessed captured entries.',
+      warnings: [],
+    });
+
+    await saveDistillationLedger('agenticos', {
+      version: '1.0.0',
+      project_id: 'agenticos',
+      updated_at: '2026-05-21T00:00:00.000Z',
+      entries: [
+        {
+          id: 'fresh',
+          project_id: 'agenticos',
+          status: 'captured',
+          created_at: '2026-05-20T00:00:00.000Z',
+          updated_at: 'not-a-date',
+        },
+      ],
+    }, new Date('2026-05-21T00:00:00.000Z'));
+
+    const fresh = await summarizeDistillationLedger({
+      projectId: 'agenticos',
+      now: new Date('2026-05-21T00:00:00.000Z'),
+      staleAfterDays: 14,
+    });
+    expect(fresh).toMatchObject({
+      status: 'PASS',
+      unprocessed_capture_count: 1,
+      stale_unprocessed_capture_count: 0,
+      oldest_unprocessed_capture_at: '2026-05-20T00:00:00.000Z',
+      latest_entry_at: null,
+      summary: 'Distillation ledger has 1 unprocessed captured entry.',
+      warnings: [],
+    });
+
+    await saveDistillationLedger('agenticos', {
+      version: '1.0.0',
+      project_id: 'agenticos',
+      updated_at: '2026-05-21T00:00:00.000Z',
+      entries: [
+        {
+          id: 'invalid-time',
+          project_id: 'agenticos',
+          status: 'captured',
+          created_at: 'not-a-date',
+          updated_at: 'not-a-date',
+        },
+      ],
+    }, new Date('2026-05-21T00:00:00.000Z'));
+
+    const invalidTime = await summarizeDistillationLedger({
+      projectId: 'agenticos',
+      now: new Date('2026-05-21T00:00:00.000Z'),
+    });
+    expect(invalidTime).toMatchObject({
+      status: 'PASS',
+      unprocessed_capture_count: 1,
+      oldest_unprocessed_capture_at: null,
+      latest_entry_at: null,
+    });
+  });
+
   it('normalizes malformed ledger content without leaking invalid entries', async () => {
     await setupHome();
     const path = getDistillationLedgerPath('agenticos');
@@ -218,8 +456,36 @@ describe('distillation ledger', () => {
     await writeFile(path, yaml.stringify({
       version: '0.1.0',
       project_id: '',
+      updated_at: '',
       entries: [
+        null,
+        'not-an-entry',
+        { status: 'captured' },
+        { id: 'invalid-status', status: 'unknown' },
         { id: '', status: 'captured' },
+        {
+          id: 'empty-values',
+          status: 'captured',
+          created_at: '',
+          updated_at: '',
+          captured_at: '',
+          processed_at: '',
+          capture_path: '',
+          capture_date: '',
+          capture_time: '',
+          summary: '',
+          knowledge_paths: ['', 1, '  '],
+          task_id: '',
+          superseded_by: '',
+          reason: '',
+          refs: [
+            null,
+            { type: '', uri: '' },
+            { type: 'doc', uri: 'gbrain://knowledge/summary', visibility: 'public' },
+            { type: 'task', uri: 'agenticos://task/follow-up', visibility: 'restricted' },
+            { uri: 'runtime://capture/fallback', visibility: 'secret' },
+          ],
+        },
         { id: 'valid', status: 'captured', created_at: 'bad-date', updated_at: '2026-05-20T00:00:00.000Z' },
       ],
     }), 'utf-8');
@@ -228,6 +494,35 @@ describe('distillation ledger', () => {
 
     expect(loaded.exists).toBe(true);
     expect(loaded.ledger.project_id).toBe('agenticos');
-    expect(loaded.ledger.entries.map((entry) => entry.id)).toEqual(['valid']);
+    expect(loaded.ledger.updated_at).toBe('2026-05-21T00:00:00.000Z');
+    expect(loaded.ledger.entries.map((entry) => entry.id)).toEqual(['empty-values', 'valid']);
+    expect(loaded.ledger.entries[0]).toMatchObject({
+      project_id: 'agenticos',
+      created_at: '2026-05-21T00:00:00.000Z',
+      updated_at: '2026-05-21T00:00:00.000Z',
+    });
+    expect(loaded.ledger.entries[0].knowledge_paths).toBeUndefined();
+    expect(loaded.ledger.entries[0].refs).toEqual([
+      { type: 'doc', uri: 'gbrain://knowledge/summary', visibility: 'public' },
+      { type: 'task', uri: 'agenticos://task/follow-up', visibility: 'restricted' },
+      { type: 'reference', uri: 'runtime://capture/fallback', visibility: 'private' },
+    ]);
+  });
+
+  it('normalizes scalar ledger content as an empty project ledger', async () => {
+    await setupHome();
+    const path = getDistillationLedgerPath('agenticos');
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, 'not-a-ledger', 'utf-8');
+
+    const loaded = await loadDistillationLedger('agenticos', new Date('2026-05-21T00:00:00.000Z'));
+
+    expect(loaded.exists).toBe(true);
+    expect(loaded.ledger).toMatchObject({
+      version: '1.0.0',
+      project_id: 'agenticos',
+      updated_at: '2026-05-21T00:00:00.000Z',
+      entries: [],
+    });
   });
 });

--- a/mcp-server/src/utils/__tests__/knowledge-evolution-health.test.ts
+++ b/mcp-server/src/utils/__tests__/knowledge-evolution-health.test.ts
@@ -6,6 +6,7 @@ import { join } from 'path';
 import yaml from 'yaml';
 import { CURRENT_TEMPLATE_VERSION } from '../distill.js';
 import { assessKnowledgeEvolutionHealth, buildKnowledgeEvolutionStatusLines } from '../knowledge-evolution-health.js';
+import { saveDistillationLedger } from '../distillation-ledger.js';
 
 const originalHome = process.env.AGENTICOS_HOME;
 const now = new Date('2026-05-21T00:00:00.000Z');
@@ -119,6 +120,7 @@ describe('knowledge evolution health', () => {
     expect(result.latest_task_update_at).toBe(recent.toISOString());
     expect(result.dirty_worktree.status).toBe('PASS');
     expect(result.registry_state_drift.status).toBe('PASS');
+    expect(result.distillation_ledger.status).toBe('MISSING');
     expect(result.adapter_template_freshness.adapters.every((adapter) => adapter.status === 'current')).toBe(true);
     expect(result.warnings).toEqual([]);
     expect(buildKnowledgeEvolutionStatusLines(result)[0]).toContain('Knowledge evolution: PASS');
@@ -150,6 +152,42 @@ describe('knowledge evolution health', () => {
       'knowledge update is stale',
       'task update is stale',
     ]));
+  });
+
+  it('warns when captured ledger entries are stale and unprocessed', async () => {
+    const projectRoot = await setupProject();
+    await saveDistillationLedger('health-project', {
+      version: '1.0.0',
+      project_id: 'health-project',
+      updated_at: now.toISOString(),
+      entries: [{
+        id: 'old-capture',
+        project_id: 'health-project',
+        status: 'captured',
+        created_at: stale.toISOString(),
+        updated_at: stale.toISOString(),
+        captured_at: stale.toISOString(),
+      }],
+    }, now);
+
+    const result = await assessKnowledgeEvolutionHealth({
+      projectPath: projectRoot,
+      repoSync: {
+        branch_line: '## main...origin/main',
+        branch_status: 'aligned',
+        dirty_paths: [],
+        runtime_dirty_paths: [],
+        source_dirty_paths: [],
+      },
+      now,
+    });
+
+    expect(result.status).toBe('WARN');
+    expect(result.distillation_ledger.status).toBe('WARN');
+    expect(result.distillation_ledger.stale_unprocessed_capture_count).toBe(1);
+    expect(result.warnings).toContain('distillation ledger has 1 stale captured entry pending promotion');
+    expect(result.recovery_actions).toContain('promote, convert, supersede, or explicitly ignore stale captured ledger entries');
+    expect(buildKnowledgeEvolutionStatusLines(result)).toContain('   Distillation ledger: distillation ledger has 1 stale captured entry pending promotion');
   });
 
   it('warns for a missing sidecar capture without blocking', async () => {

--- a/mcp-server/src/utils/distillation-ledger.ts
+++ b/mcp-server/src/utils/distillation-ledger.ts
@@ -1,0 +1,393 @@
+import { createHash } from 'crypto';
+import { mkdir, readFile, writeFile } from 'fs/promises';
+import { dirname, join } from 'path';
+import yaml from 'yaml';
+import { getAgenticOSHome } from './registry.js';
+import type { AppendedRecordCapture } from './record-capture.js';
+
+export type DistillationLedgerStatus =
+  | 'captured'
+  | 'distilled_to_knowledge'
+  | 'converted_to_task'
+  | 'superseded'
+  | 'ignored_with_reason';
+
+export interface DistillationLedgerEntry {
+  id: string;
+  project_id: string;
+  status: DistillationLedgerStatus;
+  created_at: string;
+  updated_at: string;
+  captured_at?: string;
+  processed_at?: string;
+  capture_path?: string;
+  capture_date?: string;
+  capture_time?: string;
+  summary?: string;
+  knowledge_paths?: string[];
+  task_id?: string;
+  superseded_by?: string;
+  reason?: string;
+  refs?: Array<{
+    type: string;
+    uri: string;
+    visibility: 'private' | 'public' | 'restricted';
+  }>;
+}
+
+export interface DistillationLedger {
+  version: '1.0.0';
+  project_id: string;
+  updated_at: string;
+  entries: DistillationLedgerEntry[];
+}
+
+export interface LoadedDistillationLedger {
+  path: string;
+  exists: boolean;
+  ledger: DistillationLedger;
+}
+
+export interface DistillationLedgerWriteResult {
+  path: string;
+  entry: DistillationLedgerEntry;
+  created: boolean;
+}
+
+export interface DistillationLedgerHealth {
+  status: 'PASS' | 'WARN' | 'MISSING';
+  path: string;
+  exists: boolean;
+  unprocessed_capture_count: number;
+  stale_unprocessed_capture_count: number;
+  oldest_unprocessed_capture_at: string | null;
+  latest_entry_at: string | null;
+  summary: string;
+  warnings: string[];
+}
+
+const LEDGER_VERSION: DistillationLedger['version'] = '1.0.0';
+const DEFAULT_STALE_AFTER_DAYS = 14;
+const LEDGER_STATUSES = new Set<DistillationLedgerStatus>([
+  'captured',
+  'distilled_to_knowledge',
+  'converted_to_task',
+  'superseded',
+  'ignored_with_reason',
+]);
+
+export function getDistillationLedgerPath(projectId: string): string {
+  return join(
+    getAgenticOSHome(),
+    '.agent-workspace',
+    'projects',
+    encodeURIComponent(projectId),
+    'distillation-ledger.yaml',
+  );
+}
+
+function nowIso(now: Date = new Date()): string {
+  return now.toISOString();
+}
+
+function emptyLedger(projectId: string, now: Date = new Date()): DistillationLedger {
+  return {
+    version: LEDGER_VERSION,
+    project_id: projectId,
+    updated_at: nowIso(now),
+    entries: [],
+  };
+}
+
+function asStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const values = value
+    .filter((item): item is string => typeof item === 'string')
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+  return values.length > 0 ? values : undefined;
+}
+
+function normalizeEntry(projectId: string, value: unknown): DistillationLedgerEntry | null {
+  if (!value || typeof value !== 'object') return null;
+  const raw = value as Record<string, unknown>;
+  const id = typeof raw.id === 'string' ? raw.id.trim() : '';
+  const status = typeof raw.status === 'string' && LEDGER_STATUSES.has(raw.status as DistillationLedgerStatus)
+    ? raw.status as DistillationLedgerStatus
+    : null;
+  if (!id || !status) return null;
+
+  const createdAt = typeof raw.created_at === 'string' && raw.created_at.trim() ? raw.created_at : nowIso();
+  const updatedAt = typeof raw.updated_at === 'string' && raw.updated_at.trim() ? raw.updated_at : createdAt;
+  return {
+    id,
+    project_id: typeof raw.project_id === 'string' && raw.project_id.trim() ? raw.project_id.trim() : projectId,
+    status,
+    created_at: createdAt,
+    updated_at: updatedAt,
+    ...(typeof raw.captured_at === 'string' && raw.captured_at.trim() ? { captured_at: raw.captured_at.trim() } : {}),
+    ...(typeof raw.processed_at === 'string' && raw.processed_at.trim() ? { processed_at: raw.processed_at.trim() } : {}),
+    ...(typeof raw.capture_path === 'string' && raw.capture_path.trim() ? { capture_path: raw.capture_path.trim() } : {}),
+    ...(typeof raw.capture_date === 'string' && raw.capture_date.trim() ? { capture_date: raw.capture_date.trim() } : {}),
+    ...(typeof raw.capture_time === 'string' && raw.capture_time.trim() ? { capture_time: raw.capture_time.trim() } : {}),
+    ...(typeof raw.summary === 'string' && raw.summary.trim() ? { summary: raw.summary.trim() } : {}),
+    ...(asStringArray(raw.knowledge_paths) ? { knowledge_paths: asStringArray(raw.knowledge_paths) } : {}),
+    ...(typeof raw.task_id === 'string' && raw.task_id.trim() ? { task_id: raw.task_id.trim() } : {}),
+    ...(typeof raw.superseded_by === 'string' && raw.superseded_by.trim() ? { superseded_by: raw.superseded_by.trim() } : {}),
+    ...(typeof raw.reason === 'string' && raw.reason.trim() ? { reason: raw.reason.trim() } : {}),
+    ...(Array.isArray(raw.refs) ? {
+      refs: raw.refs
+        .filter((ref): ref is Record<string, unknown> => Boolean(ref) && typeof ref === 'object')
+        .map((ref) => {
+          const visibility: 'private' | 'public' | 'restricted' =
+            ref.visibility === 'public' || ref.visibility === 'restricted' ? ref.visibility : 'private';
+          return {
+            type: typeof ref.type === 'string' && ref.type.trim() ? ref.type.trim() : 'reference',
+            uri: typeof ref.uri === 'string' && ref.uri.trim() ? ref.uri.trim() : '',
+            visibility,
+          };
+        })
+        .filter((ref) => ref.uri.length > 0),
+    } : {}),
+  };
+}
+
+function normalizeLedger(projectId: string, raw: unknown, now: Date = new Date()): DistillationLedger {
+  const parsed = raw && typeof raw === 'object' ? raw as Record<string, unknown> : {};
+  const entries = Array.isArray(parsed.entries)
+    ? parsed.entries
+        .map((entry) => normalizeEntry(projectId, entry))
+        .filter((entry): entry is DistillationLedgerEntry => entry !== null)
+    : [];
+  return {
+    version: LEDGER_VERSION,
+    project_id: typeof parsed.project_id === 'string' && parsed.project_id.trim() ? parsed.project_id.trim() : projectId,
+    updated_at: typeof parsed.updated_at === 'string' && parsed.updated_at.trim() ? parsed.updated_at.trim() : nowIso(now),
+    entries,
+  };
+}
+
+export async function loadDistillationLedger(projectId: string, now: Date = new Date()): Promise<LoadedDistillationLedger> {
+  const path = getDistillationLedgerPath(projectId);
+  try {
+    const parsed = yaml.parse(await readFile(path, 'utf-8'));
+    return {
+      path,
+      exists: true,
+      ledger: normalizeLedger(projectId, parsed, now),
+    };
+  } catch {
+    return {
+      path,
+      exists: false,
+      ledger: emptyLedger(projectId, now),
+    };
+  }
+}
+
+export async function saveDistillationLedger(projectId: string, ledger: DistillationLedger, now: Date = new Date()): Promise<string> {
+  const path = getDistillationLedgerPath(projectId);
+  const normalized = normalizeLedger(projectId, ledger, now);
+  normalized.updated_at = nowIso(now);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, yaml.stringify(normalized), 'utf-8');
+  return path;
+}
+
+function captureEntryId(args: { projectId: string; capture: AppendedRecordCapture; summary: string }): string {
+  const hash = createHash('sha256')
+    .update(`${args.projectId}\n${args.capture.filePath}\n${args.capture.date}\n${args.capture.time}\n${args.summary}`)
+    .digest('hex')
+    .slice(0, 12);
+  return `capture-${args.capture.date}-${args.capture.time.replace(/[^0-9]/g, '')}-${hash}`;
+}
+
+export async function recordCapturedDistillationEntry(args: {
+  projectId: string;
+  capture: AppendedRecordCapture;
+  summary: string;
+  now?: Date;
+}): Promise<DistillationLedgerWriteResult> {
+  const now = args.now ?? new Date();
+  const loaded = await loadDistillationLedger(args.projectId, now);
+  const id = captureEntryId(args);
+  const existing = loaded.ledger.entries.find((entry) => entry.id === id) ?? null;
+  if (existing) {
+    return {
+      path: loaded.path,
+      entry: existing,
+      created: false,
+    };
+  }
+
+  const timestamp = nowIso(now);
+  const entry: DistillationLedgerEntry = {
+    id,
+    project_id: args.projectId,
+    status: 'captured',
+    created_at: timestamp,
+    updated_at: timestamp,
+    captured_at: timestamp,
+    capture_path: args.capture.filePath,
+    capture_date: args.capture.date,
+    capture_time: args.capture.time,
+    summary: args.summary,
+    refs: [{
+      type: 'runtime_capture',
+      uri: args.capture.filePath,
+      visibility: 'private',
+    }],
+  };
+  loaded.ledger.entries.push(entry);
+  await saveDistillationLedger(args.projectId, loaded.ledger, now);
+  return {
+    path: loaded.path,
+    entry,
+    created: true,
+  };
+}
+
+function assertTransitionPatch(entry: DistillationLedgerEntry, patch: Partial<DistillationLedgerEntry> & { status: DistillationLedgerStatus }): void {
+  if (patch.status === 'captured') {
+    return;
+  }
+  if (patch.status === 'distilled_to_knowledge' && (!patch.knowledge_paths || patch.knowledge_paths.length === 0)) {
+    throw new Error('knowledge_paths is required when marking a ledger entry as distilled_to_knowledge');
+  }
+  if (patch.status === 'converted_to_task' && !patch.task_id) {
+    throw new Error('task_id is required when marking a ledger entry as converted_to_task');
+  }
+  if (patch.status === 'superseded' && !patch.superseded_by) {
+    throw new Error('superseded_by is required when marking a ledger entry as superseded');
+  }
+  if (patch.status === 'ignored_with_reason' && !patch.reason) {
+    throw new Error('reason is required when marking a ledger entry as ignored_with_reason');
+  }
+  if (entry.status !== 'captured' && entry.status !== patch.status) {
+    throw new Error(`ledger entry "${entry.id}" is already ${entry.status}`);
+  }
+}
+
+export async function markDistillationLedgerEntry(args: {
+  projectId: string;
+  entryId: string;
+  status: DistillationLedgerStatus;
+  now?: Date;
+  knowledge_paths?: string[];
+  task_id?: string;
+  superseded_by?: string;
+  reason?: string;
+}): Promise<DistillationLedgerWriteResult> {
+  const now = args.now ?? new Date();
+  const loaded = await loadDistillationLedger(args.projectId, now);
+  const index = loaded.ledger.entries.findIndex((entry) => entry.id === args.entryId);
+  if (index < 0) {
+    throw new Error(`distillation ledger entry "${args.entryId}" not found`);
+  }
+
+  const existing = loaded.ledger.entries[index];
+  const timestamp = nowIso(now);
+  const patch = {
+    status: args.status,
+    ...(args.knowledge_paths ? { knowledge_paths: args.knowledge_paths } : {}),
+    ...(args.task_id ? { task_id: args.task_id } : {}),
+    ...(args.superseded_by ? { superseded_by: args.superseded_by } : {}),
+    ...(args.reason ? { reason: args.reason } : {}),
+  };
+  assertTransitionPatch(existing, patch);
+  const entry: DistillationLedgerEntry = {
+    ...existing,
+    ...patch,
+    updated_at: timestamp,
+    ...(args.status === 'captured' ? {} : { processed_at: timestamp }),
+  };
+  loaded.ledger.entries[index] = entry;
+  await saveDistillationLedger(args.projectId, loaded.ledger, now);
+  return {
+    path: loaded.path,
+    entry,
+    created: false,
+  };
+}
+
+function normalizeEntryTime(entry: DistillationLedgerEntry): string | null {
+  const value = entry.captured_at ?? entry.created_at;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+function latestEntryTime(entries: DistillationLedgerEntry[]): string | null {
+  const times = entries
+    .map((entry) => {
+      const date = new Date(entry.updated_at);
+      return Number.isNaN(date.getTime()) ? null : date.toISOString();
+    })
+    .filter((value): value is string => value !== null)
+    .sort((a, b) => new Date(b).getTime() - new Date(a).getTime());
+  return times[0] ?? null;
+}
+
+function isStale(value: string | null, now: Date, staleAfterDays: number): boolean {
+  if (!value) return false;
+  return now.getTime() - new Date(value).getTime() > staleAfterDays * 24 * 60 * 60 * 1000;
+}
+
+export async function summarizeDistillationLedger(args: {
+  projectId: string | null;
+  now?: Date;
+  staleAfterDays?: number;
+}): Promise<DistillationLedgerHealth> {
+  const now = args.now ?? new Date();
+  const staleAfterDays = args.staleAfterDays ?? DEFAULT_STALE_AFTER_DAYS;
+  if (!args.projectId) {
+    return {
+      status: 'MISSING',
+      path: '',
+      exists: false,
+      unprocessed_capture_count: 0,
+      stale_unprocessed_capture_count: 0,
+      oldest_unprocessed_capture_at: null,
+      latest_entry_at: null,
+      summary: 'Distillation ledger is unavailable because project_id is missing.',
+      warnings: [],
+    };
+  }
+
+  const loaded = await loadDistillationLedger(args.projectId, now);
+  if (!loaded.exists) {
+    return {
+      status: 'MISSING',
+      path: loaded.path,
+      exists: false,
+      unprocessed_capture_count: 0,
+      stale_unprocessed_capture_count: 0,
+      oldest_unprocessed_capture_at: null,
+      latest_entry_at: null,
+      summary: 'No distillation ledger has been created yet.',
+      warnings: [],
+    };
+  }
+
+  const captured = loaded.ledger.entries.filter((entry) => entry.status === 'captured');
+  const capturedTimes = captured
+    .map(normalizeEntryTime)
+    .filter((value): value is string => value !== null)
+    .sort((a, b) => new Date(a).getTime() - new Date(b).getTime());
+  const stale = capturedTimes.filter((value) => isStale(value, now, staleAfterDays));
+  const warnings = stale.length > 0
+    ? [`distillation ledger has ${stale.length} stale captured entr${stale.length === 1 ? 'y' : 'ies'} pending promotion`]
+    : [];
+  return {
+    status: warnings.length > 0 ? 'WARN' : 'PASS',
+    path: loaded.path,
+    exists: true,
+    unprocessed_capture_count: captured.length,
+    stale_unprocessed_capture_count: stale.length,
+    oldest_unprocessed_capture_at: capturedTimes[0] ?? null,
+    latest_entry_at: latestEntryTime(loaded.ledger.entries),
+    summary: warnings.length > 0
+      ? warnings[0]
+      : `Distillation ledger has ${captured.length} unprocessed captured entr${captured.length === 1 ? 'y' : 'ies'}.`,
+    warnings,
+  };
+}

--- a/mcp-server/src/utils/distillation-ledger.ts
+++ b/mcp-server/src/utils/distillation-ledger.ts
@@ -108,7 +108,7 @@ function asStringArray(value: unknown): string[] | undefined {
   return values.length > 0 ? values : undefined;
 }
 
-function normalizeEntry(projectId: string, value: unknown): DistillationLedgerEntry | null {
+function normalizeEntry(projectId: string, value: unknown, now: Date = new Date()): DistillationLedgerEntry | null {
   if (!value || typeof value !== 'object') return null;
   const raw = value as Record<string, unknown>;
   const id = typeof raw.id === 'string' ? raw.id.trim() : '';
@@ -117,7 +117,7 @@ function normalizeEntry(projectId: string, value: unknown): DistillationLedgerEn
     : null;
   if (!id || !status) return null;
 
-  const createdAt = typeof raw.created_at === 'string' && raw.created_at.trim() ? raw.created_at : nowIso();
+  const createdAt = typeof raw.created_at === 'string' && raw.created_at.trim() ? raw.created_at : nowIso(now);
   const updatedAt = typeof raw.updated_at === 'string' && raw.updated_at.trim() ? raw.updated_at : createdAt;
   return {
     id,
@@ -156,7 +156,7 @@ function normalizeLedger(projectId: string, raw: unknown, now: Date = new Date()
   const parsed = raw && typeof raw === 'object' ? raw as Record<string, unknown> : {};
   const entries = Array.isArray(parsed.entries)
     ? parsed.entries
-        .map((entry) => normalizeEntry(projectId, entry))
+        .map((entry) => normalizeEntry(projectId, entry, now))
         .filter((entry): entry is DistillationLedgerEntry => entry !== null)
     : [];
   return {
@@ -327,8 +327,7 @@ function latestEntryTime(entries: DistillationLedgerEntry[]): string | null {
   return times[0] ?? null;
 }
 
-function isStale(value: string | null, now: Date, staleAfterDays: number): boolean {
-  if (!value) return false;
+function isStale(value: string, now: Date, staleAfterDays: number): boolean {
   return now.getTime() - new Date(value).getTime() > staleAfterDays * 24 * 60 * 60 * 1000;
 }
 

--- a/mcp-server/src/utils/knowledge-evolution-health.ts
+++ b/mcp-server/src/utils/knowledge-evolution-health.ts
@@ -7,6 +7,7 @@ import { resolveManagedProjectContextPaths } from './agent-context-paths.js';
 import { CURRENT_TEMPLATE_VERSION, extractTemplateVersion } from './distill.js';
 import { getRuntimeCaptureConversationDir } from './record-capture.js';
 import { loadRegistry } from './registry.js';
+import { summarizeDistillationLedger, type DistillationLedgerHealth } from './distillation-ledger.js';
 
 export interface KnowledgeEvolutionAdapterFreshness {
   path: string;
@@ -41,6 +42,7 @@ export interface KnowledgeEvolutionHealth {
     project_path: string | null;
     summary: string;
   };
+  distillation_ledger: DistillationLedgerHealth;
   warnings: string[];
   recovery_actions: string[];
 }
@@ -294,6 +296,11 @@ export async function assessKnowledgeEvolutionHealth(args: KnowledgeEvolutionArg
   };
   const dirtyWorktree = buildDirtyWorktree(await resolveRepoSync(args));
   const registryStateDrift = await buildRegistryDrift(projectPath, projectId);
+  const distillationLedger = await summarizeDistillationLedger({
+    projectId,
+    now,
+    staleAfterDays,
+  });
   const warnings: string[] = [];
 
   addFreshnessWarnings({
@@ -313,10 +320,14 @@ export async function assessKnowledgeEvolutionHealth(args: KnowledgeEvolutionArg
   }
   if (dirtyWorktree.status !== 'PASS') warnings.push(dirtyWorktree.summary);
   if (registryStateDrift.status === 'WARN') warnings.push(registryStateDrift.summary);
+  warnings.push(...distillationLedger.warnings);
 
   const recoveryActions = warnings.length > 0
     ? [
         'run agenticos_record or agenticos_task_* to refresh task/knowledge continuity',
+        ...(distillationLedger.status === 'WARN'
+          ? ['promote, convert, supersede, or explicitly ignore stale captured ledger entries']
+          : []),
         'run agenticos_refresh_entry_surfaces after important state changes',
         'review adapter templates and registry binding before relying on cross-session memory',
       ]
@@ -334,6 +345,7 @@ export async function assessKnowledgeEvolutionHealth(args: KnowledgeEvolutionArg
     adapter_template_freshness: adapterTemplateFreshness,
     dirty_worktree: dirtyWorktree,
     registry_state_drift: registryStateDrift,
+    distillation_ledger: distillationLedger,
     warnings,
     recovery_actions: recoveryActions,
   };
@@ -352,6 +364,7 @@ export function buildKnowledgeEvolutionStatusLines(assessment: KnowledgeEvolutio
     `   Task update: ${displayTimestamp(assessment.latest_task_update_at)}`,
     `   Dirty worktree: ${assessment.dirty_worktree.summary}`,
     `   Registry/state: ${assessment.registry_state_drift.summary}`,
+    `   Distillation ledger: ${assessment.distillation_ledger.summary}`,
   ];
   const staleAdapters = assessment.adapter_template_freshness.adapters.filter((adapter) => adapter.status !== 'current');
   lines.push(staleAdapters.length > 0


### PR DESCRIPTION
Fixes #451.

## Summary
- Add a private runtime distillation ledger under `${AGENTICOS_HOME}/.agent-workspace/projects/<project-id>/distillation-ledger.yaml`.
- Record `captured` ledger entries from `agenticos_record` without writing raw public transcripts.
- Add ledger utilities for lifecycle transitions: `distilled_to_knowledge`, `converted_to_task`, `superseded`, and `ignored_with_reason`.
- Extend knowledge-evolution health/status with stale unprocessed captured-entry warnings.

## Verification
- `cd mcp-server && npm ci`
- `cd mcp-server && npm run lint`
- `cd mcp-server && npm test -- --run src/utils/__tests__/distillation-ledger.test.ts src/utils/__tests__/knowledge-evolution-health.test.ts src/tools/__tests__/record.test.ts`
- `cd mcp-server && npm test -- --run`
- `GITHUB_EVENT_NAME=pull_request GITHUB_BASE_REF=main ./tools/coverage-preflight.sh`
- `git diff --check`
- `agenticos_pr_scope_check` PASS
