### PR TITLE
chore: prepare v0.4.26 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No unreleased changes._
 
+## [0.4.26] — 2026-05-22
+
+### Added
+- mcp-server: Hermes Discord worker dispatch helper can now start a routed Codex or Claude Code worker from an AgenticOS project thread, record backend/session/process metadata, and post startup or blocked status back to the Discord thread.
+- mcp-server: fake E2E smoke coverage now validates the Discord project-thread path from user command through AgenticOS project ensure, Discord thread binding, worker selection, and thread progress.
+- docs: Hermes Discord project-thread rollout guidance now documents optional setup, Homebrew verification, Discord-only MVP behavior, Codex default backend, and manual smoke expectations.
+
+### Changed
+- docs: Hermes/Discord routing guidance now explicitly treats topic and source projects as one AgenticOS project-entry operation before thread routing.
+
 ## [0.4.25] — 2026-05-21
 
 ### Added

--- a/homebrew-tap/Formula/agenticos.rb
+++ b/homebrew-tap/Formula/agenticos.rb
@@ -3,9 +3,9 @@ require "language/node"
 class Agenticos < Formula
   desc "AI-native project management MCP server for coding agents"
   homepage "https://github.com/madlouse/AgenticOS"
-  url "https://github.com/madlouse/AgenticOS/releases/download/v0.4.25/agenticos-mcp.tgz"
-  version "0.4.25"
-  sha256 "eadc75c8967d7cdefa8a20c590ec8f81be4eeb8ba69967362f12ed377e7a5229"
+  url "https://github.com/madlouse/AgenticOS/releases/download/v0.4.26/agenticos-mcp.tgz"
+  version "0.4.26"
+  sha256 "7f0011fed3b7efce549c3a0b07a507fdede6744e6321ed2b61edb8cc36d65698"
   license "MIT"
 
   depends_on "node"

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenticos-mcp",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenticos-mcp",
-      "version": "0.4.25",
+      "version": "0.4.26",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-mcp",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "description": "MCP Server for AgenticOS - AI-native project management system",
   "type": "module",
   "bin": {

--- a/mcp-server/src/__tests__/mcp-regression-baseline.json
+++ b/mcp-server/src/__tests__/mcp-regression-baseline.json
@@ -1,9 +1,9 @@
 {
-  "capturedAt": "2026-05-22T05:34:54.381Z",
-  "version": "0.4.25",
+  "capturedAt": "2026-05-22T12:08:28.437Z",
+  "version": "0.4.26",
   "serverInfo": {
     "name": "agenticos-mcp",
-    "version": "0.4.25"
+    "version": "0.4.26"
   },
   "protocolVersion": "2025-11-25",
   "capabilities": {


### PR DESCRIPTION
Fixes #477.

Summary:
- Adds the v0.4.26 changelog entry for Hermes Discord worker dispatch and rollout docs.
- Bumps mcp-server package metadata and MCP regression baseline to 0.4.26.
- Syncs the bundled Homebrew formula to the v0.4.26 release asset and verified sha256.

Validation:
- `cd mcp-server && npm ci`
- `cd mcp-server && UPDATE_BASELINE=1 npm test -- --run src/__tests__/mcp-regression.test.ts`
- `cd mcp-server && npm run lint`
- `cd mcp-server && npm test -- --run src/__tests__/mcp-regression.test.ts`
- `./scripts/readme-lint.sh`
- `ruby -c homebrew-tap/Formula/agenticos.rb`
- source formula matches external tap formula
- `git diff --check`
- manual scope check: only declared release metadata files changed

Note: AgenticOS MCP guardrail calls in this Codex session returned `unsupported call` after the local Homebrew upgrade, so this branch preserves the workflow invariants with an isolated worktree, explicit file scope, focused validation, PR, and CI.