### PR TITLE
docs: add Hermes Discord thread smoke rollout

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,30 @@ AgenticOS does not treat every fallback as equal:
 - `Skills-only Guidance` is experimental and does not provide the canonical
   AgenticOS runtime surface
 
+## Optional Hermes + Discord Project Threads
+
+Hermes-side Discord routing is optional. A machine without Hermes or Discord
+keeps the normal AgenticOS MCP workflow: `agenticos_project_ensure` can still
+resolve or create a project, and Discord thread routing is skipped.
+
+When a Discord gateway is configured, Hermes can treat "切换到 AgenticOS 项目"
+and "新建 T5T 项目" as the same project-entry operation:
+
+1. call AgenticOS MCP `agenticos_project_ensure`
+2. create or reuse one Discord project thread
+3. persist the private thread binding with `agenticos_external_thread_bind`
+4. dispatch Codex by default, or Claude Code only when explicitly requested
+
+Discord is the only threaded surface in the MVP. Feishu does not get a thread
+path yet. Older AgenticOS installs that are missing `agenticos_project_ensure`
+or external thread binding tools must be upgraded and the agent restarted
+before Hermes should claim threaded routing is available.
+
+Real Discord validation requires credentials and permissions, so automated
+tests use fake adapters only. See
+[standards/knowledge/hermes-discord-project-thread-rollout-2026-05-22.md](standards/knowledge/hermes-discord-project-thread-rollout-2026-05-22.md)
+for the rollout checklist.
+
 ## Official Supported Agents
 
 The official bootstrap surface currently covers:

--- a/homebrew-tap/README.md
+++ b/homebrew-tap/README.md
@@ -73,6 +73,25 @@ For Codex and Claude Code, `--first-run` implies `--install-skills`; bootstrap u
 For Claude Code PWD guidance after `agenticos_switch`, run `agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent claude-code --auto-configure-hooks --apply` or include `--auto-configure-hooks` with `--first-run`. The hook reads Claude's PostToolUse stdin payload and feeds the switched project path back into Claude; it does not mutate a parent shell process.
 Use `agenticos-bootstrap --workspace "$AGENTICOS_HOME" --all --install-skills --verify` with the same flags to audit the current machine state without mutating it.
 
+Hermes + Discord project threads are optional. Homebrew does not install
+Hermes, create a Discord application, store bot credentials, or enable a
+gateway. If those pieces are absent, AgenticOS still supports normal MCP
+project resolution and switching.
+
+For the Discord MVP, configure Hermes and Discord separately, then verify:
+
+```bash
+agenticos-config --validate
+agenticos-bootstrap --workspace "$AGENTICOS_HOME" --all --install-skills --verify --verify-hermes-discord
+```
+
+In Discord, Hermes should call `agenticos_project_ensure`, create or reuse a
+project thread, bind it with `agenticos_external_thread_bind`, and dispatch
+Codex unless the user explicitly requests Claude Code. Feishu thread routing is
+not part of the MVP. If verification reports missing AgenticOS MCP tools,
+upgrade with `brew update && brew upgrade agenticos`, restart Hermes and the
+execution agent, then retry.
+
 `AGENTICOS_HOME` may also be a long-term self-hosting workspace home. The
 Homebrew example path above is a default example, not the only valid workspace
 layout.

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -194,6 +194,38 @@ want to replace a local edit.
 
 These are currently experimental. Do not describe them as first-class supported agents unless they have a documented bootstrap, verification, and debugging contract.
 
+### Optional Hermes + Discord Routing
+
+Hermes + Discord project routing is an optional integration layer, not a core
+install requirement. AgenticOS works the same on machines that do not have
+Hermes, a Hermes gateway, or Discord credentials.
+
+The supported MVP flow is:
+
+1. Hermes parses a project-entry command such as "切换到 AgenticOS 项目" or
+   "新建 T5T 项目".
+2. Hermes calls AgenticOS MCP `agenticos_project_ensure` first. It must not use
+   `cd`, raw filesystem search, git branch detection, or `agenticos_switch` as
+   a lookup shortcut.
+3. If Discord is configured, Hermes creates or reuses a Discord project thread
+   and records the private binding with `agenticos_external_thread_bind`.
+4. Worker dispatch defaults to Codex. Explicit phrases such as "用 Claude Code"
+   or "Claude Agent" select Claude Code.
+5. Worker prompts must tell execution agents to use AgenticOS MCP and the
+   explicit workdir returned by AgenticOS. Progress and blocked/setup messages
+   are posted back to the Discord project thread.
+
+Feishu thread routing is intentionally out of scope for the MVP. If Discord is
+not configured, project ensure may still succeed and the response should say
+Discord routing was skipped. If older installs are missing
+`agenticos_project_ensure`, `agenticos_external_thread_get`, or
+`agenticos_external_thread_bind`, upgrade AgenticOS, rerun bootstrap verification,
+and restart the agent before retrying threaded routing.
+
+Verification without real Discord credentials is covered by fake E2E tests.
+For a real-gateway checklist, see
+`standards/knowledge/hermes-discord-project-thread-rollout-2026-05-22.md`.
+
 ### Repairing Stale Registrations
 
 The supported runtime entrypoint is `agenticos-mcp`.

