### PR TITLE
feat(gemini): global activation Skill bootstrap (#483)

### DIFF
--- a/.meta/bootstrap/agent-adapter-matrix.yaml
+++ b/.meta/bootstrap/agent-adapter-matrix.yaml
@@ -44,6 +44,7 @@ adapters:
     required_runtime_guidance:
       - '`AGENTS.md` is the Codex/generic adapter surface for this project.'
       - '## Codex / Generic Runtime Notes'
+      - 'global activation Skill at `~/.gemini/skills/agenticos/SKILL.md`'
       - 'use explicit `agenticos_*` tool calls'
       - 'Bootstrap differences are runtime concerns'
       - '`agenticos_status`'

--- a/.meta/bootstrap/agent-bootstrap-matrix.yaml
+++ b/.meta/bootstrap/agent-bootstrap-matrix.yaml
@@ -135,8 +135,15 @@ supported_agents:
     canonical_bootstrap_method: cli-command
     canonical_config_location: ~/.gemini/settings.json managed via `gemini mcp add -s user`
     bootstrap_command: gemini mcp add -s user -e AGENTICOS_HOME="$AGENTICOS_HOME" agenticos agenticos-mcp
+    activation_skill:
+      support: official
+      path: ~/.gemini/skills/agenticos/SKILL.md
+      install_command: agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent gemini-cli --install-skills --apply
+      verify_command: agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent gemini-cli --install-skills --verify
+      purpose: route project switch/status/pwd prompts through AgenticOS MCP before filesystem guessing
     verification:
       - run `gemini mcp list`
+      - run `agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent gemini-cli --install-skills --verify` when natural-language routing is required
       - restart Gemini CLI after registration
       - confirm `agenticos` appears and can call `agenticos_list`
     transport_debug:
@@ -146,8 +153,8 @@ supported_agents:
       - if the stored server environment does not include `AGENTICOS_HOME`, treat the registration as incomplete and re-add it with explicit env injection
     routing_debug:
       - transport registration only proves MCP availability, not project-intent recognition
-      - AgenticOS activation Skill install is not supported for Gemini CLI in this bootstrap version
-      - if intent routing does not trigger, use explicit `agenticos_*` calls and ensure the project instructions are loaded
+      - if the activation Skill is missing or stale, run `agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent gemini-cli --install-skills --verify`
+      - load the project `AGENTS.md` adapter surface and explicit `agenticos_*` tool calls before treating routing failure as transport failure
 experimental_agents:
   - id: generic-mcp-tool
     label: Other MCP-Compatible Tools

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No unreleased changes._
 
+## [0.4.31] — 2026-05-24
+
+### Added
+- bootstrap: managed AgenticOS activation Skill is now installed for Gemini CLI at `~/.gemini/skills/agenticos/SKILL.md` via the same `--install-skills` / `--force-skills` flow already shipped for Codex, Claude Code, and Cursor (#483 Phase 1).
+
+### Changed
+- bootstrap matrix: Gemini CLI now declares an official `activation_skill` block and updated routing-debug guidance instead of stating Skill install is unsupported.
+- docs/Homebrew caveats: Gemini CLI is included in activation-skill install guidance alongside Codex, Claude Code, and Cursor.
+
 ## [0.4.30] — 2026-05-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ agenticos-bootstrap --workspace "$AGENTICOS_HOME" --first-run --auto-configure-h
 
 On macOS, `--first-run` also sets up `launchctl` persistence so GUI tools
 inherit `AGENTICOS_HOME` across sessions. It installs the AgenticOS activation
-Skill for local-skill-capable agents: Codex, Claude Code, and Cursor.
+Skill for local-skill-capable agents: Codex, Claude Code, Cursor, and Gemini CLI.
 `--auto-configure-hooks` adds the Claude Code PostToolUse hook that reads the
 `agenticos_switch` result from hook stdin and feeds the selected project path
 back into Claude as explicit cwd guidance. The hook cannot mutate a parent
@@ -156,6 +156,12 @@ Install or refresh the Cursor activation Skill with:
 
 ```bash
 agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent cursor --install-skills --apply
+```
+
+For Gemini CLI, install or refresh the activation Skill with:
+
+```bash
+agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent gemini-cli --install-skills --apply
 ```
 
 Managed projects also receive the always-applied project rule at

--- a/homebrew-tap/Formula/agenticos.rb
+++ b/homebrew-tap/Formula/agenticos.rb
@@ -24,7 +24,7 @@ class Agenticos < Formula
     ohai "  export AGENTICOS_HOME=\"#{var}/agenticos\""
     ohai ""
     ohai "Then run: agenticos-bootstrap --workspace \"#{var}/agenticos\" --first-run --auto-configure-hooks"
-    ohai "First-run mode installs AgenticOS activation Skills for Codex, Claude Code, and Cursor when selected."
+    ohai "First-run mode installs AgenticOS activation Skills for Codex, Claude Code, Cursor, and Gemini CLI when selected."
     ohai "On macOS, first-run mode also enables launchctl persistence for GUI/session inheritance."
     ohai "To audit the current Homebrew/runtime bootstrap state without changes, use: agenticos-config --validate"
     ohai "Then run: agenticos-bootstrap --workspace \"#{var}/agenticos\" --all --install-skills --verify"
@@ -50,7 +50,7 @@ class Agenticos < Formula
            agenticos-bootstrap --workspace "$AGENTICOS_HOME" --first-run --auto-configure-hooks
 
            First-run mode registers MCP, persists AGENTICOS_HOME where applicable,
-           and installs the AgenticOS activation Skill for Codex, Claude Code, and Cursor when
+           and installs the AgenticOS activation Skill for Codex, Claude Code, Cursor, and Gemini CLI when
            those agents are selected. The Skill helps natural-language requests
            such as "switch to 360Teams" or "切换到 360Teams 项目" discover and
            call AgenticOS MCP before filesystem guessing.
@@ -68,6 +68,7 @@ class Agenticos < Formula
            agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent codex --install-skills --apply
            agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent claude-code --install-skills --apply
            agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent cursor --install-skills --apply
+           agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent gemini-cli --install-skills --apply
 
            AgenticOS-managed Skill files are updated by content hash. User-modified
            files are not overwritten unless you rerun with --force-skills.

--- a/homebrew-tap/README.md
+++ b/homebrew-tap/README.md
@@ -23,7 +23,7 @@ Homebrew does **not**:
 - verify activation for you
 
 After installation, set `AGENTICOS_HOME` explicitly, bootstrap one officially supported agent, restart it, and verify the Homebrew/runtime bootstrap state before relying on `agenticos_list`.
-The recommended bootstrap also installs the AgenticOS activation Skill for Codex, Claude Code, and Cursor when selected, which helps route "switch project", `pwd`, and "切换到 ... 项目" prompts through AgenticOS MCP:
+The recommended bootstrap also installs the AgenticOS activation Skill for Codex, Claude Code, Cursor, and Gemini CLI when selected, which helps route "switch project", `pwd`, and "切换到 ... 项目" prompts through AgenticOS MCP:
 
 ```bash
 # Example default workspace path for a Homebrew-only install
@@ -69,7 +69,7 @@ agenticos-bootstrap --workspace "$AGENTICOS_HOME" --all --install-skills --verif
 Then confirm the server appears in the tool's MCP diagnostics and verify `agenticos_list` works.
 If you prefer not to edit your shell profile, omit `--first-run` and use the explicit MCP commands above instead.
 On macOS, `--first-run` also enables `launchctl` persistence so GUI/session processes inherit `AGENTICOS_HOME`.
-For Codex, Claude Code, and Cursor, `--first-run` implies `--install-skills`; bootstrap updates AgenticOS-managed Skill files by content hash and refuses to overwrite user-modified files unless you pass `--force-skills`.
+For Codex, Claude Code, Cursor, and Gemini CLI, `--first-run` implies `--install-skills`; bootstrap updates AgenticOS-managed Skill files by content hash and refuses to overwrite user-modified files unless you pass `--force-skills`.
 For Claude Code PWD guidance after `agenticos_switch`, run `agenticos-bootstrap --workspace "$AGENTICOS_HOME" --agent claude-code --auto-configure-hooks --apply` or include `--auto-configure-hooks` with `--first-run`. The hook reads Claude's PostToolUse stdin payload and feeds the switched project path back into Claude; it does not mutate a parent shell process.
 Use `agenticos-bootstrap --workspace "$AGENTICOS_HOME" --all --install-skills --verify` with the same flags to audit the current machine state without mutating it.
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -20,7 +20,7 @@ A project management system designed for AI collaboration. When you work on comp
 
 Install AgenticOS, set `AGENTICOS_HOME` explicitly, then either run `agenticos-bootstrap --workspace "$AGENTICOS_HOME" --first-run` or bootstrap one supported agent manually, restart that agent, and explicitly verify `agenticos_list` works before relying on project-intent routing.
 On macOS, `--first-run` also enables `launchctl` persistence for GUI/session inheritance.
-It also installs the AgenticOS activation Skill for local-skill-capable agents — Codex, Claude Code, and Cursor — so switch/status/pwd prompts route to AgenticOS MCP before filesystem guessing.
+It also installs the AgenticOS activation Skill for local-skill-capable agents — Codex, Claude Code, Cursor, and Gemini CLI — so switch/status/pwd prompts route to AgenticOS MCP before filesystem guessing.
 Use `agenticos-config --validate` and `agenticos-bootstrap --workspace "$AGENTICOS_HOME" --all --install-skills --verify` to audit the Homebrew/runtime bootstrap state, activation Skill state, and optional persistence layers without mutating them.
 `--apply` and `--first-run` also record bootstrap metadata in `$AGENTICOS_HOME/.agent-workspace/bootstrap-state.yaml`.
 

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenticos-mcp",
-  "version": "0.4.30",
+  "version": "0.4.31",
   "description": "MCP Server for AgenticOS - AI-native project management system",
   "type": "module",
   "bin": {

--- a/mcp-server/src/__tests__/mcp-regression-baseline.json
+++ b/mcp-server/src/__tests__/mcp-regression-baseline.json
@@ -1,9 +1,9 @@
 {
   "capturedAt": "2026-05-24T00:42:31.675Z",
-  "version": "0.4.30",
+  "version": "0.4.31",
   "serverInfo": {
     "name": "agenticos-mcp",
-    "version": "0.4.30"
+    "version": "0.4.31"
   },
   "protocolVersion": "2025-11-25",
   "capabilities": {

--- a/mcp-server/src/utils/__tests__/agent-skill.test.ts
+++ b/mcp-server/src/utils/__tests__/agent-skill.test.ts
@@ -33,7 +33,7 @@ function createDeps() {
 }
 
 describe('agent skill bootstrap', () => {
-  it('resolves Codex, Claude Code, and Cursor Skill targets', () => {
+  it('resolves Codex, Claude Code, Cursor, and Gemini CLI Skill targets', () => {
     expect(resolveAgentSkillTarget('codex', '/Users/tester').path)
       .toBe('/Users/tester/.codex/skills/agenticos/SKILL.md');
     expect(resolveAgentSkillTarget('claude-code', '/Users/tester').path)
@@ -44,7 +44,10 @@ describe('agent skill bootstrap', () => {
     expect(cursorTarget.path).toBe('/Users/tester/.cursor/skills-cursor/agenticos/SKILL.md');
     expect(cursorTarget.reloadHint).toMatch(/Cursor/);
 
-    expect(resolveAgentSkillTarget('gemini-cli', '/Users/tester').supported).toBe(false);
+    const geminiTarget = resolveAgentSkillTarget('gemini-cli', '/Users/tester');
+    expect(geminiTarget.supported).toBe(true);
+    expect(geminiTarget.path).toBe('/Users/tester/.gemini/skills/agenticos/SKILL.md');
+    expect(geminiTarget.reloadHint).toMatch(/Gemini CLI/);
   });
 
   it('installs and verifies the Cursor managed Skill at ~/.cursor/skills-cursor/agenticos/SKILL.md', () => {
@@ -65,20 +68,41 @@ describe('agent skill bootstrap', () => {
     expect(isAgentSkillOkForVerify(inspectAgentSkill('cursor', '/Users/tester', harness.deps.readFile))).toBe(true);
   });
 
-  it('renders the same canonical Skill content for Codex, Claude Code, and Cursor', () => {
+  it('installs and verifies the Gemini CLI managed Skill at ~/.gemini/skills/agenticos/SKILL.md', () => {
+    const harness = createDeps();
+
+    const result = installAgentSkill('gemini-cli', '/Users/tester', harness.deps);
+
+    expect(result.ok).toBe(true);
+    expect(result.wrote).toBe(true);
+    expect(result.status).toBe('current');
+    expect(harness.dirs).toEqual(['/Users/tester/.gemini/skills/agenticos']);
+
+    const installedPath = '/Users/tester/.gemini/skills/agenticos/SKILL.md';
+    const installed = harness.files.get(installedPath);
+    expect(installed).toContain('AgenticOS Activation');
+    expect(installed).toMatch(/^---\n/);
+    expect(installed).toContain('agenticos-skill-managed-sha256');
+    expect(isAgentSkillOkForVerify(inspectAgentSkill('gemini-cli', '/Users/tester', harness.deps.readFile))).toBe(true);
+  });
+
+  it('renders the same canonical Skill content for Codex, Claude Code, Cursor, and Gemini CLI', () => {
     const harness = createDeps();
 
     installAgentSkill('codex', '/Users/tester', harness.deps);
     installAgentSkill('claude-code', '/Users/tester', harness.deps);
     installAgentSkill('cursor', '/Users/tester', harness.deps);
+    installAgentSkill('gemini-cli', '/Users/tester', harness.deps);
 
     const codex = harness.files.get('/Users/tester/.codex/skills/agenticos/SKILL.md');
     const claude = harness.files.get('/Users/tester/.claude/skills/agenticos/SKILL.md');
     const cursor = harness.files.get('/Users/tester/.cursor/skills-cursor/agenticos/SKILL.md');
+    const gemini = harness.files.get('/Users/tester/.gemini/skills/agenticos/SKILL.md');
 
     expect(codex).toBeDefined();
     expect(claude).toBe(codex);
     expect(cursor).toBe(codex);
+    expect(gemini).toBe(codex);
   });
 
   it('renders a managed Skill with project switch triggers and hash marker', () => {
@@ -212,15 +236,13 @@ metadata:
     expect(isAgentSkillOkForVerify(inspection)).toBe(false);
   });
 
-  it('skips unsupported agents without failing verification', () => {
+  it('reports missing Gemini CLI Skill as not OK for verify until installed', () => {
     const harness = createDeps();
 
-    const result = installAgentSkill('gemini-cli', '/Users/tester', harness.deps);
+    const inspection = inspectAgentSkill('gemini-cli', '/Users/tester', harness.deps.readFile);
 
-    expect(result.ok).toBe(true);
-    expect(result.skipped).toBe(true);
-    expect(result.status).toBe('unsupported');
-    expect(isAgentSkillOkForVerify(result)).toBe(true);
+    expect(inspection.status).toBe('missing');
+    expect(isAgentSkillOkForVerify(inspection)).toBe(false);
   });
 
   it('rejects invalid YAML frontmatter when inserting managed hash markers', () => {

--- a/mcp-server/src/utils/__tests__/bootstrap-cli.test.ts
+++ b/mcp-server/src/utils/__tests__/bootstrap-cli.test.ts
@@ -208,7 +208,7 @@ describe('bootstrap cli', () => {
 
     const text = lines.join('\n');
     expect(text).toContain('cursor-skill: install/update /Users/tester/.cursor/skills-cursor/agenticos/SKILL.md');
-    expect(text).toContain('gemini-cli-skill: skip');
+    expect(text).toContain('gemini-cli-skill: install/update /Users/tester/.gemini/skills/agenticos/SKILL.md');
     expect(text).toContain('overwrite user-modified managed Skill files');
     expect(text).toContain('hermes-discord: enforce Hermes+Discord');
   });
@@ -437,7 +437,7 @@ describe('bootstrap cli', () => {
     expect(bootstrapState.agenticos_skills[0].path).toBe('/Users/tester/.cursor/skills-cursor/agenticos/SKILL.md');
   });
 
-  it('skips unsupported activation Skill installs without failing apply', () => {
+  it('installs the Gemini CLI activation Skill during apply', () => {
     const harness = createDeps();
 
     const exitCode = runBootstrapCli(
@@ -446,7 +446,14 @@ describe('bootstrap cli', () => {
     );
 
     expect(exitCode).toBe(0);
-    expect(harness.stdout.some((line) => line.includes('SKIP gemini-cli-skill'))).toBe(true);
+    expect(harness.stdout.some((line) => line.includes('OK gemini-cli-skill'))).toBe(true);
+    const geminiSkill = harness.files.get('/Users/tester/.gemini/skills/agenticos/SKILL.md');
+    expect(geminiSkill).toContain('agenticos-skill-managed-sha256');
+    expect(geminiSkill).toContain('AgenticOS Activation');
+    const bootstrapState = yaml.parse(harness.files.get('/tmp/workspace/.agent-workspace/bootstrap-state.yaml') || '');
+    expect(bootstrapState.agenticos_skills[0].agent_id).toBe('gemini-cli');
+    expect(bootstrapState.agenticos_skills[0].status).toBe('current');
+    expect(bootstrapState.agenticos_skills[0].path).toBe('/Users/tester/.gemini/skills/agenticos/SKILL.md');
   });
 
   it('fails Skill install on user-modified files unless force is requested', () => {
@@ -849,12 +856,26 @@ describe('bootstrap cli', () => {
     expect(cursorAppliedHarness.files.get('/Users/tester/.cursor/skills-cursor/agenticos/SKILL.md'))
       .toMatch(/AgenticOS Activation/);
 
-    const unsupportedHarness = createDeps();
+    const geminiAppliedHarness = createDeps();
+    expect(runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'gemini-cli', '--install-skills', '--apply'],
+      geminiAppliedHarness.deps,
+    )).toBe(0);
+    geminiAppliedHarness.stdout.length = 0;
     expect(runBootstrapCli(
       ['--workspace', '/tmp/workspace', '--agent', 'gemini-cli', '--install-skills', '--verify'],
-      unsupportedHarness.deps,
+      geminiAppliedHarness.deps,
     )).toBe(0);
-    expect(unsupportedHarness.stdout.some((line) => line.includes('SKIP gemini-cli-skill'))).toBe(true);
+    expect(geminiAppliedHarness.stdout.some((line) => line.includes('OK gemini-cli-skill'))).toBe(true);
+    expect(geminiAppliedHarness.files.get('/Users/tester/.gemini/skills/agenticos/SKILL.md'))
+      .toMatch(/AgenticOS Activation/);
+
+    const missingGeminiHarness = createDeps();
+    expect(runBootstrapCli(
+      ['--workspace', '/tmp/workspace', '--agent', 'gemini-cli', '--install-skills', '--verify'],
+      missingGeminiHarness.deps,
+    )).toBe(1);
+    expect(missingGeminiHarness.stdout.some((line) => line.includes('FAIL gemini-cli-skill'))).toBe(true);
 
     const modifiedHarness = createDeps();
     modifiedHarness.files.set('/Users/tester/.codex/skills/agenticos/SKILL.md', '# local edit\n');

--- a/mcp-server/src/utils/agent-skill.ts
+++ b/mcp-server/src/utils/agent-skill.ts
@@ -100,18 +100,9 @@ export function inspectAgentSkill(
   readFile: (path: string) => string | null,
 ): AgentSkillInspection {
   const target = resolveAgentSkillTarget(agentId, homeDir);
-  if (!target.supported || !target.path) {
-    return {
-      agentId,
-      target,
-      status: 'unsupported',
-      installedVersion: null,
-      expectedVersion: AGENTICOS_SKILL_TEMPLATE_VERSION,
-      detail: `${target.label} is not supported by this bootstrap version.`,
-    };
-  }
+  const skillPath = target.path!;
 
-  const content = readFile(target.path);
+  const content = readFile(skillPath);
   if (content === null) {
     return {
       agentId,
@@ -119,7 +110,7 @@ export function inspectAgentSkill(
       status: 'missing',
       installedVersion: null,
       expectedVersion: AGENTICOS_SKILL_TEMPLATE_VERSION,
-      detail: `missing ${target.path}`,
+      detail: `missing ${skillPath}`,
     };
   }
 
@@ -135,7 +126,7 @@ export function inspectAgentSkill(
       status: 'modified-user',
       installedVersion,
       expectedVersion: AGENTICOS_SKILL_TEMPLATE_VERSION,
-      detail: `${target.path} exists but is not a managed AgenticOS Skill.`,
+      detail: `${skillPath} exists but is not a managed AgenticOS Skill.`,
     };
   }
 
@@ -146,7 +137,7 @@ export function inspectAgentSkill(
       status: 'modified-user',
       installedVersion,
       expectedVersion: AGENTICOS_SKILL_TEMPLATE_VERSION,
-      detail: `${target.path} was modified after AgenticOS installed it.`,
+      detail: `${skillPath} was modified after AgenticOS installed it.`,
     };
   }
 
@@ -157,7 +148,7 @@ export function inspectAgentSkill(
       status: 'current',
       installedVersion,
       expectedVersion: AGENTICOS_SKILL_TEMPLATE_VERSION,
-      detail: `current v${installedVersion} at ${target.path}`,
+      detail: `current v${installedVersion} at ${skillPath}`,
     };
   }
 
@@ -168,8 +159,8 @@ export function inspectAgentSkill(
     installedVersion,
     expectedVersion: AGENTICOS_SKILL_TEMPLATE_VERSION,
     detail: installedVersion === AGENTICOS_SKILL_TEMPLATE_VERSION
-      ? `managed Skill at ${target.path} differs from the current v${AGENTICOS_SKILL_TEMPLATE_VERSION} template`
-      : `managed Skill at ${target.path} is v${installedVersion}; expected v${AGENTICOS_SKILL_TEMPLATE_VERSION}`,
+      ? `managed Skill at ${skillPath} differs from the current v${AGENTICOS_SKILL_TEMPLATE_VERSION} template`
+      : `managed Skill at ${skillPath} is v${installedVersion}; expected v${AGENTICOS_SKILL_TEMPLATE_VERSION}`,
   };
 }
 
@@ -180,14 +171,6 @@ export function installAgentSkill(
   options: { force?: boolean } = {},
 ): AgentSkillInstallResult {
   const inspection = inspectAgentSkill(agentId, homeDir, deps.readFile);
-  if (!inspection.target.supported || !inspection.target.path) {
-    return {
-      ...inspection,
-      ok: true,
-      wrote: false,
-      skipped: true,
-    };
-  }
 
   if (inspection.status === 'current') {
     return {
@@ -208,14 +191,15 @@ export function installAgentSkill(
     };
   }
 
-  deps.mkdirp(dirname(inspection.target.path));
-  deps.writeFile(inspection.target.path, renderAgenticosSkillContent());
+  deps.mkdirp(dirname(inspection.target.path!));
+  deps.writeFile(inspection.target.path!, renderAgenticosSkillContent());
+  const installedPath = inspection.target.path!;
   return {
     ...inspectAgentSkill(agentId, homeDir, deps.readFile),
     ok: true,
     wrote: true,
     skipped: false,
-    detail: `installed v${AGENTICOS_SKILL_TEMPLATE_VERSION} at ${inspection.target.path}. ${inspection.target.reloadHint}`,
+    detail: `installed v${AGENTICOS_SKILL_TEMPLATE_VERSION} at ${installedPath}. ${inspection.target.reloadHint}`,
   };
 }
 

--- a/mcp-server/src/utils/agent-skill.ts
+++ b/mcp-server/src/utils/agent-skill.ts
@@ -78,9 +78,9 @@ export function resolveAgentSkillTarget(
       return {
         agentId,
         label: 'Gemini CLI AgenticOS activation Skill',
-        supported: false,
-        path: null,
-        reloadHint: 'Gemini CLI Skill installation is not supported by AgenticOS bootstrap yet.',
+        supported: true,
+        path: join(homeDir, '.gemini', 'skills', AGENTICOS_SKILL_NAME, 'SKILL.md'),
+        reloadHint: 'Restart Gemini CLI or run `/skills reload` so the AgenticOS activation Skill is indexed.',
       };
   }
 }


### PR DESCRIPTION
## Summary
- Enable managed AgenticOS activation Skill install/verify for Gemini CLI at `~/.gemini/skills/agenticos/SKILL.md`, matching the Codex/Claude/Cursor `--install-skills` flow.
- Update bootstrap matrix, adapter matrix, README/Homebrew docs, and bump version to **0.4.31**.

## Test plan
- [x] `npm ci && npm test` in `mcp-server` (1102 tests)
- [x] `./tools/coverage-preflight.sh` (aggregate + changed-scope pass)
- [x] `agenticos_preflight` / `agenticos_pr_scope_check` PASS
- [ ] Post-merge: verify `agenticos-bootstrap --agent gemini-cli --install-skills --verify` on a machine with Gemini CLI

Closes #483


Made with [Cursor](https://cursor.com)