### PR TITLE
feat: persist external thread bindings

### DIFF
--- a/mcp-server/src/__tests__/mcp-regression-baseline.json
+++ b/mcp-server/src/__tests__/mcp-regression-baseline.json
@@ -1,5 +1,5 @@
 {
-  "capturedAt": "2026-05-22T05:09:56.970Z",
+  "capturedAt": "2026-05-22T05:34:54.381Z",
   "version": "0.4.25",
   "serverInfo": {
     "name": "agenticos-mcp",
@@ -15,6 +15,9 @@
     "agenticos_switch",
     "agenticos_project_resolve",
     "agenticos_project_ensure",
+    "agenticos_external_thread_bind",
+    "agenticos_external_thread_get",
+    "agenticos_external_thread_list",
     "agenticos_list",
     "agenticos_task_create",
     "agenticos_task_update",
@@ -45,5 +48,5 @@
     "agenticos_enforce_git_policy",
     "agenticos_worktree_cleanup"
   ],
-  "toolCount": 33
+  "toolCount": 36
 }

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -16,7 +16,7 @@ import {
   ListResourcesRequestSchema,
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { initProject, runProjectResolve, runProjectEnsure, switchProject, listProjects, getStatus, saveState, recordSession, runPreflight, runIssueBootstrap, runBranchBootstrap, runPrScopeCheck, runHealth, runCanonicalSync, runConfig, runEditGuard, runEntrySurfaceRefresh, runStandardKitAdopt, runStandardKitUpgradeCheck, runStandardKitConformanceCheck, runNonCodeEvaluate, runArchiveImportEvaluate, runRecordCase, runListCases, runValidateDelegation, runCoverageCheck, runCoverageGenerate, runMultiAgentReview, runEnforceGitPolicy, runWorktreeCleanup, runTaskCreate, runTaskUpdate, runTaskList, runTaskClose } from './tools/index.js';
+import { initProject, runProjectResolve, runProjectEnsure, runExternalThreadBind, runExternalThreadGet, runExternalThreadList, switchProject, listProjects, getStatus, saveState, recordSession, runPreflight, runIssueBootstrap, runBranchBootstrap, runPrScopeCheck, runHealth, runCanonicalSync, runConfig, runEditGuard, runEntrySurfaceRefresh, runStandardKitAdopt, runStandardKitUpgradeCheck, runStandardKitConformanceCheck, runNonCodeEvaluate, runArchiveImportEvaluate, runRecordCase, runListCases, runValidateDelegation, runCoverageCheck, runCoverageGenerate, runMultiAgentReview, runEnforceGitPolicy, runWorktreeCleanup, runTaskCreate, runTaskUpdate, runTaskList, runTaskClose } from './tools/index.js';
 import { getProjectContext } from './resources/index.js';
 import { isDirectExecution, resolveCliPrelude } from './utils/mcp-server-cli.js';
 
@@ -92,6 +92,48 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
           github_repo: { type: 'string', description: 'Required when creating a github_versioned project. Use OWNER/REPO.' },
         },
         required: ['project'],
