### PR TITLE
fix(guardrails): resolve worktree binding gaps (#482)

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -406,10 +406,13 @@ Switch to existing project and load context.
 
 **Parameters**:
 - `project` (required) - Project ID or name
+- `repo_path` (optional) - Absolute checkout path (for example an issue worktree) to bind the MCP session to instead of the registry path. The checkout must contain a readable `.project.yaml` whose `meta.id` matches the registry project id.
 
 **Returns**: Loaded context (project config, quick-start, state)
 
 Use this when `agenticos_status` shows that no session project is bound or the bound project is not the intended one.
+
+When working in an isolated issue worktree, pass `repo_path` so guardrail tools, record/save, and session binding all target the worktree instead of the canonical registry checkout.
 
 The quick-start/state split is intentional:
 - `quick-start.md` is a concise entry surface
@@ -441,9 +444,16 @@ Capture session activity and, when allowed, distill it into project continuity.
 Save state and backup to Git.
 
 **Parameters**:
+- `project` (optional) - Project ID, name, or path. Defaults to the current session project.
+- `project_path` (optional) - Absolute project checkout path for continuity resolution. Use the issue worktree when saving from an isolated worktree.
+- `repo_path` (optional) - Absolute git checkout path for commit/push and canonical-main guard evaluation. Use the issue worktree when the git root differs from the registry project path.
 - `message` (optional) - Commit message
 
 **Returns**: Backup confirmation with timestamp
+
+**Worktree binding**:
+- when the registry path points at canonical main but edits happened in an issue worktree, pass the same worktree path as both `project_path` and `repo_path`
+- `agenticos_switch(project, repo_path=...)` should be used first so session binding and save/evaluate tools agree on the active checkout
 
 **Policy-aware behavior**:
 - `private_continuity` validates the tracked continuity plan before mutating `state.yaml` or staging files
@@ -516,10 +526,13 @@ Validate that the current branch diff stays within the intended issue scope.
 **Parameters**:
 - `issue_id` (required)
 - `repo_path` (required)
+- `project_path` (optional, but recommended when `repo_path` is a self-hosting checkout or larger worktree)
 - `declared_target_files` (required)
 - `remote_base_branch` (optional, default `origin/main`)
 
 **Returns**: JSON with `PASS` or `BLOCK`
+
+When `project_path` points at the managed project root and `repo_path` is an external issue worktree, runtime review surface paths are resolved relative to the managed project root instead of failing with a comparison-root escape.
 
 ### agenticos_health
 Evaluate whether a canonical checkout and project context are fresh enough to trust before starting work.

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -61,6 +61,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         type: 'object',
         properties: {
           project: { type: 'string', description: 'Project ID or name' },
+          repo_path: { type: 'string', description: 'Optional absolute checkout path (e.g. issue worktree) to bind the session to instead of the registry path.' },
         },
         required: ['project'],
       },
@@ -276,6 +277,8 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         type: 'object',
         properties: {
           project: { type: 'string', description: 'Optional project ID, name, or path. If omitted, uses the current session project.' },
+          project_path: { type: 'string', description: 'Optional absolute project checkout path for continuity resolution. Use the issue worktree when saving from an isolated worktree.' },
+          repo_path: { type: 'string', description: 'Optional absolute git checkout path for commit/push operations. Use the issue worktree when the git root differs from the registry project path.' },
           message: { type: 'string', description: 'Optional commit message' },
         },
       },

--- a/mcp-server/src/tools/__tests__/project.test.ts
+++ b/mcp-server/src/tools/__tests__/project.test.ts
@@ -66,6 +66,14 @@ vi.mock('../../utils/worktree-topology.js', () => ({
   inspectProjectWorktreeTopology: worktreeTopologyMock.inspectProjectWorktreeTopology,
 }));
 
