### PR TITLE
feat: add Hermes Discord project router

### DIFF
--- a/mcp-server/src/utils/__tests__/hermes-discord-router.test.ts
+++ b/mcp-server/src/utils/__tests__/hermes-discord-router.test.ts
@@ -1,0 +1,545 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildDiscordProjectThreadName,
+  parseHermesProjectCommand,
+  routeHermesDiscordProjectCommand,
+  type AgenticOSProjectRouterAdapter,
+  type DiscordThreadAdapter,
+} from '../hermes-discord-router.js';
+
+function createHarness(options: {
+  tools?: string[];
+  ensureStatus?: string;
+  ensureAsString?: boolean;
+  ensureErrorWithoutMessage?: boolean;
+  omitProjectKind?: boolean;
+  omitExplicitWorkdir?: boolean;
+  omitPath?: boolean;
+  existingBinding?: boolean;
+  getStatus?: string;
+  discordAvailable?: boolean;
+  discordThrows?: boolean;
+  discordThrowsString?: boolean;
+  omitThreadGuild?: boolean;
+  omitThreadUrl?: boolean;
+  bindStatus?: string;
+  bindErrorWithoutMessage?: boolean;
+  bindWithoutBinding?: boolean;
+  bindAsString?: boolean;
+} = {}) {
+  const calls: string[] = [];
+  const tools = options.tools ?? [
+    'agenticos_project_ensure',
+    'agenticos_external_thread_get',
+    'agenticos_external_thread_bind',
+  ];
+  const binding = {
+    project_id: 'agenticos',
+    project_name: 'AgenticOS',
+    provider: 'discord' as const,
+    guild_id: 'guild',
+    channel_id: 'job-channel',
+    thread_id: 'thread-agenticos',
+    thread_url: 'https://discord.com/channels/guild/job-channel/thread-agenticos',
+    default_backend: 'codex' as const,
+  };
+  const agenticos: AgenticOSProjectRouterAdapter = {
+    available_tools: tools,
+    async projectEnsure(args) {
+      calls.push(`agenticos_project_ensure:${args.project}`);
+      if (options.ensureStatus === 'ERROR') {
+        const errorPayload = {
+          status: 'ERROR',
+          code: 'INVALID_INPUT',
+          ...(options.ensureErrorWithoutMessage ? {} : { error: 'project name is invalid' }),
+          recovery: ['Use a valid project name.'],
+        };
+        return options.ensureAsString ? JSON.stringify(errorPayload) : errorPayload;
+      }
+      const payload = {
+        status: options.ensureStatus ?? 'ENSURED',
+        created: options.ensureStatus === 'CREATED',
+        project_id: String(args.project).toLowerCase(),
+        name: String(args.project),
+        ...(options.omitProjectKind ? {} : { project_kind: 'project' }),
+        ...(options.omitPath ? {} : { path: `/workspace/${String(args.project).toLowerCase()}` }),
+        ...(options.omitExplicitWorkdir ? {} : { explicit_workdir: `/workspace/${String(args.project).toLowerCase()}` }),
+      };
+      return options.ensureAsString ? JSON.stringify(payload) : payload;
+    },
+    async externalThreadGet(args) {
+      calls.push(`agenticos_external_thread_get:${args.project}:${args.channel_id}`);
+      if (options.getStatus === 'ERROR') {
+        return { status: 'ERROR', recovery: ['Repair thread sidecar.'] };
+      }
+      return options.existingBinding
+        ? { status: 'FOUND', binding }
+        : { status: 'NOT_FOUND', binding: null };
+    },
+    async externalThreadBind(args) {
+      calls.push(`agenticos_external_thread_bind:${args.project}:${args.thread_id}:${args.default_backend}`);
+      if (options.bindStatus === 'ERROR') {
+        return {
+          status: 'ERROR',
+          code: 'INVALID_INPUT',
+          ...(options.bindErrorWithoutMessage ? {} : { error: 'thread id rejected' }),
+          recovery: ['Pass an opaque Discord thread id.'],
+        };
+      }
+      const payload = {
+        status: 'BOUND',
+        created: true,
+        ...(options.bindWithoutBinding ? {} : { binding: {
+          project_id: String(args.project),
+          project_name: String(args.project),
+          provider: 'discord',
+          guild_id: args.guild_id,
+          channel_id: args.channel_id,
+          thread_id: args.thread_id,
+          thread_url: args.thread_url,
+          default_backend: args.default_backend,
+        } }),
+      };
+      return options.bindAsString ? JSON.stringify(payload) : payload;
+    },
+  };
+  const discord: DiscordThreadAdapter = {
+    available: options.discordAvailable ?? true,
+    async ensureProjectThread(args) {
+      calls.push(`discord.ensure_project_thread:${args.thread_name}:${args.backend}`);
+      if (options.discordThrows) {
+        throw new Error('missing Create Public Threads permission');
+      }
+      if (options.discordThrowsString) {
+        throw 'gateway unavailable';
+      }
+      return {
+        ...(options.omitThreadGuild ? {} : { guild_id: args.guild_id }),
+        channel_id: args.channel_id,
+        thread_id: `thread-${args.project_id}`,
+        ...(options.omitThreadUrl ? {} : { thread_url: `https://discord.com/channels/${args.guild_id ?? 'guild'}/${args.channel_id}/thread-${args.project_id}` }),
+        created: true,
+      };
+    },
+  };
+
+  return { calls, agenticos, discord };
+}
+
+describe('Hermes Discord project router', () => {
+  it('parses project commands and defaults to Codex', () => {
+    expect(parseHermesProjectCommand('切换到 AgenticOS 项目')).toMatchObject({
+      project: 'AgenticOS',
+      verb: 'enter_or_create',
+      backend: 'codex',
+      explicit_backend: false,
+    });
+    expect(parseHermesProjectCommand('用 Claude Code 切换到 T5T 项目，然后发 PR')).toMatchObject({
+      project: 'T5T',
+      backend: 'claude_code',
+      explicit_backend: true,
+    });
+    expect(parseHermesProjectCommand('用 Codex 进入 AgenticOS 项目')).toMatchObject({
+      project: 'AgenticOS',
+      backend: 'codex',
+      explicit_backend: true,
+    });
+    expect(parseHermesProjectCommand('switch to AgenticOS project and run tests')).toMatchObject({
+      project: 'AgenticOS',
+      backend: 'codex',
+    });
+    expect(parseHermesProjectCommand('今天帮我记一下这个想法')).toBeNull();
+    expect(parseHermesProjectCommand('   ')).toBeNull();
+    expect(parseHermesProjectCommand('切换到 项目')).toBeNull();
+  });
+
+  it('ignores non-project commands at route time', async () => {
+    const harness = createHarness();
+
+    const result = await routeHermesDiscordProjectCommand({
+      message: '今天帮我记一下这个想法',
+      origin: { provider: 'discord', guild_id: 'guild', channel_id: 'job-channel' },
+      agenticos: harness.agenticos,
+      discord: harness.discord,
+    });
+
+    expect(result.status).toBe('NOT_PROJECT_COMMAND');
+    expect(result.worker.status).toBe('not_applicable');
+    expect(harness.calls).toEqual([]);
+  });
+
+  it('ensures AgenticOS project before creating and binding a Discord project thread', async () => {
+    const harness = createHarness();
+
+    const result = await routeHermesDiscordProjectCommand({
+      message: '切换到 AgenticOS 项目',
+      origin: { provider: 'discord', guild_id: 'guild', channel_id: 'job-channel' },
+      agenticos: harness.agenticos,
+      discord: harness.discord,
+    });
+
+    expect(result.status).toBe('ROUTED');
+    expect(result.backend).toBe('codex');
+    expect(result.thread_url).toBe('https://discord.com/channels/guild/job-channel/thread-agenticos');
+    expect(result.worker).toMatchObject({
+      status: 'ready_for_dispatch',
+      backend: 'codex',
+      project_id: 'agenticos',
+      explicit_workdir: '/workspace/agenticos',
+      thread_id: 'thread-agenticos',
+    });
+    expect(result.call_order).toEqual([
+      'agenticos_project_ensure',
+      'agenticos_external_thread_get',
+      'discord.ensure_project_thread',
+      'agenticos_external_thread_bind',
+    ]);
+    expect(harness.calls).toEqual([
+      'agenticos_project_ensure:AgenticOS',
+      'agenticos_external_thread_get:agenticos:job-channel',
+      'discord.ensure_project_thread:project/agenticos:codex',
+      'agenticos_external_thread_bind:agenticos:thread-agenticos:codex',
+    ]);
+  });
+
+  it('uses the same ensure path for new projects before Discord thread routing', async () => {
+    const harness = createHarness({ ensureStatus: 'CREATED' });
+
+    const result = await routeHermesDiscordProjectCommand({
+      message: '新建 T5T 项目',
+      origin: { provider: 'discord', guild_id: 'guild', channel_id: 'job-channel' },
+      agenticos: harness.agenticos,
+      discord: harness.discord,
+    });
+
+    expect(result.status).toBe('ROUTED');
+    expect(result.project).toMatchObject({
+      status: 'CREATED',
+      project_id: 't5t',
+      name: 'T5T',
+    });
+    expect(harness.calls[0]).toBe('agenticos_project_ensure:T5T');
+  });
+
+  it('short-circuits Discord work when AgenticOS ensure fails', async () => {
+    const harness = createHarness({ ensureStatus: 'ERROR' });
+
+    const result = await routeHermesDiscordProjectCommand({
+      message: '切换到 AgenticOS 项目',
+      origin: { provider: 'discord', guild_id: 'guild', channel_id: 'job-channel' },
+      agenticos: harness.agenticos,
+      discord: harness.discord,
+    });
+
+    expect(result.status).toBe('AGENTICOS_ERROR');
+    expect(result.worker.status).toBe('blocked');
+    expect(result.error).toBe('project name is invalid');
+    expect(harness.calls).toEqual(['agenticos_project_ensure:AgenticOS']);
+  });
+
+  it('uses a generic ensure failure when AgenticOS omits an error message', async () => {
+    const harness = createHarness({
+      ensureStatus: 'ERROR',
+      ensureErrorWithoutMessage: true,
+      ensureAsString: true,
+    });
+
+    const result = await routeHermesDiscordProjectCommand({
+      message: '切换到 AgenticOS 项目',
+      origin: { provider: 'discord', guild_id: 'guild', channel_id: 'job-channel' },
+      agenticos: harness.agenticos,
+      discord: harness.discord,
+    });
+
+    expect(result.status).toBe('AGENTICOS_ERROR');
+    expect(result.error).toBe('AgenticOS project ensure failed.');
+  });
+
+  it('degrades to AgenticOS-only routing when Discord is unavailable', async () => {
+    const harness = createHarness({ discordAvailable: false });
+
+    const result = await routeHermesDiscordProjectCommand({
+      message: '切换到 AgenticOS 项目',
+      origin: { provider: 'discord', guild_id: 'guild', channel_id: 'job-channel' },
+      agenticos: harness.agenticos,
+      discord: harness.discord,
+    });
+
+    expect(result.status).toBe('AGENTICOS_ONLY');
+    expect(result.degraded_reason).toBe('Discord routing is not configured or not available.');
+    expect(result.worker).toMatchObject({
+      status: 'ready_for_dispatch',
+      backend: 'codex',
+      project_id: 'agenticos',
+    });
+    expect(harness.calls).toEqual(['agenticos_project_ensure:AgenticOS']);
+  });
+
+  it('degrades to AgenticOS-only routing when Discord channel id is missing', async () => {
+    const harness = createHarness();
+
+    const result = await routeHermesDiscordProjectCommand({
+      message: '切换到 AgenticOS 项目',
+      origin: { provider: 'discord', guild_id: 'guild' },
+      agenticos: harness.agenticos,
+      discord: harness.discord,
+    });
+
+    expect(result.status).toBe('AGENTICOS_ONLY');
+    expect(result.degraded_reason).toBe('Discord channel id is missing.');
+    expect(harness.calls).toEqual(['agenticos_project_ensure:AgenticOS']);
+  });
+
+  it('degrades to AgenticOS-only routing when Discord thread binding tools are missing', async () => {
+    const harness = createHarness({ tools: ['agenticos_project_ensure'] });
+
+    const result = await routeHermesDiscordProjectCommand({
+      message: '切换到 AgenticOS 项目',
+      origin: { provider: 'discord', guild_id: 'guild', channel_id: 'job-channel' },
+      agenticos: harness.agenticos,
+      discord: harness.discord,
+    });
+
+    expect(result.status).toBe('AGENTICOS_ONLY');
+    expect(result.degraded_reason).toContain('agenticos_external_thread_get');
+    expect(result.degraded_reason).toContain('agenticos_external_thread_bind');
+    expect(result.recovery?.join('\n')).toContain('Do not fall back to cd');
+    expect(harness.calls).toEqual(['agenticos_project_ensure:AgenticOS']);
+  });
+
+  it('reuses existing thread bindings without creating a new Discord thread', async () => {
+    const harness = createHarness({ existingBinding: true });
+
+    const result = await routeHermesDiscordProjectCommand({
+      message: '切换到 AgenticOS 项目',
+      origin: { provider: 'discord', guild_id: 'guild', channel_id: 'job-channel' },
+      agenticos: harness.agenticos,
+      discord: harness.discord,
+    });
+
+    expect(result.status).toBe('ROUTED');
+    expect(result.binding?.thread_id).toBe('thread-agenticos');
+    expect(result.call_order).toEqual([
+      'agenticos_project_ensure',
+      'agenticos_external_thread_get',
+    ]);
+    expect(harness.calls).toEqual([
+      'agenticos_project_ensure:AgenticOS',
+      'agenticos_external_thread_get:agenticos:job-channel',
+    ]);
+  });
+
+  it('reports lookup failures before creating a Discord thread', async () => {
+    const harness = createHarness({ getStatus: 'ERROR' });
+
+    const result = await routeHermesDiscordProjectCommand({
+      message: '切换到 AgenticOS 项目',
+      origin: { provider: 'discord', guild_id: 'guild', channel_id: 'job-channel' },
+      agenticos: harness.agenticos,
+      discord: harness.discord,
+    });
+
+    expect(result.status).toBe('THREAD_BINDING_ERROR');
+    expect(result.error).toBe('AgenticOS thread lookup failed.');
+    expect(result.recovery).toEqual(['Repair thread sidecar.']);
+    expect(harness.calls).toEqual([
+      'agenticos_project_ensure:AgenticOS',
+      'agenticos_external_thread_get:agenticos:job-channel',
+    ]);
+  });
+
+  it('routes with string MCP payloads and optional Discord metadata omitted', async () => {
+    const harness = createHarness({
+      ensureAsString: true,
+      omitProjectKind: true,
+      omitExplicitWorkdir: true,
+      omitThreadGuild: true,
+      omitThreadUrl: true,
+      bindAsString: true,
+    });
+
+    const result = await routeHermesDiscordProjectCommand({
+      message: '切换到 AgenticOS 项目',
+      origin: { provider: 'discord', channel_id: 'job-channel' },
+      agenticos: harness.agenticos,
+      discord: harness.discord,
+    });
+
+    expect(result.status).toBe('ROUTED');
+    expect(result.project).toMatchObject({
+      project_kind: 'project',
+      explicit_workdir: '/workspace/agenticos',
+    });
+    expect(result.thread_url).toBeUndefined();
+    expect(harness.calls).toEqual([
+      'agenticos_project_ensure:AgenticOS',
+      'agenticos_external_thread_get:agenticos:job-channel',
+      'discord.ensure_project_thread:project/agenticos:codex',
+      'agenticos_external_thread_bind:agenticos:thread-agenticos:codex',
+    ]);
+  });
+
+  it('falls back to project id for workdir and origin guild for binding when optional fields are absent', async () => {
+    const harness = createHarness({
+      omitExplicitWorkdir: true,
+      omitPath: true,
+      omitProjectKind: true,
+      omitThreadGuild: true,
+      omitThreadUrl: true,
+    });
+
+    const result = await routeHermesDiscordProjectCommand({
+      message: '切换到 AgenticOS 项目',
+      origin: { provider: 'discord', guild_id: 'guild', channel_id: 'job-channel' },
+      agenticos: harness.agenticos,
+      discord: harness.discord,
+    });
+
+    expect(result.status).toBe('ROUTED');
+    expect(result.project?.explicit_workdir).toBe('agenticos');
+    expect(result.binding).toMatchObject({
+      guild_id: 'guild',
+      thread_url: undefined,
+    });
+  });
+
+  it('honors explicit Claude Code while keeping Codex as the default backend', async () => {
+    const harness = createHarness();
+
+    const result = await routeHermesDiscordProjectCommand({
+      message: '用 Claude Code 切换到 AgenticOS 项目',
+      origin: { provider: 'discord', guild_id: 'guild', channel_id: 'job-channel' },
+      agenticos: harness.agenticos,
+      discord: harness.discord,
+    });
+
+    expect(result.status).toBe('ROUTED');
+    expect(result.backend).toBe('claude_code');
+    expect(result.worker.backend).toBe('claude_code');
+    expect(harness.calls).toContain('discord.ensure_project_thread:project/agenticos:claude_code');
+    expect(harness.calls).toContain('agenticos_external_thread_bind:agenticos:thread-agenticos:claude_code');
+  });
+
+  it('fails closed with upgrade recovery when AgenticOS project ensure is missing', async () => {
+    const harness = createHarness({ tools: ['agenticos_switch'] });
+
+    const result = await routeHermesDiscordProjectCommand({
+      message: '切换到 AgenticOS 项目',
+      origin: { provider: 'discord', guild_id: 'guild', channel_id: 'job-channel' },
+      agenticos: harness.agenticos,
+      discord: harness.discord,
+    });
+
+    expect(result.status).toBe('MISSING_AGENTICOS_TOOLS');
+    expect(result.degraded_reason).toContain('agenticos_project_ensure');
+    expect(result.recovery?.join('\n')).toContain('Do not use cd');
+    expect(harness.calls).toEqual([]);
+  });
+
+  it('does not create Feishu thread paths and only keeps AgenticOS project context', async () => {
+    const harness = createHarness();
+
+    const result = await routeHermesDiscordProjectCommand({
+      message: '切换到 AgenticOS 项目',
+      origin: { provider: 'feishu', channel_id: 'feishu-chat' },
+      agenticos: harness.agenticos,
+      discord: harness.discord,
+    });
+
+    expect(result.status).toBe('AGENTICOS_ONLY');
+    expect(result.degraded_reason).toBe('Discord project threads are not available on this origin surface.');
+    expect(harness.calls).toEqual(['agenticos_project_ensure:AgenticOS']);
+  });
+
+  it('blocks worker dispatch when Discord thread creation cannot be recorded in AgenticOS', async () => {
+    const harness = createHarness({ bindStatus: 'ERROR' });
+
+    const result = await routeHermesDiscordProjectCommand({
+      message: '切换到 AgenticOS 项目',
+      origin: { provider: 'discord', guild_id: 'guild', channel_id: 'job-channel' },
+      agenticos: harness.agenticos,
+      discord: harness.discord,
+    });
+
+    expect(result.status).toBe('THREAD_BINDING_ERROR');
+    expect(result.worker).toMatchObject({
+      status: 'blocked',
+      thread_id: 'thread-agenticos',
+    });
+    expect(result.error).toBe('thread id rejected');
+  });
+
+  it('uses a generic bind failure when AgenticOS omits a bind error message', async () => {
+    const harness = createHarness({
+      bindStatus: 'ERROR',
+      bindErrorWithoutMessage: true,
+    });
+
+    const result = await routeHermesDiscordProjectCommand({
+      message: '切换到 AgenticOS 项目',
+      origin: { provider: 'discord', guild_id: 'guild', channel_id: 'job-channel' },
+      agenticos: harness.agenticos,
+      discord: harness.discord,
+    });
+
+    expect(result.status).toBe('THREAD_BINDING_ERROR');
+    expect(result.error).toBe('AgenticOS thread binding failed after Discord thread creation.');
+  });
+
+  it('blocks worker dispatch when AgenticOS bind succeeds without returning a binding', async () => {
+    const harness = createHarness({ bindWithoutBinding: true });
+
+    const result = await routeHermesDiscordProjectCommand({
+      message: '切换到 AgenticOS 项目',
+      origin: { provider: 'discord', guild_id: 'guild', channel_id: 'job-channel' },
+      agenticos: harness.agenticos,
+      discord: harness.discord,
+    });
+
+    expect(result.status).toBe('THREAD_BINDING_ERROR');
+    expect(result.error).toBe('AgenticOS thread binding failed after Discord thread creation.');
+  });
+
+  it('blocks worker dispatch when Discord thread creation fails', async () => {
+    const harness = createHarness({ discordThrows: true });
+
+    const result = await routeHermesDiscordProjectCommand({
+      message: '切换到 AgenticOS 项目',
+      origin: { provider: 'discord', guild_id: 'guild', channel_id: 'job-channel' },
+      agenticos: harness.agenticos,
+      discord: harness.discord,
+    });
+
+    expect(result.status).toBe('THREAD_BINDING_ERROR');
+    expect(result.error).toContain('missing Create Public Threads permission');
+    expect(result.worker).toMatchObject({
+      status: 'blocked',
+      project_id: 'agenticos',
+      explicit_workdir: '/workspace/agenticos',
+    });
+    expect(harness.calls).toEqual([
+      'agenticos_project_ensure:AgenticOS',
+      'agenticos_external_thread_get:agenticos:job-channel',
+      'discord.ensure_project_thread:project/agenticos:codex',
+    ]);
+  });
+
+  it('handles non-Error Discord thread creation failures', async () => {
+    const harness = createHarness({ discordThrowsString: true });
+
+    const result = await routeHermesDiscordProjectCommand({
+      message: '切换到 AgenticOS 项目',
+      origin: { provider: 'discord', guild_id: 'guild', channel_id: 'job-channel' },
+      agenticos: harness.agenticos,
+      discord: harness.discord,
+    });
+
+    expect(result.status).toBe('THREAD_BINDING_ERROR');
+    expect(result.error).toContain('gateway unavailable');
+  });
+
+  it('uses a stable external project thread name', () => {
+    expect(buildDiscordProjectThreadName('AgenticOS')).toBe('project/agenticos');
+    expect(buildDiscordProjectThreadName('T5T Topic')).toBe('project/t5t-topic');
+  });
+});

