### PR TITLE
test: add Hermes routing scenario contract

### DIFF
--- a/mcp-server/src/utils/__tests__/hermes-routing-scenarios.test.ts
+++ b/mcp-server/src/utils/__tests__/hermes-routing-scenarios.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import {
+  FULL_PROJECT_WORKFLOW_REQUIREMENTS,
+  HERMES_ROUTING_PATHS,
+  HERMES_ROUTING_SCENARIOS,
+  PROJECT_SWITCH_SUBSTITUTES,
+  getHermesRoutingScenario,
+  validateHermesRoutingScenarios,
+  type HermesRoutingScenario,
+} from '../hermes-routing-scenarios.js';
+
+function cloneScenario(route: HermesRoutingScenario['route']): HermesRoutingScenario {
+  const scenario = getHermesRoutingScenario(route);
+  return {
+    ...scenario,
+    required_tool_calls: [...scenario.required_tool_calls],
+    rejected_switch_substitutes: [...scenario.rejected_switch_substitutes],
+    gbrain_policy: { ...scenario.gbrain_policy },
+    workflow_requirements: [...scenario.workflow_requirements],
+  };
+}
+
+describe('Hermes routing scenarios', () => {
+  it('covers all five durable routing paths', () => {
+    expect(HERMES_ROUTING_SCENARIOS.map((scenario) => scenario.route)).toEqual(HERMES_ROUTING_PATHS);
+    expect(validateHermesRoutingScenarios(HERMES_ROUTING_SCENARIOS)).toEqual([]);
+  });
+
+  it('keeps chat-only, Hermes memory, and GBrain routes out of AgenticOS task state', () => {
+    const chatOnly = getHermesRoutingScenario('chat_only');
+    const hermesMemory = getHermesRoutingScenario('hermes_memory');
+    const gbrainKnowledge = getHermesRoutingScenario('gbrain_knowledge');
+
+    expect(chatOnly).toMatchObject({
+      owner: 'Hermes',
+      durable_write: 'none',
+      requires_agenticos_mcp_first: false,
+    });
+    expect(hermesMemory).toMatchObject({
+      owner: 'Hermes',
+      durable_write: 'hermes_memory',
+      requires_agenticos_mcp_first: false,
+    });
+    expect(gbrainKnowledge).toMatchObject({
+      owner: 'GBrain',
+      durable_write: 'gbrain_summary',
+      requires_agenticos_mcp_first: false,
+      gbrain_policy: {
+        stores_distilled_summary: true,
+        stores_reference_links: true,
+        stores_active_agenticos_task_state: false,
+        stores_full_task_board: false,
+      },
+    });
+  });
+
+  it('requires AgenticOS MCP before topic or project filesystem discovery', () => {
+    for (const route of ['agenticos_topic', 'agenticos_project'] as const) {
+      const scenario = getHermesRoutingScenario(route);
+      expect(scenario.requires_agenticos_mcp_first).toBe(true);
+      expect(scenario.required_tool_calls).toEqual(expect.arrayContaining(['agenticos_switch']));
+      expect(scenario.rejected_switch_substitutes).toEqual(PROJECT_SWITCH_SUBSTITUTES);
+    }
+  });
+
+  it('requires the full issue/worktree/PR flow for AgenticOS project routing', () => {
+    const project = getHermesRoutingScenario('agenticos_project');
+    expect(project.workflow_requirements).toEqual(FULL_PROJECT_WORKFLOW_REQUIREMENTS);
+    expect(project.required_tool_calls).toEqual(expect.arrayContaining([
+      'agenticos_issue_bootstrap',
+      'agenticos_branch_bootstrap',
+      'agenticos_preflight',
+      'agenticos_edit_guard',
+      'agenticos_pr_scope_check',
+    ]));
+  });
+
+  it('reports missing routes and unsafe project switch substitutes', () => {
+    const scenarios = HERMES_ROUTING_SCENARIOS
+      .filter((scenario) => scenario.route !== 'chat_only')
+      .map((scenario) => cloneScenario(scenario.route));
+    const topic = scenarios.find((scenario) => scenario.route === 'agenticos_topic')!;
+    topic.requires_agenticos_mcp_first = false;
+    topic.required_tool_calls = ['cd'];
+    topic.rejected_switch_substitutes = ['cd'];
+
+    expect(validateHermesRoutingScenarios(scenarios)).toEqual(expect.arrayContaining([
+      'missing route: chat_only',
+      'agenticos_topic must require AgenticOS MCP before filesystem discovery',
+      'agenticos_topic must require agenticos_switch or agenticos_init',
+      'agenticos_topic must reject raw_directory_search as a project switch substitute',
+      'agenticos_topic must reject git_branch_detection as a project switch substitute',
+    ]));
+  });
+
+  it('reports GBrain task duplication and missing full-project workflow gates', () => {
+    const scenarios = HERMES_ROUTING_SCENARIOS.map((scenario) => cloneScenario(scenario.route));
+    const gbrain = scenarios.find((scenario) => scenario.route === 'gbrain_knowledge')!;
+    gbrain.gbrain_policy = {
+      stores_distilled_summary: false,
+      stores_reference_links: false,
+      stores_active_agenticos_task_state: true,
+      stores_full_task_board: true,
+    };
+    const project = scenarios.find((scenario) => scenario.route === 'agenticos_project')!;
+    project.workflow_requirements = ['issue_bootstrap'];
+
+    expect(validateHermesRoutingScenarios(scenarios)).toEqual(expect.arrayContaining([
+      'gbrain_knowledge must store distilled summaries',
+      'gbrain_knowledge must store reference links',
+      'gbrain_knowledge must not store active AgenticOS task state',
+      'gbrain_knowledge must not store the AgenticOS task board',
+      'agenticos_project must require isolated_worktree',
+      'agenticos_project must require pull_request',
+      'agenticos_project must require ci_green',
+    ]));
+  });
+
+  it('fails clearly for unknown routing paths', () => {
+    expect(() => getHermesRoutingScenario('unknown' as HermesRoutingScenario['route'])).toThrow(
+      'Hermes routing scenario not found: unknown',
+    );
+  });
+});