+const assessKnowledgeEvolutionHealthMock = vi.hoisted(() => vi.fn());
+const buildKnowledgeEvolutionStatusLinesMock = vi.hoisted(() => vi.fn(() => ['📚 Knowledge evolution: PASS']));
+
+vi.mock('../../utils/knowledge-evolution-health.js', () => ({
+  assessKnowledgeEvolutionHealth: assessKnowledgeEvolutionHealthMock,
+  buildKnowledgeEvolutionStatusLines: buildKnowledgeEvolutionStatusLinesMock,
+}));
+
 vi.mock('../../utils/standard-kit.js', () => ({
   adoptStandardKit: standardKitMock.adoptStandardKit,
   checkStandardKitUpgrade: standardKitMock.checkStandardKitUpgrade,
@@ -139,6 +147,11 @@ describe('switchProject', () => {
       source: null,
       state: {},
       state_path: null,
+    });
+    assessKnowledgeEvolutionHealthMock.mockResolvedValue({
+      status: 'PASS',
+      summary: 'Knowledge evolution healthy',
+      findings: [],
     });
     worktreeTopologyMock.inspectProjectWorktreeTopology.mockResolvedValue({
       applies: true,
@@ -2047,6 +2060,11 @@ describe('getStatus', () => {
     yamlMock.parse.mockImplementation((content: string) => {
       try { return JSON.parse(content); } catch { return undefined; }
     });
+    assessKnowledgeEvolutionHealthMock.mockResolvedValue({
+      status: 'PASS',
+      summary: 'Knowledge evolution healthy',
+      findings: [],
+    });
     worktreeTopologyMock.inspectProjectWorktreeTopology.mockResolvedValue({
       applies: true,
       status: 'PASS',
@@ -3547,5 +3565,39 @@ describe('getStatus', () => {
     const result = await getStatus();
 
     expect(result).toContain('has not completed source-control topology initialization');
+  });
+
+  it('continues status output when knowledge evolution assessment fails', async () => {
+    bindSessionProject({
+      projectId: 'test-project',
+      projectName: 'Test Project',
+      projectPath: '/test/path',
+    });
+    registryMock.loadRegistry.mockResolvedValue({
+      version: '1.0.0',
+      last_updated: '2025-01-01T00:00:00.000Z',
+      active_project: 'test-project',
+      projects: [{
+        id: 'test-project',
+        name: 'Test Project',
+        path: '/test/path',
+        status: 'active' as const,
+        created: '2025-01-01',
+        last_accessed: '2025-01-01T00:00:00.000Z',
+      }],
+    });
+    mockStatusReads({
+      meta: { id: 'test-project', name: 'Test Project' },
+      source_control: { topology: 'local_directory_only' },
+    }, {
+      session: {},
+      working_memory: { pending: [], decisions: [], facts: [] },
+    });
+    assessKnowledgeEvolutionHealthMock.mockRejectedValue(new Error('knowledge health unavailable'));
+
+    const result = await getStatus();
+
+    expect(result).toContain('# Status: Test Project');
+    expect(buildKnowledgeEvolutionStatusLinesMock).not.toHaveBeenCalled();
   });
 });

--- a/mcp-server/src/tools/__tests__/save.test.ts
+++ b/mcp-server/src/tools/__tests__/save.test.ts
@@ -1393,4 +1393,55 @@ describe('saveState', () => {
     expect(result).not.toContain('blocked');
     expect(result).toContain('State saved locally');
   });
+
+  it('uses repo_path for canonical-main guard and git binding when registry path differs', async () => {
+    const worktreePath = '/repo/worktrees/issue-482';
+    detectCanonicalMainWriteProtectionMock.mockResolvedValue({
+      blocked: false,
+      git_worktree_root: worktreePath,
+      current_branch: 'fix/482-guardrail-resolver-gaps',
+      workspace_type: 'isolated_worktree',
+    });
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry({
+      projects: [{
+        id: 'test-project',
+        name: 'Test Project',
+        path: '/repo/projects/test-project',
+        status: 'active' as const,
+        created: '2025-01-01',
+        last_accessed: '2025-01-01T00:00:00.000Z',
+      }],
+    }));
+    mockProjectFiles();
+    childProcessMock.exec.mockImplementation((cmd: string, cb: Function) => {
+      if (cmd.includes('rev-parse --show-toplevel')) { cb(null, `${worktreePath}\n`, ''); return; }
+      if (cmd.includes('rev-parse --git-common-dir')) { cb(null, '/repo/.git\n', ''); return; }
+      if (cmd.includes('worktree list')) {
+        cb(null, `${worktreePath} (isolated)`, '');
+        return;
+      }
+      if (cmd.includes('remote get-url')) { cb(null, 'https://github.com/test/project.git\n', ''); return; }
+      if (cmd.includes('add -A')) { cb(null, '', ''); return; }
+      if (cmd.includes('commit')) { cb(null, '', ''); return; }
+      if (cmd.includes('push')) { cb(new Error('push failed'), '', 'push failed'); return; }
+      cb(new Error('Unexpected command: ' + cmd), '', '');
+    });
+
+    await bindSessionProject({
+      projectId: 'test-project',
+      projectName: 'Test Project',
+      projectPath: '/repo/projects/test-project',
+    });
+
+    const result = await saveState({
+      project: 'test-project',
+      repo_path: worktreePath,
+      project_path: worktreePath,
+      message: 'save from isolated worktree',
+    });
+
+    expect(detectCanonicalMainWriteProtection).toHaveBeenCalledWith(worktreePath);
+    expect(result).not.toContain('blocked');
+    expect(result).toContain('State saved locally');
+  });
 });

--- a/mcp-server/src/tools/__tests__/save.test.ts
+++ b/mcp-server/src/tools/__tests__/save.test.ts
@@ -49,8 +49,9 @@ vi.mock('child_process', () => ({
   exec: vi.fn(),
 }));
 
-import { saveState } from '../save.js';
+import { saveState, validateGitBackedContinuityRepoBinding, extractGitHubRepoFromRemoteOrigin, resolveDeclaredSourceRepoRoots } from '../save.js';
 import * as fsPromises from 'fs/promises';
+import * as fs from 'fs';
 import * as registry from '../../utils/registry.js';
 import * as childProcess from 'child_process';
 import { updateClaudeMdState } from '../../utils/distill.js';
@@ -66,6 +67,7 @@ const registryMock = registry as typeof registry & { loadRegistry: ReturnType<ty
 const childProcessMock = childProcess as typeof childProcess & { exec: ReturnType<typeof vi.fn> };
 const updateClaudeMdStateMock = updateClaudeMdState as unknown as ReturnType<typeof vi.fn>;
 const detectCanonicalMainWriteProtectionMock = detectCanonicalMainWriteProtection as unknown as ReturnType<typeof vi.fn>;
+const fsMock = fs as typeof fs & { existsSync: ReturnType<typeof vi.fn> };
 
 function buildRegistry(overrides: Record<string, unknown> = {}) {
   return {
@@ -157,6 +159,7 @@ describe('saveState', () => {
     });
     yamlMock.stringify.mockImplementation((obj: unknown) => JSON.stringify(obj));
     updateClaudeMdStateMock.mockResolvedValue({ updated: true, created: false });
+    fsMock.existsSync.mockReturnValue(false);
     mockProjectFiles();
   });
 
@@ -1443,5 +1446,620 @@ describe('saveState', () => {
     expect(detectCanonicalMainWriteProtection).toHaveBeenCalledWith(worktreePath);
     expect(result).not.toContain('blocked');
     expect(result).toContain('State saved locally');
+  });
+
+  it('ignores blank project_path and repo_path overrides', async () => {
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry());
+    mockProjectFiles();
+    childProcessMock.exec.mockImplementation(
+      (cmd: string, cb: (err: Error | null, stdout?: string, stderr?: string) => void) => {
+        if (cmd.includes('rev-parse --show-toplevel')) {
+          cb(null, '/test/path\n', '');
+          return;
+        }
+        cb(new Error('not a git repo'), '', '');
+      },
+    );
+
+    const result = await saveState({
+      message: 'blank overrides',
+      project_path: '   ',
+      repo_path: '',
+    });
+
+    expect(detectCanonicalMainWriteProtection).toHaveBeenCalledWith('/test/path');
+    expect(result).not.toContain('blocked');
+    expect(result).toMatch(/State saved/);
+  });
+
+  it('reports full git-backed restore sync when private_continuity push succeeds', async () => {
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry());
+    mockProjectFiles({
+      projectYaml: {
+        meta: {
+          id: 'test-project',
+          name: 'Test Project',
+        },
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'private_continuity',
+          github_repo: 'example/test-project',
+          branch_strategy: 'github_flow',
+        },
+        execution: {
+          source_repo_roots: ['.'],
+        },
+      },
+      state: { session: {} },
+    });
+
+    childProcessMock.exec.mockImplementation(
+      (cmd: string, cb: (err: Error | null, stdout?: string, stderr?: string) => void) => {
+        if (cmd.includes('rev-parse --show-toplevel')) {
+          cb(null, '/test/path\n', '');
+          return;
+        }
+        if (cmd.includes('rev-parse --git-common-dir')) {
+          cb(null, '.git\n', '');
+          return;
+        }
+        if (cmd.includes('remote get-url origin')) {
+          cb(null, 'git@github.com:example/test-project.git\n', '');
+          return;
+        }
+        if (cmd.includes(' commit ')) {
+          cb(null, '', '');
+          return;
+        }
+        if (cmd.includes(' push')) {
+          cb(null, '', '');
+          return;
+        }
+        cb(null, '', '');
+      },
+    );
+
+    const result = await saveState({ message: 'synced continuity save' });
+
+    expect(result).toContain('Pushed to remote');
+    expect(result).toContain('Recovery: full tracked continuity synced for Git-backed restore');
+  });
+
+  it('reports distilled restore sync when public_distilled push succeeds', async () => {
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry());
+    mockProjectFiles({
+      projectYaml: {
+        meta: {
+          id: 'test-project',
+          name: 'Test Project',
+        },
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'public_distilled',
+          github_repo: 'example/test-project',
+          branch_strategy: 'github_flow',
+        },
+        execution: {
+          source_repo_roots: ['.'],
+        },
+      },
+      state: { session: {} },
+    });
+
+    childProcessMock.exec.mockImplementation(
+      (cmd: string, cb: (err: Error | null, stdout?: string, stderr?: string) => void) => {
+        if (cmd.includes('rev-parse --show-toplevel')) {
+          cb(null, '/test/path\n', '');
+          return;
+        }
+        if (cmd.includes('rev-parse --git-common-dir')) {
+          cb(null, '.git\n', '');
+          return;
+        }
+        if (cmd.includes('remote get-url origin')) {
+          cb(null, 'git@github.com:example/test-project.git\n', '');
+          return;
+        }
+        if (cmd.includes(' commit ')) {
+          cb(null, '', '');
+          return;
+        }
+        if (cmd.includes(' push')) {
+          cb(null, '', '');
+          return;
+        }
+        cb(null, '', '');
+      },
+    );
+
+    const result = await saveState({ message: 'public synced save' });
+
+    expect(result).toContain('Recovery: distilled continuity synced for Git-backed restore');
+  });
+
+  it('reports pending remote sync for public_distilled when push fails after commit', async () => {
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry());
+    mockProjectFiles({
+      projectYaml: {
+        meta: {
+          id: 'test-project',
+          name: 'Test Project',
+        },
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'public_distilled',
+          github_repo: 'example/test-project',
+          branch_strategy: 'github_flow',
+        },
+        execution: {
+          source_repo_roots: ['.'],
+        },
+      },
+      state: { session: {} },
+    });
+
+    childProcessMock.exec.mockImplementation(
+      (cmd: string, cb: (err: Error | null, stdout?: string, stderr?: string) => void) => {
+        if (cmd.includes('rev-parse --show-toplevel')) {
+          cb(null, '/test/path\n', '');
+          return;
+        }
+        if (cmd.includes('rev-parse --git-common-dir')) {
+          cb(null, '.git\n', '');
+          return;
+        }
+        if (cmd.includes('remote get-url origin')) {
+          cb(null, 'git@github.com:example/test-project.git\n', '');
+          return;
+        }
+        if (cmd.includes(' commit ')) {
+          cb(null, '', '');
+          return;
+        }
+        if (cmd.includes(' push')) {
+          cb(new Error('push failed'), '', '');
+          return;
+        }
+        cb(null, '', '');
+      },
+    );
+
+    const result = await saveState({ message: 'public pending sync save' });
+
+    expect(result).toContain('distilled continuity committed locally; remote sync is still pending');
+  });
+
+  it('returns resolver errors when project_path override cannot be resolved', async () => {
+    const result = await saveState({
+      project: 'missing-project',
+      project_path: '/missing/worktree',
+      message: 'resolver failure',
+    });
+
+    expect(result).toContain('❌');
+  });
+
+  it('uses project_path alone for git binding when repo_path is omitted', async () => {
+    const worktreePath = '/repo/worktrees/issue-482-only-project-path';
+    detectCanonicalMainWriteProtectionMock.mockResolvedValue({
+      blocked: false,
+      git_worktree_root: worktreePath,
+      current_branch: 'fix/482-guardrail-resolver-gaps',
+      workspace_type: 'isolated_worktree',
+    });
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry({
+      projects: [{
+        id: 'test-project',
+        name: 'Test Project',
+        path: '/repo/projects/test-project',
+        status: 'active' as const,
+        created: '2025-01-01',
+        last_accessed: '2025-01-01T00:00:00.000Z',
+      }],
+    }));
+    mockProjectFiles();
+    childProcessMock.exec.mockImplementation((cmd: string, cb: Function) => {
+      if (cmd.includes('rev-parse --show-toplevel')) { cb(null, `${worktreePath}\n`, ''); return; }
+      if (cmd.includes('rev-parse --git-common-dir')) { cb(null, '/repo/.git\n', ''); return; }
+      if (cmd.includes('remote get-url')) { cb(null, 'https://github.com/test/project.git\n', ''); return; }
+      if (cmd.includes('add -A')) { cb(null, '', ''); return; }
+      if (cmd.includes('commit')) { cb(new Error('nothing to commit'), '', 'nothing to commit'); return; }
+      cb(new Error('Unexpected command: ' + cmd), '', '');
+    });
+
+    await saveState({
+      project: 'test-project',
+      project_path: worktreePath,
+      message: 'project_path binding only',
+    });
+
+    expect(detectCanonicalMainWriteProtection).toHaveBeenCalledWith(worktreePath);
+  });
+
+  it('blocks save on gitBindingPath when canonical-main guard triggers', async () => {
+    detectCanonicalMainWriteProtectionMock.mockResolvedValue({
+      blocked: true,
+      reason: 'canonical main checkout is not a supported runtime workspace',
+      git_worktree_root: '/repo',
+      current_branch: 'main',
+      workspace_type: 'main',
+    });
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry());
+
+    const result = await saveState({
+      project: 'test-project',
+      repo_path: '/repo/projects/test-project',
+      message: 'blocked on binding path',
+    });
+
+    expect(result).toContain('agenticos_save blocked');
+    expect(detectCanonicalMainWriteProtection).toHaveBeenCalledWith('/repo/projects/test-project');
+  });
+
+  it('returns context policy errors before mutating state', async () => {
+    detectCanonicalMainWriteProtectionMock.mockResolvedValue({
+      blocked: false,
+      git_worktree_root: '/test/path',
+      current_branch: 'fix/test',
+      workspace_type: 'isolated_worktree',
+    });
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry());
+    mockProjectFiles({
+      projectYaml: {
+        meta: {
+          id: 'test-project',
+          name: 'Test Project',
+        },
+        source_control: {
+          topology: 'local_directory_only',
+          context_publication_policy: 'not-a-real-policy',
+        },
+      },
+    });
+    childProcessMock.exec.mockImplementation((cmd: string, cb: Function) => {
+      if (cmd.includes('rev-parse --show-toplevel')) { cb(null, '/test/path\n', ''); return; }
+      if (cmd.includes('rev-parse --git-common-dir')) { cb(null, '/repo/.git\n', ''); return; }
+      cb(new Error('Unexpected command: ' + cmd), '', '');
+    });
+
+    const result = await saveState({
+      project: 'test-project',
+      message: 'context policy failure',
+    });
+
+    expect(result).toMatch(/^❌/);
+    expect(fsPromisesMock.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('blocks save when github_versioned project omits execution.source_repo_roots', async () => {
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry());
+    mockProjectFiles({
+      projectYaml: {
+        meta: { id: 'test-project', name: 'Test Project' },
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'private_continuity',
+          github_repo: 'example/test-project',
+          branch_strategy: 'github_flow',
+        },
+      },
+    });
+    childProcessMock.exec.mockImplementation((cmd: string, cb: Function) => {
+      if (cmd.includes('rev-parse --show-toplevel')) { cb(null, '/test/path\n', ''); return; }
+      if (cmd.includes('rev-parse --git-common-dir')) { cb(null, '.git\n', ''); return; }
+      cb(new Error('Unexpected command: ' + cmd), '', '');
+    });
+
+    const result = await saveState({ message: 'missing source roots' });
+
+    expect(result).toContain('missing execution.source_repo_roots');
+    expect(fsPromisesMock.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('blocks save when public_distilled routing targets raw conversations in tracked paths', async () => {
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry());
+    mockProjectFiles({
+      projectYaml: {
+        meta: { id: 'test-project', name: 'Test Project' },
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'public_distilled',
+          github_repo: 'example/test-project',
+          branch_strategy: 'github_flow',
+        },
+        execution: { source_repo_roots: ['.'] },
+        agent_context: { conversations: '.private/conversations/' },
+      },
+    });
+    childProcessMock.exec.mockImplementation((cmd: string, cb: Function) => {
+      if (cmd.includes('rev-parse --show-toplevel')) { cb(null, '/test/path\n', ''); return; }
+      if (cmd.includes('rev-parse --git-common-dir')) { cb(null, '.git\n', ''); return; }
+      if (cmd.includes('remote get-url')) { cb(null, 'https://github.com/example/test-project.git\n', ''); return; }
+      cb(null, '', '');
+    });
+
+    const result = await saveState({ message: 'misconfigured routing' });
+
+    expect(result).toContain('public transcript routing is misconfigured');
+    expect(fsPromisesMock.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('reports github repo mismatch using https remote origin URLs', async () => {
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry());
+    mockProjectFiles({
+      projectYaml: {
+        meta: { id: 'test-project', name: 'Test Project' },
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'private_continuity',
+          github_repo: 'example/expected-repo',
+          branch_strategy: 'github_flow',
+        },
+        execution: { source_repo_roots: ['.'] },
+      },
+    });
+    childProcessMock.exec.mockImplementation((cmd: string, cb: Function) => {
+      if (cmd.includes('rev-parse --show-toplevel')) { cb(null, '/test/path\n', ''); return; }
+      if (cmd.includes('rev-parse --git-common-dir')) { cb(null, '/test/path\n', ''); return; }
+      if (cmd.includes('remote get-url')) { cb(null, 'https://github.com/example/actual-repo.git\n', ''); return; }
+      cb(new Error('Unexpected command: ' + cmd), '', '');
+    });
+
+    const result = await saveState({ message: 'remote mismatch' });
+
+    expect(result).toContain('does not match declared source_control.github_repo');
+    expect(fsPromisesMock.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('reports github repo mismatch using ssh:// remote origin URLs', async () => {
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry());
+    mockProjectFiles({
+      projectYaml: {
+        meta: { id: 'test-project', name: 'Test Project' },
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'private_continuity',
+          github_repo: 'example/expected-repo',
+          branch_strategy: 'github_flow',
+        },
+        execution: { source_repo_roots: ['.'] },
+      },
+    });
+    childProcessMock.exec.mockImplementation((cmd: string, cb: Function) => {
+      if (cmd.includes('rev-parse --show-toplevel')) { cb(null, '/test/path\n', ''); return; }
+      if (cmd.includes('rev-parse --git-common-dir')) { cb(null, '/test/path\n', ''); return; }
+      if (cmd.includes('remote get-url')) { cb(null, 'ssh://git@github.com/example/actual-repo.git\n', ''); return; }
+      cb(new Error('Unexpected command: ' + cmd), '', '');
+    });
+
+    const result = await saveState({ message: 'ssh remote mismatch' });
+
+    expect(result).toContain('does not match declared source_control.github_repo');
+  });
+
+  it('reports github repo mismatch when remote get-url fails', async () => {
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry());
+    mockProjectFiles({
+      projectYaml: {
+        meta: { id: 'test-project', name: 'Test Project' },
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'private_continuity',
+          github_repo: 'example/test-project',
+          branch_strategy: 'github_flow',
+        },
+        execution: { source_repo_roots: ['.'] },
+      },
+    });
+    childProcessMock.exec.mockImplementation((cmd: string, cb: Function) => {
+      if (cmd.includes('rev-parse --show-toplevel')) { cb(null, '/test/path\n', ''); return; }
+      if (cmd.includes('rev-parse --git-common-dir')) { cb(null, '/test/path\n', ''); return; }
+      if (cmd.includes('remote get-url')) { cb(new Error('no origin'), '', 'fatal: No such remote'); return; }
+      cb(new Error('Unexpected command: ' + cmd), '', '');
+    });
+
+    const result = await saveState({ message: 'missing remote' });
+
+    expect(result).toContain('does not match declared source_control.github_repo');
+  });
+
+  it('stages AGENTS.md when it exists for private_continuity projects', async () => {
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry());
+    fsMock.existsSync.mockImplementation((path: string) => path === '/test/path/AGENTS.md');
+    mockProjectFiles({
+      projectYaml: {
+        meta: { id: 'test-project', name: 'Test Project' },
+        source_control: {
+          topology: 'github_versioned',
+          context_publication_policy: 'private_continuity',
+          github_repo: 'example/test-project',
+          branch_strategy: 'github_flow',
+        },
+        execution: { source_repo_roots: ['.'] },
+      },
+      state: { session: {} },
+    });
+    const commands: string[] = [];
+    childProcessMock.exec.mockImplementation((cmd: string, cb: Function) => {
+      commands.push(cmd);
+      if (cmd.includes('rev-parse --show-toplevel')) { cb(null, '/test/path\n', ''); return; }
+      if (cmd.includes('rev-parse --git-common-dir')) { cb(null, '.git\n', ''); return; }
+      if (cmd.includes('remote get-url')) { cb(null, 'git@github.com:example/test-project.git\n', ''); return; }
+      if (cmd.includes(' add -A')) { cb(null, '', ''); return; }
+      if (cmd.includes('commit')) { cb(new Error('nothing to commit'), '', 'nothing to commit'); return; }
+      cb(null, '', '');
+    });
+
+    const result = await saveState({ message: 'stage agents guidance' });
+
+    const addCommand = commands.find((cmd) => cmd.includes(' add -A -- '));
+    expect(result).toMatch(/State saved/);
+    expect(addCommand).toBeDefined();
+    expect(addCommand).toContain('"AGENTS.md"');
+  });
+
+  it('returns partial save when tracked continuity paths escape git worktree root', async () => {
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry({
+      projects: [{
+        id: 'test-project',
+        name: 'Test Project',
+        path: '/repo/projects/app',
+        status: 'active' as const,
+        created: '2025-01-01',
+        last_accessed: '2025-01-01T00:00:00.000Z',
+      }],
+    }));
+    clearSessionProjectBinding();
+    bindSessionProject({
+      projectId: 'test-project',
+      projectName: 'Test Project',
+      projectPath: '/repo/projects/app',
+    });
+    fsPromisesMock.readFile.mockImplementation(async (path: string) => {
+      if (path === '/repo/projects/app/.project.yaml') {
+        return JSON.stringify({
+          meta: { id: 'test-project', name: 'Test Project' },
+          source_control: {
+            topology: 'github_versioned',
+            context_publication_policy: 'private_continuity',
+            github_repo: 'example/test-project',
+            branch_strategy: 'github_flow',
+          },
+          execution: { source_repo_roots: ['/repo'] },
+        });
+      }
+      if (path === '/repo/projects/app/.context/state.yaml') {
+        return JSON.stringify({ session: {} });
+      }
+      throw new Error(`unexpected path: ${path}`);
+    });
+    childProcessMock.exec.mockImplementation((cmd: string, cb: Function) => {
+      if (cmd.includes('rev-parse --show-toplevel')) { cb(null, '/other/worktree\n', ''); return; }
+      if (cmd.includes('rev-parse --git-common-dir')) { cb(null, '/repo/.git\n', ''); return; }
+      if (cmd.includes('remote get-url')) { cb(null, 'git@github.com:example/test-project.git\n', ''); return; }
+      cb(new Error('Unexpected command: ' + cmd), '', '');
+    });
+
+    const result = await saveState({ message: 'escape path' });
+
+    expect(result).toContain('Partial save completed');
+    expect(result).toContain('Path escapes git worktree root');
+  });
+
+  it('blocks save on gitBindingPath when canonical-main guard omits reason', async () => {
+    detectCanonicalMainWriteProtectionMock.mockResolvedValue({
+      blocked: true,
+      git_worktree_root: '/repo',
+      current_branch: 'main',
+      workspace_type: 'main',
+    });
+    registryMock.loadRegistry.mockResolvedValue(buildRegistry());
+
+    const result = await saveState({
+      project: 'test-project',
+      repo_path: '/repo/projects/test-project',
+      message: 'blocked on binding path',
+    });
+
+    expect(result).toContain('agenticos_save blocked');
+    expect(result).toContain('/repo');
+  });
+});
+
+describe('save repo binding helpers', () => {
+  it('resolveDeclaredSourceRepoRoots returns empty when source_repo_roots is not an array', () => {
+    expect(resolveDeclaredSourceRepoRoots('/test/path', {
+      execution: { source_repo_roots: 'invalid' as unknown as string[] },
+    })).toEqual([]);
+  });
+
+  it('extractGitHubRepoFromRemoteOrigin returns null for unrecognized remotes', () => {
+    expect(extractGitHubRepoFromRemoteOrigin('https://gitlab.com/example/repo.git')).toBeNull();
+  });
+
+  it('validateGitBackedContinuityRepoBinding reports missing source_repo_roots', async () => {
+    const reasons = await validateGitBackedContinuityRepoBinding({
+      projectName: 'Test Project',
+      policy: 'private_continuity',
+      projectPath: '/test/path',
+      projectYaml: {
+        source_control: { github_repo: 'example/test-project' },
+      },
+      gitWorktreeRoot: '/test/path',
+      gitCommonRepoRoot: '/test/path',
+    });
+
+    expect(reasons).toContain('Project "Test Project" is marked github_versioned but missing execution.source_repo_roots.');
+  });
+
+  it('validateGitBackedContinuityRepoBinding skips github_repo comparison when repo is undeclared', async () => {
+    const reasons = await validateGitBackedContinuityRepoBinding({
+      projectName: 'Test Project',
+      policy: 'private_continuity',
+      projectPath: '/test/path',
+      projectYaml: {
+        execution: { source_repo_roots: ['.'] },
+      },
+      gitWorktreeRoot: '/test/path',
+      gitCommonRepoRoot: '/test/path',
+    });
+
+    expect(reasons).toEqual([]);
+  });
+
+  it('validateGitBackedContinuityRepoBinding reports remote lookup failures', async () => {
+    childProcessMock.exec.mockImplementation((cmd: string, cb: Function) => {
+      if (cmd.includes('remote get-url')) {
+        cb(Object.assign(new Error('missing remote'), { stderr: 'fatal: No such remote' }), '', 'fatal: No such remote');
+        return;
+      }
+      cb(new Error('Unexpected command: ' + cmd), '', '');
+    });
+
+    const reasons = await validateGitBackedContinuityRepoBinding({
+      projectName: 'Test Project',
+      policy: 'private_continuity',
+      projectPath: '/test/path',
+      projectYaml: {
+        source_control: { github_repo: 'example/test-project' },
+        execution: { source_repo_roots: ['.'] },
+      },
+      gitWorktreeRoot: '/test/path',
+      gitCommonRepoRoot: '/test/path',
+    });
+
+    expect(reasons.join('\n')).toContain('fatal: No such remote');
+  });
+
+  it('validateGitBackedContinuityRepoBinding uses stdout and message fallbacks for remote lookup failures', async () => {
+    const cases = [
+      Object.assign(new Error('remote failed'), { stdout: 'origin missing from stdout' }),
+      Object.assign(new Error('remote failed'), { message: 'origin missing from message' }),
+      new Error(''),
+    ];
+
+    for (const error of cases) {
+      childProcessMock.exec.mockImplementation((cmd: string, cb: Function) => {
+        if (cmd.includes('remote get-url')) {
+          cb(error, '', '');
+          return;
+        }
+        cb(new Error('Unexpected command: ' + cmd), '', '');
+      });
+
+      const reasons = await validateGitBackedContinuityRepoBinding({
+        projectName: 'Test Project',
+        policy: 'private_continuity',
+        projectPath: '/test/path',
+        projectYaml: {
+          source_control: { github_repo: 'example/test-project' },
+          execution: { source_repo_roots: ['.'] },
+        },
+        gitWorktreeRoot: '/test/path',
+        gitCommonRepoRoot: '/test/path',
+      });
+
+      expect(reasons.length).toBeGreaterThan(0);
+    }
   });
 });

