### PR TITLE
feat(cursor): AgenticOS activation Skill + project rule (#480 Phases 1–3)

### DIFF
--- a/.meta/bootstrap/agent-adapter-matrix.yaml
+++ b/.meta/bootstrap/agent-adapter-matrix.yaml
@@ -27,13 +27,13 @@ adapters:
       - '`agenticos_issue_bootstrap`'
   - agent_id: cursor
     support_tier: official
-    adapter_file: AGENTS.md
-    adapter_family: generic
+    adapter_file: .cursor/rules/agenticos.mdc
+    adapter_family: cursor
     required_runtime_guidance:
-      - '`AGENTS.md` is the Codex/generic adapter surface for this project.'
-      - '## Codex / Generic Runtime Notes'
-      - 'use explicit `agenticos_*` tool calls'
-      - 'Bootstrap differences are runtime concerns'
+      - '`.cursor/rules/agenticos.mdc` is the Cursor adapter surface for this project.'
+      - '## Cursor Runtime Notes'
+      - 'global activation Skill at `~/.cursor/skills-cursor/agenticos/SKILL.md`'
+      - 'Use AgenticOS MCP tools before shell directory search'
       - '`agenticos_status`'
       - '`agenticos_switch`'
       - '`agenticos_issue_bootstrap`'

--- a/.meta/bootstrap/agent-bootstrap-matrix.yaml
+++ b/.meta/bootstrap/agent-bootstrap-matrix.yaml
@@ -109,9 +109,16 @@ supported_agents:
           }
         }
       }
+    activation_skill:
+      support: official
+      path: ~/.cursor/skills-cursor/agenticos/SKILL.md
+      install_command: agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent cursor --install-skills --apply
+      verify_command: agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent cursor --install-skills --verify
+      purpose: route project switch/status/pwd prompts through AgenticOS MCP before filesystem guessing
     verification:
       - restart Cursor after saving `~/.cursor/mcp.json`
       - open Cursor MCP settings or run `cursor-agent mcp list` if Cursor CLI is installed
+      - run `agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent cursor --install-skills --verify` when natural-language routing is required
       - confirm `agenticos` appears and can call `agenticos_list`
     transport_debug:
       - if `agenticos` is absent after restart, validate JSON syntax and confirm `agenticos-mcp --version`
@@ -119,8 +126,8 @@ supported_agents:
       - if using `cursor-agent`, compare `cursor-agent mcp list` with the editor view to rule out config-scope confusion
     routing_debug:
       - project-specific `.cursor/mcp.json` exists, but AgenticOS bootstrap should stay user-global by default
-      - AgenticOS activation Skill install is not supported for Cursor in this bootstrap version
-      - if tools appear but intent routing is weak, use explicit `agenticos_*` tool calls and rely on project instructions
+      - if the activation Skill is missing or stale, run `agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent cursor --install-skills --verify`
+      - load the project `.cursor/rules/agenticos.mdc` rule and explicit `agenticos_*` tool calls before treating routing failure as transport failure
   - id: gemini-cli
     label: Gemini CLI
     support_tier: official

--- a/.meta/standard-kit/manifest.yaml
+++ b/.meta/standard-kit/manifest.yaml
@@ -17,10 +17,6 @@ layers:
         canonical_source: projects/agenticos/mcp-server/src/utils/distill.ts
         inheritance: generated
         customizable: limited
-      - path: .cursor/rules/agenticos.mdc
-        canonical_source: projects/agenticos/mcp-server/src/utils/cursor-project-rule.ts
-        inheritance: generated
-        customizable: limited
 
   copied_templates:
     description: Files copied into a downstream project and then edited in-project.

--- a/.meta/standard-kit/manifest.yaml
+++ b/.meta/standard-kit/manifest.yaml
@@ -17,6 +17,10 @@ layers:
         canonical_source: projects/agenticos/mcp-server/src/utils/distill.ts
         inheritance: generated
         customizable: limited
+      - path: .cursor/rules/agenticos.mdc
+        canonical_source: projects/agenticos/mcp-server/src/utils/cursor-project-rule.ts
+        inheritance: generated
+        customizable: limited
 
   copied_templates:
     description: Files copied into a downstream project and then edited in-project.
@@ -102,6 +106,7 @@ upgrade_rules:
   template_marker_version:
     AGENTS.md: 14
     CLAUDE.md: 14
+    .cursor/rules/agenticos.mdc: 1
   compatibility_rule: >
     Generated files may be upgraded in place by distill when the template marker version changes.
   copied_template_rule: >
@@ -111,6 +116,7 @@ adoption:
   required_files:
     - AGENTS.md
     - CLAUDE.md
+    - .cursor/rules/agenticos.mdc
     - .project.yaml
     - .context/quick-start.md
     - .context/state.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No unreleased changes._
 
