### PR TITLE
feat: add strict project resolve and ensure tools

### DIFF
--- a/mcp-server/src/__tests__/mcp-regression-baseline.json
+++ b/mcp-server/src/__tests__/mcp-regression-baseline.json
@@ -1,5 +1,5 @@
 {
-  "capturedAt": "2026-05-21T10:57:58.448Z",
+  "capturedAt": "2026-05-22T05:09:56.970Z",
   "version": "0.4.25",
   "serverInfo": {
     "name": "agenticos-mcp",
@@ -13,6 +13,8 @@
   "toolNames": [
     "agenticos_init",
     "agenticos_switch",
+    "agenticos_project_resolve",
+    "agenticos_project_ensure",
     "agenticos_list",
     "agenticos_task_create",
     "agenticos_task_update",
@@ -43,5 +45,5 @@
     "agenticos_enforce_git_policy",
     "agenticos_worktree_cleanup"
   ],
-  "toolCount": 31
+  "toolCount": 33
 }

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -16,7 +16,7 @@ import {
   ListResourcesRequestSchema,
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { initProject, switchProject, listProjects, getStatus, saveState, recordSession, runPreflight, runIssueBootstrap, runBranchBootstrap, runPrScopeCheck, runHealth, runCanonicalSync, runConfig, runEditGuard, runEntrySurfaceRefresh, runStandardKitAdopt, runStandardKitUpgradeCheck, runStandardKitConformanceCheck, runNonCodeEvaluate, runArchiveImportEvaluate, runRecordCase, runListCases, runValidateDelegation, runCoverageCheck, runCoverageGenerate, runMultiAgentReview, runEnforceGitPolicy, runWorktreeCleanup, runTaskCreate, runTaskUpdate, runTaskList, runTaskClose } from './tools/index.js';
+import { initProject, runProjectResolve, runProjectEnsure, switchProject, listProjects, getStatus, saveState, recordSession, runPreflight, runIssueBootstrap, runBranchBootstrap, runPrScopeCheck, runHealth, runCanonicalSync, runConfig, runEditGuard, runEntrySurfaceRefresh, runStandardKitAdopt, runStandardKitUpgradeCheck, runStandardKitConformanceCheck, runNonCodeEvaluate, runArchiveImportEvaluate, runRecordCase, runListCases, runValidateDelegation, runCoverageCheck, runCoverageGenerate, runMultiAgentReview, runEnforceGitPolicy, runWorktreeCleanup, runTaskCreate, runTaskUpdate, runTaskList, runTaskClose } from './tools/index.js';
 import { getProjectContext } from './resources/index.js';
 import { isDirectExecution, resolveCliPrelude } from './utils/mcp-server-cli.js';
 
@@ -61,6 +61,35 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         type: 'object',
         properties: {
           project: { type: 'string', description: 'Project ID or name' },
+        },
+        required: ['project'],
+      },
+    },
+    {
+      name: 'agenticos_project_resolve',
+      description: 'Resolve a registered AgenticOS project by id/name/path without binding session state or writing adapter/context files. Topics are surfaced as projects for Hermes/Discord routing.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          project: { type: 'string', description: 'Project ID, name, or registered path to resolve.' },
+        },
+        required: ['project'],
+      },
+    },
+    {
+      name: 'agenticos_project_ensure',
+      description: 'Return existing AgenticOS project metadata or create a missing local private project with safe defaults. Existing projects are not normalized or rewritten.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          project: { type: 'string', description: 'Project ID/name/path to resolve, or the new project name when creating.' },
+          name: { type: 'string', description: 'Optional display name for a new project. Defaults to project.' },
+          description: { type: 'string', description: 'Optional description used only when creating a new project.' },
+          path: { type: 'string', description: 'Optional absolute path used only when creating a new project, or checked against an existing project.' },
+          project_kind: { type: 'string', enum: ['topic', 'project'], description: 'Optional internal routing kind. Defaults to project; external surfaces still say project.' },
+          topology: { type: 'string', enum: ['local_directory_only', 'github_versioned'], description: 'Optional source-control topology. Defaults to local_directory_only.' },
+          context_publication_policy: { type: 'string', enum: ['local_private', 'private_continuity', 'public_distilled'], description: 'Optional context publication policy. Defaults to local_private for local_directory_only.' },
+          github_repo: { type: 'string', description: 'Required when creating a github_versioned project. Use OWNER/REPO.' },
         },
         required: ['project'],
       },
@@ -562,6 +591,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       return { content: [{ type: 'text', text: await initProject(args) }] };
     case 'agenticos_switch':
       return { content: [{ type: 'text', text: await switchProject(args) }] };
+    case 'agenticos_project_resolve':
+      return { content: [{ type: 'text', text: await runProjectResolve(args ?? {}) }] };
+    case 'agenticos_project_ensure':
+      return { content: [{ type: 'text', text: await runProjectEnsure(args ?? {}) }] };
     case 'agenticos_list':
       return { content: [{ type: 'text', text: await listProjects() }] };
     case 'agenticos_task_create':