--- a/mcp-server/src/tools/__tests__/switch.test.ts
+++ b/mcp-server/src/tools/__tests__/switch.test.ts
@@ -379,6 +379,92 @@ describe('switchProject — agenticos_switch tests', () => {
       expect(result).toContain('cannot be bound to repo_path');
       expect(result).toContain('does not match registry id');
     });
+
+    it('rejects repo_path when meta.id is missing', async () => {
+      const worktreePath = '/repo/worktrees/issue-482';
+      registryMock.loadRegistry.mockResolvedValue(buildRegistry({
+        projects: [{
+          id: 'test-project',
+          name: 'Test Project',
+          path: '/repo/projects/test-project',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        }],
+      }));
+      fsPromisesMock.readFile.mockImplementation(async (path: string) => {
+        if (path.endsWith('/.project.yaml')) {
+          return JSON.stringify({
+            meta: { description: 'missing id' },
+            source_control: { topology: 'local_directory_only' },
+          });
+        }
+        return '';
+      });
+
+      const result = await switchProject({ project: 'test-project', repo_path: worktreePath });
+
+      expect(result).toContain('missing meta.id');
+    });
+
+    it('rejects repo_path when project yaml is unreadable', async () => {
+      const worktreePath = '/repo/worktrees/issue-482';
+      registryMock.loadRegistry.mockResolvedValue(buildRegistry({
+        projects: [{
+          id: 'test-project',
+          name: 'Test Project',
+          path: '/repo/projects/test-project',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        }],
+      }));
+      fsPromisesMock.readFile.mockImplementation(async (path: string) => {
+        if (path.endsWith('/.project.yaml')) {
+          throw new Error('ENOENT');
+        }
+        return '';
+      });
+
+      const result = await switchProject({ project: 'test-project', repo_path: worktreePath });
+
+      expect(result).toContain('missing or unreadable');
+    });
+
+    it('rejects repo_path when project yaml parses to null', async () => {
+      const worktreePath = '/repo/worktrees/issue-482';
+      registryMock.loadRegistry.mockResolvedValue(buildRegistry({
+        projects: [{
+          id: 'test-project',
+          name: 'Test Project',
+          path: '/repo/projects/test-project',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        }],
+      }));
+      fsPromisesMock.readFile.mockImplementation(async (path: string) => {
+        if (path.endsWith('/.project.yaml')) {
+          return '';
+        }
+        return '';
+      });
+      yamlMock.parse.mockReturnValue(null);
+
+      const result = await switchProject({ project: 'test-project', repo_path: worktreePath });
+
+      expect(result).toContain('missing meta.id');
+    });
+
+    it('ignores non-string repo_path values', async () => {
+      registryMock.loadRegistry.mockResolvedValue(buildRegistry());
+      mockDefaultReads();
+
+      const result = await switchProject({ project: 'test-project', repo_path: 123 });
+
+      expect(result).toContain('Path: /test/path');
+      expect(getSessionProjectBinding()?.projectPath).toBe('/test/path');
+    });
   });
 
   describe('registry fallback when no session binding', () => {

--- a/mcp-server/src/tools/__tests__/switch.test.ts
+++ b/mcp-server/src/tools/__tests__/switch.test.ts
@@ -310,6 +310,77 @@ describe('switchProject — agenticos_switch tests', () => {
     });
   });
 