+      },
+    },
+    {
+      name: 'agenticos_external_thread_bind',
+      description: 'Persist an optional Discord project thread binding in the private AgenticOS runtime sidecar. Does not write Discord ids into project files.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          project: { type: 'string', description: 'AgenticOS project ID, name, or path.' },
+          provider: { type: 'string', enum: ['discord'], description: 'External provider. MVP supports discord only.' },
+          guild_id: { type: 'string', description: 'Optional Discord guild/server id.' },
+          channel_id: { type: 'string', description: 'Discord channel id containing the project thread.' },
+          thread_id: { type: 'string', description: 'Discord thread id for the project cockpit.' },
+          thread_url: { type: 'string', description: 'Optional Discord thread URL.' },
+          default_backend: { type: 'string', enum: ['codex', 'claude_code'], description: 'Optional default worker backend for this project thread.' },
+        },
+        required: ['project', 'channel_id', 'thread_id'],
+      },
+    },
+    {
+      name: 'agenticos_external_thread_get',
+      description: 'Read an optional Discord project thread binding from the private runtime sidecar. Missing bindings return NOT_FOUND instead of blocking project flow.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          project: { type: 'string', description: 'AgenticOS project ID, name, or path.' },
+          provider: { type: 'string', enum: ['discord'], description: 'External provider. MVP supports discord only.' },
+          guild_id: { type: 'string', description: 'Optional Discord guild/server id filter.' },
+          channel_id: { type: 'string', description: 'Optional Discord channel id filter.' },
+        },
+        required: ['project'],
+      },
+    },
+    {
+      name: 'agenticos_external_thread_list',
+      description: 'List optional Discord project thread bindings from the private runtime sidecar.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          project: { type: 'string', description: 'Optional AgenticOS project ID, name, or path filter.' },
+          provider: { type: 'string', enum: ['discord'], description: 'External provider. MVP supports discord only.' },
+        },
       },
     },
     {
@@ -595,6 +637,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       return { content: [{ type: 'text', text: await runProjectResolve(args ?? {}) }] };
     case 'agenticos_project_ensure':
       return { content: [{ type: 'text', text: await runProjectEnsure(args ?? {}) }] };
+    case 'agenticos_external_thread_bind':
+      return { content: [{ type: 'text', text: await runExternalThreadBind(args ?? {}) }] };
+    case 'agenticos_external_thread_get':
+      return { content: [{ type: 'text', text: await runExternalThreadGet(args ?? {}) }] };
+    case 'agenticos_external_thread_list':
+      return { content: [{ type: 'text', text: await runExternalThreadList(args ?? {}) }] };
     case 'agenticos_list':
       return { content: [{ type: 'text', text: await listProjects() }] };
     case 'agenticos_task_create':

--- a/mcp-server/src/tools/__tests__/external-thread.test.ts
+++ b/mcp-server/src/tools/__tests__/external-thread.test.ts
@@ -1,0 +1,372 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import yaml from 'yaml';
+import { runExternalThreadBind, runExternalThreadGet, runExternalThreadList } from '../external-thread.js';
+import * as toolExports from '../index.js';
+
+let previousAgenticosHome: string | undefined;
+let home: string;
+
+function parseResult(value: string): any {
+  return JSON.parse(value);
+}
+
+function sidecarPath(): string {
+  return join(home, '.agent-workspace', 'integrations', 'discord', 'thread-bindings.yaml');
+}
+
+async function writeRegistry(projects: Array<{ id: string; name: string; path: string }>): Promise<void> {
+  await mkdir(join(home, '.agent-workspace'), { recursive: true });
+  await writeFile(
+    join(home, '.agent-workspace', 'registry.yaml'),
+    yaml.stringify({
+      version: '1.0.0',
+      last_updated: '2026-05-22T00:00:00.000Z',
+      active_project: null,
+      projects: projects.map((project) => ({
+        id: project.id,
+        name: project.name,
+        path: project.path,
+        status: 'active',
+        created: '2026-05-22',
+        last_accessed: '2026-05-22T00:00:00.000Z',
+      })),
+    }),
+    'utf-8',
+  );
+}
+
+async function seedProject(args: {
+  id: string;
+  name: string;
+  contextPublicationPolicy?: 'local_private' | 'public_distilled';
+}): Promise<string> {
+  const projectPath = join(home, 'projects', args.id);
+  const publicDistilled = args.contextPublicationPolicy === 'public_distilled';
+  await mkdir(join(projectPath, '.context'), { recursive: true });
+  await mkdir(join(projectPath, 'knowledge'), { recursive: true });
+  const projectYaml: any = {
+    meta: {
+      id: args.id,
+      name: args.name,
+      created: '2026-05-22',
+      version: '1.0.0',
+    },
+    source_control: publicDistilled
+      ? {
+          topology: 'github_versioned',
+          context_publication_policy: 'public_distilled',
+          github_repo: `madlouse/${args.id}`,
+          branch_strategy: 'github_flow',
+        }
+      : {
+          topology: 'local_directory_only',
+          context_publication_policy: 'local_private',
+        },
+    ...(publicDistilled ? { execution: { source_repo_roots: ['.'] } } : {}),
+    agent_context: {
+      quick_start: '.context/quick-start.md',
+      current_state: '.context/state.yaml',
+      conversations: '.context/conversations/',
+      knowledge: 'knowledge/',
+      tasks: 'tasks/',
+      artifacts: 'artifacts/',
+    },
+  };
+  await writeFile(join(projectPath, '.project.yaml'), yaml.stringify(projectYaml), 'utf-8');
+  await writeFile(join(projectPath, '.context', 'state.yaml'), 'state: preserved\n', 'utf-8');
+  await writeFile(join(projectPath, '.context', 'quick-start.md'), '# preserved\n', 'utf-8');
+  await writeFile(join(projectPath, 'knowledge', 'note.md'), '# knowledge\n', 'utf-8');
+  return projectPath;
+}
+
+async function snapshotProjectFiles(projectPath: string): Promise<Record<string, string>> {
+  const paths = [
+    '.project.yaml',
+    '.context/state.yaml',
+    '.context/quick-start.md',
+    'knowledge/note.md',
+  ];
+  const entries = await Promise.all(
+    paths.map(async (relativePath) => [relativePath, await readFile(join(projectPath, relativePath), 'utf-8')] as const),
+  );
+  return Object.fromEntries(entries);
+}
+
+beforeEach(async () => {
+  previousAgenticosHome = process.env.AGENTICOS_HOME;
+  home = await mkdtemp(join(tmpdir(), 'agenticos-external-thread-'));
+  process.env.AGENTICOS_HOME = home;
+});
+
+afterEach(async () => {
+  if (previousAgenticosHome === undefined) {
+    delete process.env.AGENTICOS_HOME;
+  } else {
+    process.env.AGENTICOS_HOME = previousAgenticosHome;
+  }
+  await rm(home, { recursive: true, force: true });
+});
+
+describe('AgenticOS external thread bindings', () => {
+  it('exports external thread tools from the public tools barrel', () => {
+    expect(toolExports.runExternalThreadBind).toBe(runExternalThreadBind);
+    expect(toolExports.runExternalThreadGet).toBe(runExternalThreadGet);
+    expect(toolExports.runExternalThreadList).toBe(runExternalThreadList);
+  });
+
+  it('binds, gets, and lists a Discord thread without changing public project files', async () => {
+    const projectPath = await seedProject({
+      id: 'agenticos',
+      name: 'AgenticOS',
+      contextPublicationPolicy: 'public_distilled',
+    });
+    await writeRegistry([{ id: 'agenticos', name: 'AgenticOS', path: projectPath }]);
+    const before = await snapshotProjectFiles(projectPath);
+
+    const bind = parseResult(await runExternalThreadBind({
+      project: 'agenticos',
+      provider: 'discord',
+      guild_id: 'guild_123',
+      channel_id: 'channel_456',
+      thread_id: 'thread_789',
+      thread_url: 'https://discord.com/channels/guild_123/channel_456/thread_789',
+      default_backend: 'codex',
+    }));
+
+    expect(bind.status).toBe('BOUND');
+    expect(bind.created).toBe(true);
+    expect(bind.updated).toBe(false);
+    expect(bind.binding).toMatchObject({
+      project_id: 'agenticos',
+      project_name: 'AgenticOS',
+      provider: 'discord',
+      guild_id: 'guild_123',
+      channel_id: 'channel_456',
+      thread_id: 'thread_789',
+      default_backend: 'codex',
+    });
+    expect(bind.storage.private_sidecar).toBe(sidecarPath());
+    expect(await snapshotProjectFiles(projectPath)).toEqual(before);
+
+    const sidecar = await readFile(sidecarPath(), 'utf-8');
+    expect(sidecar).toContain('thread_789');
+    expect(sidecar).not.toContain('.project.yaml');
+
+    const get = parseResult(await runExternalThreadGet({
+      project: 'AgenticOS',
+      guild_id: 'guild_123',
+      channel_id: 'channel_456',
+    }));
+    expect(get.status).toBe('FOUND');
+    expect(get.binding.thread_id).toBe('thread_789');
+
+    const list = parseResult(await runExternalThreadList({ provider: 'discord' }));
+    expect(list.status).toBe('OK');
+    expect(list.count).toBe(1);
+    expect(list.bindings[0].project_id).toBe('agenticos');
+  });
+
+  it('is idempotent for identical binds and updates changed thread metadata', async () => {
+    const projectPath = await seedProject({ id: 't5t', name: 'T5T' });
+    await writeRegistry([{ id: 't5t', name: 'T5T', path: projectPath }]);
+
+    const first = parseResult(await runExternalThreadBind({
+      project: 't5t',
+      channel_id: 'channel',
+      thread_id: 'thread',
+    }));
+    const firstSidecar = await readFile(sidecarPath(), 'utf-8');
+    const second = parseResult(await runExternalThreadBind({
+      project: 't5t',
+      channel_id: 'channel',
+      thread_id: 'thread',
+    }));
+    const secondSidecar = await readFile(sidecarPath(), 'utf-8');
+
+    expect(first.created).toBe(true);
+    expect(second.created).toBe(false);
+    expect(second.updated).toBe(false);
+    expect(secondSidecar).toBe(firstSidecar);
+
+    const updated = parseResult(await runExternalThreadBind({
+      project: 't5t',
+      channel_id: 'channel',
+      thread_id: 'thread_next',
+      default_backend: 'claude_code',
+    }));
+    expect(updated.created).toBe(false);
+    expect(updated.updated).toBe(true);
+    expect(updated.binding.created_at).toBe(first.binding.created_at);
+    expect(updated.binding.thread_id).toBe('thread_next');
+    expect(updated.binding.default_backend).toBe('claude_code');
+  });
+
+  it('returns NOT_FOUND for missing or filter-mismatched bindings', async () => {
+    const projectPath = await seedProject({ id: 'agenticos', name: 'AgenticOS' });
+    await writeRegistry([{ id: 'agenticos', name: 'AgenticOS', path: projectPath }]);
+
+    const missing = parseResult(await runExternalThreadGet({ project: 'agenticos' }));
+    expect(missing.status).toBe('NOT_FOUND');
+    expect(missing.binding).toBeNull();
+
+    await runExternalThreadBind({
+      project: 'agenticos',
+      guild_id: 'guild',
+      channel_id: 'channel',
+      thread_id: 'thread',
+    });
+    const mismatched = parseResult(await runExternalThreadGet({
+      project: 'agenticos',
+      guild_id: 'other_guild',
+    }));
+    expect(mismatched.status).toBe('NOT_FOUND');
+  });
+
+  it('lists bindings globally or for one project', async () => {
+    const firstPath = await seedProject({ id: 'agenticos', name: 'AgenticOS' });
+    const secondPath = await seedProject({ id: 't5t', name: 'T5T' });
+    await writeRegistry([
+      { id: 'agenticos', name: 'AgenticOS', path: firstPath },
+      { id: 't5t', name: 'T5T', path: secondPath },
+    ]);
+
+    await runExternalThreadBind({ project: 'agenticos', channel_id: 'channel_a', thread_id: 'thread_a' });
+    await runExternalThreadBind({ project: 't5t', channel_id: 'channel_b', thread_id: 'thread_b' });
+
+    const all = parseResult(await runExternalThreadList({}));
+    expect(all.count).toBe(2);
+
+    const filtered = parseResult(await runExternalThreadList({ project: 'T5T' }));
+    expect(filtered.count).toBe(1);
+    expect(filtered.bindings[0].project_id).toBe('t5t');
+  });
+
+  it('fails closed for unsupported providers and unsafe ids or urls', async () => {
+    const projectPath = await seedProject({ id: 'agenticos', name: 'AgenticOS' });
+    await writeRegistry([{ id: 'agenticos', name: 'AgenticOS', path: projectPath }]);
+
+    const nonStringProject = parseResult(await runExternalThreadBind({
+      project: 123,
+      channel_id: 'channel',
+      thread_id: 'thread',
+    }));
+    expect(nonStringProject.status).toBe('ERROR');
+    expect(nonStringProject.error).toContain('project must be a non-empty string');
+
+    const blankChannel = parseResult(await runExternalThreadBind({
+      project: 'agenticos',
+      channel_id: '   ',
+      thread_id: 'thread',
+    }));
+    expect(blankChannel.status).toBe('ERROR');
+    expect(blankChannel.error).toContain('channel_id must be a non-empty string');
+
+    const feishu = parseResult(await runExternalThreadBind({
+      project: 'agenticos',
+      provider: 'feishu',
+      channel_id: 'channel',
+      thread_id: 'thread',
+    }));
+    expect(feishu.status).toBe('ERROR');
+    expect(feishu.code).toBe('UNSUPPORTED_PROVIDER');
+
+    const pathId = parseResult(await runExternalThreadBind({
+      project: 'agenticos',
+      channel_id: '../channel',
+      thread_id: 'thread',
+    }));
+    expect(pathId.status).toBe('ERROR');
+    expect(pathId.error).toContain('opaque Discord id');
+
+    const urlId = parseResult(await runExternalThreadBind({
+      project: 'agenticos',
+      channel_id: 'https://discord.com/channels/a/b',
+      thread_id: 'thread',
+    }));
+    expect(urlId.status).toBe('ERROR');
+    expect(urlId.error).toContain('opaque Discord id');
+
+    const control = parseResult(await runExternalThreadGet({
+      project: 'agenticos',
+      guild_id: 'guild\nid',
+    }));
+    expect(control.status).toBe('ERROR');
+    expect(control.error).toContain('control characters');
+
+    const symbolId = parseResult(await runExternalThreadBind({
+      project: 'agenticos',
+      channel_id: 'channel',
+      thread_id: 'thread!',
+    }));
+    expect(symbolId.status).toBe('ERROR');
+    expect(symbolId.error).toContain('letters, numbers');
+
+    const malformedUrl = parseResult(await runExternalThreadBind({
+      project: 'agenticos',
+      channel_id: 'channel',
+      thread_id: 'thread',
+      thread_url: 'not a url',
+    }));
+    expect(malformedUrl.status).toBe('ERROR');
+    expect(malformedUrl.error).toContain('valid http');
+
+    const badUrl = parseResult(await runExternalThreadBind({
+      project: 'agenticos',
+      channel_id: 'channel',
+      thread_id: 'thread',
+      thread_url: 'ftp://discord.com/channels/a/b',
+    }));
+    expect(badUrl.status).toBe('ERROR');
+    expect(badUrl.error).toContain('http');
+
+    const authorityUrl = parseResult(await runExternalThreadBind({
+      project: 'agenticos',
+      channel_id: 'channel',
+      thread_id: 'thread',
+      thread_url: 'https://user:pass@discord.com/channels/a/b',
+    }));
+    expect(authorityUrl.status).toBe('ERROR');
+    expect(authorityUrl.error).toContain('username');
+
+    const backend = parseResult(await runExternalThreadBind({
+      project: 'agenticos',
+      channel_id: 'channel',
+      thread_id: 'thread',
+      default_backend: 'gemini',
+    }));
+    expect(backend.status).toBe('ERROR');
+    expect(backend.error).toContain('default_backend');
+
+    const unknownProject = parseResult(await runExternalThreadGet({ project: 'missing' }));
+    expect(unknownProject.status).toBe('ERROR');
+    expect(unknownProject.code).toBe('UNKNOWN');
+
+    const unknownProjectList = parseResult(await runExternalThreadList({ project: 'missing' }));
+    expect(unknownProjectList.status).toBe('ERROR');
+    expect(unknownProjectList.code).toBe('UNKNOWN');
+  });
+
+  it('treats an empty or malformed sidecar as an empty binding store', async () => {
+    const projectPath = await seedProject({ id: 'agenticos', name: 'AgenticOS' });
+    await writeRegistry([{ id: 'agenticos', name: 'AgenticOS', path: projectPath }]);
+    await mkdir(join(home, '.agent-workspace', 'integrations', 'discord'), { recursive: true });
+    await writeFile(sidecarPath(), '', 'utf-8');
+
+    const emptyList = parseResult(await runExternalThreadList({}));
+    expect(emptyList.status).toBe('OK');
+    expect(emptyList.count).toBe(0);
+
+    await writeFile(
+      sidecarPath(),
+      yaml.stringify({ version: 1, updated_at: false, bindings: { project_id: 'agenticos' } }),
+      'utf-8',
+    );
+
+    const malformedList = parseResult(await runExternalThreadList({}));
+    expect(malformedList.status).toBe('OK');
+    expect(malformedList.count).toBe(0);
+  });
+});

--- a/mcp-server/src/tools/external-thread.ts
+++ b/mcp-server/src/tools/external-thread.ts
@@ -1,0 +1,317 @@
+import { mkdir, readFile, rename, writeFile } from 'fs/promises';
+import { dirname, join } from 'path';
+import yaml from 'yaml';
+import { getAgenticOSHome } from '../utils/registry.js';
+import { resolveManagedProjectTarget } from '../utils/project-target.js';
+
+type ExternalThreadProvider = 'discord';
+type ExternalThreadBackend = 'codex' | 'claude_code';
+
+interface ExternalThreadBinding {
+  project_id: string;
+  project_name: string;
+  provider: ExternalThreadProvider;
+  guild_id?: string;
+  channel_id: string;
+  thread_id: string;
+  thread_url?: string;
+  default_backend?: ExternalThreadBackend;
+  created_at: string;
+  updated_at: string;
+}
+
+interface ExternalThreadStore {
+  version: string;
+  updated_at: string;
+  bindings: ExternalThreadBinding[];
+}
+
+interface ThreadBindArgs {
+  project?: unknown;
+  provider?: unknown;
+  guild_id?: unknown;
+  channel_id?: unknown;
+  thread_id?: unknown;
+  thread_url?: unknown;
+  default_backend?: unknown;
+}
+
+interface ThreadGetArgs {
+  project?: unknown;
+  provider?: unknown;
+  guild_id?: unknown;
+  channel_id?: unknown;
+}
+
+interface ThreadListArgs {
+  project?: unknown;
+  provider?: unknown;
+}
+
+class ExternalThreadError extends Error {
+  code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.code = code;
+  }
+}
+
+function jsonResult(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function errorResult(error: Error): string {
+  const message = error.message;
+  const code = error instanceof ExternalThreadError ? error.code : 'UNKNOWN';
+  return jsonResult({
+    status: 'ERROR',
+    code,
+    error: message,
+    recovery: [
+      'Use provider="discord" for this MVP.',
+      'Pass only opaque Discord ids in guild_id, channel_id, and thread_id; put full URLs only in thread_url.',
+    ],
+  });
+}
+
+function normalizeRequiredString(value: unknown, field: string): string {
+  if (typeof value !== 'string') {
+    throw new ExternalThreadError('INVALID_INPUT', `${field} must be a non-empty string.`);
+  }
+  if (/[\u0000-\u001F\u007F]/.test(value)) {
+    throw new ExternalThreadError('INVALID_INPUT', `${field} must not contain control characters.`);
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new ExternalThreadError('INVALID_INPUT', `${field} must be a non-empty string.`);
+  }
+  return trimmed;
+}
+
+function normalizeProvider(value: unknown, required: boolean): ExternalThreadProvider | null {
+  if ((value === undefined || value === null || value === '') && !required) {
+    return null;
+  }
+  const provider = value === undefined || value === null || value === ''
+    ? 'discord'
+    : normalizeRequiredString(value, 'provider');
+  if (provider !== 'discord') {
+    throw new ExternalThreadError('UNSUPPORTED_PROVIDER', `provider "${provider}" is not supported. Discord is the only MVP provider.`);
+  }
+  return provider;
+}
+
+function normalizeExternalId(value: unknown, field: string, required: boolean): string | undefined {
+  if ((value === undefined || value === null || value === '') && !required) {
+    return undefined;
+  }
+  const id = normalizeRequiredString(value, field);
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(id) || id.includes('/') || id.includes('\\') || id.includes('..')) {
+    throw new ExternalThreadError('INVALID_INPUT', `${field} must be an opaque Discord id, not a path or URL.`);
+  }
+  if (!/^[A-Za-z0-9_-]+$/.test(id)) {
+    throw new ExternalThreadError('INVALID_INPUT', `${field} may contain only letters, numbers, underscore, or hyphen.`);
+  }
+  return id;
+}
+
+function normalizeThreadUrl(value: unknown): string | undefined {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+  const raw = normalizeRequiredString(value, 'thread_url');
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new ExternalThreadError('INVALID_INPUT', 'thread_url must be a valid http(s) URL.');
+  }
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    throw new ExternalThreadError('INVALID_INPUT', 'thread_url must use http or https.');
+  }
+  if (parsed.username || parsed.password) {
+    throw new ExternalThreadError('INVALID_INPUT', 'thread_url must not contain username or password authority.');
+  }
+  return parsed.toString();
+}
+
+function normalizeBackend(value: unknown): ExternalThreadBackend | undefined {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+  const backend = normalizeRequiredString(value, 'default_backend');
+  if (backend !== 'codex' && backend !== 'claude_code') {
+    throw new ExternalThreadError('INVALID_INPUT', 'default_backend must be "codex" or "claude_code".');
+  }
+  return backend;
+}
+
+function storePath(provider: ExternalThreadProvider): string {
+  return join(getAgenticOSHome(), '.agent-workspace', 'integrations', provider, 'thread-bindings.yaml');
+}
+
+function emptyStore(): ExternalThreadStore {
+  return {
+    version: '1.0.0',
+    updated_at: nowIso(),
+    bindings: [],
+  };
+}
+
+async function loadStore(provider: ExternalThreadProvider): Promise<ExternalThreadStore> {
+  try {
+    const parsed = yaml.parse(await readFile(storePath(provider), 'utf-8')) || {};
+    return {
+      version: typeof parsed.version === 'string' ? parsed.version : '1.0.0',
+      updated_at: typeof parsed.updated_at === 'string' ? parsed.updated_at : nowIso(),
+      bindings: Array.isArray(parsed.bindings) ? parsed.bindings : [],
+    };
+  } catch {
+    return emptyStore();
+  }
+}
+
+async function saveStore(provider: ExternalThreadProvider, store: ExternalThreadStore): Promise<void> {
+  const path = storePath(provider);
+  const tempPath = `${path}.tmp-${process.pid}-${Date.now()}`;
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(tempPath, yaml.stringify(store), 'utf-8');
+  await rename(tempPath, path);
+}
+
+async function resolveProject(project: unknown, commandName: string): Promise<{ project_id: string; project_name: string }> {
+  const requestedProject = normalizeRequiredString(project, 'project');
+  const resolved = await resolveManagedProjectTarget({
+    project: requestedProject,
+    commandName,
+  });
+  return {
+    project_id: resolved.projectId,
+    project_name: resolved.projectName,
+  };
+}
+
+function sameBinding(a: ExternalThreadBinding, b: ExternalThreadBinding): boolean {
+  return a.guild_id === b.guild_id
+    && a.channel_id === b.channel_id
+    && a.thread_id === b.thread_id
+    && a.thread_url === b.thread_url
+    && a.default_backend === b.default_backend;
+}
+
+function findBindingIndex(store: ExternalThreadStore, projectId: string, provider: ExternalThreadProvider): number {
+  return store.bindings.findIndex((binding) => binding.project_id === projectId && binding.provider === provider);
+}
+
+function filterBinding(binding: ExternalThreadBinding, args: { guild_id?: string; channel_id?: string }): boolean {
+  return (!args.guild_id || binding.guild_id === args.guild_id)
+    && (!args.channel_id || binding.channel_id === args.channel_id);
+}
+
+export async function runExternalThreadBind(args: ThreadBindArgs = {}): Promise<string> {
+  try {
+    const provider = normalizeProvider(args.provider, true) as ExternalThreadProvider;
+    const project = await resolveProject(args.project, 'agenticos_external_thread_bind');
+    const now = nowIso();
+    const guildId = normalizeExternalId(args.guild_id, 'guild_id', false);
+    const threadUrl = normalizeThreadUrl(args.thread_url);
+    const defaultBackend = normalizeBackend(args.default_backend);
+    const nextBinding: ExternalThreadBinding = {
+      project_id: project.project_id,
+      project_name: project.project_name,
+      provider,
+      ...(guildId ? { guild_id: guildId } : {}),
+      channel_id: normalizeExternalId(args.channel_id, 'channel_id', true)!,
+      thread_id: normalizeExternalId(args.thread_id, 'thread_id', true)!,
+      ...(threadUrl ? { thread_url: threadUrl } : {}),
+      ...(defaultBackend ? { default_backend: defaultBackend } : {}),
+      created_at: now,
+      updated_at: now,
+    };
+    const store = await loadStore(provider);
+    const existingIndex = findBindingIndex(store, project.project_id, provider);
+    const existing = existingIndex >= 0 ? store.bindings[existingIndex] : null;
+
+    if (existing && sameBinding(existing, nextBinding)) {
+      return jsonResult({
+        status: 'BOUND',
+        created: false,
+        updated: false,
+        binding: existing,
+        storage: { provider, private_sidecar: storePath(provider) },
+      });
+    }
+
+    const binding = {
+      ...nextBinding,
+      created_at: existing?.created_at || now,
+      updated_at: now,
+    };
+    if (existingIndex >= 0) {
+      store.bindings[existingIndex] = binding;
+    } else {
+      store.bindings.push(binding);
+    }
+    store.updated_at = now;
+    await saveStore(provider, store);
+    return jsonResult({
+      status: 'BOUND',
+      created: existingIndex < 0,
+      updated: existingIndex >= 0,
+      binding,
+      storage: { provider, private_sidecar: storePath(provider) },
+    });
+  } catch (error) {
+    return errorResult(error as Error);
+  }
+}
+
+export async function runExternalThreadGet(args: ThreadGetArgs = {}): Promise<string> {
+  try {
+    const provider = normalizeProvider(args.provider, true) as ExternalThreadProvider;
+    const project = await resolveProject(args.project, 'agenticos_external_thread_get');
+    const guildId = normalizeExternalId(args.guild_id, 'guild_id', false);
+    const channelId = normalizeExternalId(args.channel_id, 'channel_id', false);
+    const store = await loadStore(provider);
+    const binding = store.bindings.find((candidate) =>
+      candidate.project_id === project.project_id &&
+      candidate.provider === provider &&
+      filterBinding(candidate, { guild_id: guildId, channel_id: channelId })
+    ) || null;
+    return jsonResult({
+      status: binding ? 'FOUND' : 'NOT_FOUND',
+      project_id: project.project_id,
+      provider,
+      binding,
+    });
+  } catch (error) {
+    return errorResult(error as Error);
+  }
+}
+
+export async function runExternalThreadList(args: ThreadListArgs = {}): Promise<string> {
+  try {
+    const provider = normalizeProvider(args.provider, false) || 'discord';
+    const project = args.project === undefined || args.project === null || args.project === ''
+      ? null
+      : await resolveProject(args.project, 'agenticos_external_thread_list');
+    const store = await loadStore(provider);
+    const bindings = store.bindings
+      .filter((binding) => !project || binding.project_id === project.project_id)
+      .sort((a, b) => a.project_id.localeCompare(b.project_id));
+    return jsonResult({
+      status: 'OK',
+      provider,
+      project_id: project?.project_id || null,
+      count: bindings.length,
+      bindings,
+    });
+  } catch (error) {
+    return errorResult(error as Error);
+  }
+}

--- a/mcp-server/src/tools/index.ts
+++ b/mcp-server/src/tools/index.ts
@@ -1,5 +1,6 @@
 export { initProject } from './init.js';
 export { runProjectEnsure, runProjectResolve } from './project-resolve.js';
+export { runExternalThreadBind, runExternalThreadGet, runExternalThreadList } from './external-thread.js';
 export { switchProject, listProjects, getStatus } from './project.js';
 export { saveState } from './save.js';
 export { recordSession } from './record.js';


### PR DESCRIPTION
## Summary
- add private AgenticOS sidecar storage for optional Discord project thread bindings
- expose MCP tools to bind, get, and list external thread mappings without writing Discord ids into project files
- validate opaque Discord ids, safe thread URLs, and optional default worker backend

Fixes #465

## Verification
- npm ci
- npm test -- --run src/tools/__tests__/external-thread.test.ts
- npm run lint
- UPDATE_BASELINE=1 npm test -- --run src/__tests__/mcp-regression.test.ts
- npm test -- --run src/__tests__/mcp-regression.test.ts
- npm test -- --run
- ./tools/coverage-preflight.sh
- git diff --check
- agenticos_pr_scope_check