--- a/mcp-server/src/utils/__tests__/hermes-routing-scenarios.test.ts
+++ b/mcp-server/src/utils/__tests__/hermes-routing-scenarios.test.ts
@@ -58,7 +58,7 @@ describe('Hermes routing scenarios', () => {
     for (const route of ['agenticos_topic', 'agenticos_project'] as const) {
       const scenario = getHermesRoutingScenario(route);
       expect(scenario.requires_agenticos_mcp_first).toBe(true);
-      expect(scenario.required_tool_calls).toEqual(expect.arrayContaining(['agenticos_switch']));
+      expect(scenario.required_tool_calls).toEqual(expect.arrayContaining(['agenticos_project_ensure']));
       expect(scenario.rejected_switch_substitutes).toEqual(PROJECT_SWITCH_SUBSTITUTES);
     }
   });
@@ -67,6 +67,7 @@ describe('Hermes routing scenarios', () => {
     const project = getHermesRoutingScenario('agenticos_project');
     expect(project.workflow_requirements).toEqual(FULL_PROJECT_WORKFLOW_REQUIREMENTS);
     expect(project.required_tool_calls).toEqual(expect.arrayContaining([
+      'agenticos_project_ensure',
       'agenticos_issue_bootstrap',
       'agenticos_branch_bootstrap',
       'agenticos_preflight',
@@ -87,9 +88,10 @@ describe('Hermes routing scenarios', () => {
     expect(validateHermesRoutingScenarios(scenarios)).toEqual(expect.arrayContaining([
       'missing route: chat_only',
       'agenticos_topic must require AgenticOS MCP before filesystem discovery',
-      'agenticos_topic must require agenticos_switch or agenticos_init',
+      'agenticos_topic must require agenticos_project_resolve or agenticos_project_ensure',
       'agenticos_topic must reject raw_directory_search as a project switch substitute',
       'agenticos_topic must reject git_branch_detection as a project switch substitute',
+      'agenticos_topic must reject agenticos_switch_lookup as a project switch substitute',
     ]));
   });
 

--- a/mcp-server/src/utils/hermes-discord-router.ts
+++ b/mcp-server/src/utils/hermes-discord-router.ts
@@ -1,0 +1,448 @@
+export type HermesDiscordBackend = 'codex' | 'claude_code';
+export type HermesExternalProvider = 'discord' | 'feishu' | 'unknown';
+
+export interface ParsedHermesProjectCommand {
+  project: string;
+  verb: 'enter_or_create';
+  backend: HermesDiscordBackend;
+  explicit_backend: boolean;
+}
+
+export interface HermesProjectEnsurePayload {
+  status: string;
+  project_id?: string;
+  name?: string;
+  project_kind?: string;
+  explicit_workdir?: string;
+  path?: string;
+  error?: string;
+  code?: string;
+  recovery?: string[];
+}
+
+interface HermesEnsuredProject extends HermesProjectEnsurePayload {
+  project_id: string;
+  name: string;
+  project_kind: string;
+  explicit_workdir: string;
+}
+
+export interface HermesThreadBinding {
+  project_id: string;
+  project_name?: string;
+  provider: 'discord';
+  guild_id?: string;
+  channel_id: string;
+  thread_id: string;
+  thread_url?: string;
+  default_backend?: HermesDiscordBackend;
+}
+
+export interface HermesThreadGetPayload {
+  status: string;
+  binding?: HermesThreadBinding | null;
+  error?: string;
+  code?: string;
+  recovery?: string[];
+}
+
+export interface HermesThreadBindPayload {
+  status: string;
+  binding?: HermesThreadBinding;
+  error?: string;
+  code?: string;
+  recovery?: string[];
+}
+
+export interface DiscordProjectThread {
+  guild_id?: string;
+  channel_id: string;
+  thread_id: string;
+  thread_url?: string;
+  created?: boolean;
+}
+
+export interface DiscordThreadAdapter {
+  available: boolean;
+  ensureProjectThread(args: {
+    guild_id?: string;
+    channel_id: string;
+    thread_name: string;
+    project_id: string;
+    project_name: string;
+    project_kind: string;
+    backend: HermesDiscordBackend;
+  }): Promise<DiscordProjectThread>;
+}
+
+export interface AgenticOSProjectRouterAdapter {
+  available_tools: readonly string[];
+  projectEnsure(args: Record<string, unknown>): Promise<unknown>;
+  externalThreadGet(args: Record<string, unknown>): Promise<unknown>;
+  externalThreadBind(args: Record<string, unknown>): Promise<unknown>;
+}
+
+export interface HermesProjectRouteRequest {
+  message: string;
+  origin: {
+    provider?: HermesExternalProvider;
+    guild_id?: string;
+    channel_id?: string;
+  };
+  agenticos: AgenticOSProjectRouterAdapter;
+  discord?: DiscordThreadAdapter;
+}
+
+export type HermesProjectRouteStatus =
+  | 'NOT_PROJECT_COMMAND'
+  | 'MISSING_AGENTICOS_TOOLS'
+  | 'AGENTICOS_ERROR'
+  | 'AGENTICOS_ONLY'
+  | 'THREAD_BINDING_ERROR'
+  | 'ROUTED';
+
+export interface HermesProjectRouteResult {
+  status: HermesProjectRouteStatus;
+  parsed?: ParsedHermesProjectCommand;
+  project?: HermesProjectEnsurePayload;
+  backend?: HermesDiscordBackend;
+  binding?: HermesThreadBinding;
+  thread_url?: string;
+  degraded_reason?: string;
+  error?: string;
+  recovery?: string[];
+  call_order: string[];
+  worker: {
+    backend?: HermesDiscordBackend;
+    status: 'not_applicable' | 'ready_for_dispatch' | 'blocked';
+    project_id?: string;
+    explicit_workdir?: string;
+    thread_id?: string;
+  };
+}
+
+const REQUIRED_PROJECT_TOOL = 'agenticos_project_ensure';
+const REQUIRED_THREAD_TOOLS = [
+  'agenticos_external_thread_get',
+  'agenticos_external_thread_bind',
+] as const;
+
+export function parseHermesProjectCommand(message: string): ParsedHermesProjectCommand | null {
+  const normalized = message.trim().replace(/\s+/g, ' ');
+  if (!normalized) return null;
+
+  const backend = detectBackend(normalized);
+  const project = extractProjectName(normalized);
+  if (!project) return null;
+
+  return {
+    project,
+    verb: 'enter_or_create',
+    backend: backend.value,
+    explicit_backend: backend.explicit,
+  };
+}
+
+export async function routeHermesDiscordProjectCommand(
+  request: HermesProjectRouteRequest,
+): Promise<HermesProjectRouteResult> {
+  const callOrder: string[] = [];
+  const parsed = parseHermesProjectCommand(request.message);
+  if (!parsed) {
+    return {
+      status: 'NOT_PROJECT_COMMAND',
+      call_order: callOrder,
+      worker: { status: 'not_applicable' },
+    };
+  }
+
+  const toolSet = new Set(request.agenticos.available_tools);
+  if (!toolSet.has(REQUIRED_PROJECT_TOOL)) {
+    return blockedForMissingTools(parsed, callOrder, [REQUIRED_PROJECT_TOOL]);
+  }
+
+  callOrder.push(REQUIRED_PROJECT_TOOL);
+  const ensured = parsePayload<HermesProjectEnsurePayload>(await request.agenticos.projectEnsure({
+    project: parsed.project,
+    name: parsed.project,
+    project_kind: 'project',
+    topology: 'local_directory_only',
+    context_publication_policy: 'local_private',
+  }));
+
+  if (ensured.status === 'ERROR' || !ensured.project_id || !ensured.name) {
+    return {
+      status: 'AGENTICOS_ERROR',
+      parsed,
+      project: ensured,
+      backend: parsed.backend,
+      error: ensured.error || 'AgenticOS project ensure failed.',
+      recovery: ensured.recovery,
+      call_order: callOrder,
+      worker: { status: 'blocked', backend: parsed.backend },
+    };
+  }
+
+  const project = normalizeEnsuredProject(ensured);
+  const canUseDiscord = request.origin.provider === 'discord'
+    && Boolean(request.origin.channel_id)
+    && request.discord?.available === true;
+  if (!canUseDiscord) {
+    return {
+      status: 'AGENTICOS_ONLY',
+      parsed,
+      project,
+      backend: parsed.backend,
+      degraded_reason: buildDiscordDegradedReason(request),
+      recovery: [
+        'Use Discord for project cockpit threads.',
+        'Keep using the ensured AgenticOS project context when Discord is not configured.',
+      ],
+      call_order: callOrder,
+      worker: {
+        status: 'ready_for_dispatch',
+        backend: parsed.backend,
+        project_id: project.project_id,
+        explicit_workdir: project.explicit_workdir,
+      },
+    };
+  }
+
+  const missingThreadTools = REQUIRED_THREAD_TOOLS.filter((tool) => !toolSet.has(tool));
+  if (missingThreadTools.length > 0) {
+    return {
+      status: 'AGENTICOS_ONLY',
+      parsed,
+      project,
+      backend: parsed.backend,
+      degraded_reason: `AgenticOS MCP is missing ${missingThreadTools.join(', ')}.`,
+      recovery: [
+        'Upgrade AgenticOS and restart the agent so Hermes can bind Discord project threads.',
+        'Do not fall back to cd, raw filesystem search, or agenticos_switch as a lookup substitute.',
+      ],
+      call_order: callOrder,
+      worker: {
+        status: 'ready_for_dispatch',
+        backend: parsed.backend,
+        project_id: project.project_id,
+        explicit_workdir: project.explicit_workdir,
+      },
+    };
+  }
+
+  const threadLookupArgs = {
+    project: project.project_id,
+    provider: 'discord',
+    ...(request.origin.guild_id ? { guild_id: request.origin.guild_id } : {}),
+    channel_id: request.origin.channel_id,
+  };
+  callOrder.push('agenticos_external_thread_get');
+  const existing = parsePayload<HermesThreadGetPayload>(await request.agenticos.externalThreadGet(threadLookupArgs));
+
+  if (existing.status === 'FOUND' && existing.binding) {
+    return routedResult({
+      parsed,
+      project,
+      backend: parsed.backend,
+      binding: existing.binding,
+      callOrder,
+    });
+  }
+  if (existing.status === 'ERROR') {
+    return {
+      status: 'THREAD_BINDING_ERROR',
+      parsed,
+      project,
+      backend: parsed.backend,
+      error: existing.error || 'AgenticOS thread lookup failed.',
+      recovery: existing.recovery,
+      call_order: callOrder,
+      worker: {
+        status: 'blocked',
+        backend: parsed.backend,
+        project_id: project.project_id,
+        explicit_workdir: project.explicit_workdir,
+      },
+    };
+  }
+
+  callOrder.push('discord.ensure_project_thread');
+  let thread: DiscordProjectThread;
+  try {
+    thread = await request.discord!.ensureProjectThread({
+      ...(request.origin.guild_id ? { guild_id: request.origin.guild_id } : {}),
+      channel_id: request.origin.channel_id!,
+      thread_name: buildDiscordProjectThreadName(project.project_id),
+      project_id: project.project_id,
+      project_name: project.name,
+      project_kind: project.project_kind,
+      backend: parsed.backend,
+    });
+  } catch (error) {
+    return {
+      status: 'THREAD_BINDING_ERROR',
+      parsed,
+      project,
+      backend: parsed.backend,
+      error: `Discord thread creation failed: ${error instanceof Error ? error.message : String(error)}`,
+      recovery: [
+        'Confirm Discord bot permissions and channel access.',
+        'Retry after the Hermes Discord gateway reports healthy.',
+      ],
+      call_order: callOrder,
+      worker: {
+        status: 'blocked',
+        backend: parsed.backend,
+        project_id: project.project_id,
+        explicit_workdir: project.explicit_workdir,
+      },
+    };
+  }
+
+  callOrder.push('agenticos_external_thread_bind');
+  const bind = parsePayload<HermesThreadBindPayload>(await request.agenticos.externalThreadBind({
+    project: project.project_id,
+    provider: 'discord',
+    ...(thread.guild_id || request.origin.guild_id ? { guild_id: thread.guild_id || request.origin.guild_id } : {}),
+    channel_id: thread.channel_id,
+    thread_id: thread.thread_id,
+    ...(thread.thread_url ? { thread_url: thread.thread_url } : {}),
+    default_backend: parsed.backend,
+  }));
+
+  if (bind.status === 'ERROR' || !bind.binding) {
+    return {
+      status: 'THREAD_BINDING_ERROR',
+      parsed,
+      project,
+      backend: parsed.backend,
+      error: bind.error || 'AgenticOS thread binding failed after Discord thread creation.',
+      recovery: bind.recovery,
+      call_order: callOrder,
+      worker: {
+        status: 'blocked',
+        backend: parsed.backend,
+        project_id: project.project_id,
+        explicit_workdir: project.explicit_workdir,
+        thread_id: thread.thread_id,
+      },
+    };
+  }
+
+  return routedResult({
+    parsed,
+    project,
+    backend: parsed.backend,
+    binding: bind.binding,
+    callOrder,
+  });
+}
+
+export function buildDiscordProjectThreadName(projectId: string): string {
+  return `project/${projectId.toLowerCase().replace(/[^a-z0-9_-]+/g, '-')}`;
+}
+
+function detectBackend(message: string): { value: HermesDiscordBackend; explicit: boolean } {
+  if (/\bclaude(?:\s+code|\s+agent)?\b/i.test(message) || /Claude\s*(?:Code|Agent)?/i.test(message)) {
+    return { value: 'claude_code', explicit: true };
+  }
+  if (/\bcodex\b/i.test(message)) {
+    return { value: 'codex', explicit: true };
+  }
+  return { value: 'codex', explicit: false };
+}
+
+function extractProjectName(message: string): string | null {
+  const patterns = [
+    /(?:用\s*(?:Claude\s*Code|Claude\s*Agent|Codex)\s*)?(?:切换到|进入|打开|新建|创建)\s+(.+?)(?:\s*(?:项目|topic|Topic))?(?:\s*(?:并|然后|，|,|。|$).*)?$/i,
+    /(?:switch|enter|open|create)\s+(?:to\s+)?(.+?)(?:\s+project|\s+topic)?(?:\s+(?:and|then)\s+.*)?$/i,
+  ];
+
+  for (const pattern of patterns) {
+    const match = message.match(pattern);
+    if (!match) continue;
+    const project = cleanupProjectName(match[1]);
+    if (project) return project;
+  }
+
+  return null;
+}
+
+function cleanupProjectName(value: string): string | null {
+  const cleaned = value
+    .replace(/^(?:用\s*)?(?:Claude\s*Code|Claude\s*Agent|Codex)\s*/i, '')
+    .replace(/\s*(?:项目|topic|Topic)$/i, '')
+    .trim();
+  return cleaned.length > 0 ? cleaned : null;
+}
+
+function parsePayload<T>(value: unknown): T {
+  if (typeof value === 'string') {
+    return JSON.parse(value) as T;
+  }
+  return value as T;
+}
+
+function normalizeEnsuredProject(project: HermesProjectEnsurePayload): HermesEnsuredProject {
+  return {
+    ...project,
+    project_id: project.project_id!,
+    name: project.name!,
+    project_kind: project.project_kind || 'project',
+    explicit_workdir: project.explicit_workdir || project.path || project.project_id!,
+  };
+}
+
+function blockedForMissingTools(
+  parsed: ParsedHermesProjectCommand,
+  callOrder: string[],
+  missingTools: readonly string[],
+): HermesProjectRouteResult {
+  return {
+    status: 'MISSING_AGENTICOS_TOOLS',
+    parsed,
+    backend: parsed.backend,
+    degraded_reason: `AgenticOS MCP is missing ${missingTools.join(', ')}.`,
+    recovery: [
+      'Upgrade AgenticOS and restart the agent so Hermes can resolve projects through MCP.',
+      'Do not use cd, raw filesystem search, or agenticos_switch as a lookup substitute.',
+    ],
+    call_order: callOrder,
+    worker: { status: 'blocked', backend: parsed.backend },
+  };
+}
+
+function buildDiscordDegradedReason(request: HermesProjectRouteRequest): string {
+  if (request.origin.provider && request.origin.provider !== 'discord') {
+    return 'Discord project threads are not available on this origin surface.';
+  }
+  if (!request.origin.channel_id) {
+    return 'Discord channel id is missing.';
+  }
+  return 'Discord routing is not configured or not available.';
+}
+
+function routedResult(args: {
+  parsed: ParsedHermesProjectCommand;
+  project: HermesProjectEnsurePayload;
+  backend: HermesDiscordBackend;
+  binding: HermesThreadBinding;
+  callOrder: string[];
+}): HermesProjectRouteResult {
+  return {
+    status: 'ROUTED',
+    parsed: args.parsed,
+    project: args.project,
+    backend: args.backend,
+    binding: args.binding,
+    thread_url: args.binding.thread_url,
+    call_order: args.callOrder,
+    worker: {
+      status: 'ready_for_dispatch',
+      backend: args.backend,
+      project_id: args.project.project_id,
+      explicit_workdir: args.project.explicit_workdir,
+      thread_id: args.binding.thread_id,
+    },
+  };
+}

--- a/mcp-server/src/utils/hermes-routing-scenarios.ts
+++ b/mcp-server/src/utils/hermes-routing-scenarios.ts
@@ -12,6 +12,7 @@ export const PROJECT_SWITCH_SUBSTITUTES = [
   'cd',
   'raw_directory_search',
   'git_branch_detection',
+  'agenticos_switch_lookup',
 ] as const;
 
 export type ProjectSwitchSubstitute = typeof PROJECT_SWITCH_SUBSTITUTES[number];
@@ -97,7 +98,7 @@ export const HERMES_ROUTING_SCENARIOS: readonly HermesRoutingScenario[] = [
     owner: 'AgenticOS',
     durable_write: 'agenticos_topic',
     requires_agenticos_mcp_first: true,
-    required_tool_calls: ['agenticos_switch', 'agenticos_init', 'agenticos_task_create'],
+    required_tool_calls: ['agenticos_project_ensure', 'agenticos_task_create'],
     rejected_switch_substitutes: [...PROJECT_SWITCH_SUBSTITUTES],
     gbrain_policy: {
       stores_distilled_summary: true,
@@ -113,7 +114,7 @@ export const HERMES_ROUTING_SCENARIOS: readonly HermesRoutingScenario[] = [
     durable_write: 'agenticos_project',
     requires_agenticos_mcp_first: true,
     required_tool_calls: [
-      'agenticos_switch',
+      'agenticos_project_ensure',
       'agenticos_issue_bootstrap',
       'agenticos_branch_bootstrap',
       'agenticos_preflight',
@@ -154,8 +155,8 @@ export function validateHermesRoutingScenarios(scenarios: readonly HermesRouting
     if (isAgenticosRoute && !scenario.requires_agenticos_mcp_first) {
       problems.push(`${scenario.route} must require AgenticOS MCP before filesystem discovery`);
     }
-    if (isAgenticosRoute && !scenario.required_tool_calls.some((tool) => tool === 'agenticos_switch' || tool === 'agenticos_init')) {
-      problems.push(`${scenario.route} must require agenticos_switch or agenticos_init`);
+    if (isAgenticosRoute && !scenario.required_tool_calls.some((tool) => tool === 'agenticos_project_resolve' || tool === 'agenticos_project_ensure')) {
+      problems.push(`${scenario.route} must require agenticos_project_resolve or agenticos_project_ensure`);
     }
     if (isAgenticosRoute) {
       for (const substitute of PROJECT_SWITCH_SUBSTITUTES) {

--- a/standards/knowledge/hermes-routing-scenario-coverage-2026-05-21.md
+++ b/standards/knowledge/hermes-routing-scenario-coverage-2026-05-21.md
@@ -7,9 +7,10 @@ AgenticOS coverage.
 
 The risk is not that agents forget the words "Chat-only" or "GBrain knowledge".
 The risk is that a future Hermes, Codex, or Claude Code integration treats
-`cd`, raw directory search, git branch detection, or GBrain task duplication as
-good enough substitutes for AgenticOS MCP. This document records the intended
-scenarios, and `mcp-server/src/utils/hermes-routing-scenarios.ts` provides the
+`cd`, raw directory search, git branch detection, `agenticos_switch` as lookup,
+or GBrain task duplication as good enough substitutes for AgenticOS MCP. This
+document records the intended scenarios, and
+`mcp-server/src/utils/hermes-routing-scenarios.ts` provides the
 machine-checkable contract.
 
 ## Scenario Matrix
@@ -19,7 +20,7 @@ machine-checkable contract.
 | Chat-only | Hermes | none | no | Answer in the current chat; do not write durable state |
 | Hermes memory | Hermes | Hermes local memory | no | Store only small assistant-continuity facts or preferences |
 | GBrain knowledge | GBrain | distilled summary and reference links | no | Store semantic summaries/entities/relations/links only |
-| AgenticOS topic | AgenticOS | topic state, tasks, knowledge, artifacts | yes | Call `agenticos_switch` or `agenticos_init`, then update topic surfaces |
+| AgenticOS topic | AgenticOS | topic state, tasks, knowledge, artifacts | yes | Call `agenticos_project_ensure`, then update topic surfaces |
 | AgenticOS project | AgenticOS | issue/worktree/PR governed project state | yes | Call AgenticOS MCP and follow issue/worktree/preflight/PR/CI flow |
 
 ## Executable Contract
@@ -35,8 +36,8 @@ The tests enforce:
 
 - all five routes exist and validate together
 - AgenticOS topic/project routes require MCP before filesystem discovery
-- `cd`, raw directory search, and git branch detection are rejected as project
-  switch substitutes
+- `cd`, raw directory search, git branch detection, and `agenticos_switch` as
+  lookup are rejected as project switch substitutes
 - GBrain stores distilled summary and reference links only
 - GBrain does not store active AgenticOS task state or a copied task board
 - full AgenticOS project routing requires issue bootstrap, isolated worktree,
@@ -89,9 +90,10 @@ questions, tasks, artifacts, or evolving knowledge are needed.
 
 Required behavior:
 
-1. Call `agenticos_switch` for an existing topic or `agenticos_init` for a new
-   topic.
-2. Treat the returned project path and explicit workdir as authoritative.
+1. Call `agenticos_project_ensure` for both existing and new topics. Use
+   `agenticos_project_resolve` only when creation is not allowed.
+2. Treat the returned project identity, project path, and explicit workdir as
+   authoritative.
 3. Update `tasks/<task_id>.yaml`, `.context/state.yaml`, `knowledge/`, or
    `artifacts/` through the AgenticOS topic contract.
 4. Optionally distill a GBrain summary with `agenticos://...` references.
@@ -101,6 +103,7 @@ Rejected substitutes:
 - `cd`
 - raw directory search
 - git branch detection
+- `agenticos_switch` as a read-only lookup substitute
 
 ### AgenticOS Project
 
@@ -109,7 +112,8 @@ skills, packages, or any rollback-managed product surface.
 
 Required behavior:
 
-1. Call AgenticOS MCP to align project identity.
+1. Call `agenticos_project_ensure` to align project identity. Use
+   `agenticos_project_resolve` only when creation is not allowed.
 2. Bootstrap the GitHub issue.
 3. Create an isolated worktree.
 4. Run preflight and edit guard.
@@ -119,15 +123,16 @@ Required behavior:
 8. Wait for CI green.
 9. Merge with a merge commit and cleanup.
 
-Shell `cd`, directory guessing, and git branch inspection do not satisfy project
-switching. They can only happen after AgenticOS MCP has returned the
-authoritative project path and explicit workdir.
+Shell `cd`, directory guessing, git branch inspection, and `agenticos_switch` as
+a lookup shortcut do not satisfy project switching. Filesystem work can only
+happen after AgenticOS MCP has returned the authoritative project path and
+explicit workdir.
 
 ## Regression Examples
 
 | Regression | Expected test signal |
 | --- | --- |
-| A topic route no longer requires `agenticos_switch` or `agenticos_init` | `validateHermesRoutingScenarios` reports the missing MCP requirement |
+| A topic route no longer requires `agenticos_project_resolve` or `agenticos_project_ensure` | `validateHermesRoutingScenarios` reports the missing MCP requirement |
 | A project route accepts `cd` as switching | `validateHermesRoutingScenarios` reports the missing rejected substitute |
 | GBrain route stores active AgenticOS task state | `validateHermesRoutingScenarios` reports a GBrain duplication violation |
 | Full project route omits PR or CI | `validateHermesRoutingScenarios` reports the missing workflow gate |


### PR DESCRIPTION
Fixes #467.

## Summary
- Add a pure Hermes Discord project router helper that parses project commands, ensures AgenticOS project identity first, then creates/reuses Discord project threads and records private thread bindings.
- Default backend routing to Codex, with explicit Claude Code override support.
- Degrade safely when Discord is unavailable or older AgenticOS MCP thread tools are missing; do not fall back to `cd`, raw filesystem search, or `agenticos_switch` lookup.
- Update Hermes routing scenario contract and knowledge doc to require `agenticos_project_resolve`/`agenticos_project_ensure` before filesystem work.

## Verification
- `cd mcp-server && npm ci`
- `cd mcp-server && npm run lint`
- `cd mcp-server && npm test -- --run src/utils/__tests__/hermes-discord-router.test.ts src/utils/__tests__/hermes-routing-scenarios.test.ts`
- `cd mcp-server && npm test -- --run`
- `./tools/coverage-preflight.sh`
- `./scripts/readme-lint.sh` (0 errors; existing warnings/recommendations only)
- `git diff --check`
- `agenticos_pr_scope_check` PASS