--- a/mcp-server/src/utils/__tests__/hermes-discord-project-thread-smoke.test.ts
+++ b/mcp-server/src/utils/__tests__/hermes-discord-project-thread-smoke.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'vitest';
+import {
+  routeHermesDiscordProjectCommand,
+  type AgenticOSProjectRouterAdapter,
+  type DiscordThreadAdapter,
+} from '../hermes-discord-router.js';
+import {
+  dispatchHermesProjectWorker,
+  type WorkerDispatchDeps,
+  type WorkerSessionRecord,
+} from '../hermes-worker-dispatch.js';
+
+describe('Hermes Discord project thread smoke flow', () => {
+  it('routes a project command into a Discord thread, binds it, starts the selected worker, and posts progress to the thread', async () => {
+    const calls: string[] = [];
+    const records: WorkerSessionRecord[] = [];
+    const threadMessages: Array<{ thread_id: string; content: string }> = [];
+    const agenticos: AgenticOSProjectRouterAdapter = {
+      available_tools: [
+        'agenticos_project_ensure',
+        'agenticos_external_thread_get',
+        'agenticos_external_thread_bind',
+      ],
+      async projectEnsure(args) {
+        calls.push(`agenticos_project_ensure:${args.project}`);
+        return {
+          status: 'ENSURED',
+          project_id: 'agenticos',
+          name: 'AgenticOS',
+          project_kind: 'project',
+          path: '/workspace/agenticos',
+          explicit_workdir: '/workspace/agenticos',
+        };
+      },
+      async externalThreadGet(args) {
+        calls.push(`agenticos_external_thread_get:${args.project}:${args.channel_id}`);
+        return { status: 'NOT_FOUND', binding: null };
+      },
+      async externalThreadBind(args) {
+        calls.push(`agenticos_external_thread_bind:${args.project}:${args.thread_id}:${args.default_backend}`);
+        return {
+          status: 'BOUND',
+          binding: {
+            project_id: 'agenticos',
+            project_name: 'AgenticOS',
+            provider: 'discord',
+            guild_id: args.guild_id,
+            channel_id: args.channel_id,
+            thread_id: args.thread_id,
+            thread_url: args.thread_url,
+            default_backend: args.default_backend,
+          },
+        };
+      },
+    };
+    const discord: DiscordThreadAdapter = {
+      available: true,
+      async ensureProjectThread(args) {
+        calls.push(`discord_thread:${args.thread_name}:${args.backend}`);
+        return {
+          guild_id: args.guild_id,
+          channel_id: args.channel_id,
+          thread_id: 'thread-agenticos',
+          thread_url: 'https://discord.com/channels/guild/job-channel/thread-agenticos',
+        };
+      },
+    };
+    const workerDeps: WorkerDispatchDeps = {
+      commandExists(command) {
+        calls.push(`command_exists:${command}`);
+        return command === 'claude';
+      },
+      async startWorker(args) {
+        calls.push(`start_worker:${args.backend}:${args.command}:${args.explicit_workdir}`);
+        expect(args.prompt).toContain('Use AgenticOS MCP as the source of truth');
+        expect(args.prompt).toContain('Explicit workdir: /workspace/agenticos');
+        return {
+          session_id: 'worker-session-1',
+          process_id: 20260522,
+          log_path: '/tmp/agenticos-worker.log',
+        };
+      },
+      async recordWorkerSession(record) {
+        calls.push(`record_worker:${record.backend}:${record.session_id}:${record.process_id}`);
+        records.push(record);
+      },
+      async postThreadMessage(args) {
+        calls.push(`post_thread:${args.binding.thread_id}`);
+        threadMessages.push({
+          thread_id: args.binding.thread_id,
+          content: args.content,
+        });
+        return { message_id: 'discord-message-1' };
+      },
+      now() {
+        return '2026-05-22T09:00:00.000Z';
+      },
+    };
+
+    const route = await routeHermesDiscordProjectCommand({
+      message: '用 Claude Code 切换到 AgenticOS 项目，然后修复 issue',
+      origin: { provider: 'discord', guild_id: 'guild', channel_id: 'job-channel' },
+      agenticos,
+      discord,
+    });
+    const dispatch = await dispatchHermesProjectWorker({
+      route,
+      user_task: '修复 issue 并发 PR',
+      deps: workerDeps,
+    });
+
+    expect(route.status).toBe('ROUTED');
+    expect(route.backend).toBe('claude_code');
+    expect(route.thread_url).toBe('https://discord.com/channels/guild/job-channel/thread-agenticos');
+    expect(dispatch.status).toBe('STARTED');
+    expect(dispatch.backend).toBe('claude_code');
+    expect(records).toEqual([expect.objectContaining({
+      project_id: 'agenticos',
+      backend: 'claude_code',
+      command: 'claude',
+      thread_id: 'thread-agenticos',
+      session_id: 'worker-session-1',
+      process_id: 20260522,
+    })]);
+    expect(threadMessages).toEqual([{
+      thread_id: 'thread-agenticos',
+      content: expect.stringContaining('Worker started: claude_code'),
+    }]);
+    expect(calls).toEqual([
+      'agenticos_project_ensure:AgenticOS',
+      'agenticos_external_thread_get:agenticos:job-channel',
+      'discord_thread:project/agenticos:claude_code',
+      'agenticos_external_thread_bind:agenticos:thread-agenticos:claude_code',
+      'command_exists:claude',
+      'start_worker:claude_code:claude:/workspace/agenticos',
+      'record_worker:claude_code:worker-session-1:20260522',
+      'post_thread:thread-agenticos',
+    ]);
+  });
+
+  it('keeps project ensure working when Discord is unavailable and does not claim thread or worker success', async () => {
+    const calls: string[] = [];
+    const agenticos: AgenticOSProjectRouterAdapter = {
+      available_tools: ['agenticos_project_ensure'],
+      async projectEnsure(args) {
+        calls.push(`agenticos_project_ensure:${args.project}`);
+        return {
+          status: 'ENSURED',
+          project_id: 'agenticos',
+          name: 'AgenticOS',
+          project_kind: 'project',
+          path: '/workspace/agenticos',
+          explicit_workdir: '/workspace/agenticos',
+        };
+      },
+      async externalThreadGet() {
+        calls.push('unexpected_get');
+        return { status: 'NOT_FOUND', binding: null };
+      },
+      async externalThreadBind() {
+        calls.push('unexpected_bind');
+        return { status: 'BOUND' };
+      },
+    };
+
+    const route = await routeHermesDiscordProjectCommand({
+      message: '切换到 AgenticOS 项目',
+      origin: { provider: 'discord', guild_id: 'guild', channel_id: 'job-channel' },
+      agenticos,
+      discord: { available: false, async ensureProjectThread() { throw new Error('should not run'); } },
+    });
+
+    expect(route.status).toBe('AGENTICOS_ONLY');
+    expect(route.project?.project_id).toBe('agenticos');
+    expect(route.degraded_reason).toBe('Discord routing is not configured or not available.');
+    expect(route.worker).toMatchObject({
+      status: 'ready_for_dispatch',
+      backend: 'codex',
+      project_id: 'agenticos',
+    });
+    expect(calls).toEqual(['agenticos_project_ensure:AgenticOS']);
+  });
+});