+## [0.4.30] — 2026-05-24
+
+### Added
+- bootstrap/docs: Cursor activation Skill and project-rule parity are now documented alongside Codex and Claude Code, including Homebrew caveats, `agenticos-bootstrap --agent cursor --install-skills`, and the managed project rule at `.cursor/rules/agenticos.mdc` (#480 Phase 3).
+- standard-kit: Cursor project-rule adopt/upgrade/conformance is handled through a dedicated bridge so standard-kit core stays unchanged while still creating and validating `.cursor/rules/agenticos.mdc`.
+
+### Changed
+- bootstrap matrix: Cursor now declares an official `activation_skill` block and updated routing-debug guidance instead of stating Skill install is unsupported.
+- standard-kit manifest: Cursor project rule remains required for adoption/conformance but is generated outside the AGENTS/CLAUDE generated-files loop to avoid mis-rendering adapter content.
+
 ## [0.4.29] — 2026-05-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No unreleased changes._
 
+## [0.4.28] — 2026-05-23
+
+### Added
+- bootstrap: managed AgenticOS activation Skill is now installed for Cursor at `~/.cursor/skills-cursor/agenticos/SKILL.md` via the same `--install-skills` / `--force-skills` flow already shipped for Codex and Claude Code. The Skill body is rendered from the single canonical template and sha256-guarded, so Codex, Claude Code, and Cursor share one drift-tracked routing contract (#480 Phase 1, follow-up to #432/#434).
+- bootstrap: `--verify` now reports `OK cursor-skill: Skill state: current ...` for Cursor instead of `SKIP cursor-skill: unsupported`, closing the activation-Skill coverage gap left open when #432 landed for Codex/Claude Code only.
+
 ## [0.4.27] — 2026-05-22
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No unreleased changes._
 
+## [0.4.29] — 2026-05-24
+
+### Added
+- standard-kit: managed Cursor project rule is now generated at `.cursor/rules/agenticos.mdc` with `alwaysApply: true`, sha256-managed template versioning, and the same canonical guardrail/recording/session-start policy as `AGENTS.md` and `CLAUDE.md` (#480 Phase 2).
+- init: new projects receive the Cursor adapter rule during `agenticos_init`, alongside the existing Claude and Codex adapter surfaces.
+- conformance: standard-kit adapter checks now validate the Cursor adapter surface and required Cursor runtime guidance.
+
 ## [0.4.28] — 2026-05-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ agenticos-bootstrap --workspace "$AGENTICOS_HOME" --first-run --auto-configure-h
 
 On macOS, `--first-run` also sets up `launchctl` persistence so GUI tools
 inherit `AGENTICOS_HOME` across sessions. It installs the AgenticOS activation
-Skill for local-skill-capable agents, currently Codex and Claude Code.
+Skill for local-skill-capable agents: Codex, Claude Code, and Cursor.
 `--auto-configure-hooks` adds the Claude Code PostToolUse hook that reads the
 `agenticos_switch` result from hook stdin and feeds the selected project path
 back into Claude as explicit cwd guidance. The hook cannot mutate a parent
@@ -152,6 +152,14 @@ gemini mcp add -s user -e AGENTICOS_HOME="$AGENTICOS_HOME" agenticos agenticos-m
 
 For Cursor, add `agenticos` with explicit `env.AGENTICOS_HOME` to
 `~/.cursor/mcp.json`, then restart Cursor and verify `agenticos_list`.
+Install or refresh the Cursor activation Skill with:
+
+```bash
+agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent cursor --install-skills --apply
+```
+
+Managed projects also receive the always-applied project rule at
+`.cursor/rules/agenticos.mdc` during `agenticos_init` and standard-kit adopt.
 
 ### Repairing a stale registration
 

--- a/homebrew-tap/Formula/agenticos.rb
+++ b/homebrew-tap/Formula/agenticos.rb
@@ -24,7 +24,7 @@ class Agenticos < Formula
     ohai "  export AGENTICOS_HOME=\"#{var}/agenticos\""
     ohai ""
     ohai "Then run: agenticos-bootstrap --workspace \"#{var}/agenticos\" --first-run --auto-configure-hooks"
-    ohai "First-run mode installs AgenticOS activation Skills for Codex/Claude Code when selected."
+    ohai "First-run mode installs AgenticOS activation Skills for Codex, Claude Code, and Cursor when selected."
     ohai "On macOS, first-run mode also enables launchctl persistence for GUI/session inheritance."
     ohai "To audit the current Homebrew/runtime bootstrap state without changes, use: agenticos-config --validate"
     ohai "Then run: agenticos-bootstrap --workspace \"#{var}/agenticos\" --all --install-skills --verify"
@@ -50,7 +50,7 @@ class Agenticos < Formula
            agenticos-bootstrap --workspace "$AGENTICOS_HOME" --first-run --auto-configure-hooks
 
            First-run mode registers MCP, persists AGENTICOS_HOME where applicable,
-           and installs the AgenticOS activation Skill for Codex/Claude Code when
+           and installs the AgenticOS activation Skill for Codex, Claude Code, and Cursor when
            those agents are selected. The Skill helps natural-language requests
            such as "switch to 360Teams" or "切换到 360Teams 项目" discover and
            call AgenticOS MCP before filesystem guessing.
@@ -67,6 +67,7 @@ class Agenticos < Formula
          Activation Skill install/update
            agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent codex --install-skills --apply
            agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent claude-code --install-skills --apply
+           agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent cursor --install-skills --apply
 
            AgenticOS-managed Skill files are updated by content hash. User-modified
            files are not overwritten unless you rerun with --force-skills.

--- a/homebrew-tap/README.md
+++ b/homebrew-tap/README.md
@@ -23,7 +23,7 @@ Homebrew does **not**:
 - verify activation for you
 
 After installation, set `AGENTICOS_HOME` explicitly, bootstrap one officially supported agent, restart it, and verify the Homebrew/runtime bootstrap state before relying on `agenticos_list`.
-The recommended bootstrap also installs the AgenticOS activation Skill for Codex and Claude Code when selected, which helps route "switch project", `pwd`, and "切换到 ... 项目" prompts through AgenticOS MCP:
+The recommended bootstrap also installs the AgenticOS activation Skill for Codex, Claude Code, and Cursor when selected, which helps route "switch project", `pwd`, and "切换到 ... 项目" prompts through AgenticOS MCP:
 
 ```bash
 # Example default workspace path for a Homebrew-only install
@@ -69,7 +69,7 @@ agenticos-bootstrap --workspace "$AGENTICOS_HOME" --all --install-skills --verif
 Then confirm the server appears in the tool's MCP diagnostics and verify `agenticos_list` works.
 If you prefer not to edit your shell profile, omit `--first-run` and use the explicit MCP commands above instead.
 On macOS, `--first-run` also enables `launchctl` persistence so GUI/session processes inherit `AGENTICOS_HOME`.
-For Codex and Claude Code, `--first-run` implies `--install-skills`; bootstrap updates AgenticOS-managed Skill files by content hash and refuses to overwrite user-modified files unless you pass `--force-skills`.
+For Codex, Claude Code, and Cursor, `--first-run` implies `--install-skills`; bootstrap updates AgenticOS-managed Skill files by content hash and refuses to overwrite user-modified files unless you pass `--force-skills`.
 For Claude Code PWD guidance after `agenticos_switch`, run `agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent claude-code --auto-configure-hooks --apply` or include `--auto-configure-hooks` with `--first-run`. The hook reads Claude's PostToolUse stdin payload and feeds the switched project path back into Claude; it does not mutate a parent shell process.
 Use `agenticos-bootstrap --workspace "$AGENTICOS_HOME" --all --install-skills --verify` with the same flags to audit the current machine state without mutating it.
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -20,7 +20,7 @@ A project management system designed for AI collaboration. When you work on comp
 
 Install AgenticOS, set `AGENTICOS_HOME` explicitly, then either run `agenticos-bootstrap --workspace "$AGENTICOS_HOME" --first-run` or bootstrap one supported agent manually, restart that agent, and explicitly verify `agenticos_list` works before relying on project-intent routing.
 On macOS, `--first-run` also enables `launchctl` persistence for GUI/session inheritance.
-It also installs the AgenticOS activation Skill for local-skill-capable agents, currently Codex and Claude Code, so switch/status/pwd prompts route to AgenticOS MCP before filesystem guessing.
+It also installs the AgenticOS activation Skill for local-skill-capable agents — Codex, Claude Code, and Cursor — so switch/status/pwd prompts route to AgenticOS MCP before filesystem guessing.
 Use `agenticos-config --validate` and `agenticos-bootstrap --workspace "$AGENTICOS_HOME" --all --install-skills --verify` to audit the Homebrew/runtime bootstrap state, activation Skill state, and optional persistence layers without mutating them.
 `--apply` and `--first-run` also record bootstrap metadata in `$AGENTICOS_HOME/.agent-workspace/bootstrap-state.yaml`.
 
@@ -127,12 +127,14 @@ surface:
 
 - Codex: `~/.codex/skills/agenticos/SKILL.md`
 - Claude Code: `~/.claude/skills/agenticos/SKILL.md`
+- Cursor: `~/.cursor/skills-cursor/agenticos/SKILL.md`
 
 Install or update it with:
 
 ```bash
 agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent codex --install-skills --apply
 agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent claude-code --install-skills --apply
+agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent cursor --install-skills --apply
 ```
 
 `--first-run` implies `--install-skills`. Managed Skill files carry a content
@@ -170,13 +172,16 @@ want to replace a local edit.
 ### Cursor
 
 - canonical bootstrap: add `agenticos` with explicit `env.AGENTICOS_HOME` to `~/.cursor/mcp.json`
+- activation Skill: `~/.cursor/skills-cursor/agenticos/SKILL.md`
+- project adapter rule: `.cursor/rules/agenticos.mdc` (`alwaysApply: true`)
 - verify:
   - restart Cursor
   - check Cursor MCP settings or `cursor-agent mcp list` if the Cursor CLI is installed
+  - `agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent cursor --install-skills --verify`
   - explicit `agenticos_list`
 - debug split:
   - if `agenticos` never appears after restart, validate the JSON and executable path
-  - if tools appear but project-intent routing is weak, use explicit tools and project instructions
+  - if tools appear but project-intent routing is weak, verify the activation Skill and project rule, then use explicit tools
 
 ### Gemini CLI
 

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenticos-mcp",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenticos-mcp",
-      "version": "0.4.27",
+      "version": "0.4.28",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-mcp",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "description": "MCP Server for AgenticOS - AI-native project management system",
   "type": "module",
   "bin": {

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-mcp",
-  "version": "0.4.28",
+  "version": "0.4.29",
   "description": "MCP Server for AgenticOS - AI-native project management system",
   "type": "module",
   "bin": {

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-mcp",
-  "version": "0.4.29",
+  "version": "0.4.30",
   "description": "MCP Server for AgenticOS - AI-native project management system",
   "type": "module",
   "bin": {

--- a/mcp-server/src/__tests__/mcp-regression-baseline.json
+++ b/mcp-server/src/__tests__/mcp-regression-baseline.json
@@ -1,9 +1,9 @@
 {
-  "capturedAt": "2026-05-22T12:08:28.437Z",
-  "version": "0.4.27",
+  "capturedAt": "2026-05-23T16:03:20.885Z",
+  "version": "0.4.28",
   "serverInfo": {
     "name": "agenticos-mcp",
-    "version": "0.4.27"
+    "version": "0.4.28"
   },
   "protocolVersion": "2025-11-25",
   "capabilities": {

--- a/mcp-server/src/__tests__/mcp-regression-baseline.json
+++ b/mcp-server/src/__tests__/mcp-regression-baseline.json
@@ -1,9 +1,9 @@
 {
   "capturedAt": "2026-05-24T00:42:31.675Z",
-  "version": "0.4.29",
+  "version": "0.4.30",
   "serverInfo": {
     "name": "agenticos-mcp",
-    "version": "0.4.29"
+    "version": "0.4.30"
   },
   "protocolVersion": "2025-11-25",
   "capabilities": {

--- a/mcp-server/src/__tests__/mcp-regression-baseline.json
+++ b/mcp-server/src/__tests__/mcp-regression-baseline.json
@@ -1,9 +1,9 @@
 {
-  "capturedAt": "2026-05-23T16:03:20.885Z",
-  "version": "0.4.28",
+  "capturedAt": "2026-05-24T00:42:31.675Z",
+  "version": "0.4.29",
   "serverInfo": {
     "name": "agenticos-mcp",
-    "version": "0.4.28"
+    "version": "0.4.29"
   },
   "protocolVersion": "2025-11-25",
   "capabilities": {

--- a/mcp-server/src/tools/__tests__/standard-kit.test.ts
+++ b/mcp-server/src/tools/__tests__/standard-kit.test.ts
@@ -43,7 +43,6 @@ async function setupKitHome(): Promise<{ home: string; projectRoot: string }> {
         entries: [
           { path: 'AGENTS.md', canonical_source: 'projects/agenticos/mcp-server/src/utils/distill.ts' },
           { path: 'CLAUDE.md', canonical_source: 'projects/agenticos/mcp-server/src/utils/distill.ts' },
-          { path: '.cursor/rules/agenticos.mdc', canonical_source: 'projects/agenticos/mcp-server/src/utils/cursor-project-rule.ts' },
         ],
       },
       copied_templates: {

--- a/mcp-server/src/tools/__tests__/standard-kit.test.ts
+++ b/mcp-server/src/tools/__tests__/standard-kit.test.ts
@@ -915,6 +915,30 @@ status:
     expect(result.copied_templates).toEqual([]);
   });
 
+  it('conformance check tolerates a minimal manifest without Cursor bridge augmentation', async () => {
+    const { home, projectRoot } = await setupKitHome();
+    process.env.AGENTICOS_HOME = home;
+
+    await writeManifest(home, {
+      kit_id: 'downstream-standard-kit',
+      kit_version: '0.1.0',
+      layers: {
+        copied_templates: {
+          entries: [{ path: 'tasks/templates/ignored.md' }],
+        },
+      },
+    });
+
+    const result = JSON.parse(await runStandardKitConformanceCheck({
+      project_path: projectRoot,
+      project_name: 'Sample Project',
+    })) as {
+      status: string;
+    };
+
+    expect(['FAIL', 'PASS', 'SKIP']).toContain(result.status);
+  });
+
   it('adopt fills missing state sections and preserves an explicit project phase from the template', async () => {
     const { home, projectRoot } = await setupKitHome();
     process.env.AGENTICOS_HOME = home;

--- a/mcp-server/src/tools/__tests__/standard-kit.test.ts
+++ b/mcp-server/src/tools/__tests__/standard-kit.test.ts
@@ -43,6 +43,7 @@ async function setupKitHome(): Promise<{ home: string; projectRoot: string }> {
         entries: [
           { path: 'AGENTS.md', canonical_source: 'projects/agenticos/mcp-server/src/utils/distill.ts' },
           { path: 'CLAUDE.md', canonical_source: 'projects/agenticos/mcp-server/src/utils/distill.ts' },
+          { path: '.cursor/rules/agenticos.mdc', canonical_source: 'projects/agenticos/mcp-server/src/utils/cursor-project-rule.ts' },
         ],
       },
       copied_templates: {
@@ -63,6 +64,7 @@ async function setupKitHome(): Promise<{ home: string; projectRoot: string }> {
       required_files: [
         'AGENTS.md',
         'CLAUDE.md',
+        '.cursor/rules/agenticos.mdc',
         '.project.yaml',
         '.context/quick-start.md',
         '.context/state.yaml',
@@ -158,6 +160,7 @@ async function setupKitHome(): Promise<{ home: string; projectRoot: string }> {
       adapter_surfaces: [
         { id: 'codex-generic', generated_file: 'AGENTS.md' },
         { id: 'claude-code', generated_file: 'CLAUDE.md' },
+        { id: 'cursor', generated_file: '.cursor/rules/agenticos.mdc' },
       ],
     }),
     'utf-8',
@@ -193,6 +196,21 @@ async function setupKitHome(): Promise<{ home: string; projectRoot: string }> {
             '## Codex / Generic Runtime Notes',
             'use explicit `agenticos_*` tool calls',
             'Bootstrap differences are runtime concerns',
+            '`agenticos_status`',
+            '`agenticos_switch`',
+            '`agenticos_issue_bootstrap`',
+          ],
+        },
+        {
+          agent_id: 'cursor',
+          support_tier: 'official',
+          adapter_file: '.cursor/rules/agenticos.mdc',
+          adapter_family: 'cursor',
+          required_runtime_guidance: [
+            '`.cursor/rules/agenticos.mdc` is the Cursor adapter surface for this project.',
+            '## Cursor Runtime Notes',
+            'global activation Skill at `~/.cursor/skills-cursor/agenticos/SKILL.md`',
+            'Use AgenticOS MCP tools before shell directory search',
             '`agenticos_status`',
             '`agenticos_switch`',
             '`agenticos_issue_bootstrap`',
@@ -250,6 +268,7 @@ describe('standard kit commands', () => {
     expect(result.created_files).toContain('.project.yaml');
     expect(result.created_files).toContain('AGENTS.md');
     expect(result.created_files).toContain('CLAUDE.md');
+    expect(result.created_files).toContain('.cursor/rules/agenticos.mdc');
     expect(result.created_files).toContain('tasks/templates/non-code-evaluation-rubric.yaml');
     expect(result.created_files).toContain('tasks/templates/sub-agent-handoff.md');
     expect(result.skipped_existing_templates).toContain('.context/quick-start.md');
@@ -577,6 +596,7 @@ status:
       expect.arrayContaining([
         expect.objectContaining({ agent_id: 'claude-code', status: 'PASS', adapter_file: 'CLAUDE.md' }),
         expect.objectContaining({ agent_id: 'codex', status: 'PASS', adapter_file: 'AGENTS.md' }),
+        expect.objectContaining({ agent_id: 'cursor', status: 'PASS', adapter_file: '.cursor/rules/agenticos.mdc' }),
       ]),
     );
   });

--- a/mcp-server/src/tools/init.ts
+++ b/mcp-server/src/tools/init.ts
@@ -1,8 +1,9 @@
 import { mkdir, writeFile, access, readFile } from 'fs/promises';
-import { join } from 'path';
+import { join, dirname } from 'path';
 import yaml from 'yaml';
 import { loadRegistry, patchRegistry, getAgenticOSHome } from '../utils/registry.js';
 import { generateClaudeMd, generateAgentsMd } from '../utils/distill.js';
+import { renderCursorProjectRule, CURSOR_PROJECT_RULE_RELATIVE_PATH } from '../utils/cursor-project-rule.js';
 import { buildProjectTopologyInitializationMessage, hasDeclaredContextPublicationPolicy, validateContextPublicationPolicy, validateProjectKind, type ContextPublicationPolicy, type ProjectKind, type ProjectTopology } from '../utils/project-contract.js';
 import { resolveManagedProjectContextDisplayPaths, resolveManagedProjectContextPaths } from '../utils/agent-context-paths.js';
 import { ensureCaseKnowledgeDirectories } from '../utils/case-knowledge.js';
@@ -303,6 +304,11 @@ ${description ?? existingProjectYaml?.meta?.description ?? ''}
 
   const agentsMd = generateAgentsMd(name, description ?? existingProjectYaml?.meta?.description ?? '', contextDisplayPaths);
   await writeFile(join(projectPath, 'AGENTS.md'), agentsMd, 'utf-8');
+
+  const cursorRule = renderCursorProjectRule(name, description ?? existingProjectYaml?.meta?.description ?? '', contextDisplayPaths);
+  const cursorRulePath = join(projectPath, CURSOR_PROJECT_RULE_RELATIVE_PATH);
+  await mkdir(dirname(cursorRulePath), { recursive: true });
+  await writeFile(cursorRulePath, cursorRule, 'utf-8');
 
   const projectEntry = {
     id,

--- a/mcp-server/src/tools/standard-kit.ts
+++ b/mcp-server/src/tools/standard-kit.ts
@@ -17,8 +17,8 @@ async function isCursorProjectRuleRequired(): Promise<boolean> {
   return (manifest.adoption?.required_files || []).includes(CURSOR_PROJECT_RULE_REQUIRED);
 }
 
-export async function runStandardKitAdopt(args: any): Promise<string> {
-  const result = await adoptStandardKit(args ?? {});
+export async function runStandardKitAdopt(args: any = {}): Promise<string> {
+  const result = await adoptStandardKit(args);
   if (!(await isCursorProjectRuleRequired())) {
     return JSON.stringify(result, null, 2);
   }
@@ -32,8 +32,8 @@ export async function runStandardKitAdopt(args: any): Promise<string> {
   return JSON.stringify(augmented, null, 2);
 }
 
-export async function runStandardKitUpgradeCheck(args: any): Promise<string> {
-  const result = await checkStandardKitUpgrade(args ?? {});
+export async function runStandardKitUpgradeCheck(args: any = {}): Promise<string> {
+  const result = await checkStandardKitUpgrade(args);
   if (!(await isCursorProjectRuleRequired())) {
     return JSON.stringify(result, null, 2);
   }
@@ -47,8 +47,8 @@ export async function runStandardKitUpgradeCheck(args: any): Promise<string> {
   return JSON.stringify(augmented, null, 2);
 }
 
-export async function runStandardKitConformanceCheck(args: any): Promise<string> {
-  const result = await checkStandardKitConformance(args ?? {});
+export async function runStandardKitConformanceCheck(args: any = {}): Promise<string> {
+  const result = await checkStandardKitConformance(args);
   if (!(await isCursorProjectRuleRequired())) {
     return JSON.stringify(result, null, 2);
   }

--- a/mcp-server/src/tools/standard-kit.ts
+++ b/mcp-server/src/tools/standard-kit.ts
@@ -1,16 +1,63 @@
-import { adoptStandardKit, checkStandardKitConformance, checkStandardKitUpgrade } from '../utils/standard-kit.js';
+import {
+  adoptStandardKit,
+  checkStandardKitConformance,
+  checkStandardKitUpgrade,
+  loadStandardKitManifest,
+} from '../utils/standard-kit.js';
+import {
+  adoptCursorProjectRuleFile,
+  augmentConformanceWithCursor,
+  augmentUpgradeCheckWithCursor,
+  CURSOR_PROJECT_RULE_REQUIRED,
+  resolveCursorBridgeProjectContext,
+} from '../utils/standard-kit-cursor-bridge.js';
+
+async function isCursorProjectRuleRequired(): Promise<boolean> {
+  const manifest = await loadStandardKitManifest();
+  return (manifest.adoption?.required_files || []).includes(CURSOR_PROJECT_RULE_REQUIRED);
+}
 
 export async function runStandardKitAdopt(args: any): Promise<string> {
   const result = await adoptStandardKit(args ?? {});
-  return JSON.stringify(result, null, 2);
+  if (!(await isCursorProjectRuleRequired())) {
+    return JSON.stringify(result, null, 2);
+  }
+
+  const project = resolveCursorBridgeProjectContext(
+    result.project_path,
+    result.project_name,
+    args?.project_description,
+  );
+  const augmented = adoptCursorProjectRuleFile(result, project);
+  return JSON.stringify(augmented, null, 2);
 }
 
 export async function runStandardKitUpgradeCheck(args: any): Promise<string> {
   const result = await checkStandardKitUpgrade(args ?? {});
-  return JSON.stringify(result, null, 2);
+  if (!(await isCursorProjectRuleRequired())) {
+    return JSON.stringify(result, null, 2);
+  }
+
+  const project = resolveCursorBridgeProjectContext(
+    result.project_path,
+    result.project_name,
+    args?.project_description,
+  );
+  const augmented = augmentUpgradeCheckWithCursor(result, project);
+  return JSON.stringify(augmented, null, 2);
 }
 
 export async function runStandardKitConformanceCheck(args: any): Promise<string> {
   const result = await checkStandardKitConformance(args ?? {});
-  return JSON.stringify(result, null, 2);
+  if (!(await isCursorProjectRuleRequired())) {
+    return JSON.stringify(result, null, 2);
+  }
+
+  const project = resolveCursorBridgeProjectContext(
+    result.project_path,
+    result.project_name,
+    args?.project_description,
+  );
+  const augmented = await augmentConformanceWithCursor(result, project);
+  return JSON.stringify(augmented, null, 2);
 }

--- a/mcp-server/src/utils/__tests__/agent-skill.test.ts
+++ b/mcp-server/src/utils/__tests__/agent-skill.test.ts
@@ -6,6 +6,7 @@ import {
   isAgentSkillOkForVerify,
   renderAgenticosSkillContent,
   resolveAgentSkillTarget,
+  __testInsertAfterYamlFrontmatter,
 } from '../agent-skill.js';
 
 const HASH_MARKER_RE = /^<!-- agenticos-skill-managed-sha256: [a-f0-9]{64} -->\n?/m;
@@ -220,5 +221,14 @@ metadata:
     expect(result.skipped).toBe(true);
     expect(result.status).toBe('unsupported');
     expect(isAgentSkillOkForVerify(result)).toBe(true);
+  });
+
+  it('rejects invalid YAML frontmatter when inserting managed hash markers', () => {
+    expect(() => __testInsertAfterYamlFrontmatter('no frontmatter', 'x')).toThrow(
+      'AgenticOS Skill template must start with YAML frontmatter',
+    );
+    expect(() => __testInsertAfterYamlFrontmatter('---\nopen\n', 'x')).toThrow(
+      'AgenticOS Skill template is missing a closing YAML frontmatter delimiter',
+    );
   });
 });

--- a/mcp-server/src/utils/__tests__/agent-skill.test.ts
+++ b/mcp-server/src/utils/__tests__/agent-skill.test.ts
@@ -32,12 +32,52 @@ function createDeps() {
 }
 
 describe('agent skill bootstrap', () => {
-  it('resolves Codex and Claude Code Skill targets', () => {
+  it('resolves Codex, Claude Code, and Cursor Skill targets', () => {
     expect(resolveAgentSkillTarget('codex', '/Users/tester').path)
       .toBe('/Users/tester/.codex/skills/agenticos/SKILL.md');
     expect(resolveAgentSkillTarget('claude-code', '/Users/tester').path)
       .toBe('/Users/tester/.claude/skills/agenticos/SKILL.md');
-    expect(resolveAgentSkillTarget('cursor', '/Users/tester').supported).toBe(false);
+
+    const cursorTarget = resolveAgentSkillTarget('cursor', '/Users/tester');
+    expect(cursorTarget.supported).toBe(true);
+    expect(cursorTarget.path).toBe('/Users/tester/.cursor/skills-cursor/agenticos/SKILL.md');
+    expect(cursorTarget.reloadHint).toMatch(/Cursor/);
+
+    expect(resolveAgentSkillTarget('gemini-cli', '/Users/tester').supported).toBe(false);
+  });
+
+  it('installs and verifies the Cursor managed Skill at ~/.cursor/skills-cursor/agenticos/SKILL.md', () => {
+    const harness = createDeps();
+
+    const result = installAgentSkill('cursor', '/Users/tester', harness.deps);
+
+    expect(result.ok).toBe(true);
+    expect(result.wrote).toBe(true);
+    expect(result.status).toBe('current');
+    expect(harness.dirs).toEqual(['/Users/tester/.cursor/skills-cursor/agenticos']);
+
+    const installedPath = '/Users/tester/.cursor/skills-cursor/agenticos/SKILL.md';
+    const installed = harness.files.get(installedPath);
+    expect(installed).toContain('AgenticOS Activation');
+    expect(installed).toMatch(/^---\n/);
+    expect(installed).toContain('agenticos-skill-managed-sha256');
+    expect(isAgentSkillOkForVerify(inspectAgentSkill('cursor', '/Users/tester', harness.deps.readFile))).toBe(true);
+  });
+
+  it('renders the same canonical Skill content for Codex, Claude Code, and Cursor', () => {
+    const harness = createDeps();
+
+    installAgentSkill('codex', '/Users/tester', harness.deps);
+    installAgentSkill('claude-code', '/Users/tester', harness.deps);
+    installAgentSkill('cursor', '/Users/tester', harness.deps);
+
+    const codex = harness.files.get('/Users/tester/.codex/skills/agenticos/SKILL.md');
+    const claude = harness.files.get('/Users/tester/.claude/skills/agenticos/SKILL.md');
+    const cursor = harness.files.get('/Users/tester/.cursor/skills-cursor/agenticos/SKILL.md');
+
+    expect(codex).toBeDefined();
+    expect(claude).toBe(codex);
+    expect(cursor).toBe(codex);
   });
 
   it('renders a managed Skill with project switch triggers and hash marker', () => {

--- a/mcp-server/src/utils/__tests__/bootstrap-cli.test.ts
+++ b/mcp-server/src/utils/__tests__/bootstrap-cli.test.ts
@@ -179,20 +179,21 @@ describe('bootstrap cli', () => {
     expect(lines.join('\n')).toContain('launchctl setenv AGENTICOS_HOME');
   });
 
-  it('renders dry-run Skill skip and force overwrite actions', () => {
+  it('renders dry-run Skill install, skip, and force overwrite actions', () => {
     const lines = buildDryRunLines(
       '/tmp/workspace',
       'explicit --workspace',
       [
         { id: 'cursor', label: 'Cursor', installed: true, detection_hint: 'test' },
+        { id: 'gemini-cli', label: 'Gemini CLI', installed: true, detection_hint: 'test' },
       ],
-      ['cursor'],
+      ['cursor', 'gemini-cli'],
       {
         apply: false,
         verify: false,
         firstRun: false,
         all: false,
-        agents: ['cursor'],
+        agents: ['cursor', 'gemini-cli'],
         help: false,
         persistShellEnv: false,
         persistLaunchctlEnv: false,
@@ -205,9 +206,11 @@ describe('bootstrap cli', () => {
       '/Users/tester',
     );
 
-    expect(lines.join('\n')).toContain('cursor-skill: skip');
-    expect(lines.join('\n')).toContain('overwrite user-modified managed Skill files');
-    expect(lines.join('\n')).toContain('hermes-discord: enforce Hermes+Discord');
+    const text = lines.join('\n');
+    expect(text).toContain('cursor-skill: install/update /Users/tester/.cursor/skills-cursor/agenticos/SKILL.md');
+    expect(text).toContain('gemini-cli-skill: skip');
+    expect(text).toContain('overwrite user-modified managed Skill files');
+    expect(text).toContain('hermes-discord: enforce Hermes+Discord');
   });
 
   it('reports non-Error thrown failures', () => {
@@ -415,7 +418,7 @@ describe('bootstrap cli', () => {
     expect(bootstrapState.agenticos_skills[0].status).toBe('current');
   });
 
-  it('skips unsupported activation Skill installs without failing apply', () => {
+  it('installs the Cursor activation Skill during apply', () => {
     const harness = createDeps();
 
     const exitCode = runBootstrapCli(
@@ -424,7 +427,26 @@ describe('bootstrap cli', () => {
     );
 
     expect(exitCode).toBe(0);
-    expect(harness.stdout.some((line) => line.includes('SKIP cursor-skill'))).toBe(true);
+    expect(harness.stdout.some((line) => line.includes('OK cursor-skill'))).toBe(true);
+    const cursorSkill = harness.files.get('/Users/tester/.cursor/skills-cursor/agenticos/SKILL.md');
+    expect(cursorSkill).toContain('agenticos-skill-managed-sha256');
+    expect(cursorSkill).toContain('AgenticOS Activation');
+    const bootstrapState = yaml.parse(harness.files.get('/tmp/workspace/.agent-workspace/bootstrap-state.yaml') || '');
+    expect(bootstrapState.agenticos_skills[0].agent_id).toBe('cursor');
+    expect(bootstrapState.agenticos_skills[0].status).toBe('current');
+    expect(bootstrapState.agenticos_skills[0].path).toBe('/Users/tester/.cursor/skills-cursor/agenticos/SKILL.md');
+  });
+
+  it('skips unsupported activation Skill installs without failing apply', () => {
+    const harness = createDeps();
+
+    const exitCode = runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'gemini-cli', '--install-skills', '--apply'],
+      harness.deps,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(harness.stdout.some((line) => line.includes('SKIP gemini-cli-skill'))).toBe(true);
   });
 
   it('fails Skill install on user-modified files unless force is requested', () => {
@@ -813,12 +835,26 @@ describe('bootstrap cli', () => {
     expect(missingHarness.stdout.some((line) => line.includes('FAIL codex-skill'))).toBe(true);
     expect(missingHarness.stdout.some((line) => line.includes('--install-skills --apply'))).toBe(true);
 
-    const unsupportedHarness = createDeps();
+    const cursorAppliedHarness = createDeps();
+    expect(runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'cursor', '--install-skills', '--apply'],
+      cursorAppliedHarness.deps,
+    )).toBe(0);
+    cursorAppliedHarness.stdout.length = 0;
     expect(runBootstrapCli(
       ['--workspace', '/tmp/workspace', '--agent', 'cursor', '--install-skills', '--verify'],
+      cursorAppliedHarness.deps,
+    )).toBe(0);
+    expect(cursorAppliedHarness.stdout.some((line) => line.includes('OK cursor-skill'))).toBe(true);
+    expect(cursorAppliedHarness.files.get('/Users/tester/.cursor/skills-cursor/agenticos/SKILL.md'))
+      .toMatch(/AgenticOS Activation/);
+
+    const unsupportedHarness = createDeps();
+    expect(runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'gemini-cli', '--install-skills', '--verify'],
       unsupportedHarness.deps,
-    )).toBe(1);
-    expect(unsupportedHarness.stdout.some((line) => line.includes('SKIP cursor-skill'))).toBe(true);
+    )).toBe(0);
+    expect(unsupportedHarness.stdout.some((line) => line.includes('SKIP gemini-cli-skill'))).toBe(true);
 
     const modifiedHarness = createDeps();
     modifiedHarness.files.set('/Users/tester/.codex/skills/agenticos/SKILL.md', '# local edit\n');

--- a/mcp-server/src/utils/__tests__/canonical-sync.test.ts
+++ b/mcp-server/src/utils/__tests__/canonical-sync.test.ts
@@ -55,7 +55,7 @@ describe('runCanonicalSync', () => {
   });
 
   it('resolves runtime-managed entries from configured agent context paths', () => {
-    expect(resolveRuntimeManagedEntries(null)).toEqual(['CLAUDE.md', 'AGENTS.md']);
+    expect(resolveRuntimeManagedEntries(null)).toEqual(['CLAUDE.md', 'AGENTS.md', '.cursor/rules/agenticos.mdc']);
     expect(resolveRuntimeManagedEntries({
       agent_context: {
         quick_start: './standards/.context/quick-start.md',
@@ -70,6 +70,7 @@ describe('runCanonicalSync', () => {
       'standards/.context/conversations/',
       'CLAUDE.md',
       'AGENTS.md',
+      '.cursor/rules/agenticos.mdc',
     ]);
     expect(resolveRuntimeManagedEntries({
       agent_context: {
@@ -199,7 +200,7 @@ describe('runCanonicalSync', () => {
     expect(result.status).toBe('PASS');
     expect(result.summary).toContain('no snapshot was needed');
     expect(result.snapshot).toBeUndefined();
-    expect(result.runtime_managed_entries).toEqual(['CLAUDE.md', 'AGENTS.md']);
+    expect(result.runtime_managed_entries).toEqual(['CLAUDE.md', 'AGENTS.md', '.cursor/rules/agenticos.mdc']);
   });
 
   it('succeeds without project_path and uses repo-path fallback metadata', async () => {
@@ -222,7 +223,7 @@ describe('runCanonicalSync', () => {
 
     expect(result.project_path).toBeNull();
     expect(result.status).toBe('PASS');
-    expect(result.runtime_managed_entries).toEqual(['CLAUDE.md', 'AGENTS.md']);
+    expect(result.runtime_managed_entries).toEqual(['CLAUDE.md', 'AGENTS.md', '.cursor/rules/agenticos.mdc']);
     expect(result.summary).toContain('no snapshot was needed');
   });
 

--- a/mcp-server/src/utils/__tests__/cursor-project-rule.test.ts
+++ b/mcp-server/src/utils/__tests__/cursor-project-rule.test.ts
@@ -126,6 +126,18 @@ describe('cursor-project-rule', () => {
     expect(inspectCursorProjectRule(null, 'AgenticOS', '').status).toBe('missing');
   });
 
+  it('treats managed rules without template_version as stale-managed', () => {
+    const rendered = renderCursorProjectRule('AgenticOS', '');
+    const withoutVersionLine = rendered
+      .replace(/^\s{4}template_version: 1\s*$/m, '')
+      .replace(HASH_MARKER_RE, '');
+    const staleHash = createHash('sha256').update(withoutVersionLine, 'utf-8').digest('hex');
+    const staleManaged = withoutVersionLine.replace('\n---\n', `\n---\n<!-- agenticos-skill-managed-sha256: ${staleHash} -->\n`);
+    const inspection = inspectCursorProjectRule(staleManaged, 'AgenticOS', '');
+    expect(inspection.status).toBe('stale-managed');
+    expect(inspection.detail).toContain('unknown');
+  });
+
   it('detects template drift when managed hash still matches stored body', () => {
     const rendered = renderCursorProjectRule('AgenticOS', 'Self-hosting project');
     expect(inspectCursorProjectRule(rendered, 'Other Project', 'Self-hosting project').status).toBe('modified-user');

--- a/mcp-server/src/utils/__tests__/cursor-project-rule.test.ts
+++ b/mcp-server/src/utils/__tests__/cursor-project-rule.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CURSOR_PROJECT_RULE_RELATIVE_PATH,
+  CURSOR_PROJECT_RULE_TEMPLATE_VERSION,
+  inspectCursorProjectRule,
+  renderCursorProjectRule,
+  upgradeCursorProjectRule,
+} from '../cursor-project-rule.js';
+
+describe('cursor-project-rule', () => {
+  it('renders managed Cursor project rule with alwaysApply and sha256 marker', () => {
+    const content = renderCursorProjectRule('Demo Project', 'A managed demo', {
+      quickStartPath: 'standards/.context/quick-start.md',
+      statePath: 'standards/.context/state.yaml',
+    });
+
+    expect(content).toContain('alwaysApply: true');
+    expect(content).toContain('template_version: 1');
+    expect(content).toContain('<!-- agenticos-skill-managed-sha256:');
+    expect(content).toContain('# AgenticOS — Demo Project');
+    expect(content).toContain('`.cursor/rules/agenticos.mdc` is the Cursor adapter surface');
+    expect(content).toContain('## Cursor Runtime Notes');
+    expect(content).toContain('~/.cursor/skills-cursor/agenticos/SKILL.md');
+    expect(content).toContain('standards/.context/quick-start.md');
+    expect(content).toContain('standards/.context/state.yaml');
+    expect(content).toContain('`agenticos_preflight`');
+    expect(content).toContain('`agenticos_record`');
+  });
+
+  it('reports current status for freshly rendered content', () => {
+    const content = renderCursorProjectRule('AgenticOS', 'Self-hosting project');
+    const inspection = inspectCursorProjectRule(content, 'AgenticOS', 'Self-hosting project');
+
+    expect(inspection.status).toBe('current');
+    expect(inspection.installedVersion).toBe(CURSOR_PROJECT_RULE_TEMPLATE_VERSION);
+    expect(CURSOR_PROJECT_RULE_RELATIVE_PATH).toBe('.cursor/rules/agenticos.mdc');
+  });
+
+  it('detects modified-user content and preserves it unless forced', () => {
+    const original = renderCursorProjectRule('AgenticOS', 'Self-hosting project');
+    const modified = original.replace(
+      '## Cursor Runtime Notes',
+      '## Cursor Runtime Notes\n\nOperator-local note.',
+    );
+
+    const inspection = inspectCursorProjectRule(modified, 'AgenticOS', 'Self-hosting project');
+    expect(inspection.status).toBe('modified-user');
+  });
+
+  it('renders fresh content when upgrading a missing Cursor project rule file', () => {
+    const upgraded = upgradeCursorProjectRule(
+      '/tmp/does-not-exist/agenticos.mdc',
+      'AgenticOS',
+      'Self-hosting project',
+    );
+
+    expect(upgraded).toContain('alwaysApply: true');
+    expect(inspectCursorProjectRule(upgraded, 'AgenticOS', 'Self-hosting project').status).toBe('current');
+  });
+});

--- a/mcp-server/src/utils/__tests__/cursor-project-rule.test.ts
+++ b/mcp-server/src/utils/__tests__/cursor-project-rule.test.ts
@@ -1,13 +1,29 @@
-import { describe, expect, it } from 'vitest';
+import { createHash } from 'crypto';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
 import {
   CURSOR_PROJECT_RULE_RELATIVE_PATH,
   CURSOR_PROJECT_RULE_TEMPLATE_VERSION,
+  __testInsertAfterYamlFrontmatter,
+  cursorProjectRuleUpgradeStatus,
   inspectCursorProjectRule,
   renderCursorProjectRule,
   upgradeCursorProjectRule,
 } from '../cursor-project-rule.js';
 
+const HASH_MARKER_RE = /^<!-- agenticos-skill-managed-sha256: ([a-f0-9]{64}) -->\n?/m;
+
 describe('cursor-project-rule', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('renders managed Cursor project rule with alwaysApply and sha256 marker', () => {
     const content = renderCursorProjectRule('Demo Project', 'A managed demo', {
       quickStartPath: 'standards/.context/quick-start.md',
@@ -36,25 +52,82 @@ describe('cursor-project-rule', () => {
     expect(CURSOR_PROJECT_RULE_RELATIVE_PATH).toBe('.cursor/rules/agenticos.mdc');
   });
 
-  it('detects modified-user content and preserves it unless forced', () => {
-    const original = renderCursorProjectRule('AgenticOS', 'Self-hosting project');
-    const modified = original.replace(
+  it('detects missing, stale-managed, and modified-user states', () => {
+    expect(inspectCursorProjectRule(null, 'AgenticOS', '').status).toBe('missing');
+
+    const rendered = renderCursorProjectRule('AgenticOS', '');
+    const withoutHash = rendered.replace(HASH_MARKER_RE, '');
+    expect(inspectCursorProjectRule(withoutHash, 'AgenticOS', '').status).toBe('stale-managed');
+
+    const staleVersionBody = rendered.replace('template_version: 1', 'template_version: 0').replace(HASH_MARKER_RE, '');
+    const staleHash = createHash('sha256').update(staleVersionBody, 'utf-8').digest('hex');
+    const staleVersion = staleVersionBody.replace('\n---\n', `\n---\n<!-- agenticos-skill-managed-sha256: ${staleHash} -->\n`);
+    expect(inspectCursorProjectRule(staleVersion, 'AgenticOS', '').status).toBe('stale-managed');
+
+    const hashMismatch = rendered.replace(
       '## Cursor Runtime Notes',
       '## Cursor Runtime Notes\n\nOperator-local note.',
     );
-
-    const inspection = inspectCursorProjectRule(modified, 'AgenticOS', 'Self-hosting project');
-    expect(inspection.status).toBe('modified-user');
+    expect(inspectCursorProjectRule(hashMismatch, 'AgenticOS', '').status).toBe('modified-user');
   });
 
-  it('renders fresh content when upgrading a missing Cursor project rule file', () => {
-    const upgraded = upgradeCursorProjectRule(
-      '/tmp/does-not-exist/agenticos.mdc',
-      'AgenticOS',
-      'Self-hosting project',
-    );
+  it('maps upgrade status and preserves user-modified content unless forced', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'cursor-rule-upgrade-'));
+    tempDirs.push(dir);
+    const path = join(dir, 'agenticos.mdc');
 
-    expect(upgraded).toContain('alwaysApply: true');
-    expect(inspectCursorProjectRule(upgraded, 'AgenticOS', 'Self-hosting project').status).toBe('current');
+    const created = upgradeCursorProjectRule(path, 'AgenticOS', '');
+    expect(created).toContain('alwaysApply: true');
+    writeFileSync(path, created, 'utf-8');
+    expect(upgradeCursorProjectRule(path, 'AgenticOS', '')).toBe(created);
+
+    const modified = created.replace('## Cursor Runtime Notes', '## Cursor Runtime Notes\n\nLocal note.');
+    writeFileSync(path, modified, 'utf-8');
+    expect(upgradeCursorProjectRule(path, 'AgenticOS', '')).toBe(modified);
+    expect(upgradeCursorProjectRule(path, 'AgenticOS', '', undefined, { force: true })).toBe(created);
+
+    expect(cursorProjectRuleUpgradeStatus(null, 'AgenticOS', '')).toBe('missing');
+    expect(cursorProjectRuleUpgradeStatus(created, 'AgenticOS', '')).toBe('current');
+    const staleVersion = created.replace('template_version: 1', 'template_version: 0');
+    expect(cursorProjectRuleUpgradeStatus(staleVersion, 'AgenticOS', '')).toBe('stale');
+  });
+
+  it('rejects invalid YAML frontmatter when inserting managed hash markers', () => {
+    expect(() => __testInsertAfterYamlFrontmatter('no frontmatter', 'x')).toThrow(
+      'Cursor project rule template must start with YAML frontmatter',
+    );
+    expect(() => __testInsertAfterYamlFrontmatter('---\nopen\n', 'x')).toThrow(
+      'Cursor project rule template frontmatter is not closed',
+    );
+  });
+
+  it('uses default agent context paths when custom paths are omitted', () => {
+    const content = renderCursorProjectRule('AgenticOS', '');
+    expect(content).toContain('.context/quick-start.md');
+    expect(content).toContain('.context/state.yaml');
+  });
+
+  it('renders project description and custom agent context paths when provided', () => {
+    const content = renderCursorProjectRule('AgenticOS', '  Self-hosting project  ', {
+      quickStartPath: 'standards/.context/quick-start.md',
+      statePath: 'standards/.context/state.yaml',
+      conversationsDir: 'standards/.context/conversations/',
+      markerPath: 'standards/.context/.last_record',
+      knowledgeDir: 'standards/knowledge/',
+      tasksDir: 'standards/tasks/',
+      artifactsDir: 'standards/artifacts/',
+    });
+    expect(content).toContain('Project: AgenticOS — Self-hosting project');
+    expect(content).toContain('standards/.context/quick-start.md');
+    expect(content).toContain('standards/.context/state.yaml');
+  });
+
+  it('reports missing status when inspecting a null rule', () => {
+    expect(inspectCursorProjectRule(null, 'AgenticOS', '').status).toBe('missing');
+  });
+
+  it('detects template drift when managed hash still matches stored body', () => {
+    const rendered = renderCursorProjectRule('AgenticOS', 'Self-hosting project');
+    expect(inspectCursorProjectRule(rendered, 'Other Project', 'Self-hosting project').status).toBe('modified-user');
   });
 });

--- a/mcp-server/src/utils/__tests__/standard-kit-cursor-bridge.test.ts
+++ b/mcp-server/src/utils/__tests__/standard-kit-cursor-bridge.test.ts
@@ -1,0 +1,346 @@
+import { createHash } from 'crypto';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import yaml from 'yaml';
+import {
+  adoptCursorProjectRuleFile,
+  augmentConformanceWithCursor,
+  augmentUpgradeCheckWithCursor,
+  buildCursorGeneratedStatus,
+  resolveCursorBridgeProjectContext,
+} from '../standard-kit-cursor-bridge.js';
+import {
+  CURSOR_PROJECT_RULE_RELATIVE_PATH,
+  renderCursorProjectRule,
+} from '../cursor-project-rule.js';
+import type { AdoptResult, StandardKitConformanceResult, UpgradeCheckResult } from '../standard-kit.js';
+
+const originalAgenticosHome = process.env.AGENTICOS_HOME;
+
+function setupCursorAdapterMatrixHome(): string {
+  const home = mkdtempSync(join(tmpdir(), 'cursor-bridge-matrix-'));
+  const bootstrapDir = join(home, 'projects', 'agenticos', '.meta', 'bootstrap');
+  mkdirSync(bootstrapDir, { recursive: true });
+  writeFileSync(
+    join(bootstrapDir, 'agent-adapter-matrix.yaml'),
+    yaml.stringify({
+      version: 1,
+      primary_policy_surface: 'cross-agent-execution-contract',
+      adapters: [
+        {
+          agent_id: 'cursor',
+          support_tier: 'official',
+          adapter_file: CURSOR_PROJECT_RULE_RELATIVE_PATH,
+          adapter_family: 'cursor',
+          required_runtime_guidance: [
+            '`.cursor/rules/agenticos.mdc` is the Cursor adapter surface for this project.',
+            '## Cursor Runtime Notes',
+            'global activation Skill at `~/.cursor/skills-cursor/agenticos/SKILL.md`',
+            'Use AgenticOS MCP tools before shell directory search',
+            '`agenticos_status`',
+            '`agenticos_switch`',
+            '`agenticos_issue_bootstrap`',
+          ],
+        },
+      ],
+    }),
+    'utf-8',
+  );
+  process.env.AGENTICOS_HOME = home;
+  return home;
+}
+
+function makeAdoptResult(projectPath: string): AdoptResult {
+  return {
+    command: 'agenticos_standard_kit_adopt',
+    status: 'ADOPTED',
+    project_path: projectPath,
+    project_name: 'Sample Project',
+    project_id: 'sample-project',
+    kit_id: 'downstream-standard-kit',
+    kit_version: '0.2.0',
+    created_files: [],
+    upgraded_generated_files: [],
+    skipped_existing_templates: [],
+    skipped_current_generated_files: [],
+  };
+}
+
+function makeUpgradeResult(projectPath: string): UpgradeCheckResult {
+  return {
+    command: 'agenticos_standard_kit_upgrade_check',
+    status: 'CHECKED',
+    project_path: projectPath,
+    project_name: 'Sample Project',
+    project_id: 'sample-project',
+    kit_id: 'downstream-standard-kit',
+    kit_version: '0.2.0',
+    missing_required_files: [],
+    generated_files: [],
+    copied_templates: [],
+  };
+}
+
+describe('standard-kit-cursor-bridge', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    if (originalAgenticosHome === undefined) {
+      delete process.env.AGENTICOS_HOME;
+    } else {
+      process.env.AGENTICOS_HOME = originalAgenticosHome;
+    }
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('creates a missing Cursor project rule during adopt', () => {
+    const projectPath = mkdtempSync(join(tmpdir(), 'cursor-bridge-adopt-'));
+    tempDirs.push(projectPath);
+    writeFileSync(join(projectPath, '.project.yaml'), 'meta:\n  name: Sample Project\n', 'utf-8');
+
+    const project = resolveCursorBridgeProjectContext(projectPath, 'Sample Project', 'Bridge test');
+    const result = adoptCursorProjectRuleFile(makeAdoptResult(projectPath), project);
+
+    expect(result.created_files).toContain(CURSOR_PROJECT_RULE_RELATIVE_PATH);
+    expect(readFileSync(join(projectPath, CURSOR_PROJECT_RULE_RELATIVE_PATH), 'utf-8')).toContain('alwaysApply: true');
+  });
+
+  it('skips current and preserves user-modified Cursor project rules', () => {
+    const projectPath = mkdtempSync(join(tmpdir(), 'cursor-bridge-skip-'));
+    tempDirs.push(projectPath);
+    writeFileSync(join(projectPath, '.project.yaml'), 'meta:\n  name: Sample Project\n', 'utf-8');
+
+    const project = resolveCursorBridgeProjectContext(projectPath, 'Sample Project', '');
+    const current = renderCursorProjectRule('Sample Project', '');
+    mkdirSync(join(projectPath, '.cursor', 'rules'), { recursive: true });
+    writeFileSync(join(projectPath, CURSOR_PROJECT_RULE_RELATIVE_PATH), current, 'utf-8');
+
+    const skippedCurrent = adoptCursorProjectRuleFile(makeAdoptResult(projectPath), project);
+    expect(skippedCurrent.skipped_current_generated_files).toContain(CURSOR_PROJECT_RULE_RELATIVE_PATH);
+
+    const modified = current.replace('## Cursor Runtime Notes', '## Cursor Runtime Notes\n\nLocal note.');
+    writeFileSync(join(projectPath, CURSOR_PROJECT_RULE_RELATIVE_PATH), modified, 'utf-8');
+    const skippedModified = adoptCursorProjectRuleFile(makeAdoptResult(projectPath), project);
+    expect(skippedModified.skipped_existing_templates).toContain(CURSOR_PROJECT_RULE_RELATIVE_PATH);
+  });
+
+  it('upgrades stale managed Cursor project rules', () => {
+    const projectPath = mkdtempSync(join(tmpdir(), 'cursor-bridge-upgrade-'));
+    tempDirs.push(projectPath);
+    writeFileSync(join(projectPath, '.project.yaml'), 'meta:\n  name: Sample Project\n', 'utf-8');
+
+    const rendered = renderCursorProjectRule('Sample Project', '');
+    const staleBody = rendered.replace('template_version: 1', 'template_version: 0').replace(/^<!-- agenticos-skill-managed-sha256: [a-f0-9]{64} -->\n?/m, '');
+    const staleHash = createHash('sha256').update(staleBody, 'utf-8').digest('hex');
+    const stale = staleBody.replace('\n---\n', `\n---\n<!-- agenticos-skill-managed-sha256: ${staleHash} -->\n`);
+    mkdirSync(join(projectPath, '.cursor', 'rules'), { recursive: true });
+    writeFileSync(join(projectPath, CURSOR_PROJECT_RULE_RELATIVE_PATH), stale, 'utf-8');
+
+    const project = resolveCursorBridgeProjectContext(projectPath, 'Sample Project', '');
+    const result = adoptCursorProjectRuleFile(makeAdoptResult(projectPath), project);
+
+    expect(result.upgraded_generated_files).toContain(CURSOR_PROJECT_RULE_RELATIVE_PATH);
+    expect(buildCursorGeneratedStatus(
+      readFileSync(join(projectPath, CURSOR_PROJECT_RULE_RELATIVE_PATH), 'utf-8'),
+      project,
+    ).status).toBe('current');
+  });
+
+  it('augments upgrade checks with Cursor generated status', () => {
+    const projectPath = mkdtempSync(join(tmpdir(), 'cursor-bridge-check-'));
+    tempDirs.push(projectPath);
+    writeFileSync(join(projectPath, '.project.yaml'), 'meta:\n  name: Sample Project\n', 'utf-8');
+
+    const project = resolveCursorBridgeProjectContext(projectPath, 'Sample Project', '');
+    const missing = augmentUpgradeCheckWithCursor(makeUpgradeResult(projectPath), project);
+    expect(missing.generated_files.find((item) => item.path === CURSOR_PROJECT_RULE_RELATIVE_PATH)).toMatchObject({
+      status: 'missing',
+    });
+    expect(missing.missing_required_files).toContain(CURSOR_PROJECT_RULE_RELATIVE_PATH);
+
+    mkdirSync(join(projectPath, '.cursor', 'rules'), { recursive: true });
+    writeFileSync(
+      join(projectPath, CURSOR_PROJECT_RULE_RELATIVE_PATH),
+      renderCursorProjectRule('Sample Project', ''),
+      'utf-8',
+    );
+    const current = augmentUpgradeCheckWithCursor(makeUpgradeResult(projectPath), project);
+    expect(current.generated_files.find((item) => item.path === CURSOR_PROJECT_RULE_RELATIVE_PATH)).toMatchObject({
+      status: 'current',
+    });
+    expect(current.missing_required_files).not.toContain(CURSOR_PROJECT_RULE_RELATIVE_PATH);
+  });
+
+  it('augments conformance with a passing Cursor adapter check', async () => {
+    const matrixHome = setupCursorAdapterMatrixHome();
+    tempDirs.push(matrixHome);
+    const projectPath = mkdtempSync(join(tmpdir(), 'cursor-bridge-conformance-'));
+    tempDirs.push(projectPath);
+    writeFileSync(join(projectPath, '.project.yaml'), 'meta:\n  name: Sample Project\n', 'utf-8');
+    mkdirSync(join(projectPath, '.cursor', 'rules'), { recursive: true });
+    writeFileSync(
+      join(projectPath, CURSOR_PROJECT_RULE_RELATIVE_PATH),
+      renderCursorProjectRule('Sample Project', ''),
+      'utf-8',
+    );
+
+    const project = resolveCursorBridgeProjectContext(projectPath, 'Sample Project', '');
+    const base: StandardKitConformanceResult = {
+      command: 'agenticos_standard_kit_conformance_check',
+      status: 'FAIL',
+      summary: 'standard-kit conformance failed: 0 missing files, 0 failed behaviors, 1 failed adapters',
+      project_path: projectPath,
+      project_name: 'Sample Project',
+      project_id: 'sample-project',
+      kit_id: 'downstream-standard-kit',
+      kit_version: '0.2.0',
+      missing_required_files: [],
+      generated_files: [],
+      copied_templates: [],
+      behavior_checks: [{ behavior: 'cross_agent_policy_contract', status: 'PASS', summary: 'ok', evidence_paths: [] }],
+      adapter_checks: [
+        {
+          agent_id: 'cursor',
+          adapter_file: CURSOR_PROJECT_RULE_RELATIVE_PATH,
+          status: 'FAIL',
+          summary: 'wrong content source',
+        },
+      ],
+    };
+
+    const augmented = await augmentConformanceWithCursor(base, project);
+    expect(augmented.adapter_checks.find((item) => item.agent_id === 'cursor')).toMatchObject({ status: 'PASS' });
+    expect(augmented.status).toBe('PASS');
+  });
+
+  it('returns SKIP conformance unchanged', async () => {
+    const projectPath = mkdtempSync(join(tmpdir(), 'cursor-bridge-skip-conformance-'));
+    tempDirs.push(projectPath);
+    const project = resolveCursorBridgeProjectContext(projectPath, 'Sample Project', '');
+    const skipped: StandardKitConformanceResult = {
+      command: 'agenticos_standard_kit_conformance_check',
+      status: 'SKIP',
+      summary: 'skipped',
+      project_path: projectPath,
+      project_name: 'Sample Project',
+      project_id: 'sample-project',
+      kit_id: 'downstream-standard-kit',
+      kit_version: '0.2.0',
+      missing_required_files: [],
+      generated_files: [],
+      copied_templates: [],
+      behavior_checks: [],
+      adapter_checks: [],
+    };
+
+    await expect(augmentConformanceWithCursor(skipped, project)).resolves.toBe(skipped);
+  });
+
+  it('returns conformance unchanged when the adapter matrix has no Cursor entry', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'cursor-bridge-no-cursor-matrix-'));
+    tempDirs.push(home);
+    const bootstrapDir = join(home, 'projects', 'agenticos', '.meta', 'bootstrap');
+    mkdirSync(bootstrapDir, { recursive: true });
+    writeFileSync(
+      join(bootstrapDir, 'agent-adapter-matrix.yaml'),
+      yaml.stringify({
+        version: 1,
+        primary_policy_surface: 'cross-agent-execution-contract',
+        adapters: [],
+      }),
+      'utf-8',
+    );
+    process.env.AGENTICOS_HOME = home;
+
+    const projectPath = mkdtempSync(join(tmpdir(), 'cursor-bridge-no-cursor-project-'));
+    tempDirs.push(projectPath);
+    const project = resolveCursorBridgeProjectContext(projectPath, 'Sample Project', '');
+    const base: StandardKitConformanceResult = {
+      command: 'agenticos_standard_kit_conformance_check',
+      status: 'FAIL',
+      summary: 'base failure',
+      project_path: projectPath,
+      project_name: 'Sample Project',
+      project_id: 'sample-project',
+      kit_id: 'downstream-standard-kit',
+      kit_version: '0.2.0',
+      missing_required_files: [],
+      generated_files: [],
+      copied_templates: [],
+      behavior_checks: [],
+      adapter_checks: [],
+    };
+
+    await expect(augmentConformanceWithCursor(base, project)).resolves.toBe(base);
+  });
+
+  it('marks conformance FAIL when Cursor guidance is missing from the rule file', async () => {
+    const matrixHome = setupCursorAdapterMatrixHome();
+    tempDirs.push(matrixHome);
+    const projectPath = mkdtempSync(join(tmpdir(), 'cursor-bridge-fail-conformance-'));
+    tempDirs.push(projectPath);
+    writeFileSync(join(projectPath, '.project.yaml'), 'meta:\n  name: Sample Project\n', 'utf-8');
+    mkdirSync(join(projectPath, '.cursor', 'rules'), { recursive: true });
+    writeFileSync(
+      join(projectPath, CURSOR_PROJECT_RULE_RELATIVE_PATH),
+      renderCursorProjectRule('Sample Project', '').replace('## Cursor Runtime Notes', '## Runtime Notes'),
+      'utf-8',
+    );
+
+    const project = resolveCursorBridgeProjectContext(projectPath, 'Sample Project', '');
+    const base: StandardKitConformanceResult = {
+      command: 'agenticos_standard_kit_conformance_check',
+      status: 'PASS',
+      summary: 'standard-kit conformance passed',
+      project_path: projectPath,
+      project_name: 'Sample Project',
+      project_id: 'sample-project',
+      kit_id: 'downstream-standard-kit',
+      kit_version: '0.2.0',
+      missing_required_files: [],
+      generated_files: [],
+      copied_templates: [],
+      behavior_checks: [{ behavior: 'cross_agent_policy_contract', status: 'PASS', summary: 'ok', evidence_paths: [] }],
+      adapter_checks: [],
+    };
+
+    const augmented = await augmentConformanceWithCursor(base, project);
+    expect(augmented.adapter_checks.find((item) => item.agent_id === 'cursor')).toMatchObject({ status: 'FAIL' });
+    expect(augmented.status).toBe('FAIL');
+  });
+
+  it('resolves project context when .project.yaml is missing', () => {
+    const projectPath = mkdtempSync(join(tmpdir(), 'cursor-bridge-no-project-yaml-'));
+    tempDirs.push(projectPath);
+
+    const project = resolveCursorBridgeProjectContext(projectPath, 'Fallback Name', 'Fallback description');
+    expect(project.projectName).toBe('Fallback Name');
+    expect(project.projectDescription).toBe('Fallback description');
+  });
+
+  it('keeps skipped-current adopt result when upgrade returns unchanged content', () => {
+    const projectPath = mkdtempSync(join(tmpdir(), 'cursor-bridge-no-op-upgrade-'));
+    tempDirs.push(projectPath);
+    writeFileSync(join(projectPath, '.project.yaml'), 'meta:\n  name: Sample Project\n', 'utf-8');
+
+    const project = resolveCursorBridgeProjectContext(projectPath, 'Sample Project', '');
+    const current = renderCursorProjectRule('Sample Project', '', project.agentContextPaths);
+    mkdirSync(join(projectPath, '.cursor', 'rules'), { recursive: true });
+    writeFileSync(join(projectPath, CURSOR_PROJECT_RULE_RELATIVE_PATH), current, 'utf-8');
+
+    const staleBody = current.replace('template_version: 1', 'template_version: 0').replace(/^<!-- agenticos-skill-managed-sha256: [a-f0-9]{64} -->\n?/m, '');
+    const staleHash = createHash('sha256').update(staleBody, 'utf-8').digest('hex');
+    const stale = staleBody.replace('\n---\n', `\n---\n<!-- agenticos-skill-managed-sha256: ${staleHash} -->\n`);
+    writeFileSync(join(projectPath, CURSOR_PROJECT_RULE_RELATIVE_PATH), stale, 'utf-8');
+
+    const first = adoptCursorProjectRuleFile(makeAdoptResult(projectPath), project);
+    expect(first.upgraded_generated_files).toContain(CURSOR_PROJECT_RULE_RELATIVE_PATH);
+
+    const second = adoptCursorProjectRuleFile(makeAdoptResult(projectPath), project);
+    expect(second.skipped_current_generated_files).toContain(CURSOR_PROJECT_RULE_RELATIVE_PATH);
+  });
+});

--- a/mcp-server/src/utils/__tests__/standard-kit-cursor-bridge.test.ts
+++ b/mcp-server/src/utils/__tests__/standard-kit-cursor-bridge.test.ts
@@ -2,7 +2,7 @@ import { createHash } from 'crypto';
 import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import yaml from 'yaml';
 import {
   adoptCursorProjectRuleFile,
@@ -15,6 +15,7 @@ import {
   CURSOR_PROJECT_RULE_RELATIVE_PATH,
   renderCursorProjectRule,
 } from '../cursor-project-rule.js';
+import * as cursorProjectRule from '../cursor-project-rule.js';
 import type { AdoptResult, StandardKitConformanceResult, UpgradeCheckResult } from '../standard-kit.js';
 
 const originalAgenticosHome = process.env.AGENTICOS_HOME;
@@ -87,6 +88,7 @@ describe('standard-kit-cursor-bridge', () => {
   const tempDirs: string[] = [];
 
   afterEach(() => {
+    vi.restoreAllMocks();
     if (originalAgenticosHome === undefined) {
       delete process.env.AGENTICOS_HOME;
     } else {
@@ -342,5 +344,107 @@ describe('standard-kit-cursor-bridge', () => {
 
     const second = adoptCursorProjectRuleFile(makeAdoptResult(projectPath), project);
     expect(second.skipped_current_generated_files).toContain(CURSOR_PROJECT_RULE_RELATIVE_PATH);
+  });
+
+  it('skips adopt writes when upgrade output matches the existing file bytes', () => {
+    const projectPath = mkdtempSync(join(tmpdir(), 'cursor-bridge-upgrade-noop-bytes-'));
+    tempDirs.push(projectPath);
+    writeFileSync(join(projectPath, '.project.yaml'), 'meta:\n  name: Sample Project\n', 'utf-8');
+
+    const project = resolveCursorBridgeProjectContext(projectPath);
+    const existing = renderCursorProjectRule('Sample Project', '', project.agentContextPaths);
+    mkdirSync(join(projectPath, '.cursor', 'rules'), { recursive: true });
+    writeFileSync(join(projectPath, CURSOR_PROJECT_RULE_RELATIVE_PATH), existing, 'utf-8');
+
+    vi.spyOn(cursorProjectRule, 'upgradeCursorProjectRule').mockReturnValue(existing);
+    vi.spyOn(cursorProjectRule, 'cursorProjectRuleUpgradeStatus').mockReturnValue('stale');
+    vi.spyOn(cursorProjectRule, 'inspectCursorProjectRule').mockReturnValue({
+      status: 'stale-managed',
+      installedVersion: 0,
+      expectedVersion: 1,
+      detail: 'stale',
+    });
+
+    const result = adoptCursorProjectRuleFile(makeAdoptResult(projectPath), project);
+    expect(result.skipped_current_generated_files).toContain(CURSOR_PROJECT_RULE_RELATIVE_PATH);
+    expect(readFileSync(join(projectPath, CURSOR_PROJECT_RULE_RELATIVE_PATH), 'utf-8')).toBe(existing);
+
+    vi.restoreAllMocks();
+  });
+
+  it('adds missing Cursor rule paths to conformance results', async () => {
+    const matrixHome = setupCursorAdapterMatrixHome();
+    tempDirs.push(matrixHome);
+    const projectPath = mkdtempSync(join(tmpdir(), 'cursor-bridge-missing-conformance-'));
+    tempDirs.push(projectPath);
+    writeFileSync(join(projectPath, '.project.yaml'), 'meta:\n  name: Sample Project\n', 'utf-8');
+
+    const project = resolveCursorBridgeProjectContext(projectPath, 'Sample Project', '');
+    const base: StandardKitConformanceResult = {
+      command: 'agenticos_standard_kit_conformance_check',
+      status: 'FAIL',
+      summary: 'missing cursor rule',
+      project_path: projectPath,
+      project_name: 'Sample Project',
+      project_id: 'sample-project',
+      kit_id: 'downstream-standard-kit',
+      kit_version: '0.2.0',
+      missing_required_files: [],
+      generated_files: [],
+      copied_templates: [],
+      behavior_checks: [],
+      adapter_checks: [],
+    };
+
+    const augmented = await augmentConformanceWithCursor(base, project);
+    expect(augmented.missing_required_files).toContain(CURSOR_PROJECT_RULE_RELATIVE_PATH);
+    expect(augmented.adapter_checks.find((item) => item.agent_id === 'cursor')).toMatchObject({ status: 'FAIL' });
+  });
+
+  it('reads project metadata from .project.yaml when explicit names are omitted', () => {
+    const projectPath = mkdtempSync(join(tmpdir(), 'cursor-bridge-project-meta-'));
+    tempDirs.push(projectPath);
+    writeFileSync(
+      join(projectPath, '.project.yaml'),
+      'meta:\n  name: Yaml Project\n  description: From yaml\n',
+      'utf-8',
+    );
+
+    const project = resolveCursorBridgeProjectContext(projectPath);
+    expect(project.projectName).toBe('Yaml Project');
+    expect(project.projectDescription).toBe('From yaml');
+  });
+
+  it('prefers explicit project identity over .project.yaml metadata', () => {
+    const projectPath = mkdtempSync(join(tmpdir(), 'cursor-bridge-explicit-meta-'));
+    tempDirs.push(projectPath);
+    writeFileSync(
+      join(projectPath, '.project.yaml'),
+      'meta:\n  name: Yaml Project\n  description: From yaml\n',
+      'utf-8',
+    );
+
+    const project = resolveCursorBridgeProjectContext(projectPath, 'Explicit Project', 'Explicit description');
+    expect(project.projectName).toBe('Explicit Project');
+    expect(project.projectDescription).toBe('Explicit description');
+  });
+
+  it('falls back to default project identity when metadata is unavailable', () => {
+    const projectPath = mkdtempSync(join(tmpdir(), 'cursor-bridge-default-meta-'));
+    tempDirs.push(projectPath);
+
+    const project = resolveCursorBridgeProjectContext(projectPath);
+    expect(project.projectName).toBe('Project');
+    expect(project.projectDescription).toBe('');
+  });
+
+  it('treats empty .project.yaml files as missing metadata', () => {
+    const projectPath = mkdtempSync(join(tmpdir(), 'cursor-bridge-empty-project-yaml-'));
+    tempDirs.push(projectPath);
+    writeFileSync(join(projectPath, '.project.yaml'), '', 'utf-8');
+
+    const project = resolveCursorBridgeProjectContext(projectPath);
+    expect(project.projectName).toBe('Project');
+    expect(project.projectDescription).toBe('');
   });
 });

--- a/mcp-server/src/utils/agent-skill.ts
+++ b/mcp-server/src/utils/agent-skill.ts
@@ -70,9 +70,9 @@ export function resolveAgentSkillTarget(
       return {
         agentId,
         label: 'Cursor AgenticOS activation Skill',
-        supported: false,
-        path: null,
-        reloadHint: 'Cursor Skill installation is not supported by AgenticOS bootstrap yet.',
+        supported: true,
+        path: join(homeDir, '.cursor', 'skills-cursor', AGENTICOS_SKILL_NAME, 'SKILL.md'),
+        reloadHint: 'Restart Cursor or reload its Skill index so the AgenticOS activation Skill is picked up.',
       };
     case 'gemini-cli':
       return {

--- a/mcp-server/src/utils/agent-skill.ts
+++ b/mcp-server/src/utils/agent-skill.ts
@@ -306,3 +306,8 @@ function insertAfterYamlFrontmatter(content: string, insertion: string): string 
   const insertionIndex = closingDelimiterIndex + '\n---\n'.length;
   return `${content.slice(0, insertionIndex)}${insertion}${content.slice(insertionIndex)}`;
 }
+
+/** @internal Exported for unit tests only. */
+export function __testInsertAfterYamlFrontmatter(content: string, insertion: string): string {
+  return insertAfterYamlFrontmatter(content, insertion);
+}

--- a/mcp-server/src/utils/canonical-sync.ts
+++ b/mcp-server/src/utils/canonical-sync.ts
@@ -104,7 +104,7 @@ async function readProjectYaml(projectPath?: string): Promise<any | null> {
 
 export function resolveRuntimeManagedEntries(projectYaml: any | null): string[] {
   if (!projectYaml) {
-    return ['CLAUDE.md', 'AGENTS.md'];
+    return ['CLAUDE.md', 'AGENTS.md', '.cursor/rules/agenticos.mdc'];
   }
 
   const contextPaths = resolveManagedProjectContextDisplayPaths(projectYaml);
@@ -120,6 +120,7 @@ export function resolveRuntimeManagedEntries(projectYaml: any | null): string[] 
     normalize(contextPaths.conversationsDir, { directory: true }),
     'CLAUDE.md',
     'AGENTS.md',
+    '.cursor/rules/agenticos.mdc',
   ];
 }
 

--- a/mcp-server/src/utils/cursor-project-rule.ts
+++ b/mcp-server/src/utils/cursor-project-rule.ts
@@ -231,7 +231,7 @@ export function inspectCursorProjectRule(
   if (withoutHash === expectedWithoutHash) {
     return {
       status: 'current',
-      installedVersion: installedVersion ?? expectedVersion,
+      installedVersion: expectedVersion,
       expectedVersion,
       detail: `Cursor project rule is current at v${expectedVersion}.`,
     };

--- a/mcp-server/src/utils/cursor-project-rule.ts
+++ b/mcp-server/src/utils/cursor-project-rule.ts
@@ -282,3 +282,8 @@ export function cursorProjectRuleUpgradeStatus(
   if (inspection.status === 'current') return 'current';
   return 'stale';
 }
+
+/** @internal Exported for unit tests only. */
+export function __testInsertAfterYamlFrontmatter(content: string, insertion: string): string {
+  return insertAfterYamlFrontmatter(content, insertion);
+}

--- a/mcp-server/src/utils/cursor-project-rule.ts
+++ b/mcp-server/src/utils/cursor-project-rule.ts
@@ -1,0 +1,284 @@
+import { createHash } from 'crypto';
+import { readFileSync } from 'fs';
+import type { ManagedProjectContextDisplayPaths } from './agent-context-paths.js';
+import {
+  PROJECT_SWITCH_ROUTING_CONTENT,
+  PROJECT_SWITCH_ROUTING_TITLE,
+  SHARED_POLICY_BULLETS,
+  SHARED_POLICY_TITLE,
+  TASK_INTAKE_RULE_CONTENT,
+  TASK_INTAKE_RULE_TITLE,
+} from './distill.js';
+import { STOP_HOOK_MIGRATION_BULLETS } from './stop-hook-guidance.js';
+
+export const CURSOR_PROJECT_RULE_RELATIVE_PATH = '.cursor/rules/agenticos.mdc';
+export const CURSOR_PROJECT_RULE_TEMPLATE_VERSION = 1;
+
+const HASH_MARKER_RE = /^<!-- agenticos-skill-managed-sha256: ([a-f0-9]{64}) -->\n?/m;
+const FRONTMATTER_TEMPLATE_VERSION_RE = /^\s*template_version:\s*(\d+)\s*$/m;
+
+export type CursorProjectRuleStatus =
+  | 'missing'
+  | 'current'
+  | 'stale-managed'
+  | 'modified-user';
+
+export interface CursorProjectRuleInspection {
+  status: CursorProjectRuleStatus;
+  installedVersion: number | null;
+  expectedVersion: number;
+  detail: string;
+}
+
+const DEFAULT_AGENT_CONTEXT_PATHS: ManagedProjectContextDisplayPaths = {
+  quickStartPath: '.context/quick-start.md',
+  statePath: '.context/state.yaml',
+  conversationsDir: '.context/conversations/',
+  markerPath: '.context/.last_record',
+  knowledgeDir: 'knowledge/',
+  tasksDir: 'tasks/',
+  artifactsDir: 'artifacts/',
+};
+
+function normalizeAgentContextPaths(
+  paths?: Partial<ManagedProjectContextDisplayPaths>,
+): ManagedProjectContextDisplayPaths {
+  return {
+    quickStartPath: paths?.quickStartPath || DEFAULT_AGENT_CONTEXT_PATHS.quickStartPath,
+    statePath: paths?.statePath || DEFAULT_AGENT_CONTEXT_PATHS.statePath,
+    conversationsDir: paths?.conversationsDir || DEFAULT_AGENT_CONTEXT_PATHS.conversationsDir,
+    markerPath: paths?.markerPath || DEFAULT_AGENT_CONTEXT_PATHS.markerPath,
+    knowledgeDir: paths?.knowledgeDir || DEFAULT_AGENT_CONTEXT_PATHS.knowledgeDir,
+    tasksDir: paths?.tasksDir || DEFAULT_AGENT_CONTEXT_PATHS.tasksDir,
+    artifactsDir: paths?.artifactsDir || DEFAULT_AGENT_CONTEXT_PATHS.artifactsDir,
+  };
+}
+
+function sha256(content: string): string {
+  return createHash('sha256').update(content, 'utf-8').digest('hex');
+}
+
+function insertAfterYamlFrontmatter(content: string, insertion: string): string {
+  if (!content.startsWith('---\n')) {
+    throw new Error('Cursor project rule template must start with YAML frontmatter');
+  }
+  const end = content.indexOf('\n---\n', 4);
+  if (end === -1) {
+    throw new Error('Cursor project rule template frontmatter is not closed');
+  }
+  return `${content.slice(0, end + 5)}${insertion}${content.slice(end + 5)}`;
+}
+
+function extractTemplateVersion(content: string): number | null {
+  const match = content.match(FRONTMATTER_TEMPLATE_VERSION_RE);
+  return match ? Number(match[1]) : null;
+}
+
+function extractStoredHash(content: string): string | null {
+  const match = content.match(HASH_MARKER_RE);
+  return match ? match[1] : null;
+}
+
+function stripHashMarker(content: string): string {
+  return content.replace(HASH_MARKER_RE, '');
+}
+
+function renderCursorProjectRuleWithoutHash(
+  name: string,
+  description: string,
+  paths?: Partial<ManagedProjectContextDisplayPaths>,
+): string {
+  const contextPaths = normalizeAgentContextPaths(paths);
+  const descriptionLine = description.trim()
+    ? `\nProject: ${name} — ${description.trim()}`
+    : `\nProject: ${name}`;
+
+  return `---
+description: AgenticOS project execution policy for ${name}
+alwaysApply: true
+metadata:
+  agenticos:
+    managed: true
+    template_version: ${CURSOR_PROJECT_RULE_TEMPLATE_VERSION}
+---
+
+# AgenticOS — ${name}
+
+## Adapter Role
+
+\`.cursor/rules/agenticos.mdc\` is the Cursor adapter surface for this project.
+It must expose the same canonical policy as other agent adapters while allowing Cursor-specific operator guidance.${descriptionLine}
+
+## ${SHARED_POLICY_TITLE}
+
+${SHARED_POLICY_BULLETS.map((line) => `- ${line}`).join('\n')}
+
+## Cursor Runtime Notes
+
+- This always-applied project rule complements the global activation Skill at \`~/.cursor/skills-cursor/agenticos/SKILL.md\`.
+- Use AgenticOS MCP tools before shell directory search, raw \`cd\`, or git branch inspection.
+${STOP_HOOK_MIGRATION_BULLETS.map((line) => `- ${line}`).join('\n')}
+
+## Stop-Hook (Optional)
+
+If your runtime supports local stop hooks, configure \`agenticos-record-reminder\` as a local reminder. This is optional, not a canonical guardrail.
+
+## ${TASK_INTAKE_RULE_TITLE}
+
+${TASK_INTAKE_RULE_CONTENT}
+
+## ${PROJECT_SWITCH_ROUTING_TITLE}
+
+${PROJECT_SWITCH_ROUTING_CONTENT}
+
+## Guardrail Protocol (MANDATORY)
+
+Before implementation edits, confirm session/project alignment with \`agenticos_status\`; if no session project is bound or the bound project is not the intended one, call \`agenticos_switch\`.
+
+For implementation-affecting work:
+
+1. call \`agenticos_preflight\`; if the result is \`REDIRECT\`, call \`agenticos_branch_bootstrap\` and continue in the returned worktree
+2. after the issue worktree is active, perform the normal startup load and record \`agenticos_issue_bootstrap\`
+3. rerun \`agenticos_preflight\` in that worktree before editing
+4. call \`agenticos_edit_guard\` immediately before implementation edits
+5. before PR creation or merge, call \`agenticos_pr_scope_check\`
+
+If any guardrail command returns \`BLOCK\`, stop and resolve the blocking reason before continuing.
+
+## MANDATORY: Recording Protocol
+
+> All session activity MUST be recorded. If you skip this, context is lost forever.
+
+**During session**: After completing any meaningful unit of work, call \`agenticos_record\` with summary, decisions, outcomes, pending, and current_task.
+
+**Before session ends**: Call \`agenticos_record\` with complete summary, then \`agenticos_save\` to commit to Git.
+
+## Session Start Protocol
+
+On session start:
+
+1. Call \`agenticos_status\` to confirm current project and task
+2. If not on \`${name}\` project, call \`agenticos_switch\`
+3. Read \`.project.yaml\`, \`${contextPaths.quickStartPath}\`, and \`${contextPaths.statePath}\`
+4. If implementation work requested, enter Guardrail Protocol before editing
+5. Greet with: project name, last progress, pending items, suggested next step
+`;
+}
+
+export function renderCursorProjectRule(
+  name: string,
+  description: string,
+  paths?: Partial<ManagedProjectContextDisplayPaths>,
+): string {
+  const withoutHash = renderCursorProjectRuleWithoutHash(name, description, paths);
+  const hash = sha256(withoutHash);
+  return insertAfterYamlFrontmatter(
+    withoutHash,
+    `<!-- agenticos-skill-managed-sha256: ${hash} -->\n`,
+  );
+}
+
+export function inspectCursorProjectRule(
+  content: string | null,
+  name: string,
+  description: string,
+  paths?: Partial<ManagedProjectContextDisplayPaths>,
+): CursorProjectRuleInspection {
+  const expectedVersion = CURSOR_PROJECT_RULE_TEMPLATE_VERSION;
+
+  if (content === null) {
+    return {
+      status: 'missing',
+      installedVersion: null,
+      expectedVersion,
+      detail: 'Cursor project rule is not installed.',
+    };
+  }
+
+  const installedVersion = extractTemplateVersion(content);
+  const storedHash = extractStoredHash(content);
+  const withoutHash = stripHashMarker(content);
+  const expectedContent = renderCursorProjectRule(name, description, paths);
+  const expectedWithoutHash = stripHashMarker(expectedContent);
+
+  if (storedHash === null) {
+    return {
+      status: 'stale-managed',
+      installedVersion,
+      expectedVersion,
+      detail: 'Cursor project rule is missing the managed sha256 marker.',
+    };
+  }
+
+  if (sha256(withoutHash) !== storedHash) {
+    return {
+      status: 'modified-user',
+      installedVersion,
+      expectedVersion,
+      detail: 'Cursor project rule was modified locally and no longer matches the managed template.',
+    };
+  }
+
+  if (installedVersion === null || installedVersion < expectedVersion) {
+    return {
+      status: 'stale-managed',
+      installedVersion,
+      expectedVersion,
+      detail: `Cursor project rule template v${installedVersion ?? 'unknown'} is older than expected v${expectedVersion}.`,
+    };
+  }
+
+  if (withoutHash === expectedWithoutHash) {
+    return {
+      status: 'current',
+      installedVersion: installedVersion ?? expectedVersion,
+      expectedVersion,
+      detail: `Cursor project rule is current at v${expectedVersion}.`,
+    };
+  }
+
+  return {
+    status: 'modified-user',
+    installedVersion,
+    expectedVersion,
+    detail: 'Cursor project rule was modified locally and no longer matches the managed template.',
+  };
+}
+
+export function upgradeCursorProjectRule(
+  existingPath: string,
+  name: string,
+  description: string,
+  paths?: Partial<ManagedProjectContextDisplayPaths>,
+  options: { force?: boolean } = {},
+): string {
+  let existingContent: string | null = null;
+  try {
+    existingContent = readFileSync(existingPath, 'utf-8');
+  } catch {
+    existingContent = null;
+  }
+
+  const inspection = inspectCursorProjectRule(existingContent, name, description, paths);
+  if (inspection.status === 'modified-user' && !options.force) {
+    return existingContent!;
+  }
+
+  if (inspection.status === 'current') {
+    return existingContent!;
+  }
+
+  return renderCursorProjectRule(name, description, paths);
+}
+
+export function cursorProjectRuleUpgradeStatus(
+  content: string | null,
+  name: string,
+  description: string,
+  paths?: Partial<ManagedProjectContextDisplayPaths>,
+): 'missing' | 'current' | 'stale' {
+  const inspection = inspectCursorProjectRule(content, name, description, paths);
+  if (inspection.status === 'missing') return 'missing';
+  if (inspection.status === 'current') return 'current';
+  return 'stale';
+}

--- a/mcp-server/src/utils/health.ts
+++ b/mcp-server/src/utils/health.ts
@@ -72,7 +72,7 @@ async function readProjectYaml(projectPath?: string): Promise<any | null> {
 
 function resolveRuntimeManagedEntries(projectYaml: any | null): string[] {
   if (!projectYaml) {
-    return ['CLAUDE.md', 'AGENTS.md', '.cursor/rules/agenticos.mdc'];
+    return ['CLAUDE.md', 'AGENTS.md'];
   }
 
   const contextPaths = resolveManagedProjectContextDisplayPaths(projectYaml);
@@ -85,7 +85,6 @@ function resolveRuntimeManagedEntries(projectYaml: any | null): string[] {
     toRelative(contextPaths.conversationsDir),
     'CLAUDE.md',
     'AGENTS.md',
-    '.cursor/rules/agenticos.mdc',
   ];
 }
 

--- a/mcp-server/src/utils/health.ts
+++ b/mcp-server/src/utils/health.ts
@@ -72,7 +72,7 @@ async function readProjectYaml(projectPath?: string): Promise<any | null> {
 
 function resolveRuntimeManagedEntries(projectYaml: any | null): string[] {
   if (!projectYaml) {
-    return ['CLAUDE.md', 'AGENTS.md'];
+    return ['CLAUDE.md', 'AGENTS.md', '.cursor/rules/agenticos.mdc'];
   }
 
   const contextPaths = resolveManagedProjectContextDisplayPaths(projectYaml);
@@ -85,6 +85,7 @@ function resolveRuntimeManagedEntries(projectYaml: any | null): string[] {
     toRelative(contextPaths.conversationsDir),
     'CLAUDE.md',
     'AGENTS.md',
+    '.cursor/rules/agenticos.mdc',
   ];
 }
 

--- a/mcp-server/src/utils/standard-kit-cursor-bridge.ts
+++ b/mcp-server/src/utils/standard-kit-cursor-bridge.ts
@@ -29,8 +29,7 @@ export interface CursorBridgeProjectContext {
 }
 
 function fileContainsAll(content: string | null, needles: string[]): boolean {
-  if (!content) return false;
-  return needles.every((needle) => content.includes(needle));
+  return needles.every((needle) => Boolean(content?.includes(needle)));
 }
 
 export function resolveCursorBridgeProjectContext(

--- a/mcp-server/src/utils/standard-kit-cursor-bridge.ts
+++ b/mcp-server/src/utils/standard-kit-cursor-bridge.ts
@@ -1,0 +1,254 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { dirname, join } from 'path';
+import yaml from 'yaml';
+import { resolveManagedProjectContextDisplayPaths } from './agent-context-paths.js';
+import { getOfficialAgentAdapters, loadAgentAdapterMatrix } from './agent-adapter-matrix.js';
+import {
+  CURSOR_PROJECT_RULE_RELATIVE_PATH,
+  CURSOR_PROJECT_RULE_TEMPLATE_VERSION,
+  cursorProjectRuleUpgradeStatus,
+  inspectCursorProjectRule,
+  renderCursorProjectRule,
+  upgradeCursorProjectRule,
+} from './cursor-project-rule.js';
+import type {
+  AdoptResult,
+  ResolvedProjectTarget,
+  StandardKitConformanceResult,
+  UpgradeCheckGeneratedStatus,
+  UpgradeCheckResult,
+} from './standard-kit.js';
+
+export const CURSOR_PROJECT_RULE_REQUIRED = CURSOR_PROJECT_RULE_RELATIVE_PATH;
+
+export interface CursorBridgeProjectContext {
+  projectPath: string;
+  projectName: string;
+  projectDescription: string;
+  agentContextPaths: ResolvedProjectTarget['agentContextPaths'];
+}
+
+function fileContainsAll(content: string | null, needles: string[]): boolean {
+  if (!content) return false;
+  return needles.every((needle) => content.includes(needle));
+}
+
+export function resolveCursorBridgeProjectContext(
+  projectPath: string,
+  projectName?: string,
+  projectDescription?: string,
+): CursorBridgeProjectContext {
+  let projectYaml: any = {};
+  try {
+    projectYaml = yaml.parse(readFileSync(join(projectPath, '.project.yaml'), 'utf-8')) || {};
+  } catch {
+    projectYaml = {};
+  }
+
+  const meta = projectYaml.meta || {};
+  return {
+    projectPath,
+    projectName: projectName || meta.name || 'Project',
+    projectDescription: projectDescription || meta.description || '',
+    agentContextPaths: resolveManagedProjectContextDisplayPaths(projectYaml),
+  };
+}
+
+export function buildCursorGeneratedStatus(
+  content: string | null,
+  project: Pick<CursorBridgeProjectContext, 'projectName' | 'projectDescription' | 'agentContextPaths'>,
+): UpgradeCheckGeneratedStatus {
+  const inspection = inspectCursorProjectRule(
+    content,
+    project.projectName,
+    project.projectDescription,
+    project.agentContextPaths,
+  );
+  const upgradeStatus = cursorProjectRuleUpgradeStatus(
+    content,
+    project.projectName,
+    project.projectDescription,
+    project.agentContextPaths,
+  );
+
+  return {
+    path: CURSOR_PROJECT_RULE_RELATIVE_PATH,
+    status: upgradeStatus,
+    current_version: inspection.installedVersion,
+    expected_version: CURSOR_PROJECT_RULE_TEMPLATE_VERSION,
+  };
+}
+
+export function adoptCursorProjectRuleFile(
+  result: AdoptResult,
+  project: CursorBridgeProjectContext,
+): AdoptResult {
+  const destination = join(project.projectPath, CURSOR_PROJECT_RULE_RELATIVE_PATH);
+
+  if (!existsSync(destination)) {
+    const content = renderCursorProjectRule(
+      project.projectName,
+      project.projectDescription,
+      project.agentContextPaths,
+    );
+    mkdirSync(dirname(destination), { recursive: true });
+    writeFileSync(destination, content, 'utf-8');
+    return {
+      ...result,
+      created_files: [...result.created_files, CURSOR_PROJECT_RULE_RELATIVE_PATH],
+    };
+  }
+
+  const existingContent = readFileSync(destination, 'utf-8');
+  const inspection = inspectCursorProjectRule(
+    existingContent,
+    project.projectName,
+    project.projectDescription,
+    project.agentContextPaths,
+  );
+  const upgradeStatus = cursorProjectRuleUpgradeStatus(
+    existingContent,
+    project.projectName,
+    project.projectDescription,
+    project.agentContextPaths,
+  );
+
+  if (upgradeStatus === 'current') {
+    return {
+      ...result,
+      skipped_current_generated_files: [
+        ...result.skipped_current_generated_files,
+        CURSOR_PROJECT_RULE_RELATIVE_PATH,
+      ],
+    };
+  }
+
+  if (inspection.status === 'modified-user') {
+    return {
+      ...result,
+      skipped_existing_templates: [
+        ...result.skipped_existing_templates,
+        CURSOR_PROJECT_RULE_RELATIVE_PATH,
+      ],
+    };
+  }
+
+  const upgraded = upgradeCursorProjectRule(
+    destination,
+    project.projectName,
+    project.projectDescription,
+    project.agentContextPaths,
+  );
+  if (upgraded !== existingContent) {
+    writeFileSync(destination, upgraded, 'utf-8');
+    return {
+      ...result,
+      upgraded_generated_files: [...result.upgraded_generated_files, CURSOR_PROJECT_RULE_RELATIVE_PATH],
+    };
+  }
+
+  return {
+    ...result,
+    skipped_current_generated_files: [
+      ...result.skipped_current_generated_files,
+      CURSOR_PROJECT_RULE_RELATIVE_PATH,
+    ],
+  };
+}
+
+export function augmentUpgradeCheckWithCursor(
+  upgrade: UpgradeCheckResult,
+  project: CursorBridgeProjectContext,
+): UpgradeCheckResult {
+  const destination = join(project.projectPath, CURSOR_PROJECT_RULE_RELATIVE_PATH);
+  let content: string | null = null;
+  try {
+    content = readFileSync(destination, 'utf-8');
+  } catch {
+    content = null;
+  }
+
+  const cursorStatus = buildCursorGeneratedStatus(content, project);
+  const generated_files = [
+    ...upgrade.generated_files.filter((item) => item.path !== CURSOR_PROJECT_RULE_RELATIVE_PATH),
+    cursorStatus,
+  ];
+  const missing_required_files = upgrade.missing_required_files.filter(
+    (path) => path !== CURSOR_PROJECT_RULE_RELATIVE_PATH,
+  );
+  if (cursorStatus.status === 'missing') {
+    missing_required_files.push(CURSOR_PROJECT_RULE_RELATIVE_PATH);
+  }
+
+  return {
+    ...upgrade,
+    missing_required_files,
+    generated_files,
+  };
+}
+
+export async function augmentConformanceWithCursor(
+  conformance: StandardKitConformanceResult,
+  project: CursorBridgeProjectContext,
+): Promise<StandardKitConformanceResult> {
+  if (conformance.status === 'SKIP') {
+    return conformance;
+  }
+
+  const destination = join(project.projectPath, CURSOR_PROJECT_RULE_RELATIVE_PATH);
+  const cursorRuleMd = existsSync(destination) ? readFileSync(destination, 'utf-8') : null;
+  const officialAdapters = getOfficialAgentAdapters(await loadAgentAdapterMatrix());
+  const cursorAdapter = officialAdapters.find((adapter) => adapter.agent_id === 'cursor');
+  if (!cursorAdapter) {
+    return conformance;
+  }
+
+  const generatedStatus = buildCursorGeneratedStatus(cursorRuleMd, project);
+  const pass = generatedStatus.status === 'current'
+    && fileContainsAll(cursorRuleMd, cursorAdapter.required_runtime_guidance);
+
+  const cursorCheck = {
+    agent_id: cursorAdapter.agent_id,
+    adapter_file: cursorAdapter.adapter_file,
+    status: pass ? 'PASS' as const : 'FAIL' as const,
+    summary: pass
+      ? `${cursorAdapter.agent_id} is covered by a current generated adapter surface with required runtime guidance.`
+      : `${cursorAdapter.agent_id} is missing a current generated adapter surface or required runtime guidance.`,
+  };
+
+  const adapter_checks = [
+    ...conformance.adapter_checks.filter((item) => item.agent_id !== 'cursor'),
+    cursorCheck,
+  ];
+  const generated_files = [
+    ...conformance.generated_files.filter((item) => item.path !== CURSOR_PROJECT_RULE_RELATIVE_PATH),
+    generatedStatus,
+  ];
+  const missing_required_files = conformance.missing_required_files.filter(
+    (path) => path !== CURSOR_PROJECT_RULE_RELATIVE_PATH,
+  );
+  if (generatedStatus.status === 'missing') {
+    missing_required_files.push(CURSOR_PROJECT_RULE_RELATIVE_PATH);
+  }
+
+  const failedBehaviors = conformance.behavior_checks.filter((item) => item.status === 'FAIL');
+  const failedAdapters = adapter_checks.filter((item) => item.status === 'FAIL');
+  const generatedDrift = generated_files.filter((item) => item.status !== 'current');
+  const status = missing_required_files.length === 0
+    && failedBehaviors.length === 0
+    && failedAdapters.length === 0
+    && generatedDrift.length === 0
+    ? 'PASS'
+    : 'FAIL';
+
+  return {
+    ...conformance,
+    status,
+    summary: status === 'PASS'
+      ? 'standard-kit conformance passed'
+      : `standard-kit conformance failed: ${missing_required_files.length} missing files, ${failedBehaviors.length} failed behaviors, ${failedAdapters.length} failed adapters`,
+    missing_required_files,
+    generated_files,
+    adapter_checks,
+  };
+}

--- a/mcp-server/src/utils/standard-kit.ts
+++ b/mcp-server/src/utils/standard-kit.ts
@@ -5,6 +5,14 @@ import yaml from 'yaml';
 import { getAgenticOSHome, loadRegistry } from './registry.js';
 import { getOfficialAgentAdapters, loadAgentAdapterMatrix } from './agent-adapter-matrix.js';
 import { CURRENT_TEMPLATE_VERSION, extractTemplateVersion, generateAgentsMd, generateClaudeMd, upgradeClaudeMd, upgradeAgentsMd } from './distill.js';
+import {
+  CURSOR_PROJECT_RULE_RELATIVE_PATH,
+  CURSOR_PROJECT_RULE_TEMPLATE_VERSION,
+  cursorProjectRuleUpgradeStatus,
+  inspectCursorProjectRule,
+  renderCursorProjectRule,
+  upgradeCursorProjectRule,
+} from './cursor-project-rule.js';
 import { buildArchivedReferenceMessage, isArchivedReferenceProject } from './project-contract.js';
 import { validateContextPublicationPolicy } from './project-contract.js';
 import { resolveAgenticOSProductPath, resolveAgenticOSProductRoot, toCanonicalProductRelativePath } from './product-source-root.js';
@@ -1006,6 +1014,69 @@ function getCopiedTemplateEntries(manifest: StandardKitManifest): StandardKitEnt
   return manifest.layers.copied_templates?.entries || [];
 }
 
+function renderGeneratedFileContent(
+  entryPath: string,
+  project: ResolvedProjectTarget,
+): string {
+  switch (entryPath) {
+    case 'AGENTS.md':
+      return generateAgentsMd(project.projectName, project.projectDescription, project.agentContextPaths);
+    case 'CLAUDE.md':
+      return generateClaudeMd(project.projectName, project.projectDescription, undefined, project.agentContextPaths);
+    case CURSOR_PROJECT_RULE_RELATIVE_PATH:
+      return renderCursorProjectRule(project.projectName, project.projectDescription, project.agentContextPaths);
+    default:
+      throw new Error(`Unsupported generated standard-kit file "${entryPath}".`);
+  }
+}
+
+function upgradeGeneratedFileContent(
+  entryPath: string,
+  destination: string,
+  project: ResolvedProjectTarget,
+): string {
+  switch (entryPath) {
+    case 'AGENTS.md':
+      return upgradeAgentsMd(destination, project.projectName, project.projectDescription, project.agentContextPaths);
+    case 'CLAUDE.md':
+      return upgradeClaudeMd(destination, project.projectName, project.projectDescription, undefined, project.agentContextPaths);
+    case CURSOR_PROJECT_RULE_RELATIVE_PATH:
+      return upgradeCursorProjectRule(
+        destination,
+        project.projectName,
+        project.projectDescription,
+        project.agentContextPaths,
+      );
+    default:
+      throw new Error(`Unsupported generated standard-kit file "${entryPath}".`);
+  }
+}
+
+function resolveGeneratedFileExpectedVersion(entryPath: string): number {
+  return entryPath === CURSOR_PROJECT_RULE_RELATIVE_PATH
+    ? CURSOR_PROJECT_RULE_TEMPLATE_VERSION
+    : CURRENT_TEMPLATE_VERSION;
+}
+
+function resolveGeneratedFileUpgradeStatus(
+  entryPath: string,
+  content: string | null,
+  project: ResolvedProjectTarget,
+): 'missing' | 'current' | 'stale' {
+  if (entryPath === CURSOR_PROJECT_RULE_RELATIVE_PATH) {
+    return cursorProjectRuleUpgradeStatus(
+      content,
+      project.projectName,
+      project.projectDescription,
+      project.agentContextPaths,
+    );
+  }
+
+  if (content === null) return 'missing';
+  const version = extractTemplateVersion(content);
+  return version >= CURRENT_TEMPLATE_VERSION ? 'current' : 'stale';
+}
+
 async function readProjectFile(projectPath: string, relativePath: string): Promise<string | null> {
   const absolutePath = join(projectPath, relativePath);
   if (!existsSync(absolutePath)) return null;
@@ -1048,26 +1119,36 @@ export async function adoptStandardKit(args: { project_path?: string; project?: 
   }
 
   for (const entry of getGeneratedEntries(manifest)) {
-      const destination = join(project.projectPath, entry.path);
-      if (!existsSync(destination)) {
-      const content = entry.path === 'AGENTS.md'
-        ? generateAgentsMd(project.projectName, project.projectDescription, project.agentContextPaths)
-        : generateClaudeMd(project.projectName, project.projectDescription, undefined, project.agentContextPaths);
+    const destination = join(project.projectPath, entry.path);
+    if (!existsSync(destination)) {
+      const content = renderGeneratedFileContent(entry.path, project);
+      await ensureParentDir(destination);
       await writeFile(destination, content, 'utf-8');
       createdFiles.push(entry.path);
       continue;
     }
 
     const existingContent = await readFile(destination, 'utf-8');
-    const version = extractTemplateVersion(existingContent);
-    if (version >= CURRENT_TEMPLATE_VERSION) {
+    const upgradeStatus = resolveGeneratedFileUpgradeStatus(entry.path, existingContent, project);
+    if (upgradeStatus === 'current') {
       skippedCurrentGeneratedFiles.push(entry.path);
       continue;
     }
 
-    const upgraded = entry.path === 'AGENTS.md'
-      ? upgradeAgentsMd(destination, project.projectName, project.projectDescription, project.agentContextPaths)
-      : upgradeClaudeMd(destination, project.projectName, project.projectDescription, undefined, project.agentContextPaths);
+    if (entry.path === CURSOR_PROJECT_RULE_RELATIVE_PATH) {
+      const inspection = inspectCursorProjectRule(
+        existingContent,
+        project.projectName,
+        project.projectDescription,
+        project.agentContextPaths,
+      );
+      if (inspection.status === 'modified-user') {
+        skippedExistingTemplates.push(entry.path);
+        continue;
+      }
+    }
+
+    const upgraded = upgradeGeneratedFileContent(entry.path, destination, project);
     await writeFile(destination, upgraded, 'utf-8');
     upgradedGeneratedFiles.push(entry.path);
   }
@@ -1110,23 +1191,27 @@ export async function checkStandardKitUpgrade(args: {
 
   for (const entry of getGeneratedEntries(manifest)) {
     const destination = join(project.projectPath, entry.path);
+    const expectedVersion = resolveGeneratedFileExpectedVersion(entry.path);
     if (!existsSync(destination)) {
       generatedFiles.push({
         path: entry.path,
         status: 'missing',
         current_version: null,
-        expected_version: CURRENT_TEMPLATE_VERSION,
+        expected_version: expectedVersion,
       });
       continue;
     }
 
     const content = await readFile(destination, 'utf-8');
-    const version = extractTemplateVersion(content);
+    const upgradeStatus = resolveGeneratedFileUpgradeStatus(entry.path, content, project);
+    const installedVersion = entry.path === CURSOR_PROJECT_RULE_RELATIVE_PATH
+      ? inspectCursorProjectRule(content, project.projectName, project.projectDescription, project.agentContextPaths).installedVersion
+      : extractTemplateVersion(content);
     generatedFiles.push({
       path: entry.path,
-      status: version >= CURRENT_TEMPLATE_VERSION ? 'current' : 'stale',
-      current_version: version,
-      expected_version: CURRENT_TEMPLATE_VERSION,
+      status: upgradeStatus,
+      current_version: installedVersion,
+      expected_version: expectedVersion,
     });
   }
 
@@ -1465,6 +1550,7 @@ export async function checkStandardKitConformance(args: { project_path?: string;
   const stateYaml = yaml.parse((await readProjectFile(upgrade.project_path, '.context/state.yaml')) || '{}') as any;
   const agentsMd = await readProjectFile(upgrade.project_path, 'AGENTS.md');
   const claudeMd = await readProjectFile(upgrade.project_path, 'CLAUDE.md');
+  const cursorRuleMd = await readProjectFile(upgrade.project_path, CURSOR_PROJECT_RULE_RELATIVE_PATH);
   const designBrief = await readProjectFile(upgrade.project_path, 'tasks/templates/issue-design-brief.md');
   const bootstrapMatrixSource = readFileSync(resolveAgenticOSProductPath('.meta', 'bootstrap', 'agent-bootstrap-matrix.yaml'), 'utf-8');
   const adapterMatrixSource = readFileSync(resolveAgenticOSProductPath('.meta', 'bootstrap', 'agent-adapter-matrix.yaml'), 'utf-8');
@@ -1730,7 +1816,11 @@ export async function checkStandardKitConformance(args: { project_path?: string;
   }
 
   const adapterChecks: ConformanceAdapterStatus[] = officialAdapters.map((adapter) => {
-    const content = adapter.adapter_file === 'CLAUDE.md' ? claudeMd : agentsMd;
+    const content = adapter.adapter_file === 'CLAUDE.md'
+      ? claudeMd
+      : adapter.adapter_file === CURSOR_PROJECT_RULE_RELATIVE_PATH
+        ? cursorRuleMd
+        : agentsMd;
     const generatedStatus = upgrade.generated_files.find((item) => item.path === adapter.adapter_file);
     const pass = generatedStatus?.status === 'current'
       && fileContainsAll(content, adapter.required_runtime_guidance);

--- a/mcp-server/src/utils/standard-kit.ts
+++ b/mcp-server/src/utils/standard-kit.ts
@@ -5,14 +5,6 @@ import yaml from 'yaml';
 import { getAgenticOSHome, loadRegistry } from './registry.js';
 import { getOfficialAgentAdapters, loadAgentAdapterMatrix } from './agent-adapter-matrix.js';
 import { CURRENT_TEMPLATE_VERSION, extractTemplateVersion, generateAgentsMd, generateClaudeMd, upgradeClaudeMd, upgradeAgentsMd } from './distill.js';
-import {
-  CURSOR_PROJECT_RULE_RELATIVE_PATH,
-  CURSOR_PROJECT_RULE_TEMPLATE_VERSION,
-  cursorProjectRuleUpgradeStatus,
-  inspectCursorProjectRule,
-  renderCursorProjectRule,
-  upgradeCursorProjectRule,
-} from './cursor-project-rule.js';
 import { buildArchivedReferenceMessage, isArchivedReferenceProject } from './project-contract.js';
 import { validateContextPublicationPolicy } from './project-contract.js';
 import { resolveAgenticOSProductPath, resolveAgenticOSProductRoot, toCanonicalProductRelativePath } from './product-source-root.js';
@@ -1014,69 +1006,6 @@ function getCopiedTemplateEntries(manifest: StandardKitManifest): StandardKitEnt
   return manifest.layers.copied_templates?.entries || [];
 }
 
-function renderGeneratedFileContent(
-  entryPath: string,
-  project: ResolvedProjectTarget,
-): string {
-  switch (entryPath) {
-    case 'AGENTS.md':
-      return generateAgentsMd(project.projectName, project.projectDescription, project.agentContextPaths);
-    case 'CLAUDE.md':
-      return generateClaudeMd(project.projectName, project.projectDescription, undefined, project.agentContextPaths);
-    case CURSOR_PROJECT_RULE_RELATIVE_PATH:
-      return renderCursorProjectRule(project.projectName, project.projectDescription, project.agentContextPaths);
-    default:
-      throw new Error(`Unsupported generated standard-kit file "${entryPath}".`);
-  }
-}
-
-function upgradeGeneratedFileContent(
-  entryPath: string,
-  destination: string,
-  project: ResolvedProjectTarget,
-): string {
-  switch (entryPath) {
-    case 'AGENTS.md':
-      return upgradeAgentsMd(destination, project.projectName, project.projectDescription, project.agentContextPaths);
-    case 'CLAUDE.md':
-      return upgradeClaudeMd(destination, project.projectName, project.projectDescription, undefined, project.agentContextPaths);
-    case CURSOR_PROJECT_RULE_RELATIVE_PATH:
-      return upgradeCursorProjectRule(
-        destination,
-        project.projectName,
-        project.projectDescription,
-        project.agentContextPaths,
-      );
-    default:
-      throw new Error(`Unsupported generated standard-kit file "${entryPath}".`);
-  }
-}
-
-function resolveGeneratedFileExpectedVersion(entryPath: string): number {
-  return entryPath === CURSOR_PROJECT_RULE_RELATIVE_PATH
-    ? CURSOR_PROJECT_RULE_TEMPLATE_VERSION
-    : CURRENT_TEMPLATE_VERSION;
-}
-
-function resolveGeneratedFileUpgradeStatus(
-  entryPath: string,
-  content: string | null,
-  project: ResolvedProjectTarget,
-): 'missing' | 'current' | 'stale' {
-  if (entryPath === CURSOR_PROJECT_RULE_RELATIVE_PATH) {
-    return cursorProjectRuleUpgradeStatus(
-      content,
-      project.projectName,
-      project.projectDescription,
-      project.agentContextPaths,
-    );
-  }
-
-  if (content === null) return 'missing';
-  const version = extractTemplateVersion(content);
-  return version >= CURRENT_TEMPLATE_VERSION ? 'current' : 'stale';
-}
-
 async function readProjectFile(projectPath: string, relativePath: string): Promise<string | null> {
   const absolutePath = join(projectPath, relativePath);
   if (!existsSync(absolutePath)) return null;
@@ -1119,36 +1048,26 @@ export async function adoptStandardKit(args: { project_path?: string; project?: 
   }
 
   for (const entry of getGeneratedEntries(manifest)) {
-    const destination = join(project.projectPath, entry.path);
-    if (!existsSync(destination)) {
-      const content = renderGeneratedFileContent(entry.path, project);
-      await ensureParentDir(destination);
+      const destination = join(project.projectPath, entry.path);
+      if (!existsSync(destination)) {
+      const content = entry.path === 'AGENTS.md'
+        ? generateAgentsMd(project.projectName, project.projectDescription, project.agentContextPaths)
+        : generateClaudeMd(project.projectName, project.projectDescription, undefined, project.agentContextPaths);
       await writeFile(destination, content, 'utf-8');
       createdFiles.push(entry.path);
       continue;
     }
 
     const existingContent = await readFile(destination, 'utf-8');
-    const upgradeStatus = resolveGeneratedFileUpgradeStatus(entry.path, existingContent, project);
-    if (upgradeStatus === 'current') {
+    const version = extractTemplateVersion(existingContent);
+    if (version >= CURRENT_TEMPLATE_VERSION) {
       skippedCurrentGeneratedFiles.push(entry.path);
       continue;
     }
 
-    if (entry.path === CURSOR_PROJECT_RULE_RELATIVE_PATH) {
-      const inspection = inspectCursorProjectRule(
-        existingContent,
-        project.projectName,
-        project.projectDescription,
-        project.agentContextPaths,
-      );
-      if (inspection.status === 'modified-user') {
-        skippedExistingTemplates.push(entry.path);
-        continue;
-      }
-    }
-
-    const upgraded = upgradeGeneratedFileContent(entry.path, destination, project);
+    const upgraded = entry.path === 'AGENTS.md'
+      ? upgradeAgentsMd(destination, project.projectName, project.projectDescription, project.agentContextPaths)
+      : upgradeClaudeMd(destination, project.projectName, project.projectDescription, undefined, project.agentContextPaths);
     await writeFile(destination, upgraded, 'utf-8');
     upgradedGeneratedFiles.push(entry.path);
   }
@@ -1191,27 +1110,23 @@ export async function checkStandardKitUpgrade(args: {
 
   for (const entry of getGeneratedEntries(manifest)) {
     const destination = join(project.projectPath, entry.path);
-    const expectedVersion = resolveGeneratedFileExpectedVersion(entry.path);
     if (!existsSync(destination)) {
       generatedFiles.push({
         path: entry.path,
         status: 'missing',
         current_version: null,
-        expected_version: expectedVersion,
+        expected_version: CURRENT_TEMPLATE_VERSION,
       });
       continue;
     }
 
     const content = await readFile(destination, 'utf-8');
-    const upgradeStatus = resolveGeneratedFileUpgradeStatus(entry.path, content, project);
-    const installedVersion = entry.path === CURSOR_PROJECT_RULE_RELATIVE_PATH
-      ? inspectCursorProjectRule(content, project.projectName, project.projectDescription, project.agentContextPaths).installedVersion
-      : extractTemplateVersion(content);
+    const version = extractTemplateVersion(content);
     generatedFiles.push({
       path: entry.path,
-      status: upgradeStatus,
-      current_version: installedVersion,
-      expected_version: expectedVersion,
+      status: version >= CURRENT_TEMPLATE_VERSION ? 'current' : 'stale',
+      current_version: version,
+      expected_version: CURRENT_TEMPLATE_VERSION,
     });
   }
 
@@ -1550,7 +1465,6 @@ export async function checkStandardKitConformance(args: { project_path?: string;
   const stateYaml = yaml.parse((await readProjectFile(upgrade.project_path, '.context/state.yaml')) || '{}') as any;
   const agentsMd = await readProjectFile(upgrade.project_path, 'AGENTS.md');
   const claudeMd = await readProjectFile(upgrade.project_path, 'CLAUDE.md');
-  const cursorRuleMd = await readProjectFile(upgrade.project_path, CURSOR_PROJECT_RULE_RELATIVE_PATH);
   const designBrief = await readProjectFile(upgrade.project_path, 'tasks/templates/issue-design-brief.md');
   const bootstrapMatrixSource = readFileSync(resolveAgenticOSProductPath('.meta', 'bootstrap', 'agent-bootstrap-matrix.yaml'), 'utf-8');
   const adapterMatrixSource = readFileSync(resolveAgenticOSProductPath('.meta', 'bootstrap', 'agent-adapter-matrix.yaml'), 'utf-8');
@@ -1816,11 +1730,7 @@ export async function checkStandardKitConformance(args: { project_path?: string;
   }
 
   const adapterChecks: ConformanceAdapterStatus[] = officialAdapters.map((adapter) => {
-    const content = adapter.adapter_file === 'CLAUDE.md'
-      ? claudeMd
-      : adapter.adapter_file === CURSOR_PROJECT_RULE_RELATIVE_PATH
-        ? cursorRuleMd
-        : agentsMd;
+    const content = adapter.adapter_file === 'CLAUDE.md' ? claudeMd : agentsMd;
     const generatedStatus = upgrade.generated_files.find((item) => item.path === adapter.adapter_file);
     const pass = generatedStatus?.status === 'current'
       && fileContainsAll(content, adapter.required_runtime_guidance);


### PR DESCRIPTION
## Summary
- **Phase 1 (0.4.28):** Global Cursor activation Skill at `~/.cursor/skills-cursor/agenticos/SKILL.md` via `--install-skills` / `--verify`; sha256-managed canonical template shared with Codex and Claude Code.
- **Phase 2 (0.4.29):** Managed per-project Cursor adapter rule at `.cursor/rules/agenticos.mdc` (`alwaysApply: true`) through `agenticos_init`, standard-kit adopt/upgrade/conformance, and runtime sync — same canonical guardrail/recording/session-start policy as `AGENTS.md` / `CLAUDE.md`.
- **Phase 3 (0.4.30):** Docs + Homebrew caveats + bootstrap matrix updates; Cursor standard-kit bridge (`standard-kit-cursor-bridge.ts`) keeps core standard-kit unchanged while adoption/conformance still validates `.cursor/rules/agenticos.mdc`.

## Commits
| Commit | Scope |
|---|---|
| `848c589` | Phase 1 — global Cursor activation Skill |
| `438655d` | Phase 2 — `.cursor/rules/agenticos.mdc` + standard-kit integration |
| `43f80a5` | Phase 3 — docs, Homebrew, bootstrap matrix, cursor bridge refactor |
| `6ef2088` | Tests/coverage — changed-scope CI for bridge layer |

## Test plan
- [x] `npm test` — **1100/1100** pass (worktree `mcp-server`)
- [x] `./tools/coverage-preflight.sh` — changed-scope **pass**
- [x] CI on PR — build (20/22), readme-lint, mcp-symlink-integration, **coverage-changed-scope** all green
- [x] Live verify (worktree bootstrap): `OK cursor-skill: Skill state: current v1 at ~/.cursor/skills-cursor/agenticos/SKILL.md`
- [x] `agenticos_pr_scope_check` — **PASS** (worktree as `project_path`)
- [ ] Reviewer: after merge + Homebrew bump, re-run `agenticos-bootstrap --install-skills --verify` and confirm Cursor routing in a fresh session
- [ ] Reviewer: run `agenticos_standard_kit_conformance_check` on a managed project and confirm `.cursor/rules/agenticos.mdc` + `AGENTS.md` + `CLAUDE.md` drift reporting

## Guardrail trace
- `agenticos_preflight` / `agenticos_edit_guard` / `agenticos_pr_scope_check`: **PASS**
- `agenticos_save`: **BLOCKED** in worktree sessions — tracked as **#482** (resolver/worktree binding)

## Follow-ups
- **#482** — guardrail resolver gaps (`agenticos_switch` / `agenticos_save` worktree binding)
- **Gemini CLI activation Skill** — spin-off issue (G4 from #480; Cursor leaves Gemini entry as `supported: false`)

Closes #480 (Phases 1–3). G3 stretch item (bootstrap `--verify` reporting `cursor-project-rule` / `agents-md` / `claude-md` alongside skills) remains future polish; adapter drift is covered today via standard-kit conformance.