--- a/mcp-server/src/utils/hermes-routing-scenarios.ts
+++ b/mcp-server/src/utils/hermes-routing-scenarios.ts
@@ -1,0 +1,193 @@
+export const HERMES_ROUTING_PATHS = [
+  'chat_only',
+  'hermes_memory',
+  'gbrain_knowledge',
+  'agenticos_topic',
+  'agenticos_project',
+] as const;
+
+export type HermesRoutingPath = typeof HERMES_ROUTING_PATHS[number];
+
+export const PROJECT_SWITCH_SUBSTITUTES = [
+  'cd',
+  'raw_directory_search',
+  'git_branch_detection',
+] as const;
+
+export type ProjectSwitchSubstitute = typeof PROJECT_SWITCH_SUBSTITUTES[number];
+
+export const FULL_PROJECT_WORKFLOW_REQUIREMENTS = [
+  'issue_bootstrap',
+  'isolated_worktree',
+  'preflight',
+  'edit_guard',
+  'pr_scope_check',
+  'pull_request',
+  'ci_green',
+  'merge_commit',
+  'cleanup',
+] as const;
+
+export type FullProjectWorkflowRequirement = typeof FULL_PROJECT_WORKFLOW_REQUIREMENTS[number];
+
+export interface HermesRoutingScenario {
+  route: HermesRoutingPath;
+  owner: 'Hermes' | 'GBrain' | 'AgenticOS';
+  durable_write: 'none' | 'hermes_memory' | 'gbrain_summary' | 'agenticos_topic' | 'agenticos_project';
+  requires_agenticos_mcp_first: boolean;
+  required_tool_calls: string[];
+  rejected_switch_substitutes: ProjectSwitchSubstitute[];
+  gbrain_policy: {
+    stores_distilled_summary: boolean;
+    stores_reference_links: boolean;
+    stores_active_agenticos_task_state: boolean;
+    stores_full_task_board: boolean;
+  };
+  workflow_requirements: FullProjectWorkflowRequirement[];
+}
+
+export const HERMES_ROUTING_SCENARIOS: readonly HermesRoutingScenario[] = [
+  {
+    route: 'chat_only',
+    owner: 'Hermes',
+    durable_write: 'none',
+    requires_agenticos_mcp_first: false,
+    required_tool_calls: [],
+    rejected_switch_substitutes: [],
+    gbrain_policy: {
+      stores_distilled_summary: false,
+      stores_reference_links: false,
+      stores_active_agenticos_task_state: false,
+      stores_full_task_board: false,
+    },
+    workflow_requirements: [],
+  },
+  {
+    route: 'hermes_memory',
+    owner: 'Hermes',
+    durable_write: 'hermes_memory',
+    requires_agenticos_mcp_first: false,
+    required_tool_calls: [],
+    rejected_switch_substitutes: [],
+    gbrain_policy: {
+      stores_distilled_summary: false,
+      stores_reference_links: false,
+      stores_active_agenticos_task_state: false,
+      stores_full_task_board: false,
+    },
+    workflow_requirements: [],
+  },
+  {
+    route: 'gbrain_knowledge',
+    owner: 'GBrain',
+    durable_write: 'gbrain_summary',
+    requires_agenticos_mcp_first: false,
+    required_tool_calls: [],
+    rejected_switch_substitutes: [],
+    gbrain_policy: {
+      stores_distilled_summary: true,
+      stores_reference_links: true,
+      stores_active_agenticos_task_state: false,
+      stores_full_task_board: false,
+    },
+    workflow_requirements: [],
+  },
+  {
+    route: 'agenticos_topic',
+    owner: 'AgenticOS',
+    durable_write: 'agenticos_topic',
+    requires_agenticos_mcp_first: true,
+    required_tool_calls: ['agenticos_switch', 'agenticos_init', 'agenticos_task_create'],
+    rejected_switch_substitutes: [...PROJECT_SWITCH_SUBSTITUTES],
+    gbrain_policy: {
+      stores_distilled_summary: true,
+      stores_reference_links: true,
+      stores_active_agenticos_task_state: false,
+      stores_full_task_board: false,
+    },
+    workflow_requirements: [],
+  },
+  {
+    route: 'agenticos_project',
+    owner: 'AgenticOS',
+    durable_write: 'agenticos_project',
+    requires_agenticos_mcp_first: true,
+    required_tool_calls: [
+      'agenticos_switch',
+      'agenticos_issue_bootstrap',
+      'agenticos_branch_bootstrap',
+      'agenticos_preflight',
+      'agenticos_edit_guard',
+      'agenticos_pr_scope_check',
+    ],
+    rejected_switch_substitutes: [...PROJECT_SWITCH_SUBSTITUTES],
+    gbrain_policy: {
+      stores_distilled_summary: true,
+      stores_reference_links: true,
+      stores_active_agenticos_task_state: false,
+      stores_full_task_board: false,
+    },
+    workflow_requirements: [...FULL_PROJECT_WORKFLOW_REQUIREMENTS],
+  },
+];
+
+export function getHermesRoutingScenario(route: HermesRoutingPath): HermesRoutingScenario {
+  const scenario = HERMES_ROUTING_SCENARIOS.find((item) => item.route === route);
+  if (!scenario) {
+    throw new Error(`Hermes routing scenario not found: ${route}`);
+  }
+  return scenario;
+}
+
+export function validateHermesRoutingScenarios(scenarios: readonly HermesRoutingScenario[]): string[] {
+  const problems: string[] = [];
+  const routes = new Set(scenarios.map((scenario) => scenario.route));
+
+  for (const route of HERMES_ROUTING_PATHS) {
+    if (!routes.has(route)) {
+      problems.push(`missing route: ${route}`);
+    }
+  }
+
+  for (const scenario of scenarios) {
+    const isAgenticosRoute = scenario.route === 'agenticos_topic' || scenario.route === 'agenticos_project';
+    if (isAgenticosRoute && !scenario.requires_agenticos_mcp_first) {
+      problems.push(`${scenario.route} must require AgenticOS MCP before filesystem discovery`);
+    }
+    if (isAgenticosRoute && !scenario.required_tool_calls.some((tool) => tool === 'agenticos_switch' || tool === 'agenticos_init')) {
+      problems.push(`${scenario.route} must require agenticos_switch or agenticos_init`);
+    }
+    if (isAgenticosRoute) {
+      for (const substitute of PROJECT_SWITCH_SUBSTITUTES) {
+        if (!scenario.rejected_switch_substitutes.includes(substitute)) {
+          problems.push(`${scenario.route} must reject ${substitute} as a project switch substitute`);
+        }
+      }
+    }
+
+    if (scenario.route === 'gbrain_knowledge') {
+      if (!scenario.gbrain_policy.stores_distilled_summary) {
+        problems.push('gbrain_knowledge must store distilled summaries');
+      }
+      if (!scenario.gbrain_policy.stores_reference_links) {
+        problems.push('gbrain_knowledge must store reference links');
+      }
+      if (scenario.gbrain_policy.stores_active_agenticos_task_state) {
+        problems.push('gbrain_knowledge must not store active AgenticOS task state');
+      }
+      if (scenario.gbrain_policy.stores_full_task_board) {
+        problems.push('gbrain_knowledge must not store the AgenticOS task board');
+      }
+    }
+
+    if (scenario.route === 'agenticos_project') {
+      for (const requirement of FULL_PROJECT_WORKFLOW_REQUIREMENTS) {
+        if (!scenario.workflow_requirements.includes(requirement)) {
+          problems.push(`agenticos_project must require ${requirement}`);
+        }
+      }
+    }
+  }
+
+  return problems;
+}

