### PR TITLE
feat: report optional Hermes Discord readiness

### DIFF
--- a/mcp-server/src/utils/__tests__/bootstrap-cli.test.ts
+++ b/mcp-server/src/utils/__tests__/bootstrap-cli.test.ts
@@ -74,9 +74,11 @@ describe('bootstrap cli', () => {
     expect(harness.stdout.join('\n')).toContain('agenticos-bootstrap');
     expect(buildHelpLines().join('\n')).toContain('--auto-configure-hooks');
     expect(buildHelpLines().join('\n')).toContain('--install-skills');
+    expect(buildHelpLines().join('\n')).toContain('--verify-hermes-discord');
     expect(parseCliArgs(['--all', '--auto-configure-hooks']).all).toBe(true);
     expect(parseCliArgs(['--install-skills', '--force-skills']).installSkills).toBe(true);
     expect(parseCliArgs(['--install-skills', '--force-skills']).forceSkills).toBe(true);
+    expect(parseCliArgs(['--verify-hermes-discord']).verifyHermesDiscord).toBe(true);
     expect(() => parseCliArgs(['--workspace'])).toThrow('--workspace requires a path.');
     expect(() => parseCliArgs(['--agent'])).toThrow('--agent requires a value.');
     expect(() => parseCliArgs(['--shell-profile'])).toThrow('--shell-profile requires a path.');
@@ -197,6 +199,7 @@ describe('bootstrap cli', () => {
         autoConfigureHooks: false,
         installSkills: true,
         forceSkills: true,
+        verifyHermesDiscord: true,
       },
       undefined,
       '/Users/tester',
@@ -204,6 +207,7 @@ describe('bootstrap cli', () => {
 
     expect(lines.join('\n')).toContain('cursor-skill: skip');
     expect(lines.join('\n')).toContain('overwrite user-modified managed Skill files');
+    expect(lines.join('\n')).toContain('hermes-discord: enforce Hermes+Discord');
   });
 
   it('reports non-Error thrown failures', () => {
@@ -731,6 +735,58 @@ describe('bootstrap cli', () => {
     expect(harness.stdout.some((line) => line.includes('OK shell-profile'))).toBe(true);
     expect(harness.stdout.some((line) => line.includes('OK launchctl'))).toBe(true);
     expect(harness.files.has('/tmp/workspace/.agent-workspace/bootstrap-state.yaml')).toBe(false);
+  });
+
+  it('reports optional Hermes and Discord readiness during verification without blocking normal AgenticOS checks', () => {
+    const harness = createDeps();
+
+    const exitCode = runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'codex', '--verify'],
+      harness.deps,
+    );
+
+    const output = harness.stdout.join('\n');
+    expect(exitCode).toBe(0);
+    expect(output).toContain('Optional Hermes/Discord readiness');
+    expect(output).toContain('SKIP hermes_runtime');
+    expect(output).toContain('SKIP discord_config');
+    expect(output).toContain('core AgenticOS verification is unaffected');
+  });
+
+  it('blocks Hermes+Discord routing verification only when that workflow is explicitly required', () => {
+    const harness = createDeps();
+
+    const exitCode = runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'codex', '--verify', '--verify-hermes-discord'],
+      harness.deps,
+    );
+
+    const output = harness.stdout.join('\n');
+    expect(exitCode).toBe(1);
+    expect(output).toContain('FAIL hermes_runtime');
+    expect(output).toContain('FAIL discord_config');
+    expect(output).toContain('Recovery: Install or start Hermes');
+  });
+
+  it('passes required Hermes+Discord verification when prerequisites and thread bindings are present', () => {
+    const harness = createDeps();
+    harness.deps.env.HERMES_GATEWAY_URL = 'http://127.0.0.1:8787';
+    harness.deps.env.DISCORD_APP_ID = 'app-id';
+    harness.deps.env.DISCORD_BOT_TOKEN = 'secret-token';
+    harness.files.set('/tmp/workspace/.agent-workspace/integrations/discord/thread-bindings.yaml', 'bindings:\n  - project_id: agenticos\n');
+    harness.deps.commandExists = (command: string) => command === 'codex' || command === 'hermes-gateway';
+
+    const exitCode = runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'codex', '--verify', '--verify-hermes-discord'],
+      harness.deps,
+    );
+
+    const output = harness.stdout.join('\n');
+    expect(exitCode).toBe(0);
+    expect(output).toContain('OK hermes_runtime');
+    expect(output).toContain('OK discord_config');
+    expect(output).toContain('Restart Hermes gateway');
+    expect(output).not.toContain('secret-token');
   });
 
   it('verifies activation Skill state when requested', () => {

--- a/mcp-server/src/utils/__tests__/config-audit.test.ts
+++ b/mcp-server/src/utils/__tests__/config-audit.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { createHash } from 'crypto';
 import { renderConfigAuditResult, runConfigAudit } from '../config-audit.js';
 import { renderAgenticosSkillContent } from '../agent-skill.js';
 
@@ -57,6 +58,8 @@ describe('config audit', () => {
     expect(rendered).toContain('Claude Code AgenticOS activation Skill');
     expect(rendered).toContain('Codex AgenticOS activation Skill');
     expect(rendered).toContain('Cursor MCP config');
+    expect(rendered).toContain('Hermes runtime');
+    expect(rendered).toContain('Discord configuration');
     expect(rendered).toContain('/opt/homebrew/var/agenticos');
   });
 
@@ -200,7 +203,73 @@ describe('config audit', () => {
     const codexSkill = result.sources.find((source) => source.id === 'codex_activation_skill');
 
     expect(codexSkill?.status).toBe('present');
+    expect(codexSkill?.detail).toContain('Skill state: modified-user');
     expect(codexSkill?.fix_target).toContain('--force-skills');
+  });
+
+  it('reports stale managed activation Skills with non-force upgrade recovery', () => {
+    const harness = createDeps();
+    const path = '/Users/tester/.codex/skills/agenticos/SKILL.md';
+    const staleWithoutHash = renderAgenticosSkillContent()
+      .replace(/^<!-- agenticos-skill-managed-sha256: [a-f0-9]{64} -->\n?/, '')
+      .replace('project status', 'project context');
+    const staleHash = createHash('sha256').update(staleWithoutHash, 'utf-8').digest('hex');
+    harness.files.set(path, `<!-- agenticos-skill-managed-sha256: ${staleHash} -->\n${staleWithoutHash}`);
+
+    const result = runConfigAudit({ action: 'show', scope: 'mcp' }, harness.deps);
+    const codexSkill = result.sources.find((source) => source.id === 'codex_activation_skill');
+
+    expect(codexSkill?.status).toBe('present');
+    expect(codexSkill?.detail).toContain('Skill state: stale-managed');
+    expect(codexSkill?.fix_target).toBe('agenticos-bootstrap --agent codex --install-skills --apply');
+  });
+
+  it('reports optional Hermes/Discord readiness without contributing to workspace drift', () => {
+    const harness = createDeps();
+    harness.deps.env.AGENTICOS_HOME = '/runtime/home';
+    harness.deps.env.HERMES_GATEWAY_URL = 'http://127.0.0.1:8787';
+    harness.deps.env.DISCORD_APP_ID = 'app-id';
+    harness.deps.env.DISCORD_BOT_TOKEN = 'secret-token';
+    harness.deps.commandExists = (command: string) => command === 'launchctl' || command === 'hermes-gateway';
+    harness.files.set('/runtime/home/.agent-workspace/integrations/discord/thread-bindings.yaml', 'bindings:\n  - project_id: agenticos\n');
+
+    const result = runConfigAudit({ action: 'show', scope: 'all' }, harness.deps);
+    const rendered = renderConfigAuditResult(result);
+    const hermesRuntime = result.sources.find((source) => source.id === 'hermes_discord:hermes_runtime');
+    const discordConfig = result.sources.find((source) => source.id === 'hermes_discord:discord_config');
+
+    expect(result.status).toBe('PASS');
+    expect(hermesRuntime?.status).toBe('configured');
+    expect(hermesRuntime?.contributes_to_workspace).toBe(false);
+    expect(discordConfig?.status).toBe('configured');
+    expect(rendered).toContain('Restart Hermes gateway');
+    expect(rendered).not.toContain('secret-token');
+  });
+
+  it('shows missing optional Hermes/Discord readiness as skip instead of a core failure', () => {
+    const harness = createDeps();
+
+    const result = runConfigAudit({ action: 'show', scope: 'mcp' }, harness.deps);
+    const hermesRuntime = result.sources.find((source) => source.id === 'hermes_discord:hermes_runtime');
+    const discordConfig = result.sources.find((source) => source.id === 'hermes_discord:discord_config');
+
+    expect(result.status).toBe('PASS');
+    expect(result.canonical_workspace).toBeNull();
+    expect(hermesRuntime?.status).toBe('skip');
+    expect(discordConfig?.status).toBe('skip');
+  });
+
+  it('warns about partial Hermes readiness without failing config audit show mode', () => {
+    const harness = createDeps();
+    harness.deps.commandExists = (command: string) => command === 'launchctl' || command === 'hermes';
+
+    const result = runConfigAudit({ action: 'show', scope: 'mcp' }, harness.deps);
+    const gateway = result.sources.find((source) => source.id === 'hermes_discord:hermes_gateway');
+    const discordConfig = result.sources.find((source) => source.id === 'hermes_discord:discord_config');
+
+    expect(result.status).toBe('PASS');
+    expect(gateway?.status).toBe('warn');
+    expect(discordConfig?.status).toBe('warn');
   });
 
   it('reports missing Claude Code cwd guidance hook when hooks do not match', () => {

--- a/mcp-server/src/utils/__tests__/integration-readiness.test.ts
+++ b/mcp-server/src/utils/__tests__/integration-readiness.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import {
+  inspectHermesDiscordReadiness,
+  renderHermesDiscordReadinessLines,
+} from '../integration-readiness.js';
+
+function createDeps() {
+  const files = new Map<string, string>();
+  const commands = new Set<string>();
+  const env: Record<string, string | undefined> = {};
+
+  return {
+    files,
+    commands,
+    env,
+    deps: {
+      env,
+      homeDir: '/Users/tester',
+      commandExists(command: string) {
+        return commands.has(command);
+      },
+      readFile(path: string) {
+        return files.get(path) ?? null;
+      },
+    },
+  };
+}
+
+describe('Hermes/Discord optional readiness', () => {
+  it('skips Hermes and Discord checks without failing core readiness when Hermes is absent', () => {
+    const harness = createDeps();
+
+    const result = inspectHermesDiscordReadiness(harness.deps, {
+      workspace: '/tmp/workspace',
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.required).toBe(false);
+    expect(result.checks.find((check) => check.id === 'hermes_runtime')?.marker).toBe('SKIP');
+    expect(result.checks.find((check) => check.id === 'discord_config')?.marker).toBe('SKIP');
+    expect(renderHermesDiscordReadinessLines(result).join('\n')).toContain('--verify-hermes-discord');
+  });
+
+  it('warns when Hermes is present but Discord routing is not configured', () => {
+    const harness = createDeps();
+    harness.commands.add('hermes-gateway');
+
+    const result = inspectHermesDiscordReadiness(harness.deps, {
+      workspace: '/tmp/workspace',
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.checks.find((check) => check.id === 'hermes_runtime')?.marker).toBe('OK');
+    expect(result.checks.find((check) => check.id === 'hermes_gateway')?.marker).toBe('WARN');
+    expect(result.checks.find((check) => check.id === 'discord_config')?.marker).toBe('WARN');
+  });
+
+  it('detects Hermes from local config when no Hermes command is on PATH', () => {
+    const harness = createDeps();
+    harness.files.set('/Users/tester/.hermes/config.yaml', 'gateway: true\n');
+
+    const result = inspectHermesDiscordReadiness(harness.deps);
+
+    expect(result.checks.find((check) => check.id === 'hermes_runtime')).toMatchObject({
+      marker: 'OK',
+      detail: 'Hermes detected via /Users/tester/.hermes/config.yaml.',
+    });
+  });
+
+  it('passes when Hermes gateway, Discord config, and thread bindings are present', () => {
+    const harness = createDeps();
+    harness.commands.add('hermes');
+    harness.env.HERMES_GATEWAY_URL = 'http://127.0.0.1:8787';
+    harness.env.DISCORD_APP_ID = 'app-id';
+    harness.env.DISCORD_BOT_TOKEN = 'secret-token';
+    harness.files.set('/tmp/workspace/.agent-workspace/integrations/discord/thread-bindings.yaml', 'bindings:\n  - project_id: agenticos\n');
+
+    const result = inspectHermesDiscordReadiness(harness.deps, {
+      required: true,
+      workspace: '/tmp/workspace',
+    });
+    const rendered = renderHermesDiscordReadinessLines(result).join('\n');
+
+    expect(result.ok).toBe(true);
+    expect(result.checks.every((check) => check.marker === 'OK')).toBe(true);
+    expect(rendered).toContain('Restart Hermes gateway');
+    expect(rendered).not.toContain('secret-token');
+  });
+
+  it('fails only when the Hermes+Discord workflow is explicitly required', () => {
+    const harness = createDeps();
+    harness.commands.add('hermes-agent');
+    harness.env.DISCORD_PUBLIC_KEY = 'public-key-only';
+
+    const result = inspectHermesDiscordReadiness(harness.deps, {
+      required: true,
+      workspace: '/tmp/workspace',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.checks.find((check) => check.id === 'hermes_runtime')?.marker).toBe('OK');
+    expect(result.checks.find((check) => check.id === 'hermes_gateway')?.marker).toBe('FAIL');
+    expect(result.checks.find((check) => check.id === 'discord_config')?.marker).toBe('FAIL');
+    expect(result.checks.find((check) => check.id === 'discord_thread_bindings')?.marker).toBe('FAIL');
+  });
+
+  it('treats command detection failures as absent optional Hermes commands', () => {
+    const harness = createDeps();
+    harness.deps.commandExists = () => {
+      throw new Error('PATH lookup failed');
+    };
+
+    const result = inspectHermesDiscordReadiness(harness.deps);
+
+    expect(result.ok).toBe(true);
+    expect(result.checks.find((check) => check.id === 'hermes_runtime')?.marker).toBe('SKIP');
+  });
+});

--- a/mcp-server/src/utils/bootstrap-cli.ts
+++ b/mcp-server/src/utils/bootstrap-cli.ts
@@ -12,6 +12,10 @@ import {
   isAgentSkillOkForVerify,
   type AgentSkillInstallResult,
 } from './agent-skill.js';
+import {
+  inspectHermesDiscordReadiness,
+  renderHermesDiscordReadinessLines,
+} from './integration-readiness.js';
 
 export interface CliOptions {
   apply: boolean;
@@ -27,6 +31,7 @@ export interface CliOptions {
   autoConfigureHooks: boolean;
   installSkills: boolean;
   forceSkills: boolean;
+  verifyHermesDiscord?: boolean;
 }
 
 export interface ApplyResult {
@@ -73,6 +78,7 @@ export function parseCliArgs(argv: string[]): CliOptions {
     autoConfigureHooks: false,
     installSkills: false,
     forceSkills: false,
+    verifyHermesDiscord: false,
   };
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -108,6 +114,9 @@ export function parseCliArgs(argv: string[]): CliOptions {
         break;
       case '--force-skills':
         options.forceSkills = true;
+        break;
+      case '--verify-hermes-discord':
+        options.verifyHermesDiscord = true;
         break;
       case '--workspace': {
         const value = argv[index + 1];
@@ -273,7 +282,7 @@ export function buildHelpLines(): string[] {
     'agenticos-bootstrap — bootstrap AgenticOS MCP registrations',
     '',
     'Usage:',
-    '  agenticos-bootstrap [--workspace <path>] [--agent <id>] [--all] [--first-run] [--persist-shell-env] [--persist-launchctl-env] [--auto-configure-hooks] [--install-skills] [--force-skills] [--shell-profile <path>] [--verify] [--apply]',
+    '  agenticos-bootstrap [--workspace <path>] [--agent <id>] [--all] [--first-run] [--persist-shell-env] [--persist-launchctl-env] [--auto-configure-hooks] [--install-skills] [--force-skills] [--verify-hermes-discord] [--shell-profile <path>] [--verify] [--apply]',
     '',
     'Behavior:',
     '  Without `--apply`, prints a dry-run bootstrap plan.',
@@ -285,6 +294,7 @@ export function buildHelpLines(): string[] {
     '  `--auto-configure-hooks` adds the Claude Code PostToolUse hook used to provide cwd guidance after agenticos_switch.',
     '  `--install-skills` installs or updates the AgenticOS activation Skill for agents that support local skills.',
     '  `--force-skills` allows `--install-skills` to overwrite a user-modified AgenticOS Skill.',
+    '  `--verify-hermes-discord` makes optional Hermes+Discord project routing prerequisites blocking during `--verify`.',
     '  Workspace selection is explicit: use `--workspace <path>` or set AGENTICOS_HOME beforehand.',
     '',
     'Supported agent ids: claude-code, codex, cursor, gemini-cli',
@@ -390,6 +400,11 @@ export function buildDryRunLines(
       lines.push('- agenticos-skill: overwrite user-modified managed Skill files if present');
     }
   }
+  if (options.verifyHermesDiscord) {
+    lines.push('- hermes-discord: enforce Hermes+Discord project routing prerequisites during verification');
+  } else {
+    lines.push('- hermes-discord: report optional readiness during verification without blocking core AgenticOS checks');
+  }
   if (selected.includes('claude-code')) {
     const settingsPath = `${homeDir}/${CLAUDE_SETTINGS_PATH}`;
     if (options.autoConfigureHooks) {
@@ -475,6 +490,15 @@ function runVerification(
         lines.push(`   Recovery: ${result.recovery}`);
       }
     }
+  }
+
+  const hermesDiscord = inspectHermesDiscordReadiness(deps, {
+    required: options.verifyHermesDiscord,
+    workspace,
+  });
+  lines.push('', ...renderHermesDiscordReadinessLines(hermesDiscord));
+  if (options.verifyHermesDiscord && !hermesDiscord.ok) {
+    ok = false;
   }
 
   return { ok, lines };
@@ -695,7 +719,7 @@ function verifyAgentSkill(
   return {
     ok,
     unsupported: inspection.status === 'unsupported',
-    detail: inspection.detail,
+    detail: `Skill state: ${inspection.status}. ${inspection.detail}`,
     recovery: formatCommand({ command: 'agenticos-bootstrap', args: recoveryArgs }),
   };
 }

--- a/mcp-server/src/utils/config-audit.ts
+++ b/mcp-server/src/utils/config-audit.ts
@@ -5,11 +5,23 @@ import {
   inspectClaudePwdAlignmentHook,
 } from './claude-pwd-hook.js';
 import { inspectAgentSkill } from './agent-skill.js';
+import {
+  inspectHermesDiscordReadiness,
+  type ReadinessMarker,
+} from './integration-readiness.js';
 import type { SupportedAgentId } from './bootstrap-helper.js';
 
 export type ConfigAuditAction = 'show' | 'validate';
 export type ConfigAuditScope = 'all' | 'runtime' | 'mcp' | 'homebrew';
-export type ConfigSourceStatus = 'configured' | 'unset' | 'missing' | 'unavailable' | 'present';
+export type ConfigSourceStatus = 'configured' | 'unset' | 'missing' | 'unavailable' | 'present' | 'skip' | 'warn';
+
+const READINESS_CONFIG_STATUS: Record<ReadinessMarker, ConfigSourceStatus> = {
+  OK: 'configured',
+  WARN: 'warn',
+  SKIP: 'skip',
+  INFO: 'skip',
+  FAIL: 'missing',
+};
 
 export interface CommandResult {
   ok: boolean;
@@ -205,6 +217,7 @@ function collectConfigSources(deps: ConfigAuditDeps): ConfigSourceRecord[] {
     readAgentSkillSource(deps, 'codex'),
     readCursorConfigSource(deps),
     ...readHomebrewSources(deps),
+    ...readHermesDiscordReadinessSources(deps),
   ];
 }
 
@@ -232,8 +245,8 @@ function readAgentSkillSource(
       ? `${fixTarget} --force-skills`
       : fixTarget,
     detail: status === 'configured'
-      ? inspection.detail
-      : `${inspection.detail} Rerun bootstrap with --install-skills to install or update it.`,
+      ? `Skill state: ${inspection.status}. ${inspection.detail}`
+      : `Skill state: ${inspection.status}. ${inspection.detail} Rerun bootstrap with --install-skills to install or update it.`,
     contributes_to_workspace: false,
   };
 }
@@ -465,6 +478,32 @@ function readHomebrewSources(deps: ConfigAuditDeps): ConfigSourceRecord[] {
       ? 'Default Homebrew runtime-home path exists on this machine.'
       : 'Default Homebrew runtime-home path does not exist on this machine.',
   }));
+}
+
+function readHermesDiscordReadinessSources(deps: ConfigAuditDeps): ConfigSourceRecord[] {
+  const readiness = inspectHermesDiscordReadiness(deps, {
+    required: false,
+    workspace: deps.env.AGENTICOS_HOME || null,
+  });
+  return readiness.checks.map((check) => ({
+    id: `hermes_discord:${check.id}`,
+    label: check.label,
+    scope: 'mcp' as const,
+    status: configStatusFromReadinessMarker(check.marker),
+    value: check.marker === 'OK' ? 'ready' : null,
+    location: check.location,
+    fix_target: check.recovery || 'optional; no action required for core AgenticOS verification',
+    detail: [
+      `${check.marker}: ${check.detail}`,
+      check.recovery ? `Recovery: ${check.recovery}` : null,
+      check.restart_hint ? `Restart: ${check.restart_hint}` : null,
+    ].filter(Boolean).join(' '),
+    contributes_to_workspace: false,
+  }));
+}
+
+function configStatusFromReadinessMarker(marker: ReadinessMarker): ConfigSourceStatus {
+  return READINESS_CONFIG_STATUS[marker];
 }
 
 function normalizeValue(value: string | undefined | null): string | null {

--- a/mcp-server/src/utils/integration-readiness.ts
+++ b/mcp-server/src/utils/integration-readiness.ts
@@ -1,0 +1,189 @@
+import { join } from 'path';
+
+export type ReadinessMarker = 'OK' | 'INFO' | 'SKIP' | 'WARN' | 'FAIL';
+
+export interface IntegrationReadinessDeps {
+  env: Record<string, string | undefined>;
+  homeDir: string;
+  commandExists(command: string): boolean;
+  readFile(path: string): string | null;
+}
+
+export interface ReadinessCheck {
+  id: string;
+  label: string;
+  marker: ReadinessMarker;
+  detail: string;
+  location: string;
+  recovery?: string;
+  restart_hint?: string;
+}
+
+export interface HermesDiscordReadiness {
+  id: 'hermes_discord';
+  required: boolean;
+  ok: boolean;
+  summary: string;
+  checks: ReadinessCheck[];
+}
+
+const HERMES_COMMANDS = ['hermes', 'hermes-agent', 'hermes-gateway'];
+const HERMES_CONFIG_PATHS = [
+  '.hermes/config.yaml',
+  '.hermes-agent/config.yaml',
+  '.config/hermes/config.yaml',
+  '.config/hermes-agent/config.yaml',
+];
+const DISCORD_TOKEN_ENV = ['DISCORD_BOT_TOKEN', 'HERMES_DISCORD_BOT_TOKEN'];
+const DISCORD_APP_ENV = ['DISCORD_APP_ID', 'DISCORD_CLIENT_ID', 'HERMES_DISCORD_APP_ID'];
+const DISCORD_OPTIONAL_ENV = [
+  'DISCORD_PUBLIC_KEY',
+  'DISCORD_GUILD_ID',
+  'DISCORD_CHANNEL_ID',
+  'HERMES_DISCORD_PUBLIC_KEY',
+  'HERMES_DISCORD_GUILD_ID',
+  'HERMES_DISCORD_CHANNEL_ID',
+];
+
+const HERMES_GATEWAY_RESTART = 'Restart Hermes gateway after changing Hermes or Discord integration settings.';
+
+export function inspectHermesDiscordReadiness(
+  deps: IntegrationReadinessDeps,
+  options: { required?: boolean; workspace?: string | null } = {},
+): HermesDiscordReadiness {
+  const required = options.required === true;
+  const hermesCommands = detectCommands(deps, HERMES_COMMANDS);
+  const hermesConfig = detectFirstReadableFile(deps, HERMES_CONFIG_PATHS.map((path) => join(deps.homeDir, path)));
+  const hermesDetected = hermesCommands.length > 0 || hermesConfig !== null;
+  const gatewayConfigured = hasAnyEnv(deps.env, ['HERMES_GATEWAY_URL', 'HERMES_AGENT_URL', 'HERMES_GATEWAY_ENABLED']);
+  const discordTokenConfigured = hasAnyEnv(deps.env, DISCORD_TOKEN_ENV);
+  const discordAppConfigured = hasAnyEnv(deps.env, DISCORD_APP_ENV);
+  const discordOptionalConfigured = hasAnyEnv(deps.env, DISCORD_OPTIONAL_ENV);
+  const discordConfigured = discordTokenConfigured && discordAppConfigured;
+  const threadBindingsPath = options.workspace
+    ? join(options.workspace, '.agent-workspace', 'integrations', 'discord', 'thread-bindings.yaml')
+    : null;
+  const threadBindingsPresent = threadBindingsPath
+    ? hasReadableNonEmptyFile(deps, threadBindingsPath)
+    : false;
+
+  const checks: ReadinessCheck[] = [
+    {
+      id: 'hermes_runtime',
+      label: 'Hermes runtime',
+      marker: hermesDetected ? 'OK' : required ? 'FAIL' : 'SKIP',
+      detail: hermesDetected
+        ? `Hermes detected via ${hermesCommands.length > 0 ? hermesCommands.join(', ') : hermesConfig}.`
+        : 'Hermes is not detected; optional Hermes/Discord routing is skipped and core AgenticOS verification is unaffected.',
+      location: [...HERMES_COMMANDS.map((command) => `PATH:${command}`), ...HERMES_CONFIG_PATHS.map((path) => join(deps.homeDir, path))].join(', '),
+      recovery: hermesDetected
+        ? undefined
+        : 'Install or start Hermes only if you want Hermes-side Discord project routing.',
+    },
+    {
+      id: 'hermes_gateway',
+      label: 'Hermes gateway',
+      marker: gatewayConfigured ? 'OK' : required ? 'FAIL' : hermesDetected ? 'WARN' : 'SKIP',
+      detail: gatewayConfigured
+        ? 'Hermes gateway environment is present.'
+        : hermesDetected
+          ? 'Hermes is detected, but no Hermes gateway environment was found.'
+          : 'Hermes gateway readiness is skipped because Hermes is not detected.',
+      location: 'HERMES_GATEWAY_URL, HERMES_AGENT_URL, HERMES_GATEWAY_ENABLED',
+      recovery: gatewayConfigured
+        ? undefined
+        : 'Configure Hermes gateway environment before enabling Discord project routing.',
+      restart_hint: gatewayConfigured ? HERMES_GATEWAY_RESTART : undefined,
+    },
+    {
+      id: 'discord_config',
+      label: 'Discord configuration',
+      marker: discordConfigured ? 'OK' : required ? 'FAIL' : hermesDetected ? 'WARN' : 'SKIP',
+      detail: discordConfigured
+        ? 'Discord application id and bot token are present; secret values are intentionally not displayed.'
+        : discordOptionalConfigured
+          ? 'Some Discord environment is present, but both an application id and bot token are required for routing.'
+          : 'Discord configuration is not detected; Discord routing remains optional.',
+      location: [...DISCORD_APP_ENV, ...DISCORD_TOKEN_ENV, ...DISCORD_OPTIONAL_ENV].join(', '),
+      recovery: discordConfigured
+        ? undefined
+        : 'Set DISCORD_APP_ID or DISCORD_CLIENT_ID plus DISCORD_BOT_TOKEN, then restart Hermes gateway.',
+      restart_hint: discordConfigured ? HERMES_GATEWAY_RESTART : undefined,
+    },
+    {
+      id: 'discord_thread_bindings',
+      label: 'Discord project thread bindings',
+      marker: threadBindingsPresent ? 'OK' : required ? 'FAIL' : 'INFO',
+      detail: threadBindingsPresent
+        ? 'AgenticOS Discord project thread bindings sidecar is present.'
+        : 'No Discord project thread bindings sidecar was found yet; bind a project thread when the first Discord cockpit is created.',
+      location: threadBindingsPath || '${AGENTICOS_HOME}/.agent-workspace/integrations/discord/thread-bindings.yaml',
+      recovery: threadBindingsPresent
+        ? undefined
+        : 'Use agenticos_external_thread_bind after creating or selecting the Discord project thread.',
+    },
+  ];
+
+  const blocking = checks.filter((check) => check.marker === 'FAIL');
+  return {
+    id: 'hermes_discord',
+    required,
+    ok: blocking.length === 0,
+    summary: required
+      ? blocking.length > 0
+        ? 'Hermes+Discord project routing is requested but required prerequisites are missing.'
+        : 'Hermes+Discord project routing prerequisites are ready.'
+      : 'Hermes/Discord project routing is optional; readiness is reported without blocking core AgenticOS verification.',
+    checks,
+  };
+}
+
+export function renderHermesDiscordReadinessLines(readiness: HermesDiscordReadiness): string[] {
+  const lines = [
+    'Optional Hermes/Discord readiness:',
+    readiness.summary,
+  ];
+  for (const check of readiness.checks) {
+    lines.push(`${check.marker} ${check.id}: ${check.detail}`);
+    if (check.recovery && (check.marker === 'FAIL' || check.marker === 'WARN')) {
+      lines.push(`   Recovery: ${check.recovery}`);
+    }
+    if (check.restart_hint && check.marker === 'OK') {
+      lines.push(`   Restart: ${check.restart_hint}`);
+    }
+  }
+  if (!readiness.required) {
+    lines.push('Use `agenticos-bootstrap --verify --verify-hermes-discord` to enforce this workflow as a blocking check.');
+  }
+  return lines;
+}
+
+function detectCommands(deps: IntegrationReadinessDeps, commands: string[]): string[] {
+  return commands.filter((command) => {
+    try {
+      return deps.commandExists(command);
+    } catch {
+      return false;
+    }
+  });
+}
+
+function detectFirstReadableFile(deps: IntegrationReadinessDeps, paths: string[]): string | null {
+  for (const path of paths) {
+    const content = deps.readFile(path);
+    if (content !== null) return path;
+  }
+  return null;
+}
+
+function hasReadableNonEmptyFile(deps: IntegrationReadinessDeps, path: string): boolean {
+  const content = deps.readFile(path);
+  return content !== null && content.trim().length > 0;
+}
+
+function hasAnyEnv(env: Record<string, string | undefined>, names: string[]): boolean {
+  return names.some((name) => {
+    const value = env[name]?.trim();
+    return value ? value.length > 0 : false;
+  });
+}


### PR DESCRIPTION
## Summary
- add a shared Hermes/Discord readiness inspector with secret-safe reporting
- show optional Hermes/Discord state in agenticos-bootstrap --verify without blocking normal AgenticOS verification
- add --verify-hermes-discord to make that workflow blocking when explicitly requested
- surface the same readiness and clearer Skill states through agenticos_config / config audit

Fixes #466

## Verification
- npm ci
- npm test -- --run src/utils/__tests__/integration-readiness.test.ts src/utils/__tests__/bootstrap-cli.test.ts src/utils/__tests__/config-audit.test.ts
- npm run lint
- npm test -- --run
- ./tools/coverage-preflight.sh
- git diff --check
- agenticos_pr_scope_check