### PR TITLE
fix: create follow-up for closed task duplicates

### DIFF
--- a/mcp-server/src/tools/__tests__/task.test.ts
+++ b/mcp-server/src/tools/__tests__/task.test.ts
@@ -192,6 +192,120 @@ describe('AgenticOS task MCP API', () => {
     expect(parseYamlFile(statePath).current_task.next_step).toBeNull();
   });
 
+  it('creates a related follow-up instead of reusing a done duplicate task', async () => {
+    fsMock.files.set(statePath, '');
+    const closed = {
+      id: 'sleep-plan',
+      title: 'Sleep Plan',
+      status: 'done',
+      priority: 'medium',
+      source: { kind: 'hermes', origin: 'chat', dedupe_key: 'same-key' },
+      acceptance_criteria: ['Existing criterion'],
+      refs: [],
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+      closed_at: '2026-01-02T00:00:00.000Z',
+    };
+    seedTask(closed);
+
+    const result = parseResult(await runTaskCreate({
+      title: 'Sleep Plan Follow Up',
+      status: 'in_progress',
+      acceptance_criteria: ['New criterion'],
+      source: { kind: 'hermes', origin: 'chat', dedupe_key: 'same-key' },
+    }));
+
+    expect(result.status).toBe('CREATED');
+    expect(result.duplicate).toBeUndefined();
+    expect(result.task.id).toBe('sleep-plan-follow-up');
+    expect(result.task.related_tasks).toEqual(['sleep-plan']);
+    expect(parseYamlFile(`${tasksDir}/sleep-plan.yaml`).status).toBe('done');
+    expect(parseYamlFile(`${tasksDir}/sleep-plan-follow-up.yaml`).acceptance_criteria).toEqual(['New criterion']);
+    expect(parseYamlFile(statePath).current_task).toMatchObject({
+      id: 'sleep-plan-follow-up',
+      title: 'Sleep Plan Follow Up',
+      status: 'in_progress',
+      next_step: 'New criterion',
+    });
+  });
+
+  it('creates a suffixed related task instead of reusing a canceled id duplicate', async () => {
+    fsMock.files.set(statePath, '');
+    seedTask({
+      id: 'sleep-plan',
+      title: 'Sleep Plan',
+      status: 'canceled',
+      priority: 'medium',
+      source: { kind: 'manual', origin: 'manual' },
+      acceptance_criteria: ['Old criterion'],
+      refs: [],
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+      closed_at: '2026-01-02T00:00:00.000Z',
+    });
+
+    const result = parseResult(await runTaskCreate({
+      id: 'sleep-plan',
+      title: 'Sleep Plan',
+      acceptance_criteria: ['New criterion'],
+      source: { kind: 'manual', origin: 'manual' },
+    }));
+
+    expect(result.status).toBe('CREATED');
+    expect(result.task.id).toBe('sleep-plan-2');
+    expect(result.task.related_tasks).toEqual(['sleep-plan']);
+    expect(parseYamlFile(`${tasksDir}/sleep-plan.yaml`).status).toBe('canceled');
+    expect(parseYamlFile(statePath).resume.task_id).toBe('sleep-plan-2');
+  });
+
+  it('fails closed when a closed duplicate cannot produce safe related metadata', async () => {
+    seedTask({
+      id: 'token=abc123',
+      title: 'Closed Secret Id',
+      status: 'done',
+      priority: 'medium',
+      source: { kind: 'hermes', origin: 'chat', dedupe_key: 'secret-id' },
+      acceptance_criteria: ['Old criterion'],
+      refs: [],
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+      closed_at: '2026-01-02T00:00:00.000Z',
+    });
+
+    const secretId = parseResult(await runTaskCreate({
+      title: 'Safe Follow Up',
+      acceptance_criteria: ['New criterion'],
+      source: { kind: 'hermes', origin: 'chat', dedupe_key: 'secret-id' },
+    }));
+    expect(secretId.status).toBe('ERROR');
+    expect(secretId.errors.join(' ')).toContain('secret material');
+
+    for (let index = 1; index <= 100; index += 1) {
+      const id = index === 1 ? 'exhausted' : `exhausted-${index}`;
+      seedTask({
+        id,
+        title: `Exhausted ${index}`,
+        status: 'done',
+        priority: 'medium',
+        source: { kind: 'manual', origin: 'manual' },
+        acceptance_criteria: ['Old criterion'],
+        refs: [],
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+        closed_at: '2026-01-02T00:00:00.000Z',
+      });
+    }
+
+    const exhausted = parseResult(await runTaskCreate({
+      id: 'exhausted',
+      title: 'Exhausted',
+      acceptance_criteria: ['New criterion'],
+      source: { kind: 'manual', origin: 'manual' },
+    }));
+    expect(exhausted.status).toBe('ERROR');
+    expect(exhausted.errors.join(' ')).toContain('safe follow-up id');
+  });
+
   it('rejects invalid create payloads and secret-looking input', async () => {
     const missingTitle = parseResult(await runTaskCreate({ acceptance_criteria: ['Criterion'] }));
     expect(missingTitle.status).toBe('ERROR');

--- a/mcp-server/src/tools/task.ts
+++ b/mcp-server/src/tools/task.ts
@@ -340,11 +340,42 @@ function buildTaskFromCreateArgs(args: any, now: string): { task?: AgenticOSTask
   return { task, errors };
 }
 
-function findDuplicateTask(tasks: AgenticOSTask[], task: AgenticOSTask): AgenticOSTask | null {
+function isClosedTask(task: AgenticOSTask): boolean {
+  return CLOSE_STATUSES.has(task.status);
+}
+
+function matchingDuplicateTasks(tasks: AgenticOSTask[], task: AgenticOSTask): AgenticOSTask[] {
   const dedupeKey = deriveDedupeKey(task);
-  return tasks.find((candidate) => (
+  return tasks.filter((candidate) => (
     candidate.id === task.id || deriveDedupeKey(candidate) === dedupeKey
-  )) || null;
+  ));
+}
+
+function findActiveDuplicateTask(tasks: AgenticOSTask[], task: AgenticOSTask): AgenticOSTask | null {
+  return matchingDuplicateTasks(tasks, task).find((candidate) => !isClosedTask(candidate)) || null;
+}
+
+function findClosedDuplicateTasks(tasks: AgenticOSTask[], task: AgenticOSTask): AgenticOSTask[] {
+  return matchingDuplicateTasks(tasks, task).filter((candidate) => isClosedTask(candidate));
+}
+
+function deriveAvailableTaskId(tasks: AgenticOSTask[], preferredId: string): string | null {
+  const usedIds = new Set(tasks.map((task) => task.id));
+  if (!usedIds.has(preferredId)) {
+    return preferredId;
+  }
+
+  const base = preferredId.slice(0, 72).replace(/-+$/g, '');
+  for (let index = 2; index <= 100; index += 1) {
+    const suffix = `-${index}`;
+    const candidateBase = base.slice(0, 80 - suffix.length).replace(/-+$/g, '');
+    const candidate = `${candidateBase}${suffix}`;
+    if (!usedIds.has(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
 }
 
 function taskResponse(status: string, context: TaskCommandContext, task: AgenticOSTask, extra: Record<string, unknown> = {}): string {
@@ -371,10 +402,26 @@ export async function runTaskCreate(args: any = {}): Promise<string> {
       return errorResponse(built.errors);
     }
     await mkdir(context.tasks_dir, { recursive: true });
-    const existing = findDuplicateTask(await listTaskFiles(context), built.task);
+    const existingTasks = await listTaskFiles(context);
+    const existing = findActiveDuplicateTask(existingTasks, built.task);
     if (existing) {
       await syncState(context, existing);
       return taskResponse('EXISTING', context, existing, { duplicate: true });
+    }
+    const closedDuplicates = findClosedDuplicateTasks(existingTasks, built.task);
+    if (closedDuplicates.length > 0) {
+      const nextId = deriveAvailableTaskId(existingTasks, built.task.id);
+      if (!nextId) {
+        return errorResponse([
+          `matching closed task(s) found (${closedDuplicates.map((task) => task.id).join(', ')}) but a safe follow-up id could not be derived; pass an explicit id or reopen manually`,
+        ]);
+      }
+      const relatedTaskIds = [...new Set(closedDuplicates.map((task) => task.id))];
+      if (hasSecretLikeValue(relatedTaskIds)) {
+        return errorResponse(['matching closed task id appears to contain secret material; pass a safe explicit id and reference the closed task manually']);
+      }
+      built.task.id = nextId;
+      built.task.related_tasks = relatedTaskIds;
     }
     await writeFile(taskPath(context, built.task.id), yaml.stringify(built.task), 'utf-8');
     await syncState(context, built.task);


### PR DESCRIPTION
## Summary
- keep existing task dedupe behavior for open/in_progress/blocked matches
- create a new related follow-up task for matching done/canceled tasks instead of returning them as EXISTING
- add fail-closed paths for exhausted follow-up IDs and secret-looking closed task IDs

Fixes #464

## Verification
- npm ci
- npm run lint
- npm test -- --run src/tools/__tests__/task.test.ts src/__tests__/durable-topic-task-smoke.test.ts
- npm test -- --run
- ./tools/coverage-preflight.sh
- git diff --check
- agenticos_pr_scope_check: PASS