--- a/standards/knowledge/hermes-routing-scenario-coverage-2026-05-21.md
+++ b/standards/knowledge/hermes-routing-scenario-coverage-2026-05-21.md
@@ -1,0 +1,140 @@
+# Hermes Routing Scenario Coverage - 2026-05-21
+
+## Purpose
+
+Issue #453 turns the five Hermes-side routing paths from #441 into executable
+AgenticOS coverage.
+
+The risk is not that agents forget the words "Chat-only" or "GBrain knowledge".
+The risk is that a future Hermes, Codex, or Claude Code integration treats
+`cd`, raw directory search, git branch detection, or GBrain task duplication as
+good enough substitutes for AgenticOS MCP. This document records the intended
+scenarios, and `mcp-server/src/utils/hermes-routing-scenarios.ts` provides the
+machine-checkable contract.
+
+## Scenario Matrix
+
+| Route | Owner | Durable write | AgenticOS MCP first? | Accepted behavior |
+| --- | --- | --- | --- | --- |
+| Chat-only | Hermes | none | no | Answer in the current chat; do not write durable state |
+| Hermes memory | Hermes | Hermes local memory | no | Store only small assistant-continuity facts or preferences |
+| GBrain knowledge | GBrain | distilled summary and reference links | no | Store semantic summaries/entities/relations/links only |
+| AgenticOS topic | AgenticOS | topic state, tasks, knowledge, artifacts | yes | Call `agenticos_switch` or `agenticos_init`, then update topic surfaces |
+| AgenticOS project | AgenticOS | issue/worktree/PR governed project state | yes | Call AgenticOS MCP and follow issue/worktree/preflight/PR/CI flow |
+
+## Executable Contract
+
+The executable contract lives in:
+
+```text
+mcp-server/src/utils/hermes-routing-scenarios.ts
+mcp-server/src/utils/__tests__/hermes-routing-scenarios.test.ts
+```
+
+The tests enforce:
+
+- all five routes exist and validate together
+- AgenticOS topic/project routes require MCP before filesystem discovery
+- `cd`, raw directory search, and git branch detection are rejected as project
+  switch substitutes
+- GBrain stores distilled summary and reference links only
+- GBrain does not store active AgenticOS task state or a copied task board
+- full AgenticOS project routing requires issue bootstrap, isolated worktree,
+  preflight, edit guard, PR scope check, pull request, CI green, merge commit,
+  and cleanup
+
+## Route Expectations
+
+### Chat-Only
+
+Use when the request is one-off and has no durable state, task, or artifact.
+No AgenticOS MCP call is required. No GBrain write is required.
+
+Failure mode:
+
+- Writing a one-off answer into AgenticOS state creates noise and false
+  continuity.
+
+### Hermes Memory
+
+Use when the information is a small assistant-continuity fact, such as a stable
+preference or identity cue. Hermes owns the write.
+
+Failure mode:
+
+- Storing active task state in Hermes memory makes task freshness invisible to
+  AgenticOS.
+
+### GBrain Knowledge
+
+Use when the information should be retrievable across agents as semantic
+knowledge. GBrain may store distilled summaries, entities, relations, timelines,
+decisions, and links.
+
+GBrain must not store:
+
+- active AgenticOS task state
+- `.context/state.yaml` snapshots
+- full `tasks/*.yaml` boards
+- project registry entries
+- raw secrets or raw private captures
+
+If a GBrain page suggests active work, the agent must call AgenticOS MCP to
+switch/create the topic or project and then create/update AgenticOS tasks.
+
+### AgenticOS Topic
+
+Use when a personal or work topic becomes durable: current state, open
+questions, tasks, artifacts, or evolving knowledge are needed.
+
+Required behavior:
+
+1. Call `agenticos_switch` for an existing topic or `agenticos_init` for a new
+   topic.
+2. Treat the returned project path and explicit workdir as authoritative.
+3. Update `tasks/<task_id>.yaml`, `.context/state.yaml`, `knowledge/`, or
+   `artifacts/` through the AgenticOS topic contract.
+4. Optionally distill a GBrain summary with `agenticos://...` references.
+
+Rejected substitutes:
+
+- `cd`
+- raw directory search
+- git branch detection
+
+### AgenticOS Project
+
+Use when the work changes code, config, CI, releases, public docs, MCP servers,
+skills, packages, or any rollback-managed product surface.
+
+Required behavior:
+
+1. Call AgenticOS MCP to align project identity.
+2. Bootstrap the GitHub issue.
+3. Create an isolated worktree.
+4. Run preflight and edit guard.
+5. Implement and test.
+6. Run PR scope check.
+7. Open a pull request.
+8. Wait for CI green.
+9. Merge with a merge commit and cleanup.
+
+Shell `cd`, directory guessing, and git branch inspection do not satisfy project
+switching. They can only happen after AgenticOS MCP has returned the
+authoritative project path and explicit workdir.
+
+## Regression Examples
+
+| Regression | Expected test signal |
+| --- | --- |
+| A topic route no longer requires `agenticos_switch` or `agenticos_init` | `validateHermesRoutingScenarios` reports the missing MCP requirement |
+| A project route accepts `cd` as switching | `validateHermesRoutingScenarios` reports the missing rejected substitute |
+| GBrain route stores active AgenticOS task state | `validateHermesRoutingScenarios` reports a GBrain duplication violation |
+| Full project route omits PR or CI | `validateHermesRoutingScenarios` reports the missing workflow gate |
+| One of the five routes disappears | `validateHermesRoutingScenarios` reports the missing route |
+
+## Decision
+
+Keep the five-path Hermes routing model as executable AgenticOS source, not only
+as prose. Documentation explains the behavior; tests keep the boundaries from
+drifting.