+  describe('repo_path override', () => {
+    it('binds session to repo_path when project yaml meta.id matches registry id', async () => {
+      const worktreePath = '/repo/worktrees/issue-482';
+      registryMock.loadRegistry.mockResolvedValue(buildRegistry({
+        projects: [{
+          id: 'test-project',
+          name: 'Test Project',
+          path: '/repo/projects/test-project',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        }],
+      }));
+      fsMock.existsSync.mockImplementation((path: string) =>
+        path === worktreePath || path.startsWith(`${worktreePath}/`));
+      fsPromisesMock.readFile.mockImplementation(async (path: string) => {
+        if (path.endsWith('/.project.yaml')) {
+          return JSON.stringify({
+            meta: { id: 'test-project', description: 'Test project description' },
+            source_control: { topology: 'local_directory_only' },
+          });
+        }
+        if (path.endsWith('/state.yaml')) {
+          return JSON.stringify({
+            current_task: { title: 'Test task', status: 'in_progress' },
+            working_memory: { pending: ['Next step'], decisions: ['Made a choice'] },
+          });
+        }
+        if (path.endsWith('/quick-start.md')) {
+          return '# Quick Start\n\nTest quick start content.\n\nBody text here.';
+        }
+        return '';
+      });
+
+      const result = await switchProject({ project: 'test-project', repo_path: worktreePath });
+
+      expect(result).toContain('✅ Switched to project "Test Project"');
+      expect(result).toContain(`Path: ${worktreePath}`);
+      const binding = getSessionProjectBinding();
+      expect(binding?.projectPath).toBe(worktreePath);
+    });
+
+    it('rejects repo_path when meta.id does not match registry id', async () => {
+      const worktreePath = '/repo/worktrees/issue-482';
+      registryMock.loadRegistry.mockResolvedValue(buildRegistry({
+        projects: [{
+          id: 'test-project',
+          name: 'Test Project',
+          path: '/repo/projects/test-project',
+          status: 'active' as const,
+          created: '2025-01-01',
+          last_accessed: '2025-01-01T00:00:00.000Z',
+        }],
+      }));
+      fsPromisesMock.readFile.mockImplementation(async (path: string) => {
+        if (path.endsWith('/.project.yaml')) {
+          return JSON.stringify({
+            meta: { id: 'other-project' },
+            source_control: { topology: 'local_directory_only' },
+          });
+        }
+        return '';
+      });
+
+      const result = await switchProject({ project: 'test-project', repo_path: worktreePath });
+
+      expect(result).toContain('cannot be bound to repo_path');
+      expect(result).toContain('does not match registry id');
+    });
+  });
+
   describe('registry fallback when no session binding', () => {
     it('switches using registry even when no session project is bound', async () => {
       clearSessionProjectBinding();

--- a/mcp-server/src/tools/project.ts
+++ b/mcp-server/src/tools/project.ts
@@ -403,6 +403,9 @@ async function readProjectKindForList(projectName: string, projectPath: string):
 
 export async function switchProject(args: any): Promise<string> {
   const { project } = args;
+  const explicitRepoPath = typeof args.repo_path === 'string' && args.repo_path.trim().length > 0
+    ? args.repo_path.trim()
+    : null;
   const registry = await loadRegistry();
 
   const found = registry.projects.find(
@@ -413,14 +416,31 @@ export async function switchProject(args: any): Promise<string> {
     return `❌ Project "${project}" not found.\n\nAvailable projects:\n${registry.projects.map((p) => `- ${p.name} (${p.id})`).join('\n')}`;
   }
 
+  const sessionPath = explicitRepoPath || found.path;
+  if (explicitRepoPath) {
+    const explicitProjectYamlPath = join(explicitRepoPath, '.project.yaml');
+    try {
+      const explicitProjectYaml = yaml.parse(await readFile(explicitProjectYamlPath, 'utf-8')) || {};
+      const explicitProjectId = explicitProjectYaml?.meta?.id;
+      if (!explicitProjectId) {
+        return `❌ Project "${found.name}" cannot be bound to repo_path because ${explicitProjectYamlPath} is missing meta.id.`;
+      }
+      if (explicitProjectId !== found.id) {
+        return `❌ Project "${found.name}" cannot be bound to repo_path because ${explicitProjectYamlPath} meta.id "${explicitProjectId}" does not match registry id "${found.id}".`;
+      }
+    } catch {
+      return `❌ Project "${found.name}" cannot be bound to repo_path because ${explicitProjectYamlPath} is missing or unreadable.`;
+    }
+  }
+
   // Validate the project path before loading context or binding the MCP session.
   // A stale registry entry should not produce a successful switch.
-  const pwdResult = await alignPwd(found.path);
+  const pwdResult = await alignPwd(sessionPath);
   if (!pwdResult.success) {
     return [
       `❌ Project "${found.name}" cannot be switched because its registered path is not usable.`,
       '',
-      `Path: ${JSON.stringify(found.path)}`,
+      `Path: ${JSON.stringify(sessionPath)}`,
       `Reason: ${stripPwdWarningPrefix(pwdResult.warning)}`,
       'Recovery: repair or re-register the project path, then run agenticos_switch again.',
     ].join('\n');
@@ -428,7 +448,7 @@ export async function switchProject(args: any): Promise<string> {
 
   let projectYaml: any = {};
   try {
-    projectYaml = yaml.parse(await readFile(join(found.path, '.project.yaml'), 'utf-8')) || {};
+    projectYaml = yaml.parse(await readFile(join(sessionPath, '.project.yaml'), 'utf-8')) || {};
   } catch {}
 
   if (isArchivedReferenceProject(projectYaml, found.status)) {
@@ -452,11 +472,11 @@ export async function switchProject(args: any): Promise<string> {
   bindSessionProject({
     projectId: found.id,
     projectName: found.name,
-    projectPath: found.path,
+    projectPath: sessionPath,
   });
 
   // Check if entry surface writes are allowed in this checkout
-  const writeProtection = await detectCanonicalMainWriteProtection(found.path);
+  const writeProtection = await detectCanonicalMainWriteProtection(sessionPath);
   const bootstrapNotes: string[] = [];
   try {
     await patchProjectMetadata(found.id, {
@@ -465,15 +485,15 @@ export async function switchProject(args: any): Promise<string> {
   } catch (error: any) {
     bootstrapNotes.push(`⚠️ Session bound, but registry metadata was not updated: ${error.message}`);
   }
-  const claudeMdPath = join(found.path, 'CLAUDE.md');
-  const agentsMdPath = join(found.path, 'AGENTS.md');
+  const claudeMdPath = join(sessionPath, 'CLAUDE.md');
+  const agentsMdPath = join(sessionPath, 'AGENTS.md');
 
   let description = '';
   let state: any = undefined;
   let displayState: any = undefined;
   let quickStart = '';
   description = projectYaml?.meta?.description || '';
-  const contextPaths = resolveManagedProjectContextPaths(found.path, projectYaml);
+  const contextPaths = resolveManagedProjectContextPaths(sessionPath, projectYaml);
   const contextDisplayPaths = resolveManagedProjectContextDisplayPaths(projectYaml);
   try {
     state = yaml.parse(await readFile(contextPaths.statePath, 'utf-8'));
@@ -494,7 +514,7 @@ export async function switchProject(args: any): Promise<string> {
   try {
     const contextPolicyPlan = resolveContextPolicyPlan({
       projectName: found.name,
-      projectPath: found.path,
+      projectPath: sessionPath,
       projectYaml,
     });
     transcriptRoutingSummary = buildConversationRoutingStatusLines(
@@ -547,14 +567,14 @@ export async function switchProject(args: any): Promise<string> {
   // because adoptStandardKit preserves user modifications to copied templates
   if (!writeProtection.blocked) {
     try {
-      const upgradeCheck = await checkStandardKitUpgrade({ project_path: found.path });
+      const upgradeCheck = await checkStandardKitUpgrade({ project_path: sessionPath });
       const hasIssues =
         (upgradeCheck.missing_required_files.length > 0) ||
         (upgradeCheck.generated_files.some(f => f.status === 'stale')) ||
         (upgradeCheck.copied_templates.some(t => t.status === 'missing'));
 
       if (hasIssues) {
-        const adoptResult = await adoptStandardKit({ project_path: found.path });
+        const adoptResult = await adoptStandardKit({ project_path: sessionPath });
         const summaryParts: string[] = [];
         if (adoptResult.upgraded_generated_files.length > 0) {
           summaryParts.push(`upgraded: ${adoptResult.upgraded_generated_files.join(', ')}`);
@@ -575,7 +595,7 @@ export async function switchProject(args: any): Promise<string> {
   const committedSnapshotAssessment = assessVersionedEntrySurfaceState({
     projectYaml,
     state,
-    projectPath: found.path,
+    projectPath: sessionPath,
   });
   const committedSnapshotSummary = buildCommittedSnapshotSummaryLines(committedSnapshotAssessment);
   const guardrailSummary = buildGuardrailSummaryLines(
@@ -586,8 +606,8 @@ export async function switchProject(args: any): Promise<string> {
   const bootstrapContinuity = latestSwitchBootstrap
     ? await assessIssueBootstrapContinuity({
         bootstrap: latestSwitchBootstrap,
-        currentRepoPath: found.path,
-        projectPath: found.path,
+        currentRepoPath: sessionPath,
+        projectPath: sessionPath,
       })
     : undefined;
   const issueBootstrapSummary = buildIssueBootstrapSummaryLines({
@@ -601,9 +621,9 @@ export async function switchProject(args: any): Promise<string> {
     lastRecorded: found.last_recorded,
     committedSnapshotAssessment,
   });
-  const filesystemAlignmentSummary = buildFilesystemAlignmentLines(found.path, pwdResult);
+  const filesystemAlignmentSummary = buildFilesystemAlignmentLines(sessionPath, pwdResult);
 
-  return `✅ Switched to project "${found.name}"\n\nPath: ${found.path}\nStatus: ${found.status}\nKind: ${projectKind}\n${filesystemAlignmentSummary.join('\n')}\n\n${contextSummary.join('\n')}${committedSnapshotSummary.length > 0 ? `\n${committedSnapshotSummary.join('\n')}` : ''}\n${transcriptRoutingSummary.length > 0 ? `\n${transcriptRoutingSummary.join('\n')}\n` : '\n'}Context loaded from:\n- ${found.path}/.project.yaml\n- ${contextPaths.quickStartPath}\n- ${contextPaths.statePath}\n\n${guardrailSummary.join('\n')}\n${issueBootstrapSummary.join('\n')}${bootstrap}`;
+  return `✅ Switched to project "${found.name}"\n\nPath: ${sessionPath}\nStatus: ${found.status}\nKind: ${projectKind}\n${filesystemAlignmentSummary.join('\n')}\n\n${contextSummary.join('\n')}${committedSnapshotSummary.length > 0 ? `\n${committedSnapshotSummary.join('\n')}` : ''}\n${transcriptRoutingSummary.length > 0 ? `\n${transcriptRoutingSummary.join('\n')}\n` : '\n'}Context loaded from:\n- ${sessionPath}/.project.yaml\n- ${contextPaths.quickStartPath}\n- ${contextPaths.statePath}\n\n${guardrailSummary.join('\n')}\n${issueBootstrapSummary.join('\n')}${bootstrap}`;
 }
 
 export async function listProjects(): Promise<string> {

--- a/mcp-server/src/tools/save.ts
+++ b/mcp-server/src/tools/save.ts
@@ -72,7 +72,7 @@ function toGitRelativePath(gitWorktreeRoot: string, absolutePath: string, option
   return options?.directory && !relativePath.endsWith('/') ? `${relativePath}/` : relativePath;
 }
 
-function resolveDeclaredSourceRepoRoots(projectPath: string, projectYaml: ProjectYamlSchema): string[] {
+export function resolveDeclaredSourceRepoRoots(projectPath: string, projectYaml: ProjectYamlSchema): string[] {
   if (!Array.isArray(projectYaml?.execution?.source_repo_roots)) {
     return [];
   }
@@ -90,7 +90,7 @@ function normalizeGitHubRepo(value: string): string {
   return value.trim().replace(/\.git$/i, '').replace(/^\/+|\/+$/g, '').toLowerCase();
 }
 
-function extractGitHubRepoFromRemoteOrigin(value: string): string | null {
+export function extractGitHubRepoFromRemoteOrigin(value: string): string | null {
   const trimmed = value.trim();
   if (!trimmed) {
     return null;
@@ -114,7 +114,7 @@ function extractGitHubRepoFromRemoteOrigin(value: string): string | null {
   return null;
 }
 
-async function validateGitBackedContinuityRepoBinding(args: {
+export async function validateGitBackedContinuityRepoBinding(args: {
   projectName: string;
   policy: 'private_continuity' | 'public_distilled' | 'local_private';
   projectPath: string;

--- a/mcp-server/src/tools/save.ts
+++ b/mcp-server/src/tools/save.ts
@@ -174,15 +174,22 @@ async function hasTrackedPublicTranscriptDiffs(gitRoot: string, trackedConversat
   return stdout.trim().length > 0;
 }
 
+function normalizeOptionalPath(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+}
+
 export async function saveState(args: any): Promise<string> {
   const now = new Date();
   const timestamp = now.toISOString().replace('T', ' ').substring(0, 16);
   const { message } = args;
   const commitMessage = message || `Auto-save [${timestamp}]`;
+  const explicitProjectPath = normalizeOptionalPath(args.project_path);
+  const explicitRepoPath = normalizeOptionalPath(args.repo_path);
   let resolved;
   try {
     resolved = await resolveManagedProjectTarget({
       project: args.project,
+      projectPath: explicitProjectPath || explicitRepoPath || undefined,
       commandName: 'agenticos_save',
     });
   } catch (error: any) {
@@ -190,9 +197,10 @@ export async function saveState(args: any): Promise<string> {
   }
 
   const { project, projectPath, projectYaml, statePath } = resolved;
+  const gitBindingPath = explicitRepoPath || explicitProjectPath || projectPath;
 
   // Canonical-main guard: block save on canonical main checkouts to protect the trusted baseline
-  const writeProtection = await detectCanonicalMainWriteProtection(projectPath);
+  const writeProtection = await detectCanonicalMainWriteProtection(gitBindingPath);
   if (writeProtection.blocked) {
     return `❌ agenticos_save blocked for "${project.name}" — git persistence is not allowed on the canonical main checkout.\n\n` +
       `Canonical main checkout: ${writeProtection.reason ?? writeProtection.git_worktree_root}\n` +
@@ -203,8 +211,8 @@ export async function saveState(args: any): Promise<string> {
   }
 
   try {
-    // Find git root from the project path (works regardless of AGENTICOS_HOME)
-    const gitIdentity = await findGitIdentity(projectPath);
+    // Find git root from the binding path (worktree-aware when repo_path/project_path is supplied)
+    const gitIdentity = await findGitIdentity(gitBindingPath);
     const gitWorktreeRoot = gitIdentity?.worktreeRoot || null;
     const gitCommonRepoRoot = gitIdentity?.commonRepoRoot || null;
 

--- a/mcp-server/src/utils/__tests__/runtime-review-surface.test.ts
+++ b/mcp-server/src/utils/__tests__/runtime-review-surface.test.ts
@@ -1,5 +1,28 @@
 import { describe, expect, it } from 'vitest';
-import { resolveRuntimeReviewSurfacePaths } from '../runtime-review-surface.js';
+import {
+  resolveRuntimeReviewComparisonRoot,
+  resolveRuntimeReviewSurfacePaths,
+} from '../runtime-review-surface.js';
+
+describe('resolveRuntimeReviewComparisonRoot', () => {
+  it('returns managed project path when repo root is omitted', () => {
+    expect(resolveRuntimeReviewComparisonRoot('/repo/projects/app')).toBe('/repo/projects/app');
+  });
+
+  it('returns repo root when project path equals repo root', () => {
+    expect(resolveRuntimeReviewComparisonRoot('/repo', '/repo')).toBe('/repo');
+  });
+
+  it('returns repo root when project path is nested inside the repo', () => {
+    expect(resolveRuntimeReviewComparisonRoot('/repo/projects/app', '/repo')).toBe('/repo');
+  });
+
+  it('returns managed project path when repo root is an external worktree', () => {
+    expect(
+      resolveRuntimeReviewComparisonRoot('/repo/projects/app', '/repo/worktrees/issue-482'),
+    ).toBe('/repo/projects/app');
+  });
+});
 
 describe('runtime review surface', () => {
   it('keeps tracked conversations in runtime-managed paths for private continuity', () => {
@@ -76,5 +99,48 @@ describe('runtime review surface', () => {
 
     expect(result.tracked_review_excluded_paths).toContain('standards/.context/state.yaml');
     expect(result.tracked_review_excluded_paths).toContain('standards/.context/conversations/');
+  });
+
+  it('falls back to managed context paths when context policy resolution fails', () => {
+    const result = resolveRuntimeReviewSurfacePaths('/workspace/fallback-project', {
+      meta: { name: 'Fallback Project' },
+    }, {
+      repo_root: '/workspace/fallback-project',
+      include_claude_state_mirror: true,
+    });
+
+    expect(result.tracked_review_excluded_paths).toContain('.context/state.yaml');
+    expect(result.tracked_review_excluded_paths).toContain('CLAUDE.md');
+    expect(result.sidecar_only_paths).toContain('.private/conversations/');
+  });
+
+  it('uses the project directory basename when meta.name is missing', () => {
+    const result = resolveRuntimeReviewSurfacePaths('/workspace/my-project', {
+      source_control: {
+        topology: 'local_directory_only',
+        context_publication_policy: 'local_private',
+      },
+    }, {
+      include_claude_state_mirror: true,
+    });
+
+    expect(result.tracked_review_excluded_paths).toContain('.context/state.yaml');
+  });
+
+  it('throws when fallback context paths escape the comparison root', () => {
+    expect(() => resolveRuntimeReviewSurfacePaths('/workspace/project', {
+      meta: { name: 'Broken Project' },
+      source_control: {
+        topology: 'github_versioned',
+        context_publication_policy: 'bad-policy',
+      },
+      agent_context: {
+        current_state: '../../escape/state.yaml',
+        conversations: '../../escape/conversations/',
+        last_record_marker: '../../escape/.last_record',
+      },
+    }, {
+      repo_root: '/workspace/other',
+    })).toThrow('Runtime review surface path escapes comparison root');
   });
 });

--- a/mcp-server/src/utils/__tests__/runtime-review-surface.test.ts
+++ b/mcp-server/src/utils/__tests__/runtime-review-surface.test.ts
@@ -57,4 +57,24 @@ describe('runtime review surface', () => {
       fail_closed_on_context_policy_error: true,
     })).toThrow();
   });
+
+  it('uses managed project root for surface comparison when repo_root is an external worktree', () => {
+    const result = resolveRuntimeReviewSurfacePaths('/repo/projects/agenticos', {
+      meta: { name: 'AgenticOS' },
+      source_control: {
+        topology: 'github_versioned',
+        context_publication_policy: 'private_continuity',
+      },
+      agent_context: {
+        current_state: 'standards/.context/state.yaml',
+        conversations: 'standards/.context/conversations/',
+        last_record_marker: 'standards/.context/.last_record',
+      },
+    }, {
+      repo_root: '/repo/worktrees/issue-482',
+    });
+
+    expect(result.tracked_review_excluded_paths).toContain('standards/.context/state.yaml');
+    expect(result.tracked_review_excluded_paths).toContain('standards/.context/conversations/');
+  });
 });

--- a/mcp-server/src/utils/runtime-review-surface.ts
+++ b/mcp-server/src/utils/runtime-review-surface.ts
@@ -1,4 +1,4 @@
-import { basename, join, relative } from 'path';
+import { basename, join, relative, resolve } from 'path';
 import { resolveContextPolicyPlan } from './context-policy-plan.js';
 import { resolveManagedProjectContextPaths } from './project-target.js';
 
@@ -22,6 +22,26 @@ function normalizeRelativePathFromBase(basePath: string, absolutePath: string, t
   return treatAsDirectory && !relativePath.endsWith('/') ? `${relativePath}/` : relativePath;
 }
 
+export function resolveRuntimeReviewComparisonRoot(
+  managedProjectPath: string,
+  repoRoot?: string | null,
+): string {
+  const normalizedProjectPath = resolve(managedProjectPath);
+  if (!repoRoot) {
+    return normalizedProjectPath;
+  }
+
+  const normalizedRepoRoot = resolve(repoRoot);
+  if (
+    normalizedProjectPath === normalizedRepoRoot
+    || normalizedProjectPath.startsWith(`${normalizedRepoRoot}/`)
+  ) {
+    return normalizedRepoRoot;
+  }
+
+  return normalizedProjectPath;
+}
+
 function normalizeCandidatePath(path: string): string {
   return path.replace(/\\/g, '/').replace(/^\.\//, '');
 }
@@ -31,7 +51,7 @@ export function resolveRuntimeReviewSurfacePaths(
   projectYaml: any,
   options: ResolveRuntimeReviewSurfaceOptions = {},
 ): RuntimeReviewSurfacePaths {
-  const comparisonRoot = options.repo_root || projectPath;
+  const comparisonRoot = resolveRuntimeReviewComparisonRoot(projectPath, options.repo_root);
   let contextPolicyPlan;
   try {
     contextPolicyPlan = resolveContextPolicyPlan({


### PR DESCRIPTION
## Summary
- Add `project_path` / `repo_path` to `agenticos_save` so git operations and canonical-main guard target the issue worktree instead of the registry checkout.
- Add optional `repo_path` to `agenticos_switch` to bind the MCP session to a validated worktree checkout.
- Fix runtime review surface comparison when `project_path` and `repo_path` diverge, preventing false `pr_scope_check` BLOCK results.
- Document resolver binding in `mcp-server/README.md`.

Closes #482

## Test plan
- [x] `npm test` in `mcp-server` (1105 passed)
- [x] `./tools/coverage-preflight.sh` (aggregate + changed-scope pass)
- [ ] Manual: `agenticos_switch(project, repo_path=worktree)` then `agenticos_save` from worktree
- [ ] Manual: `agenticos_pr_scope_check` with separate `project_path` + `repo_path`


Made with [Cursor](https://cursor.com)