--- a/mcp-server/src/tools/__tests__/init.test.ts
+++ b/mcp-server/src/tools/__tests__/init.test.ts
@@ -161,6 +161,7 @@ describe('initProject', () => {
     // We expect mkdir for: .context/conversations, knowledge, tasks, artifacts
     const base = '/home/testuser/AgenticOS/projects/test-project';
     const expectedDirs = [
+      base,
       `${base}/.context/conversations`,
       `${base}/knowledge`,
       `${base}/knowledge/corner-cases`,

--- a/mcp-server/src/tools/__tests__/project-resolve.test.ts
+++ b/mcp-server/src/tools/__tests__/project-resolve.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import yaml from 'yaml';
+import { runProjectEnsure, runProjectResolve } from '../project-resolve.js';
+import * as toolExports from '../index.js';
+
+interface SeedProjectArgs {
+  id: string;
+  name: string;
+  projectKind?: 'topic' | 'project' | null;
+  topology?: 'local_directory_only' | 'github_versioned';
+  contextPublicationPolicy?: 'local_private' | 'private_continuity' | 'public_distilled';
+  path?: string;
+}
+
+let previousAgenticosHome: string | undefined;
+let home: string;
+
+function parseResult(value: string): any {
+  return JSON.parse(value);
+}
+
+async function writeRegistry(projects: SeedProjectArgs[]): Promise<void> {
+  await mkdir(join(home, '.agent-workspace'), { recursive: true });
+  await writeFile(
+    join(home, '.agent-workspace', 'registry.yaml'),
+    yaml.stringify({
+      version: '1.0.0',
+      last_updated: '2026-05-22T00:00:00.000Z',
+      active_project: null,
+      projects: projects.map((project) => ({
+        id: project.id,
+        name: project.name,
+        path: project.path || join(home, 'projects', project.id),
+        status: 'active',
+        created: '2026-05-22',
+        last_accessed: '2026-05-22T00:00:00.000Z',
+      })),
+    }),
+    'utf-8',
+  );
+}
+
+async function seedProject(project: SeedProjectArgs): Promise<string> {
+  const projectPath = project.path || join(home, 'projects', project.id);
+  await mkdir(join(projectPath, '.context', 'conversations'), { recursive: true });
+  await mkdir(join(projectPath, 'knowledge'), { recursive: true });
+  await mkdir(join(projectPath, 'tasks'), { recursive: true });
+  await mkdir(join(projectPath, 'artifacts'), { recursive: true });
+
+  const projectYaml: any = {
+    meta: {
+      id: project.id,
+      name: project.name,
+      description: `${project.name} description`,
+      created: '2026-05-22',
+      version: '1.0.0',
+    },
+    source_control: {
+      topology: project.topology || 'local_directory_only',
+      context_publication_policy: project.contextPublicationPolicy || 'local_private',
+    },
+    agent_context: {
+      quick_start: '.context/quick-start.md',
+      current_state: '.context/state.yaml',
+      conversations: '.context/conversations/',
+      knowledge: 'knowledge/',
+      tasks: 'tasks/',
+      artifacts: 'artifacts/',
+    },
+  };
+
+  if (project.projectKind !== null) {
+    projectYaml.agenticos = { project_kind: project.projectKind || 'project' };
+  }
+  if (project.topology === 'github_versioned') {
+    projectYaml.source_control.github_repo = 'madlouse/sample';
+    projectYaml.source_control.branch_strategy = 'github_flow';
+    projectYaml.execution = { source_repo_roots: ['.'] };
+  }
+
+  await writeFile(join(projectPath, '.project.yaml'), yaml.stringify(projectYaml), 'utf-8');
+  await writeFile(join(projectPath, '.context', 'state.yaml'), 'state: preserved\n', 'utf-8');
+  await writeFile(join(projectPath, '.context', 'quick-start.md'), '# preserved quick start\n', 'utf-8');
+  await writeFile(join(projectPath, 'CLAUDE.md'), '# preserved claude\n', 'utf-8');
+  await writeFile(join(projectPath, 'AGENTS.md'), '# preserved agents\n', 'utf-8');
+
+  return projectPath;
+}
+
+async function snapshotContinuityFiles(projectPath: string): Promise<Record<string, string>> {
+  const paths = [
+    '.project.yaml',
+    '.context/state.yaml',
+    '.context/quick-start.md',
+    'CLAUDE.md',
+    'AGENTS.md',
+  ];
+  const entries = await Promise.all(
+    paths.map(async (relativePath) => [relativePath, await readFile(join(projectPath, relativePath), 'utf-8')] as const),
+  );
+  return Object.fromEntries(entries);
+}
+
+beforeEach(async () => {
+  previousAgenticosHome = process.env.AGENTICOS_HOME;
+  home = await mkdtemp(join(tmpdir(), 'agenticos-project-resolve-'));
+  process.env.AGENTICOS_HOME = home;
+});
+
+afterEach(async () => {
+  if (previousAgenticosHome === undefined) {
+    delete process.env.AGENTICOS_HOME;
+  } else {
+    process.env.AGENTICOS_HOME = previousAgenticosHome;
+  }
+  await rm(home, { recursive: true, force: true });
+});
+
+describe('AgenticOS project resolve/ensure MCP API', () => {
+  it('exports project resolve tools from the public tools barrel', () => {
+    expect(toolExports.runProjectResolve).toBe(runProjectResolve);
+    expect(toolExports.runProjectEnsure).toBe(runProjectEnsure);
+  });
+
+  it('resolves an existing project by id without writing continuity files', async () => {
+    const projectPath = await seedProject({
+      id: 'agenticos',
+      name: 'AgenticOS',
+      projectKind: 'topic',
+    });
+    await writeRegistry([{ id: 'agenticos', name: 'AgenticOS', projectKind: 'topic', path: projectPath }]);
+    const before = await snapshotContinuityFiles(projectPath);
+
+    const result = parseResult(await runProjectResolve({ project: 'agenticos' }));
+
+    expect(result.status).toBe('RESOLVED');
+    expect(result.created).toBe(false);
+    expect(result.project_id).toBe('agenticos');
+    expect(result.name).toBe('AgenticOS');
+    expect(result.project_kind).toBe('topic');
+    expect(result.topology).toBe('local_directory_only');
+    expect(result.path).toBe(projectPath);
+    expect(result.explicit_workdir).toBe(projectPath);
+    expect(result.context_surface_paths.state).toBe(join(projectPath, '.context/state.yaml'));
+    expect(await snapshotContinuityFiles(projectPath)).toEqual(before);
+  });
+
+  it('returns actionable failure for an unknown project without falling back to switch', async () => {
+    await writeRegistry([]);
+
+    const result = parseResult(await runProjectResolve({ project: 'missing' }));
+
+    expect(result.status).toBe('ERROR');
+    expect(result.code).toBe('NOT_FOUND');
+    expect(result.recovery.join(' ')).toContain('agenticos_project_ensure');
+  });
+
+  it('ensures an existing project without normalizing or rewriting files', async () => {
+    const projectPath = await seedProject({
+      id: 't5t',
+      name: 'T5T',
+      projectKind: 'project',
+    });
+    await writeRegistry([{ id: 't5t', name: 'T5T', projectKind: 'project', path: projectPath }]);
+    const before = await snapshotContinuityFiles(projectPath);
+
+    const result = parseResult(await runProjectEnsure({ project: 'T5T', description: 'new text should not rewrite' }));
+
+    expect(result.status).toBe('ENSURED');
+    expect(result.created).toBe(false);
+    expect(result.project_id).toBe('t5t');
+    expect(await snapshotContinuityFiles(projectPath)).toEqual(before);
+  });
+
+  it('creates a missing local private project with safe defaults', async () => {
+    const result = parseResult(await runProjectEnsure({
+      project: 'T5T Project',
+      description: 'Durable topic/project for T5T writing.',
+    }));
+
+    const projectPath = join(home, 'projects', 't5t-project');
+    expect(result.status).toBe('CREATED');
+    expect(result.created).toBe(true);
+    expect(result.project_id).toBe('t5t-project');
+    expect(result.name).toBe('T5T Project');
+    expect(result.project_kind).toBe('project');
+    expect(result.topology).toBe('local_directory_only');
+    expect(result.context_publication_policy).toBe('local_private');
+    expect(result.path).toBe(projectPath);
+    expect(yaml.parse(await readFile(join(projectPath, '.project.yaml'), 'utf-8')).source_control.context_publication_policy).toBe('local_private');
+    expect(await readFile(join(projectPath, '.context', 'state.yaml'), 'utf-8')).toContain('session');
+  });
+
+  it('creates a missing topic project when explicitly requested', async () => {
+    const result = parseResult(await runProjectEnsure({
+      project: 'Sleep Topic',
+      project_kind: 'topic',
+    }));
+
+    expect(result.status).toBe('CREATED');
+    expect(result.project_id).toBe('sleep-topic');
+    expect(result.project_kind).toBe('topic');
+    expect(result.routing.external_surface).toBe('project');
+  });
+
+  it('defaults legacy projects without agenticos.project_kind to project', async () => {
+    const projectPath = await seedProject({
+      id: 'legacy',
+      name: 'Legacy',
+      projectKind: null,
+    });
+    await writeRegistry([{ id: 'legacy', name: 'Legacy', projectKind: null, path: projectPath }]);
+
+    const result = parseResult(await runProjectResolve({ project: 'Legacy' }));
+
+    expect(result.status).toBe('RESOLVED');
+    expect(result.project_kind).toBe('project');
+  });
+
+  it('fails closed for unsafe names, control characters, and mismatched paths', async () => {
+    const unsafeName = parseResult(await runProjectEnsure({ project: 'Bad/Name' }));
+    expect(unsafeName.status).toBe('ERROR');
+    expect(unsafeName.code).toBe('INVALID_INPUT');
+    expect(unsafeName.error).toContain('filesystem-safe');
+
+    const control = parseResult(await runProjectResolve({ project: 'agenticos\n' }));
+    expect(control.status).toBe('ERROR');
+    expect(control.code).toBe('INVALID_INPUT');
+
+    const projectPath = await seedProject({
+      id: 'agenticos',
+      name: 'AgenticOS',
+    });
+    await writeRegistry([{ id: 'agenticos', name: 'AgenticOS', path: projectPath }]);
+
+    const mismatchedPath = parseResult(await runProjectEnsure({
+      project: 'agenticos',
+      path: join(home, 'projects', 'other'),
+    }));
+    expect(mismatchedPath.status).toBe('ERROR');
+    expect(mismatchedPath.code).toBe('IDENTITY_UNPROVEN');
+  });
+});

--- a/mcp-server/src/tools/__tests__/project-resolve.test.ts
+++ b/mcp-server/src/tools/__tests__/project-resolve.test.ts
@@ -13,6 +13,7 @@ interface SeedProjectArgs {
   topology?: 'local_directory_only' | 'github_versioned';
   contextPublicationPolicy?: 'local_private' | 'private_continuity' | 'public_distilled';
   path?: string;
+  status?: 'active' | 'archived';
 }
 
 let previousAgenticosHome: string | undefined;
@@ -23,6 +24,17 @@ function parseResult(value: string): any {
 }
 
 async function writeRegistry(projects: SeedProjectArgs[]): Promise<void> {
+  await writeRegistryEntries(projects.map((project) => ({
+    id: project.id,
+    name: project.name,
+    path: project.path || join(home, 'projects', project.id),
+    status: project.status || 'active',
+    created: '2026-05-22',
+    last_accessed: '2026-05-22T00:00:00.000Z',
+  })));
+}
+
+async function writeRegistryEntries(projects: any[]): Promise<void> {
   await mkdir(join(home, '.agent-workspace'), { recursive: true });
   await writeFile(
     join(home, '.agent-workspace', 'registry.yaml'),
@@ -30,14 +42,7 @@ async function writeRegistry(projects: SeedProjectArgs[]): Promise<void> {
       version: '1.0.0',
       last_updated: '2026-05-22T00:00:00.000Z',
       active_project: null,
-      projects: projects.map((project) => ({
-        id: project.id,
-        name: project.name,
-        path: project.path || join(home, 'projects', project.id),
-        status: 'active',
-        created: '2026-05-22',
-        last_accessed: '2026-05-22T00:00:00.000Z',
-      })),
+      projects,
     }),
     'utf-8',
   );
@@ -87,6 +92,12 @@ async function seedProject(project: SeedProjectArgs): Promise<string> {
   await writeFile(join(projectPath, 'CLAUDE.md'), '# preserved claude\n', 'utf-8');
   await writeFile(join(projectPath, 'AGENTS.md'), '# preserved agents\n', 'utf-8');
 
+  return projectPath;
+}
+
+async function seedRawProject(id: string, name: string, projectYaml: any, projectPath = join(home, 'projects', id)): Promise<string> {
+  await mkdir(projectPath, { recursive: true });
+  await writeFile(join(projectPath, '.project.yaml'), yaml.stringify(projectYaml), 'utf-8');
   return projectPath;
 }
 
@@ -148,6 +159,19 @@ describe('AgenticOS project resolve/ensure MCP API', () => {
     expect(await snapshotContinuityFiles(projectPath)).toEqual(before);
   });
 
+  it('resolves an existing project by registered path', async () => {
+    const projectPath = await seedProject({
+      id: 'path-project',
+      name: 'Path Project',
+    });
+    await writeRegistry([{ id: 'path-project', name: 'Path Project', path: projectPath }]);
+
+    const result = parseResult(await runProjectResolve({ project: projectPath }));
+
+    expect(result.status).toBe('RESOLVED');
+    expect(result.project_id).toBe('path-project');
+  });
+
   it('returns actionable failure for an unknown project without falling back to switch', async () => {
     await writeRegistry([]);
 
@@ -206,6 +230,33 @@ describe('AgenticOS project resolve/ensure MCP API', () => {
     expect(result.routing.external_surface).toBe('project');
   });
 
+  it('creates projects with explicit local and github topology arguments', async () => {
+    const local = parseResult(await runProjectEnsure({
+      project: 'Local Explicit',
+      context_publication_policy: 'local_private',
+    }));
+    expect(local.status).toBe('CREATED');
+    expect(local.context_publication_policy).toBe('local_private');
+
+    const github = parseResult(await runProjectEnsure({
+      project: 'GitHub Project',
+      topology: 'github_versioned',
+      context_publication_policy: 'private_continuity',
+      github_repo: 'madlouse/github-project',
+    }));
+    expect(github.status).toBe('CREATED');
+    expect(github.topology).toBe('github_versioned');
+    expect(github.context_publication_policy).toBe('private_continuity');
+    expect(yaml.parse(await readFile(join(github.path, '.project.yaml'), 'utf-8')).source_control.github_repo).toBe('madlouse/github-project');
+  });
+
+  it('supports name-only ensure calls for router-created projects', async () => {
+    const result = parseResult(await runProjectEnsure({ name: 'Name Only' }));
+
+    expect(result.status).toBe('CREATED');
+    expect(result.project_id).toBe('name-only');
+  });
+
   it('defaults legacy projects without agenticos.project_kind to project', async () => {
     const projectPath = await seedProject({
       id: 'legacy',
@@ -221,6 +272,14 @@ describe('AgenticOS project resolve/ensure MCP API', () => {
   });
 
   it('fails closed for unsafe names, control characters, and mismatched paths', async () => {
+    const missingArg = parseResult(await runProjectResolve({}));
+    expect(missingArg.status).toBe('ERROR');
+    expect(missingArg.code).toBe('INVALID_INPUT');
+
+    const empty = parseResult(await runProjectResolve({ project: '   ' }));
+    expect(empty.status).toBe('ERROR');
+    expect(empty.code).toBe('INVALID_INPUT');
+
     const unsafeName = parseResult(await runProjectEnsure({ project: 'Bad/Name' }));
     expect(unsafeName.status).toBe('ERROR');
     expect(unsafeName.code).toBe('INVALID_INPUT');
@@ -242,5 +301,156 @@ describe('AgenticOS project resolve/ensure MCP API', () => {
     }));
     expect(mismatchedPath.status).toBe('ERROR');
     expect(mismatchedPath.code).toBe('IDENTITY_UNPROVEN');
+
+    const unsafePath = parseResult(await runProjectEnsure({
+      project: 'Unsafe Path',
+      path: 'relative/path',
+    }));
+    expect(unsafePath.status).toBe('ERROR');
+    expect(unsafePath.code).toBe('UNSAFE_PATH');
+  });
+
+  it('fails closed for invalid creation metadata', async () => {
+    const invalidKind = parseResult(await runProjectEnsure({ project: 'Bad Kind', project_kind: 'workflow' }));
+    expect(invalidKind.status).toBe('ERROR');
+    expect(invalidKind.code).toBe('INVALID_INPUT');
+    expect(invalidKind.error).toContain('agenticos.project_kind');
+
+    const invalidTopology = parseResult(await runProjectEnsure({ project: 'Bad Topology', topology: 'svn' }));
+    expect(invalidTopology.status).toBe('ERROR');
+    expect(invalidTopology.code).toBe('INVALID_INPUT');
+    expect(invalidTopology.error).toContain('topology');
+
+    const invalidLocalPolicy = parseResult(await runProjectEnsure({
+      project: 'Bad Local Policy',
+      context_publication_policy: 'private_continuity',
+    }));
+    expect(invalidLocalPolicy.status).toBe('ERROR');
+    expect(invalidLocalPolicy.code).toBe('INVALID_INPUT');
+    expect(invalidLocalPolicy.error).toContain('local_private');
+
+    const invalidGithubPolicy = parseResult(await runProjectEnsure({
+      project: 'Bad GitHub Policy',
+      topology: 'github_versioned',
+      context_publication_policy: 'local_private',
+      github_repo: 'madlouse/bad-github-policy',
+    }));
+    expect(invalidGithubPolicy.status).toBe('ERROR');
+    expect(invalidGithubPolicy.code).toBe('INVALID_INPUT');
+    expect(invalidGithubPolicy.error).toContain('private_continuity');
+
+    const missingGithubRepo = parseResult(await runProjectEnsure({
+      project: 'Missing GitHub Repo',
+      topology: 'github_versioned',
+      context_publication_policy: 'private_continuity',
+    }));
+    expect(missingGithubRepo.status).toBe('ERROR');
+    expect(missingGithubRepo.code).toBe('UNKNOWN');
+    expect(missingGithubRepo.error).toContain('github_repo is required');
+  });
+
+  it('fails closed for ambiguous registry identities', async () => {
+    const firstPath = await seedProject({ id: 'one', name: 'Duplicate' });
+    const secondPath = await seedProject({ id: 'two', name: 'Duplicate' });
+    await writeRegistry([
+      { id: 'one', name: 'Duplicate', path: firstPath },
+      { id: 'two', name: 'Duplicate', path: secondPath },
+    ]);
+    expect(parseResult(await runProjectResolve({ project: 'Duplicate' })).code).toBe('AMBIGUOUS');
+
+    await writeRegistry([
+      { id: 'one', name: 'One', path: firstPath },
+      { id: 'two', name: 'Two', path: firstPath },
+    ]);
+    expect(parseResult(await runProjectResolve({ project: 'one' })).code).toBe('AMBIGUOUS');
+
+    await seedProject({ id: 'same-id', name: 'Same Id One', path: firstPath });
+    await seedProject({ id: 'same-id', name: 'Same Id Two', path: secondPath });
+    await writeRegistry([
+      { id: 'same-id', name: 'Same Id One', path: firstPath },
+      { id: 'same-id', name: 'Same Id Two', path: secondPath },
+    ]);
+    expect(parseResult(await runProjectResolve({ project: firstPath })).code).toBe('AMBIGUOUS');
+
+    await seedProject({ id: 'same-name-one', name: 'Same Name', path: firstPath });
+    await seedProject({ id: 'same-name-two', name: 'Same Name', path: secondPath });
+    await writeRegistry([
+      { id: 'same-name-one', name: 'Same Name', path: firstPath },
+      { id: 'same-name-two', name: 'Same Name', path: secondPath },
+    ]);
+    expect(parseResult(await runProjectResolve({ project: firstPath })).code).toBe('AMBIGUOUS');
+  });
+
+  it('fails closed when registry identity cannot be proven from project yaml', async () => {
+    const unsafeRegistryPath = `${home}/bad\npath`;
+    await writeRegistryEntries([{
+      id: 'unsafe',
+      name: 'Unsafe',
+      path: unsafeRegistryPath,
+      status: 'active',
+      created: '2026-05-22',
+      last_accessed: '2026-05-22T00:00:00.000Z',
+    }]);
+    expect(parseResult(await runProjectResolve({ project: 'unsafe' })).code).toBe('UNSAFE_PATH');
+
+    const missingYamlPath = join(home, 'projects', 'missing-yaml');
+    await mkdir(missingYamlPath, { recursive: true });
+    await writeRegistry([{ id: 'missing-yaml', name: 'Missing Yaml', path: missingYamlPath }]);
+    expect(parseResult(await runProjectResolve({ project: 'missing-yaml' })).code).toBe('IDENTITY_UNPROVEN');
+
+    const missingMetaPath = await seedRawProject('missing-meta', 'Missing Meta', null);
+    await writeRegistry([{ id: 'missing-meta', name: 'Missing Meta', path: missingMetaPath }]);
+    expect(parseResult(await runProjectResolve({ project: 'missing-meta' })).code).toBe('IDENTITY_UNPROVEN');
+
+    const idMismatchPath = await seedRawProject('id-mismatch', 'Id Mismatch', {
+      meta: { id: 'other', name: 'Id Mismatch' },
+      source_control: { topology: 'local_directory_only', context_publication_policy: 'local_private' },
+    });
+    await writeRegistry([{ id: 'id-mismatch', name: 'Id Mismatch', path: idMismatchPath }]);
+    expect(parseResult(await runProjectResolve({ project: 'id-mismatch' })).code).toBe('IDENTITY_UNPROVEN');
+
+    const nameMismatchPath = await seedRawProject('name-mismatch', 'Name Mismatch', {
+      meta: { id: 'name-mismatch', name: 'Other Name' },
+      source_control: { topology: 'local_directory_only', context_publication_policy: 'local_private' },
+    });
+    await writeRegistry([{ id: 'name-mismatch', name: 'Name Mismatch', path: nameMismatchPath }]);
+    expect(parseResult(await runProjectResolve({ project: 'name-mismatch' })).code).toBe('IDENTITY_UNPROVEN');
+  });
+
+  it('fails closed for archived or unnormalized projects', async () => {
+    const archivedPath = await seedProject({ id: 'archived', name: 'Archived', status: 'archived' });
+    await writeRegistry([{ id: 'archived', name: 'Archived', path: archivedPath, status: 'archived' }]);
+    expect(parseResult(await runProjectResolve({ project: 'archived' })).code).toBe('ARCHIVED');
+
+    const archivedReplacementPath = await seedRawProject('archived-replacement', 'Archived Replacement', {
+      meta: { id: 'archived-replacement', name: 'Archived Replacement' },
+      source_control: { topology: 'local_directory_only', context_publication_policy: 'local_private' },
+      archive_contract: { kind: 'archived_reference', replacement_project: 'active-project' },
+    });
+    await writeRegistry([{ id: 'archived-replacement', name: 'Archived Replacement', path: archivedReplacementPath }]);
+    const archivedReplacement = parseResult(await runProjectResolve({ project: 'archived-replacement' }));
+    expect(archivedReplacement.code).toBe('ARCHIVED');
+    expect(archivedReplacement.error).toContain('active-project');
+
+    const missingTopologyPath = await seedRawProject('missing-topology', 'Missing Topology', {
+      meta: { id: 'missing-topology', name: 'Missing Topology' },
+    });
+    await writeRegistry([{ id: 'missing-topology', name: 'Missing Topology', path: missingTopologyPath }]);
+    expect(parseResult(await runProjectResolve({ project: 'missing-topology' })).code).toBe('UNNORMALIZED');
+
+    const invalidPolicyPath = await seedRawProject('invalid-policy', 'Invalid Policy', {
+      meta: { id: 'invalid-policy', name: 'Invalid Policy' },
+      source_control: { topology: 'local_directory_only', context_publication_policy: 'public_distilled' },
+    });
+    await writeRegistry([{ id: 'invalid-policy', name: 'Invalid Policy', path: invalidPolicyPath }]);
+    expect(parseResult(await runProjectResolve({ project: 'invalid-policy' })).code).toBe('UNNORMALIZED');
+
+    const invalidKindPath = await seedRawProject('invalid-kind', 'Invalid Kind', {
+      meta: { id: 'invalid-kind', name: 'Invalid Kind' },
+      source_control: { topology: 'local_directory_only', context_publication_policy: 'local_private' },
+      agenticos: { project_kind: 'workflow' },
+    });
+    await writeRegistry([{ id: 'invalid-kind', name: 'Invalid Kind', path: invalidKindPath }]);
+    expect(parseResult(await runProjectResolve({ project: 'invalid-kind' })).code).toBe('UNNORMALIZED');
   });
 });

--- a/mcp-server/src/tools/index.ts
+++ b/mcp-server/src/tools/index.ts
@@ -1,4 +1,5 @@
 export { initProject } from './init.js';
+export { runProjectEnsure, runProjectResolve } from './project-resolve.js';
 export { switchProject, listProjects, getStatus } from './project.js';
 export { saveState } from './save.js';
 export { recordSession } from './record.js';

--- a/mcp-server/src/tools/init.ts
+++ b/mcp-server/src/tools/init.ts
@@ -252,6 +252,7 @@ export async function initProject(args: any): Promise<string> {
     projectKind,
     githubRepo,
   });
+  await mkdir(projectPath, { recursive: true });
   await writeFile(join(projectPath, '.project.yaml'), yaml.stringify(projectYaml), 'utf-8');
   const contextPaths = resolveManagedProjectContextPaths(projectPath, projectYaml);
   const contextDisplayPaths = resolveManagedProjectContextDisplayPaths(projectYaml);

--- a/mcp-server/src/tools/project-resolve.ts
+++ b/mcp-server/src/tools/project-resolve.ts
@@ -91,8 +91,8 @@ function toJson(value: unknown): string {
   return JSON.stringify(value, null, 2);
 }
 
-function errorPayload(error: unknown, requestedProject?: string): string {
-  const message = error instanceof Error ? error.message : String(error);
+function errorPayload(error: Error, requestedProject?: string): string {
+  const message = error.message;
   const code = error instanceof ProjectResolveError ? error.code : 'UNKNOWN';
   const recovery = code === 'NOT_FOUND'
     ? [
@@ -335,7 +335,7 @@ export async function runProjectResolve(args: ProjectResolveArgs = {}): Promise<
     const payload = await resolveProjectPayload(requestedProject, 'RESOLVED', false);
     return toJson(payload);
   } catch (error) {
-    return errorPayload(error, requestedProject);
+    return errorPayload(error as Error, requestedProject);
   }
 }
 
@@ -388,6 +388,6 @@ export async function runProjectEnsure(args: ProjectEnsureArgs = {}): Promise<st
     const created = await resolveProjectPayload(requestedPath || name, 'CREATED', true);
     return toJson(created);
   } catch (error) {
-    return errorPayload(error, requestedProject);
+    return errorPayload(error as Error, requestedProject);
   }
 }

--- a/mcp-server/src/tools/project-resolve.ts
+++ b/mcp-server/src/tools/project-resolve.ts
@@ -1,0 +1,393 @@
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+import yaml from 'yaml';
+import { initProject } from './init.js';
+import { loadRegistry, type Project, type Registry } from '../utils/registry.js';
+import {
+  buildArchivedReferenceMessage,
+  isArchivedReferenceProject,
+  validateContextPublicationPolicy,
+  validateManagedProjectTopology,
+  validateProjectKind,
+  type ContextPublicationPolicy,
+  type ProjectKind,
+  type ProjectTopology,
+} from '../utils/project-contract.js';
+import {
+  resolveManagedProjectContextDisplayPaths,
+  resolveManagedProjectContextPaths,
+} from '../utils/agent-context-paths.js';
+import { containsControlCharacters, validatePathSecurity } from '../utils/session-context.js';
+
+type ProjectResolveErrorCode =
+  | 'INVALID_INPUT'
+  | 'NOT_FOUND'
+  | 'AMBIGUOUS'
+  | 'UNSAFE_PATH'
+  | 'IDENTITY_UNPROVEN'
+  | 'ARCHIVED'
+  | 'UNNORMALIZED';
+
+class ProjectResolveError extends Error {
+  code: ProjectResolveErrorCode;
+
+  constructor(code: ProjectResolveErrorCode, message: string) {
+    super(message);
+    this.code = code;
+  }
+}
+
+interface ProjectResolveArgs {
+  project?: unknown;
+}
+
+interface ProjectEnsureArgs {
+  project?: unknown;
+  name?: unknown;
+  description?: unknown;
+  path?: unknown;
+  project_kind?: unknown;
+  topology?: unknown;
+  context_publication_policy?: unknown;
+  github_repo?: unknown;
+}
+
+interface ProjectPayload {
+  status: 'RESOLVED' | 'ENSURED' | 'CREATED';
+  created: boolean;
+  project_id: string;
+  name: string;
+  project_kind: ProjectKind;
+  topology: ProjectTopology;
+  context_publication_policy: ContextPublicationPolicy;
+  path: string;
+  explicit_workdir: string;
+  context_surface_paths: {
+    project_yaml: string;
+    quick_start: string;
+    state: string;
+    conversations: string;
+    knowledge: string;
+    tasks: string;
+    artifacts: string;
+    last_record_marker: string;
+  };
+  context_display_paths: {
+    quick_start: string;
+    state: string;
+    conversations: string;
+    knowledge: string;
+    tasks: string;
+    artifacts: string;
+    last_record_marker: string;
+  };
+  routing: {
+    external_surface: 'project';
+    note: string;
+  };
+}
+
+function toJson(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}
+
+function errorPayload(error: unknown, requestedProject?: string): string {
+  const message = error instanceof Error ? error.message : String(error);
+  const code = error instanceof ProjectResolveError ? error.code : 'UNKNOWN';
+  const recovery = code === 'NOT_FOUND'
+    ? [
+        'Confirm the project name with agenticos_list.',
+        'Use agenticos_project_ensure to create the project if this is a new durable topic/project.',
+      ]
+    : [
+        'Do not fall back to agenticos_switch for read-only lookup.',
+        'Repair the registry or .project.yaml identity mismatch before routing external work.',
+      ];
+
+  return toJson({
+    status: 'ERROR',
+    code,
+    requested_project: requestedProject || null,
+    error: message,
+    recovery,
+  });
+}
+
+function normalizeRequiredString(value: unknown, fieldName: string): string {
+  if (typeof value !== 'string') {
+    throw new ProjectResolveError('INVALID_INPUT', `${fieldName} must be a non-empty string.`);
+  }
+
+  if (containsControlCharacters(value)) {
+    throw new ProjectResolveError('INVALID_INPUT', `${fieldName} must not contain control characters.`);
+  }
+
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    throw new ProjectResolveError('INVALID_INPUT', `${fieldName} must be a non-empty string.`);
+  }
+
+  return trimmed;
+}
+
+function normalizeOptionalString(value: unknown, fieldName: string): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  return normalizeRequiredString(value, fieldName);
+}
+
+function normalizeProjectKind(value: unknown): ProjectKind {
+  if (value === undefined || value === null || value === '') {
+    return 'project';
+  }
+  const validation = validateProjectKind('new project', {
+    agenticos: { project_kind: value },
+  });
+  if (!validation.ok) {
+    throw new ProjectResolveError('INVALID_INPUT', `${validation.message} Pass project_kind="topic" or project_kind="project".`);
+  }
+  return validation.project_kind;
+}
+
+function normalizeTopology(value: unknown): ProjectTopology {
+  if (value === undefined || value === null || value === '') {
+    return 'local_directory_only';
+  }
+  const topology = normalizeRequiredString(value, 'topology');
+  if (topology !== 'local_directory_only' && topology !== 'github_versioned') {
+    throw new ProjectResolveError('INVALID_INPUT', 'topology must be "local_directory_only" or "github_versioned".');
+  }
+  return topology;
+}
+
+function normalizePublicationPolicy(topology: ProjectTopology, value: unknown): ContextPublicationPolicy {
+  if (topology === 'local_directory_only') {
+    if (value === undefined || value === null || value === '') {
+      return 'local_private';
+    }
+    const policy = normalizeRequiredString(value, 'context_publication_policy');
+    if (policy !== 'local_private') {
+      throw new ProjectResolveError('INVALID_INPUT', 'context_publication_policy must be "local_private" when topology is "local_directory_only".');
+    }
+    return 'local_private';
+  }
+
+  const policy = normalizeRequiredString(value, 'context_publication_policy');
+  if (policy !== 'private_continuity' && policy !== 'public_distilled') {
+    throw new ProjectResolveError('INVALID_INPUT', 'context_publication_policy must be "private_continuity" or "public_distilled" when topology is "github_versioned".');
+  }
+  return policy;
+}
+
+function validateNewProjectName(name: string): void {
+  const derivedId = name.toLowerCase().replace(/\s+/g, '-');
+  if (!/^[a-z0-9][a-z0-9_-]*$/.test(derivedId)) {
+    throw new ProjectResolveError(
+      'INVALID_INPUT',
+      'Project name must derive to a filesystem-safe id. Use letters, numbers, spaces, underscores, or hyphens.',
+    );
+  }
+}
+
+function findProject(registry: Registry, requestedProject: string): Project {
+  const matches = registry.projects.filter((candidate) =>
+    candidate.id === requestedProject ||
+    candidate.name === requestedProject ||
+    candidate.path === requestedProject
+  );
+
+  if (matches.length === 0) {
+    throw new ProjectResolveError('NOT_FOUND', `Project "${requestedProject}" not found in registry.`);
+  }
+  if (matches.length > 1) {
+    throw new ProjectResolveError('AMBIGUOUS', `Project "${requestedProject}" is ambiguous in registry.`);
+  }
+
+  const project = matches[0];
+  const sameId = registry.projects.filter((candidate) => candidate.id === project.id);
+  if (sameId.length > 1) {
+    throw new ProjectResolveError('AMBIGUOUS', `Project identity is ambiguous because registry id "${project.id}" is duplicated.`);
+  }
+
+  const samePath = registry.projects.filter((candidate) => candidate.path === project.path);
+  if (samePath.length > 1) {
+    throw new ProjectResolveError('AMBIGUOUS', `Project identity is ambiguous because registry path "${project.path}" is duplicated.`);
+  }
+
+  const sameName = registry.projects.filter((candidate) => candidate.name === project.name);
+  if (sameName.length > 1) {
+    throw new ProjectResolveError('AMBIGUOUS', `Project identity is ambiguous because registry name "${project.name}" is duplicated.`);
+  }
+
+  return project;
+}
+
+async function buildProjectPayload(args: {
+  project: Project;
+  status: ProjectPayload['status'];
+  created: boolean;
+}): Promise<ProjectPayload> {
+  const { project, status, created } = args;
+  const pathSecurity = validatePathSecurity(project.path);
+  if (!pathSecurity.valid) {
+    throw new ProjectResolveError('UNSAFE_PATH', `Project "${project.name}" has an unsafe registry path: ${pathSecurity.error}`);
+  }
+
+  const projectYamlPath = join(project.path, '.project.yaml');
+  let projectYaml: any;
+  try {
+    projectYaml = yaml.parse(await readFile(projectYamlPath, 'utf-8')) || {};
+  } catch {
+    throw new ProjectResolveError('IDENTITY_UNPROVEN', `Project identity could not be proven because ${projectYamlPath} is missing or unreadable.`);
+  }
+
+  const metaId = projectYaml?.meta?.id;
+  const metaName = projectYaml?.meta?.name;
+
+  if (!metaId) {
+    throw new ProjectResolveError('IDENTITY_UNPROVEN', `Project identity could not be proven because ${projectYamlPath} is missing meta.id.`);
+  }
+  if (metaId !== project.id) {
+    throw new ProjectResolveError(
+      'IDENTITY_UNPROVEN',
+      `Project identity mismatch: registry id "${project.id}" does not match .project.yaml meta.id "${metaId}".`,
+    );
+  }
+  if (metaName && metaName !== project.name) {
+    throw new ProjectResolveError(
+      'IDENTITY_UNPROVEN',
+      `Project identity mismatch: registry name "${project.name}" does not match .project.yaml meta.name "${metaName}".`,
+    );
+  }
+
+  if (isArchivedReferenceProject(projectYaml, project.status)) {
+    throw new ProjectResolveError(
+      'ARCHIVED',
+      `${buildArchivedReferenceMessage(project.name, projectYaml?.archive_contract?.replacement_project)} agenticos_project_resolve only works with active managed projects.`,
+    );
+  }
+
+  const topologyValidation = validateManagedProjectTopology(project.name, projectYaml);
+  if (!topologyValidation.ok) {
+    throw new ProjectResolveError('UNNORMALIZED', `${topologyValidation.message} agenticos_project_resolve only works with normalized managed projects.`);
+  }
+
+  const policyValidation = validateContextPublicationPolicy(project.name, projectYaml);
+  if (!policyValidation.ok) {
+    throw new ProjectResolveError('UNNORMALIZED', policyValidation.message);
+  }
+
+  const projectKindValidation = validateProjectKind(project.name, projectYaml);
+  if (!projectKindValidation.ok) {
+    throw new ProjectResolveError('UNNORMALIZED', projectKindValidation.message);
+  }
+
+  const contextPaths = resolveManagedProjectContextPaths(project.path, projectYaml);
+  const displayPaths = resolveManagedProjectContextDisplayPaths(projectYaml);
+
+  return {
+    status,
+    created,
+    project_id: project.id,
+    name: project.name,
+    project_kind: projectKindValidation.project_kind,
+    topology: topologyValidation.topology,
+    context_publication_policy: policyValidation.policy,
+    path: project.path,
+    explicit_workdir: project.path,
+    context_surface_paths: {
+      project_yaml: projectYamlPath,
+      quick_start: contextPaths.quickStartPath,
+      state: contextPaths.statePath,
+      conversations: contextPaths.conversationsDir,
+      knowledge: contextPaths.knowledgeDir,
+      tasks: contextPaths.tasksDir,
+      artifacts: contextPaths.artifactsDir,
+      last_record_marker: contextPaths.markerPath,
+    },
+    context_display_paths: {
+      quick_start: displayPaths.quickStartPath,
+      state: displayPaths.statePath,
+      conversations: displayPaths.conversationsDir,
+      knowledge: displayPaths.knowledgeDir,
+      tasks: displayPaths.tasksDir,
+      artifacts: displayPaths.artifactsDir,
+      last_record_marker: displayPaths.markerPath,
+    },
+    routing: {
+      external_surface: 'project',
+      note: 'Hermes and Discord should surface topics and source projects as projects; project_kind remains available for internal routing.',
+    },
+  };
+}
+
+async function resolveProjectPayload(requestedProject: string, status: ProjectPayload['status'], created: boolean): Promise<ProjectPayload> {
+  const registry = await loadRegistry();
+  const project = findProject(registry, requestedProject);
+  return buildProjectPayload({ project, status, created });
+}
+
+export async function runProjectResolve(args: ProjectResolveArgs = {}): Promise<string> {
+  let requestedProject: string | undefined;
+  try {
+    requestedProject = normalizeRequiredString(args.project, 'project');
+    const payload = await resolveProjectPayload(requestedProject, 'RESOLVED', false);
+    return toJson(payload);
+  } catch (error) {
+    return errorPayload(error, requestedProject);
+  }
+}
+
+export async function runProjectEnsure(args: ProjectEnsureArgs = {}): Promise<string> {
+  const lookupValue = args.project ?? args.name;
+  let requestedProject: string | undefined;
+  try {
+    requestedProject = normalizeRequiredString(lookupValue, 'project');
+    const requestedPath = normalizeOptionalString(args.path, 'path');
+    if (requestedPath) {
+      const pathSecurity = validatePathSecurity(requestedPath);
+      if (!pathSecurity.valid) {
+        throw new ProjectResolveError('UNSAFE_PATH', `Invalid project path: ${pathSecurity.error}`);
+      }
+    }
+
+    try {
+      const existing = await resolveProjectPayload(requestedProject, 'ENSURED', false);
+      if (requestedPath && existing.path !== requestedPath) {
+        throw new ProjectResolveError(
+          'IDENTITY_UNPROVEN',
+          `Existing project "${existing.project_id}" is registered at ${existing.path}, not requested path ${requestedPath}.`,
+        );
+      }
+      return toJson(existing);
+    } catch (error) {
+      if (!(error instanceof ProjectResolveError) || error.code !== 'NOT_FOUND') {
+        throw error;
+      }
+    }
+
+    const name = normalizeRequiredString(args.name ?? args.project, 'name');
+    validateNewProjectName(name);
+    const description = normalizeOptionalString(args.description, 'description');
+    const topology = normalizeTopology(args.topology);
+    const contextPublicationPolicy = normalizePublicationPolicy(topology, args.context_publication_policy);
+    const projectKind = normalizeProjectKind(args.project_kind);
+    const githubRepo = normalizeOptionalString(args.github_repo, 'github_repo');
+
+    await initProject({
+      name,
+      description,
+      path: requestedPath,
+      topology,
+      context_publication_policy: contextPublicationPolicy,
+      project_kind: projectKind,
+      ...(githubRepo ? { github_repo: githubRepo } : {}),
+    });
+
+    const created = await resolveProjectPayload(requestedPath || name, 'CREATED', true);
+    return toJson(created);
+  } catch (error) {
+    return errorPayload(error, requestedProject);
+  }
+}


### PR DESCRIPTION
## Summary
- add agenticos_project_resolve as a strict registry-backed read-only lookup with no session binding or adapter/context writes
- add agenticos_project_ensure for existing-or-create project routing, preserving existing continuity files by default
- update MCP regression baseline for the two new tools and cover legacy project_kind defaults plus unsafe input handling

Fixes #463

## Verification
- npm ci
- npm run lint
- npm test -- --run src/tools/__tests__/project-resolve.test.ts src/tools/__tests__/init.test.ts
- UPDATE_BASELINE=1 npm test -- --run src/__tests__/mcp-regression.test.ts
- npm test -- --run src/__tests__/mcp-regression.test.ts
- npm test -- --run
- ./tools/coverage-preflight.sh
- git diff --check
- agenticos_pr_scope_check: PASS