### PR TITLE
fix(release): guard Homebrew bump when HOMEBREW_TAP_PAT missing (#438)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,20 @@ jobs:
           curl -sL -o agenticos-mcp.tgz \
             "https://github.com/madlouse/AgenticOS/releases/download/${{ github.ref_name }}/agenticos-mcp.tgz"
 
+      - name: Verify Homebrew tap PAT
+        id: homebrew_pat
+        env:
+          HOMEBREW_TAP_PAT: ${{ secrets.HOMEBREW_TAP_PAT }}
+        run: |
+          if [ -z "$HOMEBREW_TAP_PAT" ]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::warning title=Homebrew tap bump skipped::HOMEBREW_TAP_PAT is not configured. The GitHub release artifact is still published, but ${{ env.HOMEBREW_TAP }} must be updated manually. See standards/.context/release-process.md."
+          else
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Update Homebrew formula in tap repo
+        if: steps.homebrew_pat.outputs.available == 'true'
         uses: mislav/bump-homebrew-formula-action@ccf2332299a883f6af50a1d2d41e5df7904dd769 # v4.1
         with:
           formula-name: ${{ env.FORMULA_NAME }}
@@ -111,6 +124,13 @@ jobs:
           tag-name: ${{ github.ref_name }}
         env:
           COMMITTER_TOKEN: ${{ secrets.HOMEBREW_TAP_PAT }}
+
+      - name: Report skipped Homebrew tap bump
+        if: steps.homebrew_pat.outputs.available != 'true'
+        run: |
+          echo "Skipped automated bump to ${{ env.HOMEBREW_TAP }} because HOMEBREW_TAP_PAT is unset or empty."
+          echo "Manual intervention required: update ${{ env.FORMULA_PATH }} in the tap repository after verifying the release artifact."
+          echo "The source-repo formula sync step below still runs when possible."
 
       - name: Sync formula to source repo
         run: |
@@ -140,7 +160,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Notify on Homebrew update failure
-        if: failure()
+        if: failure() && steps.homebrew_pat.outputs.available == 'true'
         run: |
           echo "Homebrew formula update failed for ${{ github.ref_name }}"
           echo "Manual intervention required in ${{ env.HOMEBREW_TAP }} repository"

--- a/standards/.context/release-process.md
+++ b/standards/.context/release-process.md
@@ -92,17 +92,17 @@ Both must be updated on every release. The local tap is what `brew install` read
 
 ## Required Secrets
 
-For automated Homebrew bumps, the repository needs:
+For automated Homebrew bumps, configure **Settings → Secrets and variables → Actions** on the AgenticOS repository:
 
 | Secret | Purpose |
 |--------|---------|
-| `HOMEBREW_TAP_PAT` | PAT with `repo` scope for `mislav/bump-homebrew-formula-action` to create PRs |
+| `HOMEBREW_TAP_PAT` | Fine-grained or classic PAT with `contents: write` on `madlouse/homebrew-agenticos` (or full `repo` scope) for `mislav/bump-homebrew-formula-action` |
 
-If `HOMEBREW_TAP_PAT` is absent or empty, the release can still create the
-GitHub Release artifact, but the Homebrew tap update will fail and the source
-formula sync step will be skipped. In that case, manually update both formula
-locations to the release artifact URL and SHA256 before considering the release
-complete.
+If `HOMEBREW_TAP_PAT` is absent or empty, the release workflow skips the tap-repo
+bump step with an explicit warning instead of failing on an empty
+`COMMITTER_TOKEN`. The GitHub Release artifact and source-repo formula sync still
+run. Manually update both formula locations (canonical source and local tap) to
+the release artifact URL and SHA256 before considering the release complete.
 
 ## Post-release
 


### PR DESCRIPTION
## Summary
- Add an early `HOMEBREW_TAP_PAT` check in the release workflow so missing secrets skip the tap bump with a clear warning instead of an opaque HTTP 303 failure.
- Keep source-repo formula sync running when the PAT is absent.
- Document secret configuration and manual fallback in `standards/.context/release-process.md`.

Closes #438

## Test plan
- [ ] Dry-run review of `release.yml` job conditions
- [ ] After merge, verify next tag release skips tap bump cleanly when PAT unset (or bumps when configured)


Made with [Cursor](https://cursor.com)