### PR DESCRIPTION
## Summary

- adds an executable five-route Hermes routing scenario contract
- covers chat-only, Hermes memory, GBrain knowledge, AgenticOS topic, and AgenticOS project routes
- rejects cd/raw directory search/git branch detection as project switch substitutes for topic/project routes
- verifies GBrain remains summary/reference-only and full project routing requires issue/worktree/PR/CI flow
- documents the scenario coverage in standards/knowledge

Closes #453

## Verification

- cd mcp-server && npm ci
- cd mcp-server && npm test -- --run src/utils/__tests__/hermes-routing-scenarios.test.ts
- cd mcp-server && npm run lint
- cd mcp-server && npm test -- --run
- GITHUB_EVENT_NAME=pull_request GITHUB_BASE_REF=main ./tools/coverage-preflight.sh
- ./scripts/readme-lint.sh (passes with existing README warnings/recommendations only)
- git diff --check
- rg -n "chat_only|hermes_memory|gbrain_knowledge|agenticos_topic|agenticos_project|agenticos_switch|raw_directory_search|git_branch_detection|task board" mcp-server/src/utils/hermes-routing-scenarios.ts mcp-server/src/utils/__tests__/hermes-routing-scenarios.test.ts standards/knowledge/hermes-routing-scenario-coverage-2026-05-21.md
- agenticos_pr_scope_check PASS