--- a/standards/knowledge/hermes-discord-project-thread-rollout-2026-05-22.md
+++ b/standards/knowledge/hermes-discord-project-thread-rollout-2026-05-22.md
@@ -1,0 +1,140 @@
+# Hermes Discord Project Thread Rollout - 2026-05-22
+
+## Purpose
+
+This runbook covers the optional Hermes + Discord project-thread workflow after
+the AgenticOS router and worker dispatch helpers landed.
+
+The goal is to let a Discord message such as "切换到 AgenticOS 项目" enter a
+durable AgenticOS project context, create or reuse a Discord project thread,
+bind that thread privately, and start the selected execution worker without
+polluting the main Hermes session.
+
+## Compatibility Contract
+
+- AgenticOS does not require Hermes.
+- AgenticOS does not require Discord.
+- Homebrew does not install Hermes, create Discord applications, write Discord
+  credentials, or start a gateway.
+- Machines without Hermes or Discord keep the normal AgenticOS MCP workflow.
+- Discord is the only threaded surface in the MVP.
+- Feishu thread routing is intentionally not supported in this rollout.
+- Older AgenticOS installs that lack `agenticos_project_ensure`,
+  `agenticos_external_thread_get`, or `agenticos_external_thread_bind` must be
+  upgraded and restarted before threaded routing is claimed available.
+- User-customized AgenticOS Skill files are not overwritten unless the operator
+  reruns bootstrap with `--force-skills`.
+
+## Automated Smoke Coverage
+
+The fake E2E test lives at:
+
+```text
+mcp-server/src/utils/__tests__/hermes-discord-project-thread-smoke.test.ts
+```
+
+It verifies:
+
+- project command parsing selects the explicit Claude Code backend when the
+  user asks for Claude Code
+- AgenticOS `project_ensure` runs before Discord thread work
+- Discord thread creation happens before private thread binding
+- worker dispatch records backend, session id, process id, and thread id
+- worker progress is posted to the Discord project thread
+- no-Discord mode still completes AgenticOS project ensure and reports that
+  Discord routing was skipped
+
+The test uses fake adapters only. It does not require network, Discord
+credentials, Hermes, Codex, or Claude Code.
+
+## Manual Discord Smoke Checklist
+
+Run this only on a machine where Hermes, Discord credentials, and the execution
+backend are intentionally configured.
+
+1. Upgrade AgenticOS and restart long-lived agent sessions:
+
+   ```bash
+   brew update && brew upgrade agenticos
+   agenticos-config --validate
+   agenticos-bootstrap --workspace "$AGENTICOS_HOME" --all --install-skills --verify --verify-hermes-discord
+   ```
+
+2. Confirm Discord prerequisites outside AgenticOS:
+
+   - Discord application id is configured.
+   - Discord bot token is configured in the Hermes runtime environment.
+   - The bot can read and create threads in the target job channel.
+   - The Hermes gateway has been restarted after credential changes.
+
+3. In the Discord job channel, send:
+
+   ```text
+   切换到 AgenticOS 项目
+   ```
+
+   Expected result:
+
+   - Hermes calls `agenticos_project_ensure`.
+   - Hermes creates or reuses a `project/agenticos` Discord thread.
+   - The origin channel response includes the thread link.
+   - AgenticOS private sidecar contains a Discord binding.
+   - No Feishu thread path is used.
+
+4. In the same Discord job channel, send:
+
+   ```text
+   用 Claude Code 切换到 AgenticOS 项目，然后查看当前状态
+   ```
+
+   Expected result:
+
+   - backend is `claude_code`
+   - command availability is checked for `claude`
+   - worker prompt includes AgenticOS MCP and explicit workdir guidance
+   - worker started or blocked/setup status is posted inside the project thread
+
+5. Send a default backend command:
+
+   ```text
+   切换到 AgenticOS 项目，然后查看当前状态
+   ```
+
+   Expected result:
+
+   - backend defaults to `codex`
+   - command availability is checked for `codex`
+   - existing Discord binding is reused
+
+6. Temporarily disable Discord configuration and retry a project command.
+
+   Expected result:
+
+   - AgenticOS project ensure still succeeds
+   - response says Discord routing was skipped
+   - no thread creation is claimed
+   - no worker is claimed started from a missing thread
+
+## Failure Handling
+
+| Failure | Expected behavior | Recovery |
+| --- | --- | --- |
+| Missing `agenticos_project_ensure` | block project routing | upgrade AgenticOS and restart Hermes/agent sessions |
+| Missing external thread binding tools | project ensure may succeed, Discord binding is skipped or blocked | upgrade AgenticOS, rerun bootstrap verification |
+| Discord credentials missing | report optional Discord routing skipped | configure Hermes Discord env and restart gateway |
+| Discord bot lacks thread permissions | worker/thread flow blocks with setup guidance | grant channel/thread permissions and retry |
+| Selected Claude Code missing | worker blocks without changing thread mapping | install Claude Code or use Codex |
+| Selected Codex missing | worker blocks without changing thread mapping | install Codex or explicitly use Claude Code |
+| User-customized Skill exists | bootstrap verify reports stale/custom state | review file, then use `--force-skills` only if replacement is intended |
+
+## Release Readiness
+
+Before a release that advertises this workflow:
+
+- fake E2E test passes
+- `./tools/coverage-preflight.sh` passes
+- `./scripts/readme-lint.sh` has no ERROR findings
+- manual Discord smoke has been run on an intentionally configured machine, or
+  release notes clearly mark real Discord validation as pending operator setup
+- Homebrew caveats still state that Hermes/Discord are optional and not installed
+  by Homebrew


### PR DESCRIPTION
Fixes #469.

Summary:
- Adds fake E2E smoke coverage for the Hermes Discord project-thread path: user project-entry command -> AgenticOS project ensure -> Discord thread create/reuse -> private thread binding -> worker selection -> thread progress.
- Adds no-Discord degrade coverage so AgenticOS-only routing is explicit and never claims thread/worker success.
- Documents optional Hermes + Discord rollout behavior in the root README, MCP server README, Homebrew tap README, and a dedicated rollout runbook.

Verification:
- `cd mcp-server && npm ci`
- `cd mcp-server && npm run lint`
- `cd mcp-server && npm test -- --run src/utils/__tests__/hermes-discord-project-thread-smoke.test.ts`
- `./scripts/readme-lint.sh`
- `./tools/coverage-preflight.sh`
- `cd mcp-server && npm test -- --run`
- `git diff --check`
- `agenticos_pr_scope_check` PASS